### PR TITLE
docs(style): Constrain maps to a maximum of `90vh`

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -71,4 +71,5 @@ td {
 
 .llwp-map {
     height: 800px;
+    max-height: 90vh;
 }


### PR DESCRIPTION
On my laptop (and mobile) the height of the maps in the examples exceed the viewport, which makes it harder to interact with them. This change constrains the example maps to `90vh` (to give some leeway).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canadian-geospatial-platform/geoview/230)
<!-- Reviewable:end -->
