### PR TITLE
676-Legend and duplicate geoview layer bug

### DIFF
--- a/packages/geoview-core/public/geojson/metadata.json
+++ b/packages/geoview-core/public/geojson/metadata.json
@@ -21,10 +21,12 @@
           "label": "Polygon label",
           "settings": {
             "type": "filledPolygon",
+            "color": "rgba(0,0,255,0.25)",
             "paternSize": 10,
             "paternWidth": 2,
             "fillStyle": "diagonalCross",
             "stroke": {
+              "color": "rgba(128,0,0,1)",
               "lineStyle": "dot"
             }
           }

--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -57,7 +57,8 @@
     "layer": {
       "loadfailed": "Layer [__param__] failed to load on map __param__.",
       "notfound": "The sublayer __param__ of the GeoView layer __param__ does not exist on the server",
-      "createtwice": "Can not execute twice the createGeoViewRasterLayers method for the map __param__"
+      "createtwice": "Can not execute twice the createGeoViewRasterLayers method for the map __param__",
+      "usedtwice": "Duplicate use of geoview layer identifier [__param__] on map __param__"
     }
   }
 }

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -57,7 +57,8 @@
     "layer": {
       "loadfailed": "Le chargement de la couche [__param__] a échoué sur la carte __param__.",
       "notfound": "La sous couche __param__ de la couche GeoView __param__ n'existe pas sur le sereur",
-      "createtwice": "On ne peut exécuter deux fois la méthode createGeoViewRasterLayers pour la carte __param__"
+      "createtwice": "On ne peut exécuter deux fois la méthode createGeoViewRasterLayers pour la carte __param__",
+      "usedtwice": "Utilisation en double de l'identifiant de couche geoview [__param__] sur la carte __param__"
     }
   }
 }

--- a/packages/geoview-core/public/templates/test.html
+++ b/packages/geoview-core/public/templates/test.html
@@ -40,6 +40,17 @@
                 'layerId': '8'
               }
             ]
+          },
+          {
+            'geoviewLayerId': 'esriDynamicLYR3z',
+            'geoviewLayerName': { 'en': 'Energy (Esri-dynamic)' },
+            'metadataAccessPath': { 'en': 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer' },
+            'geoviewLayerType': 'esriDynamic',
+            'listOfLayerEntryConfig': [
+              {
+                'layerId': '8'
+              }
+            ]
           }
         ]
       },

--- a/packages/geoview-core/src/api/events/payloads/get-feature-info-payload.ts
+++ b/packages/geoview-core/src/api/events/payloads/get-feature-info-payload.ts
@@ -15,8 +15,8 @@ const validEvents: EventStringId[] = [
 export type TypeQueryType = 'at pixel' | 'at coordinate' | 'at long lat' | 'using a bounding box' | 'using a polygon';
 
 export type TypeFeatureInfoEntry = Record<string, string | number | null>;
-export type TypeArrayOfRecords = TypeFeatureInfoEntry[];
-export type TypeFeatureInfoResultSets = { [layerPath: string]: TypeArrayOfRecords | undefined };
+export type TypeArrayOfFeatureInfoEntries = TypeFeatureInfoEntry[];
+export type TypeFeatureInfoResultSets = { [layerPath: string]: TypeArrayOfFeatureInfoEntries | undefined };
 
 /**
  * type guard function that redefines a PayloadBaseClass as a TypeQueryLayerPayload
@@ -80,7 +80,7 @@ export interface TypeQueryResultPayload extends GetFeatureInfoPayload {
   // the layer path used by the query
   layerPath: string;
   // the resultset of the query
-  arrayOfRecords: TypeArrayOfRecords;
+  arrayOfRecords: TypeArrayOfFeatureInfoEntries;
 }
 
 /**
@@ -160,14 +160,14 @@ export class GetFeatureInfoPayload extends PayloadBaseClass {
    *
    * @param {string | null} handlerName the handler Name
    * @param {string} layerPath the layer path
-   * @param {TypeArrayOfRecords} arrayOfRecords the resultset of the get feature info query
+   * @param {TypeArrayOfFeatureInfoEntries} arrayOfRecords the resultset of the get feature info query
    *
    * @returns {TypeQueryResultPayload} the queryResultPayload object created
    */
   static createQueryResultPayload = (
     handlerName: string,
     layerPath: string,
-    arrayOfRecords: TypeArrayOfRecords
+    arrayOfRecords: TypeArrayOfFeatureInfoEntries
   ): TypeQueryResultPayload => {
     const queryResultPayload = new GetFeatureInfoPayload(EVENT_NAMES.GET_FEATURE_INFO.QUERY_RESULT, handlerName) as TypeQueryResultPayload;
     queryResultPayload.layerPath = layerPath;

--- a/packages/geoview-core/src/api/events/payloads/get-legends-payload.ts
+++ b/packages/geoview-core/src/api/events/payloads/get-legends-payload.ts
@@ -188,7 +188,7 @@ export class GetLegendsPayload extends PayloadBaseClass {
    * @returns {TypeTriggerLegendsPayload} the triggerLegendsPayload object created
    */
   static createTriggerLegendPayload = (handlerName: string, layerSetId: string): TypeTriggerLegendsPayload => {
-    const triggerLegendsPayload = new GetLegendsPayload(EVENT_NAMES.GET_LEGENDS.QUERY_LEGEND, handlerName) as TypeTriggerLegendsPayload;
+    const triggerLegendsPayload = new GetLegendsPayload(EVENT_NAMES.GET_LEGENDS.TRIGGER, handlerName) as TypeTriggerLegendsPayload;
     triggerLegendsPayload.layerSetId = layerSetId;
     return triggerLegendsPayload;
   };

--- a/packages/geoview-core/src/core/components/data-grid/data-grid-api.ts
+++ b/packages/geoview-core/src/core/components/data-grid/data-grid-api.ts
@@ -36,8 +36,8 @@ export class DataGridAPI {
    */
   createDataGrid = (props: TypeLayerDataGridProps): ReactElement => {
     const { layerId } = props;
-    const rootGeoViewLayer = api.map(this.mapId).layer.geoviewLayers[layerId];
-    const values = (rootGeoViewLayer as AbstractGeoViewVector).getAllFeatureInfo();
+    const geoviewLayerInstance = api.map(this.mapId).layer.geoviewLayers[layerId];
+    const values = (geoviewLayerInstance as AbstractGeoViewVector).getAllFeatureInfo();
 
     // set columns
     const columnHeader = Object.keys(values[0]);
@@ -55,7 +55,7 @@ export class DataGridAPI {
     const rows = values;
 
     return createElement('div', {}, [
-      createElement('h4', { key: `${layerId}-title` }, getLocalizedValue(rootGeoViewLayer.geoviewLayerName, this.mapId)),
+      createElement('h4', { key: `${layerId}-title` }, getLocalizedValue(geoviewLayerInstance.geoviewLayerName, this.mapId)),
       createElement(LayerDataGrid, {
         key: `${layerId}-datagrid`,
         columns,

--- a/packages/geoview-core/src/core/components/details/details-api.ts
+++ b/packages/geoview-core/src/core/components/details/details-api.ts
@@ -36,8 +36,8 @@ export class DetailsAPI {
    */
   createDetails = (props: TypeLayerDetailsProps): ReactElement => {
     const { layerId } = props;
-    const rootGeoViewLayer = api.map(this.mapId).layer.geoviewLayers[layerId];
-    const values = (rootGeoViewLayer as AbstractGeoViewVector).getAllFeatureInfo();
+    const geoviewLayerInstance = api.map(this.mapId).layer.geoviewLayers[layerId];
+    const values = (geoviewLayerInstance as AbstractGeoViewVector).getAllFeatureInfo();
 
     // set columns
     const columnHeader = Object.keys(values[0]);
@@ -55,7 +55,7 @@ export class DetailsAPI {
     const rows = values;
 
     return createElement('div', {}, [
-      createElement('h4', { key: `${layerId}-title` }, getLocalizedValue(rootGeoViewLayer.geoviewLayerName, this.mapId)),
+      createElement('h4', { key: `${layerId}-title` }, getLocalizedValue(geoviewLayerInstance.geoviewLayerName, this.mapId)),
       createElement(LayerDetails, {
         key: `${layerId}-details`,
         columns,

--- a/packages/geoview-core/src/core/components/legend/legend-api.ts
+++ b/packages/geoview-core/src/core/components/legend/legend-api.ts
@@ -26,8 +26,6 @@ export class LegendApi {
    *
    */
   createLegend = () => {
-    // TODO emit create legend event instead see issue 576
-    // api.event.emit(legendPayload(EVENT_NAMES.FOOTER_TABS.EVENT_LEGEND_CREATE, this.mapId));
     return Legend;
   };
 
@@ -37,7 +35,7 @@ export class LegendApi {
    */
   createLegendItem = (props: TypeLegendItemProps) => {
     const { layerId } = props;
-    const rootGeoViewLayer = api.map(this.mapId).layer.geoviewLayers[layerId];
-    return createElement(LegendItem, { layerId, rootGeoViewLayer });
+    const geoviewLayerInstance = api.map(this.mapId).layer.geoviewLayers[layerId];
+    return createElement(LegendItem, { layerId, geoviewLayerInstance });
   };
 }

--- a/packages/geoview-core/src/core/components/legend/legend.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend.tsx
@@ -57,6 +57,7 @@ export function Legend(): JSX.Element | null {
       api.event.off(api.eventNames.LAYER.EVENT_ADD_LAYER, mapId);
       api.event.off(api.eventNames.LAYER.EVENT_REMOVE_LAYER, mapId);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -67,7 +68,7 @@ export function Legend(): JSX.Element | null {
             <LegendItem
               key={layerId}
               layerId={layerId}
-              rootGeoViewLayer={mapLayers[layerId]}
+              geoviewLayerInstance={mapLayers[layerId]}
               isRemoveable={!configLayerIds.includes(layerId)}
             />
           );

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -24,7 +24,7 @@ import {
 import {
   GetFeatureInfoPayload,
   payloadIsQueryLayer,
-  TypeArrayOfRecords,
+  TypeArrayOfFeatureInfoEntries,
   TypeQueryType,
 } from '../../../api/events/payloads/get-feature-info-payload';
 import { snackbarMessagePayload } from '../../../api/events/payloads/snackbar-message-payload';
@@ -428,8 +428,8 @@ export abstract class AbstractGeoViewLayer {
     location: Pixel | Coordinate | Coordinate[],
     layerPathOrConfig: string | TypeLayerEntryConfig | null = this.activeLayer,
     queryType: TypeQueryType = 'at pixel'
-  ): Promise<TypeArrayOfRecords> {
-    const queryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  ): Promise<TypeArrayOfFeatureInfoEntries> {
+    const queryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       const layerConfig = (typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig) : layerPathOrConfig) as
         | TypeVectorLayerEntryConfig
         | TypeImageLayerEntryConfig
@@ -469,7 +469,7 @@ export abstract class AbstractGeoViewLayer {
    *
    * @returns {Promise<TypeFeatureInfoResult>} The feature info table.
    */
-  protected abstract getFeatureInfoAtPixel(location: Pixel, layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfRecords>;
+  protected abstract getFeatureInfoAtPixel(location: Pixel, layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfFeatureInfoEntries>;
 
   /** ***************************************************************************************************************************
    * Return feature information for all the features around the provided coordinate.
@@ -479,7 +479,10 @@ export abstract class AbstractGeoViewLayer {
    *
    * @returns {Promise<TypeFeatureInfoResult>} The feature info table.
    */
-  protected abstract getFeatureInfoAtCoordinate(location: Coordinate, layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfRecords>;
+  protected abstract getFeatureInfoAtCoordinate(
+    location: Coordinate,
+    layerConfig: TypeLayerEntryConfig
+  ): Promise<TypeArrayOfFeatureInfoEntries>;
 
   /** ***************************************************************************************************************************
    * Return feature information for all the features around the provided longitude latitude.
@@ -489,7 +492,10 @@ export abstract class AbstractGeoViewLayer {
    *
    * @returns {Promise<TypeFeatureInfoResult>} The feature info table.
    */
-  protected abstract getFeatureInfoAtLongLat(location: Coordinate, layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfRecords>;
+  protected abstract getFeatureInfoAtLongLat(
+    location: Coordinate,
+    layerConfig: TypeLayerEntryConfig
+  ): Promise<TypeArrayOfFeatureInfoEntries>;
 
   /** ***************************************************************************************************************************
    * Return feature information for all the features in the provided bounding box.
@@ -499,7 +505,10 @@ export abstract class AbstractGeoViewLayer {
    *
    * @returns {Promise<TypeFeatureInfoResult>} The feature info table.
    */
-  protected abstract getFeatureInfoUsingBBox(location: Coordinate[], layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfRecords>;
+  protected abstract getFeatureInfoUsingBBox(
+    location: Coordinate[],
+    layerConfig: TypeLayerEntryConfig
+  ): Promise<TypeArrayOfFeatureInfoEntries>;
 
   /** ***************************************************************************************************************************
    * Return feature information for all the features in the provided polygon.
@@ -509,7 +518,10 @@ export abstract class AbstractGeoViewLayer {
    *
    * @returns {Promise<TypeFeatureInfoResult>} The feature info table.
    */
-  protected abstract getFeatureInfoUsingPolygon(location: Coordinate[], layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfRecords>;
+  protected abstract getFeatureInfoUsingPolygon(
+    location: Coordinate[],
+    layerConfig: TypeLayerEntryConfig
+  ): Promise<TypeArrayOfFeatureInfoEntries>;
 
   /** ***************************************************************************************************************************
    * This method register the layer entry to layer sets.

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-param-reassign */
 import axios from 'axios';
 import { ImageArcGISRest } from 'ol/source';
@@ -25,7 +26,7 @@ import {
   layerEntryIsGroupLayer,
   TypeFeatureInfoLayerConfig,
 } from '../../../map/map-schema-types';
-import { TypeFeatureInfoEntry, TypeArrayOfRecords } from '../../../../api/events/payloads/get-feature-info-payload';
+import { TypeFeatureInfoEntry, TypeArrayOfFeatureInfoEntries } from '../../../../api/events/payloads/get-feature-info-payload';
 import { api } from '../../../../app';
 import { Layer } from '../../layer';
 
@@ -383,18 +384,21 @@ export class EsriDynamic extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Translate the get feature information at coordinate result set to the TypeArrayOfRecords used by GeoView.
+   * Translate the get feature information at coordinate result set to the TypeArrayOfFeatureInfoEntries used by GeoView.
    *
    * @param {TypeJsonArray} features An array of found features formatted using the query syntax.
    * @param {TypeFeatureInfoLayerConfig} featureInfo Feature information describing the user's desired output format.
    *
-   * @returns {TypeArrayOfRecords} The feature info table.
+   * @returns {TypeArrayOfFeatureInfoEntries} The feature info table.
    */
-  private formatFeatureInfoAtCoordinateResult(features: TypeJsonArray, featureInfo?: TypeFeatureInfoLayerConfig): TypeArrayOfRecords {
+  private formatFeatureInfoAtCoordinateResult(
+    features: TypeJsonArray,
+    featureInfo?: TypeFeatureInfoLayerConfig
+  ): TypeArrayOfFeatureInfoEntries {
     if (!features.length) return [];
     const outfields = getLocalizedValue(featureInfo?.outfields, this.mapId)?.split(',');
     const aliasFields = getLocalizedValue(featureInfo?.aliasFields, this.mapId)?.split(',');
-    const queryResult: TypeArrayOfRecords = [];
+    const queryResult: TypeArrayOfFeatureInfoEntries = [];
     features.forEach((feature) => {
       const featureFields = Object.keys(feature.attributes);
       const featureInfoEntry: TypeFeatureInfoEntry = {};
@@ -415,11 +419,10 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @param {Coordinate} location The pixel coordinate that will be used by the query.
    * @param {TypeEsriDynamicLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoAtPixel(location: Pixel, layerConfig: TypeEsriDynamicLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoAtPixel(location: Pixel, layerConfig: TypeEsriDynamicLayerEntryConfig): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       const { map } = api.map(this.mapId);
       resolve(this.getFeatureInfoAtCoordinate(map.getCoordinateFromPixel(location), layerConfig));
     });
@@ -432,9 +435,12 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {TypeEsriDynamicLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The promised feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The promised feature info table.
    */
-  protected getFeatureInfoAtCoordinate(location: Coordinate, layerConfig: TypeEsriDynamicLayerEntryConfig): Promise<TypeArrayOfRecords> {
+  protected getFeatureInfoAtCoordinate(
+    location: Coordinate,
+    layerConfig: TypeEsriDynamicLayerEntryConfig
+  ): Promise<TypeArrayOfFeatureInfoEntries> {
     const convertedLocation = transform(location, `EPSG:${api.map(this.mapId).currentProjection}`, 'EPSG:4326');
     return this.getFeatureInfoAtLongLat(convertedLocation, layerConfig);
   }
@@ -445,10 +451,13 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @param {Coordinate} lnglat The coordinate that will be used by the query.
    * @param {TypeEsriDynamicLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The promised feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The promised feature info table.
    */
-  protected getFeatureInfoAtLongLat(lnglat: Coordinate, layerConfig: TypeEsriDynamicLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoAtLongLat(
+    lnglat: Coordinate,
+    layerConfig: TypeEsriDynamicLayerEntryConfig
+  ): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       if (!this.getVisible(layerConfig) || !layerConfig.gvLayer) resolve([]);
       else {
         if (!(layerConfig as TypeEsriDynamicLayerEntryConfig).source.featureInfo?.queryable) resolve([]);
@@ -494,11 +503,13 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {TypeEsriDynamicLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoUsingBBox(location: Coordinate[], layerConfig: TypeEsriDynamicLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoUsingBBox(
+    location: Coordinate[],
+    layerConfig: TypeEsriDynamicLayerEntryConfig
+  ): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       resolve([]);
     });
     return promisedQueryResult;
@@ -510,15 +521,13 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {TypeEsriDynamicLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
   protected getFeatureInfoUsingPolygon(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     location: Coordinate[],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     layerConfig: TypeEsriDynamicLayerEntryConfig
-  ): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  ): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       resolve([]);
     });
     return promisedQueryResult;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-param-reassign */
 import axios from 'axios';
 
@@ -26,7 +27,7 @@ import {
   TypeLayerGroupEntryConfig,
   TypeFeatureInfoLayerConfig,
 } from '../../../map/map-schema-types';
-import { TypeFeatureInfoEntry, TypeArrayOfRecords } from '../../../../api/events/payloads/get-feature-info-payload';
+import { TypeFeatureInfoEntry, TypeArrayOfFeatureInfoEntries } from '../../../../api/events/payloads/get-feature-info-payload';
 import { getLocalizedValue, xmlToJson } from '../../../../core/utils/utilities';
 import { snackbarMessagePayload } from '../../../../api/events/payloads/snackbar-message-payload';
 import { EVENT_NAMES } from '../../../../api/events/event-types';
@@ -389,11 +390,10 @@ export class WMS extends AbstractGeoViewRaster {
    * @param {Coordinate} location The pixel coordinate that will be used by the query.
    * @param {TypeWmsLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoAtPixel(location: Pixel, layerConfig: TypeWmsLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoAtPixel(location: Pixel, layerConfig: TypeWmsLayerEntryConfig): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       const { map } = api.map(this.mapId);
       resolve(this.getFeatureInfoAtCoordinate(map.getCoordinateFromPixel(location), layerConfig));
     });
@@ -406,9 +406,9 @@ export class WMS extends AbstractGeoViewRaster {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {TypeWmsLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The promised feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The promised feature info table.
    */
-  protected getFeatureInfoAtCoordinate(location: Coordinate, layerConfig: TypeWmsLayerEntryConfig): Promise<TypeArrayOfRecords> {
+  protected getFeatureInfoAtCoordinate(location: Coordinate, layerConfig: TypeWmsLayerEntryConfig): Promise<TypeArrayOfFeatureInfoEntries> {
     const convertedLocation = transform(location, `EPSG:${api.map(this.mapId).currentProjection}`, 'EPSG:4326');
     return this.getFeatureInfoAtLongLat(convertedLocation, layerConfig);
   }
@@ -419,10 +419,10 @@ export class WMS extends AbstractGeoViewRaster {
    * @param {Coordinate} lnglat The coordinate that will be used by the query.
    * @param {TypeWmsLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The promised feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The promised feature info table.
    */
-  protected getFeatureInfoAtLongLat(lnglat: Coordinate, layerConfig: TypeWmsLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoAtLongLat(lnglat: Coordinate, layerConfig: TypeWmsLayerEntryConfig): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       if (!this.getVisible(layerConfig) || !layerConfig.gvLayer) resolve([]);
       else {
         const viewResolution = api.map(this.mapId).getView().getResolution() as number;
@@ -453,11 +453,10 @@ export class WMS extends AbstractGeoViewRaster {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {TypeWmsLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoUsingBBox(location: Coordinate[], layerConfig: TypeWmsLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoUsingBBox(location: Coordinate[], layerConfig: TypeWmsLayerEntryConfig): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       resolve([]);
     });
     return promisedQueryResult;
@@ -469,11 +468,13 @@ export class WMS extends AbstractGeoViewRaster {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {TypeWmsLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoUsingPolygon(location: Coordinate[], layerConfig: TypeWmsLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoUsingPolygon(
+    location: Coordinate[],
+    layerConfig: TypeWmsLayerEntryConfig
+  ): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       resolve([]);
     });
     return promisedQueryResult;
@@ -573,17 +574,20 @@ export class WMS extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Translate the get feature information at coordinate result set to the TypeArrayOfRecords used by GeoView.
+   * Translate the get feature information at coordinate result set to the TypeArrayOfFeatureInfoEntries used by GeoView.
    *
    * @param {TypeJsonObject} featureMember An object formatted using the query syntax.
    * @param {TypeFeatureInfoLayerConfig} featureInfo Feature information describing the user's desired output format.
    *
-   * @returns {TypeArrayOfRecords} The feature info table.
+   * @returns {TypeArrayOfFeatureInfoEntries} The feature info table.
    */
-  private formatFeatureInfoAtCoordinateResult(featureMember: TypeJsonObject, featureInfo?: TypeFeatureInfoLayerConfig): TypeArrayOfRecords {
+  private formatFeatureInfoAtCoordinateResult(
+    featureMember: TypeJsonObject,
+    featureInfo?: TypeFeatureInfoLayerConfig
+  ): TypeArrayOfFeatureInfoEntries {
     const outfields = getLocalizedValue(featureInfo?.outfields, this.mapId)?.split(',');
     const aliasFields = getLocalizedValue(featureInfo?.aliasFields, this.mapId)?.split(',');
-    const queryResult: TypeArrayOfRecords = [];
+    const queryResult: TypeArrayOfFeatureInfoEntries = [];
 
     const featureInfoEntry: TypeFeatureInfoEntry = {};
     const createFieldEntries = (entry: TypeJsonObject, prefix = '') => {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable block-scoped-var, no-var, vars-on-top, no-param-reassign */
 import TileLayer from 'ol/layer/Tile';
 import { Options as TileOptions } from 'ol/layer/BaseTile';
@@ -20,7 +21,7 @@ import {
   layerEntryIsGroupLayer,
 } from '../../../map/map-schema-types';
 import { getLocalizedValue, getXMLHttpRequest } from '../../../../core/utils/utilities';
-import { TypeArrayOfRecords } from '../../../../api/events/payloads/get-feature-info-payload';
+import { TypeArrayOfFeatureInfoEntries } from '../../../../api/events/payloads/get-feature-info-payload';
 import { Cast, toJsonObject } from '../../../../core/types/global-types';
 import { api } from '../../../../app';
 import { Layer } from '../../layer';
@@ -270,11 +271,10 @@ export class XYZTiles extends AbstractGeoViewRaster {
    * @param {Coordinate} location The pixel coordinate that will be used by the query.
    * @param {TypeXYZTilesLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoAtPixel(location: Pixel, layerConfig: TypeXYZTilesLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoAtPixel(location: Pixel, layerConfig: TypeXYZTilesLayerEntryConfig): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       resolve([]);
     });
     return promisedQueryResult;
@@ -287,11 +287,13 @@ export class XYZTiles extends AbstractGeoViewRaster {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {TypeXYZTilesLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoAtCoordinate(location: Coordinate, layerConfig: TypeXYZTilesLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoAtCoordinate(
+    location: Coordinate,
+    layerConfig: TypeXYZTilesLayerEntryConfig
+  ): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       resolve([]);
     });
     return promisedQueryResult;
@@ -304,11 +306,13 @@ export class XYZTiles extends AbstractGeoViewRaster {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {TypeXYZTilesLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoAtLongLat(location: Coordinate, layerConfig: TypeXYZTilesLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoAtLongLat(
+    location: Coordinate,
+    layerConfig: TypeXYZTilesLayerEntryConfig
+  ): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       resolve([]);
     });
     return promisedQueryResult;
@@ -321,11 +325,13 @@ export class XYZTiles extends AbstractGeoViewRaster {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {TypeXYZTilesLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoUsingBBox(location: Coordinate[], layerConfig: TypeXYZTilesLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoUsingBBox(
+    location: Coordinate[],
+    layerConfig: TypeXYZTilesLayerEntryConfig
+  ): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       resolve([]);
     });
     return promisedQueryResult;
@@ -338,11 +344,13 @@ export class XYZTiles extends AbstractGeoViewRaster {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {TypeXYZTilesLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoUsingPolygon(location: Coordinate[], layerConfig: TypeXYZTilesLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoUsingPolygon(
+    location: Coordinate[],
+    layerConfig: TypeXYZTilesLayerEntryConfig
+  ): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       resolve([]);
     });
     return promisedQueryResult;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../map/map-schema-types';
 import { api } from '../../../../app';
 import { getLocalizedValue } from '../../../../core/utils/utilities';
-import { TypeFeatureInfoEntry, TypeArrayOfRecords } from '../../../../api/events/payloads/get-feature-info-payload';
+import { TypeFeatureInfoEntry, TypeArrayOfFeatureInfoEntries } from '../../../../api/events/payloads/get-feature-info-payload';
 
 /* *******************************************************************************************************************************
  * AbstractGeoViewVector types
@@ -157,18 +157,18 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
   }
 
   /** ***************************************************************************************************************************
-   * Convert the feature information to an array of TypeArrayOfRecords.
+   * Convert the feature information to an array of TypeArrayOfFeatureInfoEntries.
    *
    * @param {Feature<Geometry>[]} features The array of features to convert.
    * @param {TypeFeatureInfoLayerConfig} featureInfo The featureInfo configuration.
    *
-   * @returns {TypeArrayOfRecords} The Array of feature information.
+   * @returns {TypeArrayOfFeatureInfoEntries} The Array of feature information.
    */
-  private formatFeatureInfoResult(features: Feature<Geometry>[], featureInfo?: TypeFeatureInfoLayerConfig): TypeArrayOfRecords {
+  private formatFeatureInfoResult(features: Feature<Geometry>[], featureInfo?: TypeFeatureInfoLayerConfig): TypeArrayOfFeatureInfoEntries {
     if (!features.length) return [];
     const outfields = getLocalizedValue(featureInfo?.outfields, this.mapId)?.split(',');
     const aliasFields = getLocalizedValue(featureInfo?.aliasFields, this.mapId)?.split(',');
-    const queryResult: TypeArrayOfRecords = [];
+    const queryResult: TypeArrayOfFeatureInfoEntries = [];
     features.forEach((feature) => {
       const featureFields = feature.getKeys();
       const featureInfoEntry: TypeFeatureInfoEntry = {};
@@ -190,9 +190,9 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    *
    * @param {string | TypeLayerEntryConfig | null} layerPathOrConfig Optional layer path or configuration.
    *
-   * @returns {TypeArrayOfRecords} The feature info table.
+   * @returns {TypeArrayOfFeatureInfoEntries} The feature info table.
    */
-  getAllFeatureInfo(layerPathOrConfig: string | TypeLayerEntryConfig | null | undefined = this.activeLayer): TypeArrayOfRecords {
+  getAllFeatureInfo(layerPathOrConfig: string | TypeLayerEntryConfig | null | undefined = this.activeLayer): TypeArrayOfFeatureInfoEntries {
     const layerConfig = typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig) : layerPathOrConfig;
     if (!layerConfig?.gvLayer) return [];
     return this.formatFeatureInfoResult(
@@ -207,11 +207,11 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * @param {Coordinate} location The pixel coordinate that will be used by the query.
    * @param {TypeLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoAtPixel(location: Pixel, layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoAtPixel(location: Pixel, layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       const layerFilter = (layer: BaseLayer) => {
         const layerSource = layer.get('layerEntryConfig')?.source;
         const configSource = layerConfig?.source;
@@ -232,11 +232,11 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * @param {Coordinate} location The pixel coordinate that will be used by the query.
    * @param {TypeLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoAtCoordinate(location: Coordinate, layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoAtCoordinate(location: Coordinate, layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       const { map } = api.map(this.mapId);
       resolve(this.getFeatureInfoAtPixel(map.getPixelFromCoordinate(location as Coordinate), layerConfig));
     });
@@ -249,11 +249,11 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {TypeLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoAtLongLat(location: Coordinate, layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoAtLongLat(location: Coordinate, layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       const { map } = api.map(this.mapId);
       const convertedLocation = transform(location, 'EPSG:4326', `EPSG:${api.map(this.mapId).currentProjection}`);
       resolve(this.getFeatureInfoAtPixel(map.getPixelFromCoordinate(convertedLocation as Coordinate), layerConfig));
@@ -267,11 +267,11 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {TypeLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoUsingBBox(location: Coordinate[], layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoUsingBBox(location: Coordinate[], layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       resolve([]);
     });
     return promisedQueryResult;
@@ -283,11 +283,11 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {TypeLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {Promise<TypeArrayOfRecords>} The feature info table.
+   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getFeatureInfoUsingPolygon(location: Coordinate[], layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfRecords> {
-    const promisedQueryResult = new Promise<TypeArrayOfRecords>((resolve) => {
+  protected getFeatureInfoUsingPolygon(location: Coordinate[], layerConfig: TypeLayerEntryConfig): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
       resolve([]);
     });
     return promisedQueryResult;

--- a/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
@@ -231,11 +231,12 @@ export class GeoviewRenderer {
     const size = pointStyle?.getImage().getSize() as Size;
     const [width, height] = Array.isArray(size) ? size : [this.LEGEND_CANVAS_WIDTH, this.LEGEND_CANVAS_HEIGHT];
     const drawingCanvas = document.createElement('canvas');
-    drawingCanvas.width = width;
-    drawingCanvas.height = height;
+    drawingCanvas.width = width + 4;
+    drawingCanvas.height = height + 4;
     const drawingContext = toContext(drawingCanvas.getContext('2d')!);
     drawingContext.setStyle(pointStyle!);
-    drawingContext.drawGeometry(new Point([width / 2, height / 2]));
+    drawingContext.setTransform([1, 0, 0, 1, 0, 0]);
+    drawingContext.drawGeometry(new Point([drawingCanvas.width / 2, drawingCanvas.width / 2]));
     return drawingCanvas;
   }
 
@@ -259,10 +260,11 @@ export class GeoviewRenderer {
     context.fillRect(0, 0, drawingCanvas.width, drawingCanvas.height);
     const drawingContext = toContext(context);
     drawingContext.setStyle(lineStringStyle!);
+    drawingContext.setTransform([1, 0, 0, 1, 0, 0]);
     drawingContext.drawGeometry(
       new LineString([
-        [4, this.LEGEND_CANVAS_HEIGHT - 4],
-        [this.LEGEND_CANVAS_WIDTH - 4, 4],
+        [4, drawingCanvas.height - 4],
+        [drawingCanvas.width - 4, 4],
       ])
     );
     return drawingCanvas;
@@ -288,17 +290,19 @@ export class GeoviewRenderer {
     context.fillRect(0, 0, drawingCanvas.width, drawingCanvas.height);
     const drawingContext = toContext(context);
     drawingContext.setStyle(polygonStyle!);
+    drawingContext.setTransform([1, 0, 0, 1, 0, 0]);
     drawingContext.drawGeometry(
       new Polygon([
         [
           [4, 4],
-          [this.LEGEND_CANVAS_WIDTH - 4, 4],
-          [this.LEGEND_CANVAS_WIDTH - 4, this.LEGEND_CANVAS_HEIGHT - 4],
-          [4, this.LEGEND_CANVAS_HEIGHT - 4],
+          [drawingCanvas.width - 4, 4],
+          [drawingCanvas.width - 4, drawingCanvas.height - 4],
+          [4, drawingCanvas.height - 4],
           [4, 4],
         ],
       ])
     );
+    const test = context.getImageData(0, 0, drawingCanvas.width, drawingCanvas.height);
     return drawingCanvas;
   }
 

--- a/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
@@ -6,10 +6,10 @@ import { api } from '../../app';
 import { LayerSet } from './layer-set';
 
 /** ***************************************************************************************************************************
- * A class to hold a set of layers associated with an array of TypeArrayOfRecords. When this class is instantiated, all layers
- * already loaded on the specified map that are queryable will be added to the set. Layers added afterwards will be added to
- * the set if they are queryable. Deleted layers will be removed from the set. If you click on the map, all queryable layers
- * will execute a query and return their result set.
+ * A class to hold a set of layers associated with an array of TypeArrayOfFeatureInfoEntries. When this class is instantiated,
+ * all layers already loaded on the specified map that are queryable will be added to the set. Layers added afterwards will be
+ * added to the set if they are queryable. Deleted layers will be removed from the set. If you click on the map, all queryable
+ * layers will execute a query and return their result set.
  *
  * @class FeatureInfoLayerSet
  */

--- a/packages/geoview-core/src/geo/utils/layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/layer-set.ts
@@ -4,9 +4,9 @@ import { LayerSetPayload, payloadIsLayerRegistration, TypeResultSets } from '../
 import { api } from '../../app';
 
 /** ***************************************************************************************************************************
- * A class to hold a set of layers associated with an array of TypeArrayOfRecords. When this class is instantiated, all layers
- * already loaded on the specified map that are queryable will be added to the set. Layers added afterwards will be added to
- * the set if they are queryable. Deleted layers will be removed from the set.
+ * A class to hold a set of layers associated with an array of TypeArrayOfFeatureInfoEntries. When this class is instantiated,
+ * all layers already loaded on the specified map that are queryable will be added to the set. Layers added afterwards will be
+ * added to the set if they are queryable. Deleted layers will be removed from the set.
  *
  * @class FeatureInfoLayerSet
  */

--- a/packages/geoview-core/src/ui/list/list-item-button.tsx
+++ b/packages/geoview-core/src/ui/list/list-item-button.tsx
@@ -3,7 +3,7 @@ import makeStyles from '@mui/styles/makeStyles';
 
 import { ListItemButtonProps } from '@mui/material';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   listItemButton: {
     //
   },

--- a/packages/geoview-core/src/ui/list/list-item-icon.tsx
+++ b/packages/geoview-core/src/ui/list/list-item-icon.tsx
@@ -3,7 +3,7 @@ import makeStyles from '@mui/styles/makeStyles';
 
 import { ListItemIconProps } from '@mui/material';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   listItemIcon: {
     //
   },


### PR DESCRIPTION
Three changes:
#673 - Clipped canvas bug in legends
#674 - Duplicate geoview layer creation bug
#675 - Confusing property names

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canadian-geospatial-platform/geoview/676)
<!-- Reviewable:end -->
