### PR TITLE
Solution for issue 714-WMS-unsupported-query

### DIFF
--- a/packages/geoview-core/public/templates/layers.html
+++ b/packages/geoview-core/public/templates/layers.html
@@ -78,7 +78,7 @@
                 {
                   'geoviewLayerId': 'wmsLYR1-Root',
                   'geoviewLayerName': { 'en': 'Root' },
-                  'metadataAccessPath': { 'en': 'https://ows.mundialis.de/services/service' },
+                  'metadataAccessPath': { 'en': 'https://geo.weather.gc.ca/geomet' },
                   'geoviewLayerType': 'ogcWms',
                   'initialSettings': { 'visible': true },
                   'listOfLayerEntryConfig': [
@@ -88,10 +88,13 @@
                       'layerName': { 'en': 'Group' },
                       'listOfLayerEntryConfig': [
                         {
-                          'layerId': 'OSM-WMS'
+                          'layerId': 'CURRENT_CONDITIONS'
                         },
                         {
-                          'layerId': 'TOPO-OSM-WMS'
+                          'layerId': 'METNOTES'
+                        },
+                        {
+                          'layerId': 'CGSL.ETA_ICEC'
                         }
                       ]
                     }
@@ -568,14 +571,6 @@
 
     var addGeoJsonLegendButton = document.getElementsByClassName('Get-wms-Legend')[0];
     addGeoJsonLegendButton.addEventListener('click', function (e) {
-      const geoviewLayerIds = Object.keys(cgpv.api.map('LYR1').layer.geoviewLayers);
-      geoviewLayerIds.forEach((geoviewLayerId) => {
-        const pathArray = Object.keys(cgpv.api.map('LYR1').layer.registeredLayers);
-        for (let i = 0; i < pathArray.length; i++) {
-          if (pathArray[i].startsWith(geoviewLayerId))
-            console.log(cgpv.api.map('LYR1').layer.geoviewLayers[geoviewLayerId].getMetadataBounds(pathArray[i]));
-        }
-      });
       cgpv.api.event.emit({ handlerName: 'LYR1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'wmsLegendsId');
     });
 


### PR DESCRIPTION
While fixing the conflicts, I noticed that the time dimension has been added in the layerEntryConfig object. So far, most of the properties of the layerEntryConfig object have a mapping to the schema entries. There are some exceptions, but this is to chain the entries together. The schema does not contain a definition for the temporalDimension property. I think we should place this property on the instance of the WMS objects to avoid breaking the mapping rule between the schema and the configuration objects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/802)
<!-- Reviewable:end -->
