### PR TITLE
618-WMS metadata extent bug

### DIFF
--- a/docs/app/components-packages.md
+++ b/docs/app/components-packages.md
@@ -1,43 +1,44 @@
 # Components versus Packages
-The main difference between a component and a package is their level of customization. A component is the basic item to build with and as no configuration options. In the other hand, a package is something build with one to many core components and custom one as well. We can see the component as a Lego block and a package as the resulting contructed structure.
+The main difference between a component and a package is their level of customization. Components are potentially configurable basic elements with which we can build other more complex elements. On the other hand, a package is something built with several basic or customized components. By analogy, we can compare components to Lego blocks and packages to structures built with them.
 
 ## What is a components
-Components are part of geoview-core package where we can find the barebone functionnalities of GeoView (api, events, translation, ...).
-Some components like legend and data-grid can be reuse within another package or direclty from GeoView API as we can see in these demo:
+Components are part of the geoview-core package where we find the basic functionality of GeoView (api, events, translation, ...).
+Some components, like legends and data grids can be reused in another package or directly from the GeoView API as we can see in these demos:
 - [legend](https://canadian-geospatial-platform.github.io/geoview/public/legend.html)
 - [data-grid](https://canadian-geospatial-platform.github.io/geoview/public/package-footer-panel.html)
 
-Other components can be added to the map from the configuration like this:
+Other components can be added to the map from the configuration via the following line:
 
 ```js
 'components': ['app-bar', 'nav-bar', 'north-arrow', 'overview-map']
 ```
 
-In both cases these components are basic items on wich we can build bigger functionalities.
+In all these cases, components are building blocks on which we can build more important functionality.
 
 
 ## What is a packages
-Packages are a collection of components bundled together to extend the viewer's functionalities. There is two types of package, **Core Package** and **External Package**.
+Packages are collections of components that extend the functionality of the viewer. There are two types of packages, **Core Package** and **External Package**.
 
-A **Core Package** is a package developed and maintained by the viewer team. The viewer supports few core packages such as a [basemap panel](https://canadian-geospatial-platform.github.io/geoview/public/package-basemap-panel.html), details panel, layers panel or [footer panel](https://canadian-geospatial-platform.github.io/geoview/public/package-footer-panel.html). Core package can be added by configuration like this:
+A **Core Package** is a package developed and maintained by the viewer team. The viewer supports few core packages such as a [basemap panel](https://canadian-geospatial-platform.github.io/geoview/public/package-basemap-panel.html), details panel, layers panel or [footer panel](https://canadian-geospatial-platform.github.io/geoview/public/package-footer-panel.html). Core packages can be added to the map from the configuration via the following line:
 
 ```js
 'corePackages': ['details-panel', 'layers-panel', 'basemap-panel', 'footer-panel'],
 ```
 
-Each package is configurable, at some extent, as they have their own schema and default configuration. For exemple, the basemap panel has this [schema](https://github.com/Canadian-Geospatial-Platform/geoview/blob/develop/packages/geoview-basemap-panel/schema.json) and [default configuration](https://github.com/Canadian-Geospatial-Platform/geoview/blob/develop/packages/geoview-basemap-panel/default-config-basemap-panel.json). If needed, user can customize the package by providing a custom configuration file to initialize the package.
+Each of these packages is associated with a default schema and configuration. It is therefore possible to configure them to some extent according to our needs. For exemple, the basemap panel has this [schema](https://github.com/Canadian-Geospatial-Platform/geoview/blob/develop/packages/geoview-basemap-panel/schema.json) and [default configuration](https://github.com/Canadian-Geospatial-Platform/geoview/blob/develop/packages/geoview-basemap-panel/default-config-basemap-panel.json). If necessary, the user can customize the package by providing a custom configuration file to initialize the package.
 
-To use a custom configuration for a package, follow these steps:
-- Provide a json configuration file to load to the map div
+To associate  a custom configuration with a package, follow these steps:
+- Provide in the map's div tag a json configuration file, say package-bp1-lcc-config.json using the key **data-config-url** as shown below:
 ```html
 <div id="mapLCC" class="llwp-map" data-lang="en" data-config-url="./configs/package-bp1-lcc-config.json"></div>
 ```
-- Inside this file, add the core package to use
+- In the provided json file, specify the desired core package using the **corePackages** key as follows:
 ```js
 'corePackages': ['basemap-panel'],
 ```
-- Create a configuration for the package and name it <config-file-name>-<package-name>(i.e.  `package-bp1-lcc-config-basemap-panel.json`)
+- Then, create a configuration file for the package and name it <config-file-name>-<package-name>(i.e.  `package-bp1-lcc-config-basemap-panel.json`)
 - Put both configuration files in the same folder
 
-An **External Package** is a package developed outside of the GeoView repository and not maintain by the viewer team. You can se a demonstration in this [repository](https://github.com/Canadian-Geospatial-Platform/geoview-ce-demo).
-**Currently there is no mechanism to reuse an external package inside another viewer instance, this is work in progress.**
+An **External Package** is a package developed outside the GeoView repository and not maintained by the viewer team. You can see a demonstration in this [repository](https://github.com/Canadian-Geospatial-Platform/geoview-ce-demo).
+  
+**Currently there is no mechanism to reuse an external package in another viewer instance, this is a work in progress.**

--- a/packages/geoview-core/public/templates/layers.html
+++ b/packages/geoview-core/public/templates/layers.html
@@ -710,7 +710,7 @@
       legendTable.appendChild(table);
       var createHeader = true;
       Object.keys(resultSets).forEach((layerPath) => {
-        if (resultSets[layerPath].type === 'ogcWms') {
+        if (resultSets[layerPath]?.type === 'ogcWms') {
           if (createHeader) {
             createHeader = false;
             const tableRow1 = document.createElement('tr');
@@ -738,26 +738,29 @@
             addHeader("Label", tableRow1);
             addHeader("Symbology", tableRow1);
           }
-          Object.keys(resultSets[layerPath].legend).forEach((geometryKey) => {
-            if (resultSets[layerPath].styleConfig[geometryKey].styleType === "uniqueValue") {
-              for (let i = 0; i < resultSets[layerPath].legend[geometryKey].length; i++) {
-                addRow(layerPath,
-                       resultSets[layerPath].styleConfig[geometryKey].uniqueValueStyleInfo[i].label,
-                       resultSets[layerPath].legend[geometryKey][i]);
+          if (resultSets[layerPath]?.legend) {
+            Object.keys(resultSets[layerPath].legend).forEach((geometryKey) => {
+              if (geometryKey) {
+                if (resultSets[layerPath].styleConfig[geometryKey].styleType === "uniqueValue") {
+                  for (let i = 0; i < resultSets[layerPath].legend[geometryKey].length; i++) {
+                    addRow(layerPath,
+                          resultSets[layerPath].styleConfig[geometryKey].uniqueValueStyleInfo[i].label,
+                          resultSets[layerPath].legend[geometryKey][i]);
+                  }
+                } else if (resultSets[layerPath].styleConfig[geometryKey].styleType === "classBreaks") {
+                  for (let i = 0; i < resultSets[layerPath].legend[geometryKey].length; i++) {
+                    addRow(layerPath,
+                          resultSets[layerPath].styleConfig[geometryKey].classBreakStyleInfos[i].label,
+                          resultSets[layerPath].legend[geometryKey][i]);
+                  }
+                } else if (resultSets[layerPath].styleConfig[geometryKey].styleType === "simple") {
+                  addRow(layerPath,
+                        resultSets[layerPath].styleConfig[geometryKey].label,
+                        resultSets[layerPath].legend[geometryKey]);
+                }
               }
-            } else if (resultSets[layerPath].styleConfig[geometryKey].styleType === "classBreaks") {
-              for (let i = 0; i < resultSets[layerPath].legend[geometryKey].length; i++) {
-                addRow(layerPath,
-                       resultSets[layerPath].styleConfig[geometryKey].classBreakStyleInfos[i].label,
-                       resultSets[layerPath].legend[geometryKey][i]);
-              }
-            } else if (resultSets[layerPath].styleConfig[geometryKey].styleType === "simple") {
-              addRow(layerPath,
-                     resultSets[layerPath].styleConfig[geometryKey].label,
-                     resultSets[layerPath].legend[geometryKey]);
-            }
-
-          });
+            });
+          }
         }
       });
     }

--- a/packages/geoview-core/public/templates/test.html
+++ b/packages/geoview-core/public/templates/test.html
@@ -16,35 +16,28 @@
   </head>
   <body>
     <button id="get-feature-info">Run getFeatureInfo</button><br />
-    <div id="mapId" class="llwp-map" data-lang="en" data-config="{
+    <div id="LYR1" class="llwp-map" data-lang="en" data-config="{
       'map': {
         'interaction': 'dynamic',
         'viewSettings': {
           'zoom': 4,
           'center': [-100, 60],
-          'projection': 3978
+          'projection': 3857
         },
         'basemapOptions': {
-          'basemapId': 'nogeom',
-          'shaded': true,
+          'basemapId': 'transport',
+          'shaded': false,
           'labeled': false
         },
         'listOfGeoviewLayerConfig': [
           {
-            'geoviewLayerId': 'geojsonLYR',
-            'geoviewLayerName': { 'en': 'GeoJSON Sample' },
-            'metadataAccessPath': { 'en': './geojson/metadata.json' },
-            'geoviewLayerType': 'GeoJSON',
+            'geoviewLayerId': 'wmsLYR1',
+            'geoviewLayerName': { 'en': 'Hydro Network' },
+            'metadataAccessPath': { 'en': 'https://maps.geogratis.gc.ca/wms/hydro_network_en' },
+            'geoviewLayerType': 'ogcWms',
             'listOfLayerEntryConfig': [
-              { 'layerId': 'polygons.json' },
               {
-                'entryType': 'group',
-                'layerId': 'Group',
-                'layerName': { 'en': 'Group' },
-                'listOfLayerEntryConfig': [
-                  { 'layerId': 'icon_points.json' },
-                  { 'layerId': 'points.json' }
-                ]
+                'layerId': 'hydro_network'
               }
             ]
           }
@@ -56,13 +49,15 @@
       'suportedLanguages': ['en']
     }">
     </div>
-    <button id="add-geojson">Add GeoJSON Layer</button><button id="remove-geojson">Remove GeoJSON Layer</button> <br />
-    <label> Added Layer ID : </label><label id="new-layer-id-label"></label>
+    <button class="Get-wms-Legend">Get Legend</button>
+    <div id="wmsLegendsId-table-div"></div>
     <button type="button" class="collapsible">Get Feature Info</button>
-    <pre id="mapId-INFO" class="panel">Click on the map</pre>
+    <pre style="height: 20pc; overflow-y: scroll;"  id="wmsResultSetId" class="panel">Click on feature on the map</pre>
     <hr />
-    <button type="button" class="collapsible">Code Snippet</button>
-    <pre id="codeSnippet" class="panel"></pre>
+    <p>This map has a wms layer added from configuration.</p>
+    <button type="button" class="collapsible">Configuration Snippet</button>
+    <pre id="LYR1CS" class="panel"></pre>
+    <hr />
     <script src="codedoc.js"></script>
     <script>
       // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
@@ -71,48 +66,105 @@
         //create snippets
         createCodeSnippet();
         createConfigSnippet();
+      });
+    // WMS ======================================================================================================================
+    const featureInfoWmsLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR1', 'wmsResultSetId');
+    cgpv.api.event.on(cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE, (payload) => {
+      const {  layerSetId, resultSets } = payload;
+      document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
+    }, 'LYR1');
 
-        // GeoJson
-        const featureInfoGeoJsonLayerSet = cgpv.api.createFeatureInfoLayerSet('mapId', 'mapId-INFO');
-        cgpv.api.event.on(cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE, (payload) => {
-          const {  layerSetId, resultSets } = payload;
-          document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
-        }, 'mapId');
+    const LegendsWmsLayerSet = cgpv.api.createLegendsLayerSet('LYR1', 'wmsLegendsId');
+    cgpv.api.event.on(cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE, (payload) => {
+      const {  layerSetId, resultSets } = payload;
+      displayLegend(layerSetId, resultSets);
+    }, 'LYR1');
 
+    var addGeoJsonLegendButton = document.getElementsByClassName('Get-wms-Legend')[0];
+    addGeoJsonLegendButton.addEventListener('click', function (e) {
+      cgpv.api.event.emit({ handlerName: 'LYR1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER, layerSetId: 'wmsLegendsId' });
     });
 
-      // find the button element by ID
-      var addGeoJSONButton = document.getElementById('add-geojson');
-
-      // add an event listener when a button is clicked
-      // TODO: Repair
-      addGeoJSONButton.addEventListener('click', function (e) {
-        // adding a geojson layer requires a type of geojson and url
-        const layerID = cgpv.api.map('mapId').layer.addGeoviewLayer(
-          {
-            'geoviewLayerId': 'lines.json',
-            'geoviewLayerName': { 'en': 'GeoJSON Sample' },
-            'metadataAccessPath': { 'en': './geojson/metadata.json' },
-            'geoviewLayerType': 'GeoJSON',
-            'listOfLayerEntryConfig': [
-              { 'layerId': 'lines.json' }
-            ]
-          },
-          ['en']
-        );
-        document.getElementById('new-layer-id-label').innerText = layerID;
+    // ==========================================================================================================================
+    function displayLegend(layerSetId, resultSets) {
+      const addHeader = (title, container) => {
+        const tableHeader = document.createElement('th');
+        tableHeader.style = "text-align: center; vertical-align: middle;"
+        tableHeader.innerHTML =  title;
+        container.appendChild(tableHeader);
+      }
+      const addData = (data, container) => {
+        const tableData = document.createElement('td');
+        tableData.style.verticalAlign = 'middle';
+        tableData.style.textAlign = 'center';
+        if (typeof data === 'string') tableData.innerHTML =  data;
+        else tableData.appendChild(data);
+        container.appendChild(tableData);
+      }
+      var oldTable = document.getElementById(`${layerSetId}-table`);
+      if (oldTable) oldTable.parentNode.removeChild(oldTable)
+      var legendTable = document.getElementById(`${layerSetId}-table-div`);
+      const table = document.createElement('table');
+      table.id = `${layerSetId}-table`;
+      table.border="1";
+      table.style="width:50%";
+      legendTable.appendChild(table);
+      var createHeader = true;
+      Object.keys(resultSets).forEach((layerPath) => {
+        if (resultSets[layerPath]?.type === 'ogcWms') {
+          if (createHeader) {
+            createHeader = false;
+            const tableRow1 = document.createElement('tr');
+            table.appendChild(tableRow1);
+            addHeader("Layer Path", tableRow1);
+            addHeader("Symbology", tableRow1);
+          }
+          const tableRow = document.createElement('tr');
+          addData(resultSets[layerPath].layerPath, tableRow);
+          addData(resultSets[layerPath].legend, tableRow);
+          table.appendChild(tableRow);
+        } else {
+          const addRow = (layerPath, label, canvas) => {
+            const tableRow = document.createElement('tr');
+            addData(layerPath, tableRow);
+            addData(label, tableRow); // canvas.style = "border: 1px solid black;"
+            addData(canvas, tableRow);
+            table.appendChild(tableRow);
+          }
+          if (createHeader) {
+            createHeader = false;
+            const tableRow1 = document.createElement('tr');
+            table.appendChild(tableRow1);
+            addHeader("Layer Path", tableRow1);
+            addHeader("Label", tableRow1);
+            addHeader("Symbology", tableRow1);
+          }
+          if (resultSets[layerPath]?.legend) {
+            Object.keys(resultSets[layerPath].legend).forEach((geometryKey) => {
+              if (geometryKey) {
+                if (resultSets[layerPath].styleConfig[geometryKey].styleType === "uniqueValue") {
+                  for (let i = 0; i < resultSets[layerPath].legend[geometryKey].length; i++) {
+                    addRow(layerPath,
+                          resultSets[layerPath].styleConfig[geometryKey].uniqueValueStyleInfo[i].label,
+                          resultSets[layerPath].legend[geometryKey][i]);
+                  }
+                } else if (resultSets[layerPath].styleConfig[geometryKey].styleType === "classBreaks") {
+                  for (let i = 0; i < resultSets[layerPath].legend[geometryKey].length; i++) {
+                    addRow(layerPath,
+                          resultSets[layerPath].styleConfig[geometryKey].classBreakStyleInfos[i].label,
+                          resultSets[layerPath].legend[geometryKey][i]);
+                  }
+                } else if (resultSets[layerPath].styleConfig[geometryKey].styleType === "simple") {
+                  addRow(layerPath,
+                        resultSets[layerPath].styleConfig[geometryKey].label,
+                        resultSets[layerPath].legend[geometryKey]);
+                }
+              }
+            });
+          }
+        }
       });
-
-      // find the button element by ID
-      var removeGeoJSONButton = document.getElementById('remove-geojson');
-
-      // add an event listener when a button is clicked
-      removeGeoJSONButton.addEventListener('click', function (e) {
-        // removing a geojson layer using the ID
-        cgpv.api.map('mapId').layer.removeLayersUsingPath(document.getElementById('new-layer-id-label').innerText);
-        document.getElementById('new-layer-id-label').innerText = '';
-      });
-
+    }
     </script>
   </body>
 </html>

--- a/packages/geoview-core/src/core/components/legend/legend-item.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-item.tsx
@@ -112,7 +112,7 @@ export function LegendItem(props: TypeLegendItemProps): JSX.Element {
         } else if (isVectorLegend(layerLegend)) {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           Object.entries(layerLegend.legend).forEach(([key1, canvas]) => {
-            if ('length' in canvas) {
+            if ('length' in canvas!) {
               setIconType('list');
               const iconImageList = (canvas as HTMLCanvasElement[]).map((c) => {
                 return c.toDataURL();

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -76,7 +76,7 @@ export interface TypeVectorLegend extends TypeLegend {
   legend: TypeLayerStyle;
 }
 
-export type TypeLayerStyle = Partial<Record<TypeStyleConfigKey, HTMLCanvasElement | HTMLCanvasElement[]>>;
+export type TypeLayerStyle = Partial<Record<TypeStyleConfigKey, HTMLCanvasElement | null | (HTMLCanvasElement | null)[]>>;
 
 /** ******************************************************************************************************************************
  * GeoViewAbstractLayers types
@@ -280,7 +280,7 @@ export abstract class AbstractGeoViewLayer {
       const promisedAllLayerDone: Promise<void>[] = [];
       listOfLayerEntryConfig.forEach((layerEntryConfig: TypeLayerEntryConfig) => {
         if (layerEntryIsGroupLayer(layerEntryConfig))
-          if (layerEntryConfig.isDynamicLayerGroup) promisedAllLayerDone.push(this.processDynamicGroupLayer(layerEntryConfig));
+          if (layerEntryConfig.isMetadataLayerGroup) promisedAllLayerDone.push(this.processMetadataGroupLayer(layerEntryConfig));
           else promisedAllLayerDone.push(this.processListOfLayerEntryMetadata(layerEntryConfig.listOfLayerEntryConfig));
         else promisedAllLayerDone.push(this.processLayerMetadata(layerEntryConfig));
       });
@@ -290,15 +290,15 @@ export abstract class AbstractGeoViewLayer {
   }
 
   /** ***************************************************************************************************************************
-   * This method is used to process dynamic group layer entries. These layers behave as a GeoView group layer and also as a data
-   * layer (i.e. they have extent, visibility and query flag definition). Dynamic group layers can be identified by
-   * the presence of an isDynamicLayerGroup attribute set to true.
+   * This method is used to process metadata group layer entries. These layers behave as a GeoView group layer and also as a data
+   * layer (i.e. they have extent, visibility and query flag definition). Metadata group layers can be identified by
+   * the presence of an isMetadataLayerGroup attribute set to true.
    *
    * @param {TypeLayerGroupEntryConfig} layerEntryConfig The layer entry configuration to process.
    *
    * @returns {Promise<void>} A promise that the vector layer configuration has its metadata and group layers processed.
    */
-  private processDynamicGroupLayer(layerEntryConfig: TypeLayerGroupEntryConfig): Promise<void> {
+  private processMetadataGroupLayer(layerEntryConfig: TypeLayerGroupEntryConfig): Promise<void> {
     const promisedListOfLayerEntryProcessed = new Promise<void>((resolve) => {
       this.processLayerMetadata(layerEntryConfig).then(() => {
         this.processListOfLayerEntryMetadata(layerEntryConfig.listOfLayerEntryConfig!).then(() => resolve());

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -551,9 +551,9 @@ export type TypeBaseLayerEntryConfig = {
   parentLayerConfig?: TypeGeoviewLayerConfig | TypeLayerGroupEntryConfig;
   /** This attribute is not part of the schema. It is used to link the displayed layer to its layer entry config. */
   gvLayer?: BaseLayer;
-  /** This attribute is not part of the schema. It is used internally to distinguish dynamic layer groups derived from the
+  /** This attribute is not part of the schema. It is used internally to distinguish layer groups derived from the
    * metadata. */
-  isDynamicLayerGroup?: boolean;
+  isMetadataLayerGroup?: boolean;
   /** Layer entry data type. */
   entryType?: 'vector' | 'vectorTile' | 'vectorHeatmap' | 'raster' | 'group';
   /** The id of the layer to display on the map. */
@@ -784,9 +784,9 @@ export type TypeSourceGeocoreConfig = {
  * Type used to define a layer group.
  */
 export interface TypeLayerGroupEntryConfig extends Omit<TypeBaseLayerEntryConfig, 'listOfLayerEntryConfig'> {
-  /** This attribute is not part of the schema. It is used internally to distinguish dynanic layer groups derived from the
+  /** This attribute is not part of the schema. It is used internally to distinguish layer groups derived from the
    * metadata. */
-  isDynamicLayerGroup?: boolean;
+  isMetadataLayerGroup?: boolean;
   /** Layer entry data type. */
   entryType: 'group';
   /** The source attribute does not exists on the layer group entry. */


### PR DESCRIPTION
Added properties inheritance as specified in the WMS standard.
Added a catch on the methode that load the legend images. When there is an error, a null value is returned instead of a canvas.
Changed isDynamicLayerGroup to isMetadataLayerGroup to eliminate confusion with esri-dynamic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canadian-geospatial-platform/geoview/633)
<!-- Reviewable:end -->
