### PR TITLE
fix(core): fix esri-feature ids out of order

### DIFF
--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -159,7 +159,12 @@ export class EsriFeature extends AbstractGeoViewVector {
         return false;
       }
 
-      const esriIndex = Number(layerEntryConfig.layerId);
+      let esriIndex = Number(layerEntryConfig.layerId);
+      if (this.metadata && this.metadata.layers) {
+        const layerIndex = (this.metadata.layers as TypeJsonArray).findIndex((layerInfo: TypeJsonObject) => layerInfo.id === esriIndex);
+        if (layerIndex !== -1) esriIndex = layerIndex;
+      }
+
       if (Number.isNaN(esriIndex)) {
         this.layerLoadError.push({
           layer: Layer.getLayerPath(layerEntryConfig),


### PR DESCRIPTION
Closes #665

In newer versions of ArcGIS Pro you can publish services with IDs that are not in order. This specific layer still fails because multi-polygons are not supported, but this point layer from the same service will now work
https://ws.lioservices.lrc.gov.on.ca/arcgis1071a/rest/services/LIO_OPEN_DATA/LIO_Open08/MapServer/22

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canadian-geospatial-platform/geoview/719)
<!-- Reviewable:end -->
