### PR TITLE
721-Hierarchical geoview bug

### DIFF
--- a/packages/geoview-core/public/templates/test.html
+++ b/packages/geoview-core/public/templates/test.html
@@ -31,16 +31,12 @@
         'listOfGeoviewLayerConfig': [
           {
             'geoviewLayerId': 'wmsLYR1-Root',
-            'geoviewLayerName': { 'en': 'HRDEM Mosaic Hillshade DSM' },
-            'metadataAccessPath': { 'en': 'https://datacube.services.geo.ca/ows/elevation' },
-            'geoviewLayerType': 'ogcWms',
-            'initialSettings': {
-              'visible': true,
-              'extent': [-149.79297785997943, 35.77540615585467, -32.353404567984725, 85]
-            },
-            'listOfLayerEntryConfig': [
+            'geoviewLayerName': { 'en': '900A' },
+            'metadataAccessPath': { 'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/900A_and_top_100_en/MapServer' },
+            'geoviewLayerType': 'esriFeature',
+           'listOfLayerEntryConfig': [
               {
-                'layerId': 'dsm-hillshade'
+                'layerId': '1'
               }
             ]
           }
@@ -133,8 +129,10 @@
 
       var showBoundsButton = document.getElementsByClassName('Show-Bounds-wms')[0];
       showBoundsButton.addEventListener('click', function (e) {
-          addBoundsPolygon('LYR1', 'wmsLYR1-Root', 'dsm-hillshade');
+        Object.keys(cgpv.api.map('LYR1').layer.registeredLayers).forEach((layerPath) => {
+          addBoundsPolygon('LYR1', 'wmsLYR1-Root', layerPath);
         });
+      });
 
       // WFS ======================================================================================================================
       const featureInfoWfsLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR6', 'wfsResultSetId');
@@ -156,14 +154,14 @@
 
       var showBoundsButton = document.getElementsByClassName('Show-Bounds-wfs')[0];
       showBoundsButton.addEventListener('click', function (e) {
-          addBoundsPolygon('LYR6', 'wfsLYR6', 'GISDATA.AIRPORTS_PT');
+          addBoundsPolygon('LYR6', 'wfsLYR6', 'wfsLYR6/GISDATA.AIRPORTS_PT');
         });
 
       // ==========================================================================================================================
-      function addBoundsPolygon(map, geoviewLayerId, subLayerId) {
+      function addBoundsPolygon(map, geoviewLayerId, layerPath) {
         cgpv.api.map(map).layer.vector.setActiveGeometryGroup();
         // call an api function to draw a polygon
-        const bbox = cgpv.api.map(map).layer.geoviewLayers[geoviewLayerId].getBounds(`${geoviewLayerId}/${subLayerId}`, 4326);
+        const bbox = cgpv.api.map(map).layer.geoviewLayers[geoviewLayerId].getBounds(layerPath, 4326);
         cgpv.api.map(map).fitBounds(bbox, 4326);
         const polygon = cgpv.api.map(map).layer.vector.addPolygon(
           [

--- a/packages/geoview-core/src/core/utils/config/config-validation.ts
+++ b/packages/geoview-core/src/core/utils/config/config-validation.ts
@@ -522,12 +522,6 @@ export class ConfigValidation {
         if (!layerEntryConfig?.source?.format) layerEntryConfig.source.format = 'EsriJSON';
         if (!layerEntryConfig.source.dataAccessPath)
           layerEntryConfig.source.dataAccessPath = { ...rootLayerConfig.metadataAccessPath } as TypeLocalizedString;
-        layerEntryConfig.source.dataAccessPath!.en = layerEntryConfig.source.dataAccessPath!.en!.endsWith('/')
-          ? `${layerEntryConfig.source.dataAccessPath!.en}${layerEntryConfig.layerId}`
-          : `${layerEntryConfig.source.dataAccessPath!.en}/${layerEntryConfig.layerId}`;
-        layerEntryConfig.source.dataAccessPath!.fr = layerEntryConfig.source.dataAccessPath!.fr!.endsWith('/')
-          ? `${layerEntryConfig.source.dataAccessPath!.fr}${layerEntryConfig.layerId}`
-          : `${layerEntryConfig.source.dataAccessPath!.fr}/${layerEntryConfig.layerId}`;
       } else if (geoviewEntryIsWFS(layerEntryConfig)) {
         // Default value for layerEntryConfig.entryType is vector
         if (!layerEntryConfig.entryType) layerEntryConfig.entryType = 'vector';

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -256,6 +256,7 @@ export class WMS extends AbstractGeoViewRaster {
         en: layerFound.Title as string,
         fr: layerFound.Title as string,
       };
+
       api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);
       return true;
     });
@@ -280,14 +281,18 @@ export class WMS extends AbstractGeoViewRaster {
         fr: subLayer.Title as string,
       };
       newListOfLayerEntryConfig.push(subLayerEntryConfig);
-      api.map(this.mapId).layer.registerLayerConfig(subLayerEntryConfig);
-      if ('Layer' in subLayer) this.createGroupLayer(subLayer, subLayerEntryConfig);
     });
+
     const switchToGroupLayer = Cast<TypeLayerGroupEntryConfig>(layerEntryConfig);
     switchToGroupLayer.entryType = 'group';
+    switchToGroupLayer.layerName = {
+      en: layer.Title as string,
+      fr: layer.Title as string,
+    };
     switchToGroupLayer.isMetadataLayerGroup = true;
     switchToGroupLayer.listOfLayerEntryConfig = newListOfLayerEntryConfig;
     api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);
+    this.validateListOfLayerEntryConfig(newListOfLayerEntryConfig);
     return true;
   }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -172,7 +172,7 @@ export class XYZTiles extends AbstractGeoViewRaster {
         return true;
       }
 
-      // Note that geojson metadata as we defined it does not contains layer group. If you need geogson layer group,
+      // Note that geojson metadata as we defined it does not contains metadata layer group. If you need geogson layer group,
       // you can define them in the configuration section.
       if (Array.isArray(this.metadata?.listOfLayerEntryConfig)) {
         const metadataLayerList = Cast<TypeLayerEntryConfig[]>(this.metadata?.listOfLayerEntryConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -174,6 +174,7 @@ export class GeoJSON extends AbstractGeoViewVector {
         api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);
         return true;
       }
+
       this.layerLoadError.push({
         layer: Layer.getLayerPath(layerEntryConfig),
         consoleMessage: `Invalid GeoJSON metadata (listOfLayerEntryConfig) prevent loading of layer (mapId:  ${


### PR DESCRIPTION
This PR correct the metadata group layer bug and the getBounds improvment.
A good candidat to test the metadata group layer correction is layerId=1 and metadataAccessPath=https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/900A_and_top_100_en/MapServer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canadian-geospatial-platform/geoview/723)
<!-- Reviewable:end -->
