### PR TITLE
OGC WMS Legend does not display when configured from a template.

### DIFF
--- a/packages/geoview-core/public/templates/loading-packages.html
+++ b/packages/geoview-core/public/templates/loading-packages.html
@@ -131,6 +131,22 @@
               ]
             },
             {
+              'id': 'wmsMSI',
+              'name': {
+                'en': 'Probability of permanent snow and ice (94% or more)',
+                'fr': 'Probabilité de neige et glace permanente (94% ou plus)'
+              },
+              'url': {
+                'en': 'https://datacube.services.geo.ca/ows/msi',
+                'fr': 'https://datacube.services.geo.ca/ows/msi'
+              },
+              'layerType': 'ogcWms',
+              'layerEntries': [
+              {
+                'id': 'msi-94-or-more'
+              }          ]
+            },
+            {
               'id': 'esriDynamicLYR2',
               'name': {
                 'en': 'Energy Infrastructure of North America',

--- a/packages/geoview-core/src/geo/layer/web-layers/ogc/wms.ts
+++ b/packages/geoview-core/src/geo/layer/web-layers/ogc/wms.ts
@@ -199,10 +199,10 @@ export class WMS extends AbstractWebLayersClass {
    * @returns {TypeJsonObject | null} URL of a Legend image in png format or null
    */
   getLegendUrlFromCapabilities = (): TypeJsonObject | null => {
-    const layerName = this.layer!.options.layers;
+    const layerNames = this.layer!.options.layers!.split(',');
     let legendUrl = null;
     (this.#capabilities.Capability.Layer.Layer as TypeJsonArray).forEach((currentLayer) => {
-      if (currentLayer.Name === layerName && currentLayer.Style) {
+      if (layerNames.includes(currentLayer.Name as string) && currentLayer.Style) {
         (currentLayer.Style as TypeJsonArray).forEach((currentStyle) => {
           if (currentStyle.LegendURL) {
             (currentStyle.LegendURL as TypeJsonArray).forEach((currentLegend) => {


### PR DESCRIPTION
When added manually, OGC WMS layers display correctly their legend in the layer panel. However, this is not the case when the layer is configured in a template.