### PR TITLE
feat(footer-panel): Panel collapsed on map load

### DIFF
--- a/packages/geoview-core/public/configs/package-footer2-config-footer-panel.json
+++ b/packages/geoview-core/public/configs/package-footer2-config-footer-panel.json
@@ -1,10 +1,13 @@
 {
   "tabs": {
     "defaultTabs": [],
-    "customTabs": [{
-      "title": "What is this Map?",
-      "contentHTML": "<div>This is a custom tab define as HTML content in configuration! By the way, this is a static map.</div>"
-    }]
+    "customTabs": [
+      {
+        "title": "What is this Map?",
+        "contentHTML": "<div>This is a custom tab define as HTML content in configuration! By the way, this is a static map.</div>"
+      }
+    ]
   },
-  "suportedLanguages": ["en", "fr"]
+  "suportedLanguages": ["en", "fr"],
+  "collapsed": false
 }

--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
@@ -14,7 +14,6 @@ export const useStyles = makeStyles((theme) => ({
     position: 'relative',
     backgroundColor: theme.palette.background.default,
     width: '100%',
-    height: '300px',
     transition: 'height 0.2s ease-out',
   },
 }));
@@ -72,16 +71,16 @@ export function FooterTabs(): JSX.Element | null {
   const handleCollapse = () => {
     // check if tabs component is created
     if (tabsContainerRef && tabsContainerRef.current) {
-      const tabsContaine = tabsContainerRef.current as HTMLDivElement;
-      const mapContaine = tabsContaine.previousElementSibling as HTMLDivElement;
-      mapContaine.style.transition = 'height 0.2s ease-out';
+      const tabsContainer = tabsContainerRef.current as HTMLDivElement;
+      const mapContainer = tabsContainer.previousElementSibling as HTMLDivElement;
+      mapContainer.style.transition = 'height 0.2s ease-out';
       // check if the tabs container is collapsed
-      if (isCollapsed) {
-        tabsContaine.style.height = '55px';
-        mapContaine.style.height = 'calc( 100% - 55px)';
+      if (!isCollapsed) {
+        tabsContainer.style.height = '55px';
+        mapContainer.style.height = 'calc( 100% - 55px)';
       } else {
-        tabsContaine.style.height = '300px';
-        mapContaine.style.height = 'calc( 100% - 300px)';
+        tabsContainer.style.height = '300px';
+        mapContainer.style.height = 'calc( 100% - 300px)';
       }
     }
     setIsFullscreen(false);
@@ -104,7 +103,7 @@ export function FooterTabs(): JSX.Element | null {
         // eslint-disable-next-line no-lonely-if
         tabsContaine.style.height = '300px';
         mapContaine.style.height = 'calc( 100% - 300px)';
-        setIsCollapsed(true);
+        setIsCollapsed(false);
       } else {
         tabsContaine.style.height = '100%';
         mapContaine.style.height = '0';
@@ -127,6 +126,17 @@ export function FooterTabs(): JSX.Element | null {
         if (payloadIsAFooterTab(payload)) {
           if (payload.handlerName && payload.handlerName === mapId) {
             addTab(payload);
+            // Check if footer-panel is collapsed or not, and size accordingly
+            if (tabsContainerRef && tabsContainerRef.current) {
+              const tabsContainer = tabsContainerRef.current as HTMLDivElement;
+              const mapContainer = tabsContainer.previousElementSibling as HTMLDivElement;
+              if (mapContainer.style.height === 'calc(100% - 300px)') {
+                setIsCollapsed(false);
+                tabsContainer.style.height = '300px';
+              } else {
+                tabsContainer.style.height = '55px';
+              }
+            }
           }
         }
       },
@@ -169,6 +179,8 @@ export function FooterTabs(): JSX.Element | null {
   return api.map(mapId).footerTabs.tabs.length > 0 ? (
     <div ref={tabsContainerRef as MutableRefObject<HTMLDivElement>} className={classes.tabsContainer}>
       <Tabs
+        isCollapsed={isCollapsed}
+        handleCollapse={handleCollapse}
         selectedTab={selectedTab}
         tabsProps={{ variant: 'scrollable' }}
         tabs={footerTabs.map((tab) => {
@@ -178,11 +190,14 @@ export function FooterTabs(): JSX.Element | null {
         })}
         rightButtons={
           <>
-            {!isFullscreen && <IconButton onClick={handleCollapse}>{isCollapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}</IconButton>}
+            {!isFullscreen && <IconButton onClick={handleCollapse}>{!isCollapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}</IconButton>}
             <IconButton onClick={handleFullscreen}>{isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}</IconButton>
           </>
         }
       />
     </div>
   ) : null;
+}
+function componentDidMount() {
+  throw new Error('Function not implemented.');
 }

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -32,6 +32,9 @@ export interface TypeTabsProps {
   tabsProps?: TabsProps;
   tabProps?: TabProps;
   rightButtons?: unknown;
+  isCollapsed?: boolean;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  handleCollapse?: Function | undefined;
 }
 
 /**
@@ -41,7 +44,7 @@ export interface TypeTabsProps {
  * @returns {JSX.Element} returns the tabs ui
  */
 export function Tabs(props: TypeTabsProps): JSX.Element {
-  const { tabs, rightButtons, selectedTab } = props;
+  const { tabs, rightButtons, selectedTab, isCollapsed, handleCollapse } = props;
 
   const [value, setValue] = useState(0);
 
@@ -53,6 +56,14 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
    */
   const handleChange = (event: SyntheticEvent<Element, Event>, newValue: number) => {
     setValue(newValue);
+  };
+
+  /**
+   * Handle a tab click
+   * If the panel is collapsed when tab is clicked, expand the panel
+   */
+  const handleClick = () => {
+    if (isCollapsed && handleCollapse !== undefined) handleCollapse();
   };
 
   useEffect(() => {
@@ -82,6 +93,7 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
                 key={index}
                 {...props.tabProps}
                 id={`tab-${index}`}
+                onClick={handleClick}
                 sx={{
                   fontSize: 16,
                   minWidth: 'min(4vw, 24px)',

--- a/packages/geoview-footer-panel/schema.json
+++ b/packages/geoview-footer-panel/schema.json
@@ -59,6 +59,11 @@
       "type": "string",
       "enum": ["1.0"],
       "description": "The schema version used to validate the configuration file. The schema should enumerate the list of versions accepted by this version of the viewer."
+    },
+    "collapsed": {
+      "type": "boolean",
+      "default": true,
+      "description": "State of footer panel when map is loaded"
     }
   },
   "required": ["suportedLanguages", "tabs"]

--- a/packages/geoview-footer-panel/src/index.tsx
+++ b/packages/geoview-footer-panel/src/index.tsx
@@ -83,8 +83,13 @@ class FooterPanelPlugin extends AbstractPlugin {
       const { displayLanguage, footerTabs, map } = api.map(mapId);
 
       const mapContainer = map.getTargetElement().parentElement;
+      // Set size of map container based on whether footer-panel is collapsed or not
       if (mapContainer) {
-        mapContainer.style.height = 'calc( 100% - 300px )';
+        if (configObj?.collapsed === false) {
+          mapContainer.style.height = 'calc( 100% - 300px )';
+        } else {
+          mapContainer.style.height = 'calc( 100% - 55px )';
+        }
       }
 
       const defaultTabs = configObj?.tabs.defaultTabs as Array<string>;


### PR DESCRIPTION
Closes #842

# Description

Default behaviour for footer-panel is initially collapsed. Clicking a tab now opens it, and there is a setting in the config to change initial behaviour.

Fixes #842 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on the three footer panel maps, with setting in config file for the second map set to true and false.

# Checklist:

- [x ] I have connected the issues(s) to this PR
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/871)
<!-- Reviewable:end -->
