### PR TITLE
605-Esri-dynamic-layer-visibility-bug-resolution

### DIFF
--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -38,7 +38,7 @@
     "version": "Accéder au repo sur GitHub"
   },
   "legend": {
-    "unknown": "Titre de calque inconnu"
+    "unknown": "Titre de légende inconnu"
   },
   "keyboardnav": {
     "start": "Aller après l'élément carte",

--- a/packages/geoview-core/public/templates/legend.html
+++ b/packages/geoview-core/public/templates/legend.html
@@ -227,7 +227,7 @@
                 },
                 'geoviewLayerType': 'esriDynamic',
                 'listOfLayerEntryConfig': [
-                  {'layerId': '0'}
+                  {'layerId': '8'}
                 ]
               }
             ]

--- a/packages/geoview-core/public/templates/test.html
+++ b/packages/geoview-core/public/templates/test.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body>
+    <button class="Test-Visibility">Test Visibility</button>
     <div id="LYR1" class="llwp-map" data-lang="en" data-config="{
       'map': {
         'interaction': 'dynamic',
@@ -36,7 +37,7 @@
             'geoviewLayerType': 'esriDynamic',
             'listOfLayerEntryConfig': [
               {
-                'layerId': '2'
+                'layerId': '8'
               }
             ]
           }
@@ -171,6 +172,63 @@
         }
       });
     }
+
+    const cycleThroughtLayers = (delay) => {
+      setTimeout(() => {
+        cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(delay, 'esriDynamicLYR3z/8/9');
+        cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(false, 'esriDynamicLYR3z/8/20');
+        setTimeout(() => {
+          cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(delay, 'esriDynamicLYR3z/8/10');
+          cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(false, 'esriDynamicLYR3z/8/9');
+          setTimeout(() => {
+            cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(delay, 'esriDynamicLYR3z/8/11');
+            cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(false, 'esriDynamicLYR3z/8/10');
+            setTimeout(() => {
+              cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(delay, 'esriDynamicLYR3z/8/12');
+              cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(false, 'esriDynamicLYR3z/8/11');
+              setTimeout(() => {
+                cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(delay, 'esriDynamicLYR3z/8/13');
+                cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(false, 'esriDynamicLYR3z/8/12');
+                setTimeout(() => {
+                  cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(delay, 'esriDynamicLYR3z/8/14');
+                  cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(false, 'esriDynamicLYR3z/8/13');
+                  setTimeout(() => {
+                    cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(delay, 'esriDynamicLYR3z/8/15');
+                    cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(false, 'esriDynamicLYR3z/8/14');
+                    setTimeout(() => {
+                      cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(delay, 'esriDynamicLYR3z/8/16');
+                      cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(false, 'esriDynamicLYR3z/8/15');
+                      setTimeout(() => {
+                        cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(delay, 'esriDynamicLYR3z/8/17');
+                        cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(false, 'esriDynamicLYR3z/8/16');
+                        setTimeout(() => {
+                          cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(delay, 'esriDynamicLYR3z/8/18');
+                          cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(false, 'esriDynamicLYR3z/8/17');
+                          setTimeout(() => {
+                            cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(delay, 'esriDynamicLYR3z/8/19');
+                            cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(false, 'esriDynamicLYR3z/8/18');
+                            setTimeout(() => {
+                              cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(delay, 'esriDynamicLYR3z/8/20');
+                              cgpv.api.maps.LYR1.layer.geoviewLayers.esriDynamicLYR3z.setVisible(false, 'esriDynamicLYR3z/8/19');
+                            }, delay);
+                          }, delay);
+                        }, delay);
+                      }, delay);
+                    }, delay);
+                  }, delay);
+                }, delay);
+              }, delay);
+            }, delay);
+          }, delay);
+        }, delay);
+      }, delay);
+    }
+
+    var testVisibility = document.getElementsByClassName('Test-Visibility')[0];
+    testVisibility.addEventListener('click', function (e) {
+      cycleThroughtLayers(0);
+      cycleThroughtLayers(2000);
+    });
     </script>
   </body>
 </html>

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -197,6 +197,10 @@ export class EsriDynamic extends AbstractGeoViewRaster {
         });
         const switchToGroupLayer = Cast<TypeLayerGroupEntryConfig>(layerEntryConfig);
         switchToGroupLayer.entryType = 'group';
+        switchToGroupLayer.layerName = {
+          en: this.metadata!.layers[esriIndex].name as string,
+          fr: this.metadata!.layers[esriIndex].name as string,
+        };
         switchToGroupLayer.isMetadataLayerGroup = true;
         switchToGroupLayer.listOfLayerEntryConfig = newListOfLayerEntryConfig;
         api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);
@@ -352,7 +356,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
       const sourceOptions: SourceOptions = {};
       sourceOptions.attributions = [(this.metadata.copyrightText ? this.metadata.copyrightText : '') as string];
       sourceOptions.url = getLocalizedValue(layerEntryConfig.source.dataAccessPath!, this.mapId);
-      sourceOptions.params = { LAYERS: layerEntryConfig.layerId };
+      sourceOptions.params = { LAYERS: `show:${layerEntryConfig.layerId}` };
       if (layerEntryConfig.source.transparent)
         Object.defineProperty(sourceOptions.params, 'transparent', layerEntryConfig.source.transparent!);
       if (layerEntryConfig.source.format) Object.defineProperty(sourceOptions.params, 'format', layerEntryConfig.source.format!);


### PR DESCRIPTION
Correction to the Esri Dynamic visibility bug. You can use the legend.html or the test.html to verify the behaviour of the new code.
Cancel old PR 605-esri-dynamic-layer-visibility and the related PR 642

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canadian-geospatial-platform/geoview/651)
<!-- Reviewable:end -->
