### PR TITLE
715-Add bounds to the schema and the code

### DIFF
--- a/packages/geoview-basemap-panel/src/basemap-panel.tsx
+++ b/packages/geoview-basemap-panel/src/basemap-panel.tsx
@@ -8,7 +8,7 @@ import {
   TypeViewSettings,
   mapViewProjectionPayload,
   TypeBasemapOptions,
-  TypeProjectionCodes,
+  TypeValidMapProjectionCodes,
 } from 'geoview-core';
 
 const w = window as TypeWindow;
@@ -134,7 +134,7 @@ export function BasemapPanel(props: BaseMapPanelProps): JSX.Element {
    *
    * @param {number} projection the projection to create basemaps for
    */
-  const createBasemapArray = async (projection: TypeProjectionCodes) => {
+  const createBasemapArray = async (projection: TypeValidMapProjectionCodes) => {
     const basemapsArray = toJsonObject(
       (config.supportedProjections as Array<TypeJsonObject>).find((obj: TypeJsonObject) => obj.projectionCode === projection)
     );
@@ -182,18 +182,18 @@ export function BasemapPanel(props: BaseMapPanelProps): JSX.Element {
    * @param {SelectChangeEvent} event select change element event
    */
   const setSelectedProjection = (event: SelectChangeEvent<unknown>) => {
-    const projection = event.target.value as TypeProjectionCodes;
+    const projection = event.target.value as TypeValidMapProjectionCodes;
 
     // set basemap to no geom to clean up the view
     setBasemap('nogeom');
-    setMapProjection(projection as TypeProjectionCodes);
+    setMapProjection(projection as TypeValidMapProjectionCodes);
 
     // get view status (center and projection) to calculate new center
     const currentView = myMap.getView();
     const currentCenter = currentView.getCenter();
     const currentProjection = currentView.getProjection().getCode();
     const newCenter = api.projection.transformPoints(currentCenter, currentProjection, 'EPSG:4326')[0];
-    const newProjection = event.target.value as TypeProjectionCodes;
+    const newProjection = event.target.value as TypeValidMapProjectionCodes;
 
     const newView: TypeViewSettings = {
       zoom: currentView.getZoom() as number,

--- a/packages/geoview-core/public/templates/layers.html
+++ b/packages/geoview-core/public/templates/layers.html
@@ -205,12 +205,12 @@
                   'en': 'Flood'
                 },
                 'metadataAccessPath': {
-                  'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/historical_flood_event_en/MapServer/'
+                  'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/900A_and_top_100_en/MapServer'
                 },
                 'geoviewLayerType': 'esriDynamic',
                 'listOfLayerEntryConfig': [
                   {
-                    'layerId': '0'
+                    'layerId': '4'
                   }
                 ]
               }
@@ -252,11 +252,11 @@
                 'geoviewLayerId': 'esriFeatureLYR4',
                 'geoviewLayerName': { 'en': 'Water quality at monitoring sites' },
                 'metadataAccessPath': {
-                  'en': 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/Overlays/Cities/MapServer'
+                  'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/900A_and_top_100_en/MapServer'
                 },
                 'geoviewLayerType': 'esriFeature',
                 'listOfLayerEntryConfig': [
-                  { 'layerId': '2' }
+                  { 'layerId': '4' }
                 ]
               }
             ]
@@ -465,6 +465,9 @@
                   },
                   {
                     'layerId': '0fca08b5-e9d0-414b-a3c4-092ff9c5e326'
+                  },
+                  {
+                    'layerId': '03ccfb5c-a06e-43e3-80fd-09d4f8f69703'
                   }
                 ]
               }
@@ -565,6 +568,14 @@
 
     var addGeoJsonLegendButton = document.getElementsByClassName('Get-wms-Legend')[0];
     addGeoJsonLegendButton.addEventListener('click', function (e) {
+      const geoviewLayerIds = Object.keys(cgpv.api.map('LYR1').layer.geoviewLayers);
+      geoviewLayerIds.forEach((geoviewLayerId) => {
+        const pathArray = Object.keys(cgpv.api.map('LYR1').layer.registeredLayers);
+        for (let i = 0; i < pathArray.length; i++) {
+          if (pathArray[i].startsWith(geoviewLayerId))
+            console.log(cgpv.api.map('LYR1').layer.geoviewLayers[geoviewLayerId].getBounds(pathArray[i]));
+        }
+      });
       cgpv.api.event.emit({ handlerName: 'LYR1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'wmsLegendsId');
     });
 

--- a/packages/geoview-core/public/templates/test.html
+++ b/packages/geoview-core/public/templates/test.html
@@ -15,13 +15,13 @@
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body>
-    <div id="LYR8" class="llwp-map" data-lang="en" data-config="{
+    <div id="LYR1" class="llwp-map" data-lang="en" data-config="{
       'map': {
         'interaction': 'dynamic',
         'viewSettings': {
           'zoom': 4,
           'center': [-100, 60],
-          'projection': 3978
+          'projection': 3857
         },
         'basemapOptions': {
           'basemapId': 'transport',
@@ -30,11 +30,17 @@
         },
         'listOfGeoviewLayerConfig': [
           {
-            'geoviewLayerId': 'LYR8',
-            'geoviewLayerType': 'geoCore',
+            'geoviewLayerId': 'wmsLYR1-Root',
+            'geoviewLayerName': { 'en': 'Root' },
+            'metadataAccessPath': { 'en': 'https://datacube.services.geo.ca/web/elevation.xml' },
+            'geoviewLayerType': 'ogcWms',
+            'initialSettings': {
+              'visible': true,
+              'extent': [-120, 60, -100, 70]
+            },
             'listOfLayerEntryConfig': [
               {
-                'layerId': '0fe65119-e96e-4a57-8bfe-9d9245fba06b'
+                'layerId': 'dsm-hillshade'
               }
             ]
           }
@@ -45,14 +51,58 @@
       'theme': 'dark',
       'suportedLanguages': ['en']
     }">
-</div>
-<button class="Get-Legend">Get Legend</button>
+    </div>
+    <button class="Get-Legend">Get Legend</button>
+    <button class="Show-Bounds-wms">Show Bounds</button>
     <div id="legend-table-div"></div>
     <button type="button" class="collapsible">Get Feature Info</button>
     <pre style="height: 20pc; overflow-y: scroll;"  id="wmsResultSetId" class="panel">Click on feature on the map</pre>
     <hr />
     <button type="button" class="collapsible">Configuration Snippet</button>
     <pre id="LYR1CS" class="panel"></pre>
+    <hr />
+    <div id="LYR6" class="llwp-map" data-lang="en" data-config="{
+          'map': {
+            'interaction': 'dynamic',
+            'viewSettings': {
+              'zoom': 8,
+              'center': [-71.370748, 42.001058],
+              'projection': 3857
+            },
+            'basemapOptions': {
+              'basemapId': 'transport',
+              'shaded': false,
+              'labeled': true
+            },
+            'listOfGeoviewLayerConfig': [
+              {
+                'geoviewLayerId': 'wfsLYR6',
+                'geoviewLayerName': {
+                  'en': 'Airport data'
+                },
+                'metadataAccessPath': {
+                  'en': 'https://giswebservices.massgis.state.ma.us/geoserver/wfs'
+                },
+                'geoviewLayerType': 'ogcWfs',
+                'listOfLayerEntryConfig': [
+                  {
+                    'layerId': 'GISDATA.AIRPORTS_PT'
+                  }
+                ]
+              }
+            ]
+          },
+          'components': ['overview-map', 'nav-bar'],
+          'corePackages': [],
+          'theme': 'dark',
+          'suportedLanguages': ['en']
+        }">
+    </div>
+    <button class="Get-wfs-Legend">Get Legend</button>
+    <button class="Show-Bounds-wfs">Show Bounds</button>
+    <div id="wfsLegendsId-table-div"></div>
+    <button type="button" class="collapsible">Get Feature Info</button>
+    <pre style="height: 20pc; overflow-y: scroll;"  id="wfsResultSetId" class="panel">Click on feature on the map</pre>
     <hr />
     <script src="codedoc.js"></script>
     <script>
@@ -63,112 +113,165 @@
         createCodeSnippet();
         createConfigSnippet();
       });
-    // WMS ======================================================================================================================
-    const featureInfoWmsLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR8', 'wmsResultSetId');
-    cgpv.api.event.on(cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE, (payload) => {
-      const {  layerSetId, resultSets } = payload;
-      document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
-    }, 'LYR8');
+      // WMS ======================================================================================================================
+      const featureInfoWmsLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR1', 'wmsResultSetId');
+      cgpv.api.event.on(cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE, (payload) => {
+        const {  layerSetId, resultSets } = payload;
+        document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
+      }, 'LYR1');
 
-    const LegendsWmsLayerSet = cgpv.api.createLegendsLayerSet('LYR8', 'wmsLegendsId');
-    cgpv.api.event.on(cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE, (payload) => {
-      const {  resultSets } = payload;
-      displayLegend('wmsLegendsId', resultSets);
-    }, 'LYR8', 'wmsLegendsId');
+      const LegendsWmsLayerSet = cgpv.api.createLegendsLayerSet('LYR1', 'wmsLegendsId');
+      cgpv.api.event.on(cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE, (payload) => {
+        const {  resultSets } = payload;
+        displayLegend('wmsLegendsId', resultSets);
+      }, 'LYR1', 'wmsLegendsId');
 
-    var addGeoJsonLegendButton = document.getElementsByClassName('Get-Legend')[0];
-    addGeoJsonLegendButton.addEventListener('click', function (e) {
-      cgpv.api.event.emit({ handlerName: 'LYR8', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'wmsLegendsId');
-    });
-
-    // ==========================================================================================================================
-    function displayLegend(layerSetId, resultSets) {
-      const addHeader = (title, container) => {
-        const tableHeader = document.createElement('th');
-        tableHeader.style = "text-align: center; vertical-align: middle;"
-        tableHeader.innerHTML =  title;
-        container.appendChild(tableHeader);
-      }
-      const addData = (data, container) => {
-        const tableData = document.createElement('td');
-        tableData.style.verticalAlign = 'middle';
-        tableData.style.textAlign = 'center';
-        if (typeof data === 'string') tableData.innerHTML =  data.replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-        else tableData.appendChild(data);
-        container.appendChild(tableData);
-      }
-      var oldTable = document.getElementById(`${layerSetId}-table`);
-      if (oldTable) oldTable.parentNode.removeChild(oldTable)
-      var legendTable = document.getElementById('legend-table-div');
-      const table = document.createElement('table');
-      table.id = `${layerSetId}-table`;
-      table.border="1";
-      table.style="width:50%";
-      legendTable.appendChild(table);
-      var createHeader = true;
-      Object.keys(resultSets).forEach((layerPath) => {
-        if (resultSets[layerPath]?.type === 'ogcWms') {
-          if (createHeader) {
-            createHeader = false;
-            const tableRow1 = document.createElement('tr');
-            table.appendChild(tableRow1);
-            addHeader("Layer Path", tableRow1);
-            addHeader("Symbology", tableRow1);
-          }
-          const tableRow = document.createElement('tr');
-          addData(resultSets[layerPath].layerPath, tableRow);
-          addData(resultSets[layerPath].legend, tableRow);
-          table.appendChild(tableRow);
-        } else {
-          const addRow = (layerPath, label, canvas) => {
-            const tableRow = document.createElement('tr');
-            addData(layerPath, tableRow);
-            addData(label, tableRow); // canvas.style = "border: 1px solid black;"
-            addData(canvas, tableRow);
-            table.appendChild(tableRow);
-          }
-          if (createHeader) {
-            createHeader = false;
-            const tableRow1 = document.createElement('tr');
-            table.appendChild(tableRow1);
-            addHeader("Layer Path", tableRow1);
-            addHeader("Label", tableRow1);
-            addHeader("Symbology", tableRow1);
-          }
-          if (resultSets[layerPath]?.legend) {
-            Object.keys(resultSets[layerPath].legend).forEach((geometryKey) => {
-              if (geometryKey) {
-                if (resultSets[layerPath].styleConfig[geometryKey].styleType === "uniqueValue") {
-                  if (resultSets[layerPath].legend[geometryKey].defaultCanvas)
-                    addRow(layerPath,
-                            resultSets[layerPath].styleConfig[geometryKey].defaultLabel,
-                            resultSets[layerPath].legend[geometryKey].defaultCanvas);
-                  for (let i = 0; i < resultSets[layerPath].legend[geometryKey].arrayOfCanvas.length; i++) {
-                    addRow(layerPath,
-                          resultSets[layerPath].styleConfig[geometryKey].uniqueValueStyleInfo[i].label,
-                          resultSets[layerPath].legend[geometryKey].arrayOfCanvas[i]);
-                  }
-                } else if (resultSets[layerPath].styleConfig[geometryKey].styleType === "classBreaks") {
-                  if (resultSets[layerPath].legend[geometryKey].defaultCanvas)
-                    addRow(layerPath,
-                            resultSets[layerPath].styleConfig[geometryKey].defaultLabel,
-                            resultSets[layerPath].legend[geometryKey].defaultCanvas);
-                  for (let i = 0; i < resultSets[layerPath].legend[geometryKey].arrayOfCanvas.length; i++) {
-                    addRow(layerPath,
-                          resultSets[layerPath].styleConfig[geometryKey].classBreakStyleInfos[i].label,
-                          resultSets[layerPath].legend[geometryKey].arrayOfCanvas[i]);
-                  }
-                } else if (resultSets[layerPath].styleConfig[geometryKey].styleType === "simple") {
-                  addRow(layerPath,
-                        resultSets[layerPath].styleConfig[geometryKey].label,
-                        resultSets[layerPath].legend[geometryKey].defaultCanvas);
-                }
-              }
-            });
-          }
-        }
+      var addGeoJsonLegendButton = document.getElementsByClassName('Get-Legend')[0];
+      addGeoJsonLegendButton.addEventListener('click', function (e) {
+        cgpv.api.event.emit({ handlerName: 'LYR1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'wmsLegendsId');
       });
-    }
+
+      var showBoundsButton = document.getElementsByClassName('Show-Bounds-wms')[0];
+      showBoundsButton.addEventListener('click', function (e) {
+          addBoundsPolygon('LYR1', 'wmsLYR1-Root', 'dsm-hillshade');
+        });
+
+      // WFS ======================================================================================================================
+      const featureInfoWfsLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR6', 'wfsResultSetId');
+      cgpv.api.event.on(cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE, (payload) => {
+        const {  layerSetId, resultSets } = payload;
+        document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
+      }, 'LYR6');
+
+      const LegendsWfsLayerSet = cgpv.api.createLegendsLayerSet('LYR6', 'wfsLegendsId');
+      cgpv.api.event.on(cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE, (payload) => {
+        const {  resultSets } = payload;
+        displayLegend('wfsLegendsId', resultSets);
+      }, 'LYR6', 'wfsLegendsId');
+
+      var addGeoJsonLegendButton = document.getElementsByClassName('Get-wfs-Legend')[0];
+      addGeoJsonLegendButton.addEventListener('click', function (e) {
+        cgpv.api.event.emit({ handlerName: 'LYR6', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'wfsLegendsId');
+      });
+
+      var showBoundsButton = document.getElementsByClassName('Show-Bounds-wfs')[0];
+      showBoundsButton.addEventListener('click', function (e) {
+          addBoundsPolygon('LYR6', 'wfsLYR6', 'GISDATA.AIRPORTS_PT');
+        });
+
+      // ==========================================================================================================================
+      function addBoundsPolygon(map, geoviewLayerId, subLayerId) {
+        cgpv.api.map(map).layer.vector.setActiveGeometryGroup();
+        // call an api function to draw a polygon
+        const bbox = cgpv.api.map(map).layer.geoviewLayers[geoviewLayerId].getBounds(`${geoviewLayerId}/${subLayerId}`, 4326);
+        cgpv.api.map(map).fitBounds(bbox, 4326);
+        const polygon = cgpv.api.map(map).layer.vector.addPolygon(
+          [
+            [
+              [bbox[0], bbox[1]],
+              [bbox[0], bbox[3]],
+              [bbox[2], bbox[3]],
+              [bbox[2], bbox[1]],
+            ],
+          ],
+          {
+            style: {
+              strokeColor: '#000',
+              strokeWidth: 5,
+              strokeOpacity: 0.8,
+            },
+          }
+        );
+      }
+
+      // ==========================================================================================================================
+      function displayLegend(layerSetId, resultSets) {
+        const addHeader = (title, container) => {
+          const tableHeader = document.createElement('th');
+          tableHeader.style = "text-align: center; vertical-align: middle;"
+          tableHeader.innerHTML =  title;
+          container.appendChild(tableHeader);
+        }
+        const addData = (data, container) => {
+          const tableData = document.createElement('td');
+          tableData.style.verticalAlign = 'middle';
+          tableData.style.textAlign = 'center';
+          if (typeof data === 'string') tableData.innerHTML =  data.replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+          else tableData.appendChild(data);
+          container.appendChild(tableData);
+        }
+        var oldTable = document.getElementById(`${layerSetId}-table`);
+        if (oldTable) oldTable.parentNode.removeChild(oldTable)
+        var legendTable = document.getElementById('legend-table-div');
+        const table = document.createElement('table');
+        table.id = `${layerSetId}-table`;
+        table.border="1";
+        table.style="width:50%";
+        legendTable.appendChild(table);
+        var createHeader = true;
+        Object.keys(resultSets).forEach((layerPath) => {
+          if (resultSets[layerPath]?.type === 'ogcWms') {
+            if (createHeader) {
+              createHeader = false;
+              const tableRow1 = document.createElement('tr');
+              table.appendChild(tableRow1);
+              addHeader("Layer Path", tableRow1);
+              addHeader("Symbology", tableRow1);
+            }
+            const tableRow = document.createElement('tr');
+            addData(resultSets[layerPath].layerPath, tableRow);
+            addData(resultSets[layerPath].legend, tableRow);
+            table.appendChild(tableRow);
+          } else {
+            const addRow = (layerPath, label, canvas) => {
+              const tableRow = document.createElement('tr');
+              addData(layerPath, tableRow);
+              addData(label, tableRow); // canvas.style = "border: 1px solid black;"
+              addData(canvas, tableRow);
+              table.appendChild(tableRow);
+            }
+            if (createHeader) {
+              createHeader = false;
+              const tableRow1 = document.createElement('tr');
+              table.appendChild(tableRow1);
+              addHeader("Layer Path", tableRow1);
+              addHeader("Label", tableRow1);
+              addHeader("Symbology", tableRow1);
+            }
+            if (resultSets[layerPath]?.legend) {
+              Object.keys(resultSets[layerPath].legend).forEach((geometryKey) => {
+                if (geometryKey) {
+                  if (resultSets[layerPath].styleConfig[geometryKey].styleType === "uniqueValue") {
+                    if (resultSets[layerPath].legend[geometryKey].defaultCanvas)
+                      addRow(layerPath,
+                              resultSets[layerPath].styleConfig[geometryKey].defaultLabel,
+                              resultSets[layerPath].legend[geometryKey].defaultCanvas);
+                    for (let i = 0; i < resultSets[layerPath].legend[geometryKey].arrayOfCanvas.length; i++) {
+                      addRow(layerPath,
+                            resultSets[layerPath].styleConfig[geometryKey].uniqueValueStyleInfo[i].label,
+                            resultSets[layerPath].legend[geometryKey].arrayOfCanvas[i]);
+                    }
+                  } else if (resultSets[layerPath].styleConfig[geometryKey].styleType === "classBreaks") {
+                    if (resultSets[layerPath].legend[geometryKey].defaultCanvas)
+                      addRow(layerPath,
+                              resultSets[layerPath].styleConfig[geometryKey].defaultLabel,
+                              resultSets[layerPath].legend[geometryKey].defaultCanvas);
+                    for (let i = 0; i < resultSets[layerPath].legend[geometryKey].arrayOfCanvas.length; i++) {
+                      addRow(layerPath,
+                            resultSets[layerPath].styleConfig[geometryKey].classBreakStyleInfos[i].label,
+                            resultSets[layerPath].legend[geometryKey].arrayOfCanvas[i]);
+                    }
+                  } else if (resultSets[layerPath].styleConfig[geometryKey].styleType === "simple") {
+                    addRow(layerPath,
+                          resultSets[layerPath].styleConfig[geometryKey].label,
+                          resultSets[layerPath].legend[geometryKey].defaultCanvas);
+                  }
+                }
+              });
+            }
+          }
+        });
+      }
     </script>
   </body>
 </html>

--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -359,6 +359,15 @@
           "default": true,
           "description": "Initial visibility setting."
         },
+        "bounds": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {
+            "type": "number"
+          },
+          "description": "The bounding box that contains all the layer's features."
+        },
         "extent": {
           "type": "array",
           "minItems": 4,
@@ -539,20 +548,11 @@
       "properties": {
         "extent": {
           "type": "array",
-          "prefixItems": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {
+            "type": "number"
+          },
           "description": "The extent that constrains the view. Called with [minX, minY, maxX, maxY] extent coordinates."
         },
         "origin": {
@@ -576,14 +576,11 @@
         },
         "tileSize": {
           "type": "array",
-          "prefixItems": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "type": "number"
+          },
           "default": [256, 256],
           "description": "The tile grid origin, i.e. where the x and y axes meet ([z, 0, 0]). Tile coordinates increase left to right and downwards. If not specified, extent must be provided."
         }
@@ -703,63 +700,7 @@
           "description": "The projection code of the source. Used only for GeoJSON format. Default value is EPSG:4326."
         },
         "featureInfo": { "$ref": "#/definitions/TypeFeatureInfoLayerConfig" },
-        "tileGrid": {
-          "additionalProperties": false,
-          "type": "object",
-          "properties": {
-            "extent": {
-              "type": "array",
-              "prefixItems": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                }
-              ],
-              "description": "The extent that constrains the view. Called with [minX, minY, maxX, maxY] extent coordinates."
-            },
-            "origin": {
-              "type": "array",
-              "prefixItems": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                }
-              ],
-              "description": "The tile grid origin, i.e. where the x and y axes meet ([z, 0, 0]). Tile coordinates increase left to right and downwards. If not specified, extent must be provided."
-            },
-            "resolutions": {
-              "type": "array",
-              "items": {
-                "type": "number"
-              },
-              "description": "Resolutions. The array index of each resolution needs to match the zoom level. This means that even if a minZoom is configured, the resolutions array will have a length of maxZoom + 1."
-            },
-            "tileSize": {
-              "type": "array",
-              "prefixItems": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                }
-              ],
-              "default": [256, 256],
-              "description": "The tile grid origin, i.e. where the x and y axes meet ([z, 0, 0]). Tile coordinates increase left to right and downwards. If not specified, extent must be provided."
-            }
-          },
-          "required": ["origin", "resolutions"]
-        }
+        "tileGrid": { "$ref": "#/definitions/TypeTileGrid" }
       }
     },
 
@@ -1018,20 +959,11 @@
         },
         "extent": {
           "type": "array",
-          "prefixItems": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {
+            "type": "number"
+          },
           "description": "The extent that constrains the view. Called with [minX, minY, maxX, maxY] extent coordinates."
         },
         "minZoom": {
@@ -1046,7 +978,7 @@
           "minimum": 0,
           "maximum": 50
         },
-        "projection": { "$ref": "#/definitions/TypeProjectionCodes" },
+        "projection": { "$ref": "#/definitions/TypeValidMapProjectionCodes" },
         "rotation": {
           "type": "integer",
           "minimum": -360,
@@ -1065,7 +997,7 @@
       "required": ["zoom", "center"]
     },
 
-    "TypeProjectionCodes": {
+    "TypeValidMapProjectionCodes": {
       "enum": [3978, 3857],
       "default": 3978,
       "description": "Spatial Reference EPSG code supported (https://epsg.io/). We support Web Mercator and Lambert Conical Conform Canada."
@@ -1193,7 +1125,7 @@
         "navBar": { "$ref": "#/definitions/TypeNavBarProps" },
         "components": { "$ref": "#/definitions/TypeMapComponents" },
         "corePackages": { "$ref": "#/definitions/TypeMapCorePackages" },
-        "externalPackages": { "$ref": "#/definitionsTypeExternalPackages" },
+        "externalPackages": { "$ref": "#/definitions/TypeExternalPackages" },
         "serviceUrls": { "$ref": "#/definitions/TypeServiceUrls" },
         "suportedLanguages": { "$ref": "#/definitions/TypeListOfLocalizedLanguages" },
         "versionUsed": { "$ref": "#/definitions/TypeValidVersions" }

--- a/packages/geoview-core/src/api/events/payloads/map-view-projection-payload.ts
+++ b/packages/geoview-core/src/api/events/payloads/map-view-projection-payload.ts
@@ -1,7 +1,7 @@
 import { PayloadBaseClass } from './payload-base-class';
 
 import { EventStringId, EVENT_NAMES } from '../event-types';
-import { TypeProjectionCodes } from '../../../geo/map/map-schema-types';
+import { TypeValidMapProjectionCodes } from '../../../geo/map/map-schema-types';
 
 /** Valid events that can create MapViewProjectionPayload */
 const validEvents: EventStringId[] = [EVENT_NAMES.MAP.EVENT_MAP_VIEW_PROJECTION_CHANGE];
@@ -26,7 +26,7 @@ export const payloadIsAMapViewProjection = (verifyIfPayload: PayloadBaseClass): 
  */
 export class MapViewProjectionPayload extends PayloadBaseClass {
   // the map configuration
-  projection: TypeProjectionCodes;
+  projection: TypeValidMapProjectionCodes;
 
   /**
    * Constructor for the class
@@ -35,7 +35,7 @@ export class MapViewProjectionPayload extends PayloadBaseClass {
    * @param {string | null} handlerName the handler Name
    * @param {number} projection the map view projection
    */
-  constructor(event: EventStringId, handlerName: string | null, projection: TypeProjectionCodes) {
+  constructor(event: EventStringId, handlerName: string | null, projection: TypeValidMapProjectionCodes) {
     if (!validEvents.includes(event)) throw new Error(`MapViewProjectionPayload can't be instanciated for event of type ${event}`);
     super(event, handlerName);
     this.projection = projection;
@@ -55,7 +55,7 @@ export class MapViewProjectionPayload extends PayloadBaseClass {
 export const mapViewProjectionPayload = (
   event: EventStringId,
   handlerName: string | null,
-  projection: TypeProjectionCodes
+  projection: TypeValidMapProjectionCodes
 ): MapViewProjectionPayload => {
   return new MapViewProjectionPayload(event, handlerName, projection);
 };

--- a/packages/geoview-core/src/core/utils/config/config-validation.ts
+++ b/packages/geoview-core/src/core/utils/config/config-validation.ts
@@ -20,7 +20,7 @@ import {
   TypeDisplayLanguage,
   TypeLayerEntryConfig,
   TypeLocalizedString,
-  TypeProjectionCodes,
+  TypeValidMapProjectionCodes,
   TypeValidVersions,
   TypeListOfLayerEntryConfig,
   TypeLayerGroupEntryConfig,
@@ -85,25 +85,25 @@ export class ConfigValidation {
   };
 
   // valid basemap ids
-  private _basemapId: Record<TypeProjectionCodes, TypeBasemapId[]> = {
+  private _basemapId: Record<TypeValidMapProjectionCodes, TypeBasemapId[]> = {
     3857: VALID_BASEMAP_ID,
     3978: VALID_BASEMAP_ID,
   };
 
   // valid shaded basemap values for each projection
-  private _basemapShaded: Record<TypeProjectionCodes, boolean[]> = {
+  private _basemapShaded: Record<TypeValidMapProjectionCodes, boolean[]> = {
     3857: [true, false],
     3978: [true, false],
   };
 
   // valid labeled basemap values for each projection
-  private _basemaplabeled: Record<TypeProjectionCodes, boolean[]> = {
+  private _basemaplabeled: Record<TypeValidMapProjectionCodes, boolean[]> = {
     3857: [true, false],
     3978: [true, false],
   };
 
   // valid center levels from each projection
-  private _center: Record<TypeProjectionCodes, Record<string, number[]>> = {
+  private _center: Record<TypeValidMapProjectionCodes, Record<string, number[]>> = {
     3857: { lat: [-90, 90], long: [-180, 180] },
     3978: { lat: [40, 90], long: [-140, 40] },
   };
@@ -181,12 +181,12 @@ export class ConfigValidation {
 
   /** ***************************************************************************************************************************
    * Validate basemap options.
-   * @param {TypeProjectionCodes} projection The projection code of the basemap.
+   * @param {TypeValidMapProjectionCodes} projection The projection code of the basemap.
    * @param {TypeBasemapOptions} basemapOptions The basemap options to validate.
    *
    * @returns {TypeBasemapOptions} A valid basemap options.
    */
-  validateBasemap(projection?: TypeProjectionCodes, basemapOptions?: TypeBasemapOptions): TypeBasemapOptions {
+  validateBasemap(projection?: TypeValidMapProjectionCodes, basemapOptions?: TypeBasemapOptions): TypeBasemapOptions {
     if (projection && basemapOptions) {
       const basemapId = this._basemapId[projection].includes(basemapOptions.basemapId)
         ? basemapOptions.basemapId
@@ -260,11 +260,11 @@ export class ConfigValidation {
 
   /** ***************************************************************************************************************************
    * Validate projection.
-   * @param {TypeProjectionCodes} projection The projection to validate.
+   * @param {TypeValidMapProjectionCodes} projection The projection to validate.
    *
-   * @returns {TypeProjectionCodes} A valid projection.
+   * @returns {TypeValidMapProjectionCodes} A valid projection.
    */
-  private validateProjection(projection?: TypeProjectionCodes): TypeProjectionCodes {
+  private validateProjection(projection?: TypeValidMapProjectionCodes): TypeValidMapProjectionCodes {
     return projection && VALID_PROJECTION_CODES.includes(projection)
       ? projection
       : this._defaultMapFeaturesConfig.map.viewSettings.projection;
@@ -272,12 +272,12 @@ export class ConfigValidation {
 
   /** ***************************************************************************************************************************
    * Validate the center.
-   * @param {TypeProjectionCodes} projection The projection used by the map.
+   * @param {TypeValidMapProjectionCodes} projection The projection used by the map.
    * @param {[number, number]} center The map center to valdate.
    *
    * @returns {[number, number]} A valid map center.
    */
-  private validateCenter(projection?: TypeProjectionCodes, center?: [number, number]): [number, number] {
+  private validateCenter(projection?: TypeValidMapProjectionCodes, center?: [number, number]): [number, number] {
     if (projection && center) {
       const xVal = Number(center[0]);
       const yVal = Number(center[1]);

--- a/packages/geoview-core/src/core/utils/config/reader/url-config-reader.ts
+++ b/packages/geoview-core/src/core/utils/config/reader/url-config-reader.ts
@@ -3,7 +3,7 @@ import {
   TypeListOfGeoviewLayerConfig,
   TypeInteraction,
   TypeMapCorePackages,
-  TypeProjectionCodes,
+  TypeValidMapProjectionCodes,
   TypeValidVersions,
   TypeDisplayLanguage,
   TypeMapComponents,
@@ -153,7 +153,7 @@ export class URLmapConfigReader {
           viewSettings: {
             zoom: parseInt(urlParams.z as TypeJsonValue as string, 10),
             center: [parseInt(center[0], 10), parseInt(center[1], 10)],
-            projection: parseInt(urlParams.p as string, 10) as TypeProjectionCodes,
+            projection: parseInt(urlParams.p as string, 10) as TypeValidMapProjectionCodes,
           },
           basemapOptions,
           listOfGeoviewLayerConfig,

--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -15,7 +15,7 @@ import { TypeJsonObject, toJsonObject, TypeJsonArray } from '../../../core/types
 import { generateId, showMessage } from '../../../core/utils/utilities';
 import { basemapLayerArrayPayload } from '../../../api/events/payloads/basemap-layers-payload';
 import { TypeBasemapProps, TypeBasemapOptions, TypeBasemapLayer } from './basemap-types';
-import { TypeDisplayLanguage, TypeProjectionCodes, TypeLocalizedString } from '../../map/map-schema-types';
+import { TypeDisplayLanguage, TypeValidMapProjectionCodes, TypeLocalizedString } from '../../map/map-schema-types';
 
 /**
  * A class to get a Basemap for a define projection and language. For the moment, a list maps are available and
@@ -51,7 +51,7 @@ export class Basemap {
   basemapOptions: TypeBasemapOptions;
 
   // the projection number
-  private projection: TypeProjectionCodes;
+  private projection: TypeValidMapProjectionCodes;
 
   // the map id to be used in events
   #mapId: string;
@@ -61,10 +61,10 @@ export class Basemap {
    *
    * @param {TypeBasemapOptions} basemapOptions optional basemap option properties, passed in from map config
    * @param {TypeDisplayLanguage} displayLanguage language to be used, either en or fr
-   * @param {TypeProjectionCodes} projection projection number
+   * @param {TypeValidMapProjectionCodes} projection projection number
    * @param {string} mapId the map id
    */
-  constructor(basemapOptions: TypeBasemapOptions, displayLanguage: TypeDisplayLanguage, projection: TypeProjectionCodes, mapId: string) {
+  constructor(basemapOptions: TypeBasemapOptions, displayLanguage: TypeDisplayLanguage, projection: TypeValidMapProjectionCodes, mapId: string) {
     this.#mapId = mapId;
 
     this.basemapOptions = basemapOptions;
@@ -148,12 +148,12 @@ export class Basemap {
    * Get basemap thumbnail url
    *
    * @param {string[]} basemapTypes basemap layer type (shaded, transport, label, simple)
-   * @param {TypeProjectionCodes} projection basemap projection
+   * @param {TypeValidMapProjectionCodes} projection basemap projection
    * @param {TypeDisplayLanguage} displayLanguage basemap language
    *
    * @returns {string[]} array of thumbnail urls
    */
-  private getThumbnailUrl = (basemapTypes: string[], projection: TypeProjectionCodes, displayLanguage: TypeDisplayLanguage): string[] => {
+  private getThumbnailUrl = (basemapTypes: string[], projection: TypeValidMapProjectionCodes, displayLanguage: TypeDisplayLanguage): string[] => {
     const thumbnailUrls: string[] = [];
 
     for (let typeIndex = 0; typeIndex < basemapTypes.length; typeIndex++) {
@@ -492,7 +492,7 @@ export class Basemap {
           altText: info[1],
           thumbnailUrl: this.getThumbnailUrl(
             basemaplayerTypes,
-            projectionCode as TypeProjectionCodes,
+            projectionCode as TypeValidMapProjectionCodes,
             this.displayLanguage as TypeDisplayLanguage
           ),
           attribution: this.attribution,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -4,6 +4,7 @@ import { Coordinate } from 'ol/coordinate';
 import { Pixel } from 'ol/pixel';
 import { Extent } from 'ol/extent';
 import LayerGroup, { Options as LayerGroupOptions } from 'ol/layer/Group';
+import { transformExtent } from 'ol/proj';
 
 import { generateId } from '../../../core/utils/utilities';
 import {
@@ -627,6 +628,25 @@ export abstract class AbstractGeoViewLayer {
   }
 
   /** ***************************************************************************************************************************
+   * Return the bounds of the layer or undefined if it is not defined in the layer configuration or the metadata.
+   * if projectionCode is set, returns the bounds in the specified projection otherwise use the map projection.
+   *
+   * @param {string | TypeLayerEntryConfig | null} layerPathOrConfig Optional layer path or configuration.
+   * @param {string | number | undefined} projectionCode Optional projection code to use for the returned bounds.
+   *
+   * @returns {Extent} The layer bounding box.
+   */
+  getBounds(
+    layerPathOrConfig: string | TypeLayerEntryConfig | null = this.activeLayer,
+    projectionCode: string | number | undefined = undefined
+  ): Extent | undefined {
+    const layerConfig = typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig) : layerPathOrConfig;
+    if (projectionCode && layerConfig?.initialSettings?.bounds)
+      return transformExtent(layerConfig.initialSettings.bounds, `EPSG:${api.map(this.mapId).currentProjection}`, `EPSG:${projectionCode}`);
+    return layerConfig ? layerConfig.initialSettings?.bounds : undefined;
+  }
+
+  /** ***************************************************************************************************************************
    * Return the extent of the layer or undefined if it will be visible regardless of extent. The layer extent is an array of
    * numbers representing an extent: [minx, miny, maxx, maxy]. If layerPathOrConfig is undefined, the activeLayer of the class
    * will be used. This routine return undefined when no layerPathOrConfig is specified and the active layer is null.
@@ -635,7 +655,7 @@ export abstract class AbstractGeoViewLayer {
    *
    * @returns {Extent} The layer extent.
    */
-  getBounds(layerPathOrConfig: string | TypeLayerEntryConfig | null = this.activeLayer): Extent | undefined {
+  getExtent(layerPathOrConfig: string | TypeLayerEntryConfig | null = this.activeLayer): Extent | undefined {
     const gvLayer = typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig)?.gvLayer : layerPathOrConfig?.gvLayer;
     return gvLayer ? gvLayer.getExtent() : undefined;
   }
@@ -648,7 +668,7 @@ export abstract class AbstractGeoViewLayer {
    * @param {Extent} layerExtent The extent to assign to the layer.
    * @param {string | TypeLayerEntryConfig | null} layerPathOrConfig Optional layer path or configuration.
    */
-  setBounds(layerExtent: Extent, layerPathOrConfig: string | TypeLayerEntryConfig | null = this.activeLayer) {
+  setExtent(layerExtent: Extent, layerPathOrConfig: string | TypeLayerEntryConfig | null = this.activeLayer) {
     const gvLayer = typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig)?.gvLayer : layerPathOrConfig?.gvLayer;
     if (gvLayer) gvLayer.setExtent(layerExtent);
   }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -283,17 +283,31 @@ export class EsriDynamic extends AbstractGeoViewRaster {
     layerEntryConfig: TypeEsriDynamicLayerEntryConfig
   ) {
     if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
-    // ! TODO: TThe solution implemented in the following two lines is not right. scale and zoom are not the same things.
+    if (!layerEntryConfig.initialSettings?.visible) layerEntryConfig.initialSettings.visible = visibility;
+    // ! TODO: The solution implemented in the following two lines is not right. scale and zoom are not the same things.
     // ! if (layerEntryConfig.initialSettings?.minZoom === undefined && minScale !== 0) layerEntryConfig.initialSettings.minZoom = minScale;
     // ! if (layerEntryConfig.initialSettings?.maxZoom === undefined && maxScale !== 0) layerEntryConfig.initialSettings.maxZoom = maxScale;
-    if (layerEntryConfig.initialSettings?.visible === undefined) layerEntryConfig.initialSettings.visible = visibility;
-    if (!layerEntryConfig.initialSettings?.extent) {
-      const layerExtent: Extent = [extent.xmin as number, extent.ymin as number, extent.xmax as number, extent.ymax as number];
+    if (layerEntryConfig.initialSettings?.extent)
       layerEntryConfig.initialSettings.extent = transformExtent(
+        layerEntryConfig.initialSettings.extent,
+        'EPSG:4326',
+        `EPSG:${api.map(this.mapId).currentProjection}`
+      );
+
+    if (layerEntryConfig.initialSettings?.bounds)
+      layerEntryConfig.initialSettings.bounds = transformExtent(
+        layerEntryConfig.initialSettings.bounds,
+        'EPSG:4326',
+        `EPSG:${api.map(this.mapId).currentProjection}`
+      );
+    else {
+      if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
+      const layerExtent = [extent.xmin, extent.ymin, extent.xmax, extent.ymax] as Extent;
+      layerEntryConfig.initialSettings.bounds = transformExtent(
         layerExtent,
         `EPSG:${extent.spatialReference.wkid as number}`,
         `EPSG:${api.map(this.mapId).currentProjection}`
-      ) as Extent;
+      );
     }
   }
 
@@ -314,7 +328,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
     layerEntryConfig: TypeEsriDynamicLayerEntryConfig
   ) {
     if (!layerEntryConfig.source.featureInfo) layerEntryConfig.source.featureInfo = { queryable: capabilities.includes('Query') };
-    // dynamic group layer doesn't have fields definition
+    // metadata layer group doesn't have fields definition
     if (!layerEntryConfig.isMetadataLayerGroup) {
       if (!layerEntryConfig.source.featureInfo.nameField)
         layerEntryConfig.source.featureInfo.nameField = {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -253,11 +253,20 @@ export class XYZTiles extends AbstractGeoViewRaster {
         for (var i = 0; i < metadataLayerList.length; i++) if (metadataLayerList[i].layerId === layerEntryConfig.layerId) break;
         layerEntryConfig.source = defaultsDeep(layerEntryConfig.source, metadataLayerList[i].source);
         layerEntryConfig.initialSettings = defaultsDeep(layerEntryConfig.initialSettings, metadataLayerList[i].initialSettings);
-        const extent = layerEntryConfig.initialSettings?.extent;
-        if (extent) {
-          const layerExtent = transformExtent(extent, 'EPSG:4326', `EPSG:${api.map(this.mapId).currentProjection}`) as Extent;
-          layerEntryConfig.initialSettings!.extent = layerExtent;
-        }
+
+        if (layerEntryConfig.initialSettings?.extent)
+          layerEntryConfig.initialSettings.extent = transformExtent(
+            layerEntryConfig.initialSettings.extent,
+            'EPSG:4326',
+            `EPSG:${api.map(this.mapId).currentProjection}`
+          );
+
+        if (layerEntryConfig.initialSettings?.bounds)
+          layerEntryConfig.initialSettings!.bounds = transformExtent(
+            layerEntryConfig.initialSettings.bounds,
+            'EPSG:4326',
+            `EPSG:${api.map(this.mapId).currentProjection}`
+          );
         resolve();
       }
     });

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -89,6 +89,8 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * Create a source configuration for the vector layer.
    *
    * @param {TypeBaseLayerEntryConfig} layerEntryConfig The layer entry configuration.
+   * @param {SourceOptions} sourceOptions The source options (default: { strategy: all }).
+   * @param {ReadOptions} readOptions The read options (default: {}).
    *
    * @returns {VectorSource<Geometry>} The source configuration that will be used to create the vector layer.
    */

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -292,13 +292,27 @@ export class EsriFeature extends AbstractGeoViewVector {
     // ! if (layerEntryConfig.initialSettings?.minZoom === undefined && minScale !== 0) layerEntryConfig.initialSettings.minZoom = minScale;
     // ! if (layerEntryConfig.initialSettings?.maxZoom === undefined && maxScale !== 0) layerEntryConfig.initialSettings.maxZoom = maxScale;
     if (layerEntryConfig.initialSettings?.visible === undefined) layerEntryConfig.initialSettings.visible = visibility;
-    if (!layerEntryConfig.initialSettings?.extent) {
-      const layerExtent: Extent = [extent.xmin as number, extent.ymin as number, extent.xmax as number, extent.ymax as number];
+
+    if (layerEntryConfig.initialSettings?.extent)
       layerEntryConfig.initialSettings.extent = transformExtent(
+        layerEntryConfig.initialSettings.extent,
+        'EPSG:4326',
+        `EPSG:${api.map(this.mapId).currentProjection}`
+      );
+    if (layerEntryConfig.initialSettings?.bounds)
+      layerEntryConfig.initialSettings.bounds = transformExtent(
+        layerEntryConfig.initialSettings.bounds,
+        'EPSG:4326',
+        `EPSG:${api.map(this.mapId).currentProjection}`
+      );
+    else {
+      if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
+      const layerExtent: Extent = [extent.xmin as number, extent.ymin as number, extent.xmax as number, extent.ymax as number];
+      layerEntryConfig.initialSettings.bounds = transformExtent(
         layerExtent,
         `EPSG:${extent.spatialReference.wkid as number}`,
         `EPSG:${api.map(this.mapId).currentProjection}`
-      ) as Extent;
+      );
     }
   }
 
@@ -354,6 +368,8 @@ export class EsriFeature extends AbstractGeoViewVector {
    * Create a source configuration for the vector layer.
    *
    * @param {TypeEsriFeatureLayerEntryConfig} layerEntryConfig The layer entry configuration.
+   * @param {SourceOptions} sourceOptions The source options (default: { strategy: all }).
+   * @param {ReadOptions} readOptions The read options (default: {}).
    *
    * @returns {VectorSource<Geometry>} The source configuration that will be used to create the vector layer.
    */

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -1,6 +1,5 @@
 /* eslint-disable block-scoped-var, no-var, vars-on-top, no-param-reassign */
 import { transformExtent } from 'ol/proj';
-import { Extent } from 'ol/extent';
 import { Options as SourceOptions } from 'ol/source/Vector';
 import { all } from 'ol/loadingstrategy';
 import { GeoJSON as FormatGeoJSON } from 'ol/format';
@@ -202,10 +201,20 @@ export class GeoJSON extends AbstractGeoViewVector {
         layerEntryConfig.source = defaultsDeep(layerEntryConfig.source, metadataLayerList[i].source);
         layerEntryConfig.initialSettings = defaultsDeep(layerEntryConfig.initialSettings, metadataLayerList[i].initialSettings);
         layerEntryConfig.style = defaultsDeep(layerEntryConfig.style, metadataLayerList[i].style);
-        const extent = layerEntryConfig.initialSettings?.extent;
-        if (extent) {
-          const layerExtent = transformExtent(extent, 'EPSG:4326', `EPSG:${api.map(this.mapId).currentProjection}`) as Extent;
-          layerEntryConfig.initialSettings!.extent = layerExtent;
+
+        if (layerEntryConfig.initialSettings?.extent)
+          layerEntryConfig.initialSettings.extent = transformExtent(
+            layerEntryConfig.initialSettings.extent,
+            'EPSG:4326',
+            `EPSG:${api.map(this.mapId).currentProjection}`
+          );
+
+        if (layerEntryConfig.initialSettings?.bounds) {
+          layerEntryConfig.initialSettings.bounds = transformExtent(
+            layerEntryConfig.initialSettings.bounds,
+            'EPSG:4326',
+            `EPSG:${api.map(this.mapId).currentProjection}`
+          );
         }
         resolve();
       }

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -31,6 +31,8 @@ export type TypeLayerInitialSettings = {
   opacity?: number;
   /** Initial visibility setting. Default = true. */
   visible?: boolean;
+  /** The bounding box that contains all the layer's features. */
+  bounds?: Extent;
   /** The extent that constrains the view. Called with [minX, minY, maxX, maxY] extent coordinates. */
   extent?: Extent;
   /** The minimum view zoom level (exclusive) above which this layer will be visible. */
@@ -619,7 +621,7 @@ export type TypeBaseSourceImageInitialConfig = {
    * */
   crossOrigin?: string;
   /** Spatial Reference EPSG code supported (https://epsg.io/). We support Web Mercator and Lambert Conical Conform Canada. */
-  projection?: TypeProjectionCodes;
+  projection?: TypeValidMapProjectionCodes;
   /** Definition of the feature information structure that will be used by the getFeatureInfo method. */
   featureInfo?: TypeFeatureInfoLayerConfig;
 };
@@ -681,7 +683,7 @@ export type TypeSourceTileInitialConfig = {
    */
   crossOrigin?: string;
   /** The source type for the tile layer. Default = XYZ. */
-  projection?: TypeProjectionCodes;
+  projection?: TypeValidMapProjectionCodes;
   /** Tile grid parameters to use. */
   tileGrid?: TypeTileGrid;
 };
@@ -957,7 +959,7 @@ export type TypeViewSettings = {
    * Spatial Reference EPSG code supported (https://epsg.io/). We support Web Mercator and Lambert Conical Conform Canada.
    * Default = 3978.
    */
-  projection: TypeProjectionCodes;
+  projection: TypeValidMapProjectionCodes;
   /** Initial map zoom level. Zoom level are define by the basemap zoom levels. Domaine = [0..28], default = 12. */
   zoom: number;
 };
@@ -965,10 +967,10 @@ export type TypeViewSettings = {
 /** ******************************************************************************************************************************
  *  Type used to define valid projection codes.
  */
-export type TypeProjectionCodes = 3978 | 3857;
+export type TypeValidMapProjectionCodes = 3978 | 3857;
 
 /** ******************************************************************************************************************************
- *  Constant mainly used to test if a TypeProjectionCodes variable is a valid projection codes.
+ *  Constant mainly used to test if a TypeValidMapProjectionCodes variable is a valid projection codes.
  */
 export const VALID_PROJECTION_CODES = [3978, 3857];
 

--- a/packages/geoview-core/src/geo/map/map.ts
+++ b/packages/geoview-core/src/geo/map/map.ts
@@ -454,13 +454,18 @@ export class MapViewer {
   };
 
   /**
-   * Create bounds on map
+   * Fit the map to its boundaries. It is assumed that the boundaries use the map projection. If projectionCode is undefined,
+   * the boundaries are used as is, otherwise they are reprojected from the specified projection code to the map projection.
    *
    * @param {Extent} bounds map bounds
+   * @param {string | number | undefined} projectionCode Optional projection code used by the bounds.
    * @returns the bounds
    */
-  fitBounds = (bounds: Extent) =>
-    this.map.getView().fit(transformExtent(bounds, 'EPSG:4326', api.projection.projections[this.currentProjection]), {
-      size: this.map.getSize(),
-    });
+  fitBounds = (bounds: Extent, projectionCode: string | number | undefined = undefined) => {
+    const mapBounds = projectionCode
+      ? transformExtent(bounds, `EPSG:${projectionCode}`, api.projection.projections[this.currentProjection])
+      : bounds;
+    this.map.getView().fit(mapBounds, { size: this.map.getSize() });
+    this.map.getView().setZoom(this.map.getView().getZoom()! - 0.15);
+  };
 }

--- a/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
@@ -9,7 +9,7 @@ import { Options as RegularShapeOptions } from 'ol/style/RegularShape';
 import { Options as StrokeOptions } from 'ol/style/Stroke';
 import { Options as FillOptions } from 'ol/style/Fill';
 import { Options as TextOptions } from 'ol/style/Text';
-import { FeatureLike } from 'ol/Feature';
+import Feature, { FeatureLike } from 'ol/Feature';
 import { toContext } from 'ol/render';
 import { Size } from 'ol/size';
 
@@ -1131,8 +1131,13 @@ export class GeoviewRenderer {
   ): number | undefined {
     for (let i = 0; i < uniqueValueStyleInfo.length; i++) {
       for (let j = 0; j < fields.length; j++) {
+        // For obscure reasons, it seems that sometimes the field names in the feature do not have the same case as those in the
+        // unique value definition.
+        const featureKey = (feature as Feature).getKeys().filter((key) => {
+          return key.toLowerCase() === fields[j].toLowerCase();
+        });
         // eslint-disable-next-line eqeqeq
-        if (feature.get(fields[j]) == uniqueValueStyleInfo[i].values[j] && j + 1 === fields.length) return i;
+        if (feature.get(featureKey[0]) == uniqueValueStyleInfo[i].values[j] && j + 1 === fields.length) return i;
       }
     }
     return undefined;
@@ -1202,7 +1207,12 @@ export class GeoviewRenderer {
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
    */
   private searchClassBreakEntry(field: string, classBreakStyleInfos: TypeClassBreakStyleInfo[], feature: FeatureLike): number | undefined {
-    const fieldValue = feature.get(field) as number;
+    // For obscure reasons, it seems that sometimes the field names in the feature do not have the same case as those in the
+    // class break definition.
+    const featureKey = (feature as Feature).getKeys().filter((key) => {
+      return key.toLowerCase() === field.toLowerCase();
+    });
+    const fieldValue = feature.get(featureKey[0]) as number;
     if (fieldValue >= classBreakStyleInfos[0].minValue! && fieldValue <= classBreakStyleInfos[0].maxValue) return 0;
 
     for (let i = 1; i < classBreakStyleInfos.length; i++) {


### PR DESCRIPTION
To test, use the test.html template. It has an example of a WMS configured with an extent and having a bounds derived from the service metadata. It also have an example using a WFS and a smaller bounds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canadian-geospatial-platform/geoview/716)
<!-- Reviewable:end -->
