### PR TITLE
refactor(marker-cluster): Type usage rectification on the marker cluster feature

### DIFF
--- a/packages/geoview-core/src/core/components/click-marker/click-marker.tsx
+++ b/packages/geoview-core/src/core/components/click-marker/click-marker.tsx
@@ -46,7 +46,7 @@ export const ClickMarker = (): JSX.Element => {
   const classes = useStyles();
 
   const map = useMap();
-  const mapId = api.mapInstance(map).id;
+  const mapId = api.mapInstance(map)!.id;
   const overlay = document.createElement("div");
 
   /**

--- a/packages/geoview-core/src/core/components/crosshair/crosshair.tsx
+++ b/packages/geoview-core/src/core/components/crosshair/crosshair.tsx
@@ -65,7 +65,7 @@ export function Crosshair(props: CrosshairProps): JSX.Element {
 
   const map = useMap();
 
-  const mapId = api.mapInstance(map).id;
+  const mapId = api.mapInstance(map)!.id;
 
   const mapContainer = map.getContainer();
 

--- a/packages/geoview-core/src/core/types/cgp-leaflet-config.ts
+++ b/packages/geoview-core/src/core/types/cgp-leaflet-config.ts
@@ -212,7 +212,7 @@ L.Circle.addInitHook(function fn(this: L.Circle) {
 
 /*-----------------------------------------------------------------------------
  *
- * L.Polyline and Polygon configuration
+ * L.Polyline and L.Polygon configuration
  *
  *---------------------------------------------------------------------------*/
 
@@ -249,14 +249,7 @@ declare module "leaflet" {
   }
 
   interface Marker {
-    initialize: (latLng: L.LatLng, options: L.MarkerOptions) => void;
-  }
-
-  interface MarkerCluster {
-    spiderfy: () => void;
-    unspiderfy: () => void;
-    getAllChildMarkers(): L.MarkerClusterElement[];
-    zoomToBounds(options: { padding: [number, number] }): void;
+    initialize: (latLng: LatLng, options: MarkerOptions) => void;
   }
 }
 
@@ -289,12 +282,28 @@ declare module "leaflet" {
     options?: FeatureGroupOptions
   ): FeatureGroup;
 
+  export interface Evented extends Class {
+    on(
+        type: "clusterclick" | "unspiderfied" | "spiderfied",
+        fn: MarkerClusterMouseEventHandlerFn
+      ): void;
+      off(
+        type: "clusterclick" | "unspiderfied" | "spiderfied",
+        fn: MarkerClusterMouseEventHandlerFn
+      ): void;
+      fire(
+        type: "click",
+        event: MarkerClusterMouseEvent,
+        propagate: boolean
+      ): void;
+  }
+
   export interface MarkerClusterMouseEvent extends LeafletMouseEvent {
     latlng: LatLng;
     layerPoint: Point;
     containerPoint: Point;
     originalEvent: MouseEvent;
-    propagatedFrom: MarkerCluster;
+    propagatedFrom: MarkerClusterElement;
     target: MarkerClusterGroup;
     type: string;
   }
@@ -309,7 +318,7 @@ declare module "leaflet" {
     spiderfied?: MarkerClusterMouseEventHandlerFn;
   }
 
-  interface MarkerClusterGroupOptions {
+  interface MarkerClusterGroupOptions extends LayerOptions {
     id?: string;
     visible?: boolean;
     on?: MarkerClusterGroupOnOptions;
@@ -318,25 +327,9 @@ declare module "leaflet" {
   interface MarkerClusterGroup extends FeatureGroup {
     visible: boolean;
     type: string;
-    addLayer(marker: MarkerClusterElement): this;
-    removeLayer(marker: MarkerClusterElement): this;
-    eachLayer(fn: (layer: L.MarkerClusterElement) => void, context?: any): this;
-    getLayers(): MarkerClusterElement[];
     getVisibleParent(marker: MarkerClusterElement): MarkerCluster;
     unspiderfy(): void;
-    on(
-      type: "clusterclick" | "unspiderfied" | "spiderfied",
-      fn: MarkerClusterMouseEventHandlerFn
-    ): void;
-    off(
-      type: "clusterclick" | "unspiderfied" | "spiderfied",
-      fn: MarkerClusterMouseEventHandlerFn
-    ): void;
-    fire(
-      type: "click",
-      event: MarkerClusterMouseEvent,
-      propagate: boolean
-    ): void;
+    eachLayer(fn: (marker: MarkerClusterElement) => void, context?: any): this;
   }
 }
 

--- a/packages/geoview-core/src/core/types/marker-cluster-element.d.ts
+++ b/packages/geoview-core/src/core/types/marker-cluster-element.d.ts
@@ -1,6 +1,6 @@
 // Type modification for Leaflet.markercluster 1.0
 
-/// <reference types="leaflet" />
+/// <reference types="leaflet.markercluster" />
 
 declare namespace L {
     export interface MarkerClusterElementMouseEvent extends LeafletMouseEvent {
@@ -28,25 +28,22 @@ declare namespace L {
         on?: MarkerClusterElementOnOptions;
     }
 
-    interface MarkerClusterElement {
+    interface MarkerClusterElement extends MarkerCluster {
         id: string;
         type: string;
         options: MarkerClusterElementOptions;
         blinking: boolean;
         selected: boolean;
-        setSelectedMarkerIconCreator(f: () => L.DivIcon): void;
-        setUnselectedMarkerIconCreator(f: () => L.DivIcon): void;
-        getSelectedMarkerIcon(): L.DivIcon;
-        getUnselectedMarkerIcon(): L.DivIcon;
+        setSelectedMarkerIconCreator(f: () => DivIcon): void;
+        setUnselectedMarkerIconCreator(f: () => DivIcon): void;
+        getSelectedMarkerIcon(): DivIcon;
+        getUnselectedMarkerIcon(): DivIcon;
         setSelectedFlag(newValue: boolean): void;
         startBlinking(): void;
         stopBlinking(): void;
-        addTo(map: L.Map | L.MarkerClusterGroup): this;
         remove(): this;
         getLatLng(): LatLng;
-        on(type: 'click', fn: MarkerClusterElementMouseEventHandlerFn): void;
-        off(type: 'click', fn: MarkerClusterElementMouseEventHandlerFn): void;
     }
 
-    function markerClusterElement(latlng: L.LatLngExpression, options?: MarkerClusterElementOptions): MarkerClusterElement;
+    function markerClusterElement(latlng: LatLngExpression, options?: MarkerClusterElementOptions): MarkerClusterElement;
 }

--- a/packages/geoview-core/src/core/types/marker-cluster-element.ts
+++ b/packages/geoview-core/src/core/types/marker-cluster-element.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-underscore-dangle */
 import L, { LeafletEventHandlerFn } from "leaflet";
+import "./marker-cluster-element.d"
 import "leaflet.markercluster/src";
 
-import { api } from "../../../api/api";
-import { EVENT_NAMES } from "../../../api/event";
-import { TypeIconCreationFunction } from "../../../core/types/cgpv-types";
-import * as MarkerDefinitions from "../../../core/types/marker-definitions";
+import { api } from "../../api/api";
+import { EVENT_NAMES } from "../../api/event";
+import { TypeIconCreationFunction } from "./cgpv-types";
+import * as MarkerDefinitions from "./marker-definitions";
 
 let { unselectedMarkerIconCreator, selectedMarkerIconCreator } =
   MarkerDefinitions;

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -8,7 +8,7 @@ import { OgcFeature } from "./ogc/ogc_feature";
 import { XYZTiles } from "./map-tile/xyz-tiles";
 import { GeoJSON } from "./file/geojson";
 import { Vector } from "./vector/vector";
-import { MarkerCluster } from "./vector/marker-cluster";
+import { MarkerClusterClass } from "./vector/marker-cluster";
 
 import { api } from "../../api/api";
 import { EVENT_NAMES } from "../../api/event";
@@ -54,7 +54,7 @@ export class Layer {
     this.#map = map;
 
     this.vector = new Vector(map);
-    this.markerCluster = new MarkerCluster(map);
+    this.markerCluster = new MarkerClusterClass(map);
 
     // listen to outside events to add layers
     api.event.on(


### PR DESCRIPTION
Some section of the code didn't use the types appropriately. Did not correct everything, but it a starting point.
Type usage rectification is on the marker cluster feature of GeoView.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canadian-geospatial-platform/geoview/371)
<!-- Reviewable:end -->
