### PR TITLE
538-Add_a_flag_to_layers_configuration_items

### DIFF
--- a/packages/geoview-core/public/geojson/metadata.json
+++ b/packages/geoview-core/public/geojson/metadata.json
@@ -32,7 +32,7 @@
               "lineStyle": "dot"
             }
           },
-          "defaultVisible": true,
+          "defaultVisible": "yes",
           "fields": ["Province"],
           "uniqueValueStyleInfo": [
             {
@@ -49,7 +49,7 @@
                 }
               },
               "values": ["Quebec"],
-              "visible": true
+              "visible": "yes"
             },
             {
               "label": "Alberta",
@@ -65,7 +65,7 @@
                 }
               },
               "values": ["Alberta"],
-              "visible": true
+              "visible": "yes"
             }
           ]
         }

--- a/packages/geoview-core/public/templates/layers.html
+++ b/packages/geoview-core/public/templates/layers.html
@@ -239,7 +239,7 @@
                           'src': 'iVBORw0KGgoAAAANSUhEUgAAABIAAAAPCAYAAADphp8SAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAUhJREFUOI2d0z1Lw1AUBuD3hppCLSo4iLg6dFZBEYtZQgeFgB+jrSIEQXSxFUIFg1jTYhBHyWITEVwDOhXUSVz8Bf4DcahgBxtvrkNrIbamSd/tXM557llOBAGiGQtxRb779OuJdEOUm9UY+6o+6KYkZDN2rWdooF7dZ6BTdXzsATjqCSpaqTGXOblGxeVUc/JCzby8hYZc5pwAiDXLOM8GDwFsh4KOy8kJAGueRwK5cDl7nt94eg0MEdJ3BoC09XO8BmAlEFQwhSUCzHf8ANyyVhZnlPXKsy+0a4An4Er/bQoAjNBTAElfaCQq7gB03A8CMKdZgqSkH+2OUMmaHqaMHnRBGlsxrmgYuJVl0DboG/0qAYaCQAAS71FxE6gYHki7SiWY62wFRJqhqm5K19mMXWtBLnN0EuBk/mT093Rag/n0/WJIxJMfY79g/IvbH/IAAAAASUVORK5CYII=',
                           'type': 'iconSymbol'
                         },
-                        'defaultVisible': true,
+                        'defaultVisible': 'always',
                         'fields': ['E_Regulated', 'E_SampleType', 'E_Overall_Condition'],
                         'uniqueValueStyleInfo': [
                           {
@@ -253,7 +253,7 @@
                               'type': 'iconSymbol'
                             },
                             'values': ['Natural', 'Seasonal', 'High'],
-                            'visible': true
+                            'visible': 'yes'
                           },
                           {
                             'label': 'Natural, Seasonal, Low',
@@ -266,7 +266,7 @@
                               'type': 'iconSymbol'
                             },
                             'values': ['Natural', 'Seasonal', 'Low'],
-                            'visible': false
+                            'visible': 'no'
                           },
                           {
                             'label': 'Natural, Seasonal, Normal',
@@ -279,7 +279,7 @@
                               'type': 'iconSymbol'
                             },
                             'values': ['Natural', 'Seasonal', 'Normal'],
-                            'visible': false
+                            'visible': 'always'
                           },
                           {
                             'label': 'Natural, Yearly, High',
@@ -292,7 +292,7 @@
                               'type': 'iconSymbol'
                             },
                             'values': ['Natural', 'Yearly', 'High'],
-                            'visible': true
+                            'visible': 'yes'
                           },
                           {
                             'label': 'Natural, Yearly, Low',
@@ -305,7 +305,7 @@
                               'type': 'iconSymbol'
                             },
                             'values': ['Natural', 'Yearly', 'Low'],
-                            'visible': false
+                            'visible': 'no'
                           },
                           {
                             'label': 'Natural, Yearly, Normal',
@@ -318,7 +318,7 @@
                               'type': 'iconSymbol'
                             },
                             'values': ['Natural', 'Yearly', 'Normal'],
-                            'visible': false
+                            'visible': 'no'
                           },
                           {
                             'label': 'Regulated, Seasonal, High',
@@ -331,7 +331,7 @@
                               'type': 'iconSymbol'
                             },
                             'values': ['Regulated', 'Seasonal', 'High'],
-                            'visible': false
+                            'visible': 'no'
                           },
                           {
                             'label': 'Regulated, Seasonal, Low',
@@ -344,7 +344,7 @@
                               'type': 'iconSymbol'
                             },
                             'values': ['Regulated', 'Seasonal', 'Low'],
-                            'visible': false
+                            'visible': 'no'
                           },
                           {
                             'label': 'Regulated, Seasonal, Normal',
@@ -357,7 +357,7 @@
                               'type': 'iconSymbol'
                             },
                             'values': ['Regulated', 'Seasonal', 'Normal'],
-                            'visible': false
+                            'visible': 'no'
                           },
                           {
                             'label': 'Regulated, Yearly, High',
@@ -370,7 +370,7 @@
                               'type': 'iconSymbol'
                             },
                             'values': ['Regulated', 'Yearly', 'High'],
-                            'visible': false
+                            'visible': 'no'
                           },
                           {
                             'label': 'Regulated, Yearly, Low',
@@ -383,7 +383,7 @@
                               'type': 'iconSymbol'
                             },
                             'values': ['Regulated', 'Yearly', 'Low'],
-                            'visible': false
+                            'visible': 'no'
                           }
                         ]
                       }
@@ -419,14 +419,14 @@
                             'width': 0.5
                           }
                         },
-                        'defaultVisible': true,
+                        'defaultVisible': 'always',
                         'field': 'Total_CSO_Volume',
                         'classBreakStyleInfo': [
                           {
                             'label': '0 m3',
                             'minValue': 0,
                             'maxValue': 0,
-                            'visible': true,
+                            'visible': 'yes',
                             'settings': {
                               'symbol': 'circle',
                               'type': 'simpleSymbol',
@@ -445,7 +445,7 @@
                             'label': '0.0001 - ≤ 5,000,000 m3',
                             'minValue': 0,
                             'maxValue': 5000000,
-                            'visible': true,
+                            'visible': 'yes',
                             'settings': {
                               'symbol': 'circle',
                               'type': 'simpleSymbol',
@@ -464,7 +464,7 @@
                             'label': '> 5,000,000 - ≤ 10,000,000 m3',
                             'minValue': 5000000,
                             'maxValue': 10000000,
-                            'visible': true,
+                            'visible': 'yes',
                             'settings': {
                               'symbol': 'circle',
                               'type': 'simpleSymbol',
@@ -483,7 +483,7 @@
                             'label': '> 10,000,000 - ≤ 15,000,000 m3',
                             'minValue': 10000000,
                             'maxValue': 15000000,
-                            'visible': true,
+                            'visible': 'yes',
                             'settings': {
                               'symbol': 'circle',
                               'type': 'simpleSymbol',
@@ -502,7 +502,7 @@
                             'label': '> 15,000,000 - ≤ 20,000,000 m3',
                             'minValue': 15000000,
                             'maxValue': 20000000,
-                            'visible': true,
+                            'visible': 'yes',
                             'settings': {
                               'symbol': 'circle',
                               'type': 'simpleSymbol',
@@ -521,7 +521,7 @@
                             'label': '> 20,000,000 - ≤ 25,000,000 m3',
                             'minValue': 20000000,
                             'maxValue': 25000000,
-                            'visible': true,
+                            'visible': 'yes',
                             'settings': {
                               'symbol': 'circle',
                               'type': 'simpleSymbol',
@@ -540,7 +540,7 @@
                             'label': '> 25,000,000 - ≤ 30,000,000 m3',
                             'minValue': 25000000,
                             'maxValue': 30000000,
-                            'visible': true,
+                            'visible': 'yes',
                             'settings': {
                               'symbol': 'circle',
                               'type': 'simpleSymbol',
@@ -559,7 +559,7 @@
                             'label': '> 30,000,000 - ≤ 35,000,000 m3',
                             'minValue': 30000000,
                             'maxValue': 35000000,
-                            'visible': true,
+                            'visible': 'yes',
                             'settings': {
                               'symbol': 'circle',
                               'type': 'simpleSymbol',
@@ -578,7 +578,7 @@
                             'label': '> 35,000,000 m3',
                             'minValue': 35000000,
                             'maxValue': 999000000,
-                            'visible': true,
+                            'visible': 'always',
                             'settings': {
                               'symbol': 'circle',
                               'type': 'simpleSymbol',
@@ -877,6 +877,7 @@
     <div
       id="LYR8"
       class="llwp-map"
+      triggerReadyCallback="true"
       data-lang="en"
       data-config="{
           'map': {
@@ -893,20 +894,135 @@
             },
             'listOfGeoviewLayerConfig': [
               {
-                'geoviewLayerId': 'LYR8',
                 'geoviewLayerType': 'geoCore',
                 'listOfLayerEntryConfig': [
                   {
-                    'layerId': '0fe65119-e96e-4a57-8bfe-9d9245fba06b'
+                    'layerId': '0fe65119-e96e-4a57-8bfe-9d9245fba06b',
+                    'geocoreLayerName': { 'en': 'HRDEM Mosaic Hillshade' },
+                    'listOfLayerEntryConfig': [
+                      {
+                        'layerId': 'dsm-hillshade',
+                        'layerName': { 'en': 'Map' }
+                      }
+                    ]
                   },
                   {
-                    'layerId': 'ccc75c12-5acc-4a6a-959f-ef6f621147b9'
+                    'layerId': 'ccc75c12-5acc-4a6a-959f-ef6f621147b9',
+                    'geocoreLayerName': { 'en': 'Commemorative Map' },
+                    'listOfLayerEntryConfig': [
+                      {
+                        'layerId': '0',
+                        'layerName': { 'en': 'Map' },
+                        'style': {
+                          'Point': {
+                            'styleId': 'uniqueValueId',
+                            'styleType': 'uniqueValue',
+                           'fields': ['SYMBOL_EN'],
+                            'uniqueValueStyleInfo': [
+                              {
+                                'label': 'Confederation to 1914',
+                                'settings': {
+                                  'mimeType': 'image/png',
+                                  'offset': [0, 0],
+                                  'opacity': 1,
+                                  'rotation': 0,
+                                  'src': 'iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAahJREFUKJGd0ksoRFEcBvDvjMvci3E9GkxMxttYIIQo8igWHkmsRikLoSxlbSVZjKasyIIFmhQa5JmFZOGxMHYjeSQLxsw05ozhHgtcMWYWvjqbU7/zP9/pcPhnuN8blDqiGSONBCQHYG8gOPV62ZooijQgpB5XtySxsZvLu+j72weEcApoUzVQJ8TeejyuHkFQWfwgpc6BpwfH+PToCs4Xrn/com6oIKm1q26ZUmc7z0ctypBSZ7qX+sZMg3O42nn067M1cgoffVUYBpomKXXs8rxo5wCAMfQc7VtD/0Jf2TOeoaq5OEabmmgAYOIAgABlZ4e2wE/4GZv1ClqdpkyGAAl/dtGg6KPSCwAWLndkgE2bpS6y4joojE+KAwi5kCEBzKXVeR3rw8cBkSqbhz4/DYzBLEMlH2lOTtHsd07UVsz0bfuhsIQQ9BvbwAv8vCCoDr4nEsJe3O62yoaSVY0lvnB36QjWzUsoxVAU1megpqUU6sTYDUlSdH8dJn+AsIiIe8bs5Zm5ut5Mvc6AIegBvAE4AcGUUhk5SwiR/ODH5BgvAOPnCpp3ofqRTtNnzMYAAAAASUVORK5CYII=',
+                                  'type': 'iconSymbol'
+                                },
+                                'values': ['Confederation to 1914'],
+                                'visible': 'no'
+                              },
+                              {
+                                'label': 'First World War',
+                                'settings': {
+                                  'mimeType': 'image/png',
+                                  'offset': [0, 0],
+                                  'opacity': 1,
+                                  'rotation': 0,
+                                  'src': 'iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAZ5JREFUKJGd0ssvA1EUBvDvjqmZelUH7UwkbZQFQSKqImw8dtLEomFlZ9HY+EssiC07G1IWBInEYyMWgiZeG7owI6lE23REemdavRZqhCqJLzmbm/zuOefm8vhn+O8HlKZrGSNBAtIKsFcQRA2D7TgcDloS0szzFMuz2Xg8XvuUSILjOCiyDElyPmQyz2G7vXqrCFKqz+hpfX5jcweapn2Zoqurs3FkeGiDUn1cFGvWLUip3mwY2dmV1TUkEsmifaLRC+SyOS4YHF2kNH0gio4UDwCMIXx9fWP7CX3k8uoG/p5up6K4JwEs8ABAgL6721jpJyzk/l6FIst9FgRIhWGaf0LTNAGwCmtHBty5XPV+VdV+hXV1EkBIzIIEiHR0tE+cnkZLIkEQ4PM1gTFELCiIVRFFlo9GhgcH9vYPi5DNxiMUGoMgiCt2e/XxZ0dCmPnyEgoE/Nsud0P3yckZVFUDz5ehpcWH3t4AJMm5m89zUx+XWR+gvLLykbFUv9frmfZ6PJMA2gC8AjgHwZIgVC0TQvJF8L2z0wAwV6hf8waIeZGd6U5WcwAAAABJRU5ErkJggg==',
+                                  'type': 'iconSymbol'
+                                },
+                                'values': ['First World War'],
+                                'visible': 'no'
+                              },
+                              {
+                                'label': 'Second World War',
+                                'settings': {
+                                  'mimeType': 'image/png',
+                                  'offset': [0, 0],
+                                  'opacity': 1,
+                                  'rotation': 0,
+                                  'src': 'iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAZ5JREFUKJGd0EsoRFEYB/D/GZe511zzyhhiMTMiQxI2YsPKMylRSkqKlFhpSspGSRSSjcdOpAalPGJhpUkWrFiI2RiSzDTX454rc48FrhiP8q9TX6d+fQ8O/wz39YPSsJkxUkNAsgAWAcGRorBNk8lEf4RUvmtjqjoa8vvN94FL6LgYmF0uiHZ7QJbvOgQhYT0KUip1y7fBicOhEUgzC5+mSBnuT81pbVmjVGrgeeOKBimV0p+pMnrQ68Hj8nbUPleeQahU0eX3dM1SGt7leVOIAwDG0HGx54v9Dr3nemAEwdpqi9XlaAYwyQEAAYpufPs/n/AtweMTWJ3OIg0CJP5ZCv8JI7IMgMVrOzLgTMzKLPyLGtJSAULONUgAb1pZaWPgF8QV5iApLxeMwatBPS96LQ7nXsbidMlpU3sUinHYkDc1hljBsCQICb6PjoSwp4eH+vTK8g2jb6vAv7oGaWMHxGpEYlUFXHW1EJPt26qqa9MmeC/iDIZrxkLFtmx3p83tbkafxw0gAuAQBHN6vThPCFGj4GtniwJg/O39mhf/K5CfkLtGyAAAAABJRU5ErkJggg==',
+                                  'type': 'iconSymbol'
+                                },
+                                'values': ['Second World War'],
+                                'visible': 'always'
+                              },
+                              {
+                                'label': 'Korean War',
+                                'settings': {
+                                  'mimeType': 'image/png',
+                                  'offset': [0, 0],
+                                  'opacity': 1,
+                                  'rotation': 0,
+                                  'src': 'iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAYtJREFUKJGdz79rU2EUxvHvSa+5N2libixtwEpTEYkZjKBLsItQapfiInYKXTIEQd0U/AdcTKG2a91cxCCoVEEonSTiYkEIVKiIYCQdDEkoeW+09zioVzTGgg+8cHjhc35Y/GesPz+MabmqMifICdA9hE3P02eJRMIMhKbbKeL7Zdl572qzDkNDMHoU20197HY7pUgkvtYHjWlfo/P5jr++CI0Hv6+RuT4uUwuPjWlfcpyDDwNoTPsYPa/sr92E1kbfPbp1G756IZm+smpMa8NxEk0LQJUSb6sH/oYCvL0MJ+eSkkoXgBULQCCvH14NREHqNRibzAcQJKq99v7wiwE0GtyosC0jx89oYx/oHgaRdwEUqGjm3Dy1W4ORnYF0DlUqAbSdWMUbnXxBfmVKX17tR9YhZKYM4ej9SCRe/TVRRHu7uxf93OxTRh6d1jdP4NM6WHFk4jycugBu6rnvh4pBr59FeHi4odo86x3JXpbxbAFuZIE94DXCXduO3RMRvw9+n5z0gKUf75/5BuXZh6Fohy1dAAAAAElFTkSuQmCC',
+                                  'type': 'iconSymbol'
+                                },
+                                'values': ['Korean War'],
+                                'visible': 'yes'
+                              },
+                              {
+                                'label': 'Peacekeeping',
+                                'settings': {
+                                  'mimeType': 'image/png',
+                                  'offset': [0, 0],
+                                  'opacity': 1,
+                                  'rotation': 0,
+                                  'src': 'iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAatJREFUKJGd0jFoE1Ecx/HvP7kmd03iJSElwaLYq4OpRSQKFgUFt0IpFNGpkx2Ki1hcHNxdCio6OOjmoBAiiFZwEYTSrRYpioNBtLYErUlzxHuJ5p6D7YnGVPAH/+XB5/3//8cz+M8Yfx4otZHUWsYE2Qe6jbDUbOontm2rrlB57pTv69l3lVpyZb1BOCwMZm1yqfhHz3OnLSvxuAMqVT+/Xv96/crcMjfX3N+muDqc7T97Iv9Qqfpp09xRCqBS9UHVas9eLC1xr+p17DOzXKH5zQ9dGD1wW6mNZ6ZpVw0ArZmef73a8ze0lUtvPjFeqKWcnD0J3DAABEYWyp+7P+FmXn34gpNNjgQQpLfW+v5P6LXagO4NdtTwNp+JH2LV3Rb2p2MgUg6gQPHk/p1neLnWFR2JGBx0+tCaYgCjZrw4kGX+wXHn2MTzcgfaGw5xa3wYK9Jz37ISC786iuhWo3FqtDAwt9iXKJQW3/NoxSVtCGNOmonDe8ilYk99PzS1dVnwASKxWEXr6tGh3ZlzQ7syk5chD7SBFwh3otH4XRHxO+DPzqkmcG2zts0PBFWRZ33W55YAAAAASUVORK5CYII=',
+                                  'type': 'iconSymbol'
+                                },
+                                'values': ['Peacekeeping'],
+                                'visible': 'no'
+                              },
+                              {
+                                'label': 'Afghanistan',
+                                'settings': {
+                                  'mimeType': 'image/png',
+                                  'offset': [0, 0],
+                                  'opacity': 1,
+                                  'rotation': 0,
+                                  'src': 'iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAadJREFUKJGd0ksoRFEYB/D/MZe5dzzGlccUxjOZsRksyLBRkkghVlZmISWRzSzsWShkFhQ7CzKNyCsbG1KTmBSJvMpzYYaZpjl35B4L44oxlH99m1O/833f6XD4Z7jvB5Q+JzJGGghIIcBeQeCSJLam1WppREgDPossy8OXD1eJ1+57qFQq5KVmQyem3AQCvk5BiF8Jg5R6ex59nrHB9UnY7pxfphgpak7vqGpbotTbyvMJDgVS6s2jweBw/+IQZt2nYfv0HTogvUhRvbWWKUqfN3le6+EAgDF0bh87o39CH7GerKDRVCPm6jLbAYxzAECA8p0LV+QnDOXo5gS5afpyBQJE8/Ti/xMGghQA0yg7MuDMkJxVilvnrzBd1AGEnCuQAPZqg7kNB/MRUZlahCnHCMZgV6Caj7PnpOq3Fyq7zU1btjCUz/GYqLdCiNHMCUL8zmdHQljQ72+pK65e3UvOKHG4NrB8u4skjkdDthlNJbXQiSkbshxl+bhM+QAxsbEPjHkqjPqCLmNmQfsAYADwCmAfBNNqddwMIUQOg++dRQnAaKh+zRtAE5CN4Z5HEQAAAABJRU5ErkJggg==',
+                                  'type': 'iconSymbol'
+                                },
+                                'values': ['Afghanistan'],
+                                'visible': 'no'
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
                   },
                   {
-                    'layerId': '0fca08b5-e9d0-414b-a3c4-092ff9c5e326'
+                    'layerId': '0fca08b5-e9d0-414b-a3c4-092ff9c5e326',
+                    'geocoreLayerName': { 'en': 'Marine Water Quality' },
+                    'listOfLayerEntryConfig': [
+                      {
+                        'layerId': '6',
+                        'layerName': { 'en': 'Map' }
+                      }
+                    ]
+
                   },
                   {
-                    'layerId': '03ccfb5c-a06e-43e3-80fd-09d4f8f69703'
+                    'layerId': '03ccfb5c-a06e-43e3-80fd-09d4f8f69703',
+                    'geocoreLayerName': { 'en': 'NAPL Temporal Series' },
+                    'listOfLayerEntryConfig': [
+                      {
+                        'layerId': 'regina',
+                        'layerName': { 'en': 'Map of Regina' }
+                      }
+                    ]
                   }
                 ]
               }
@@ -918,6 +1034,7 @@
           'suportedLanguages': ['en']
         }"
     ></div>
+    <div class="layer8-buttons-div"></div>
     <button class="Get-geocore-Legend">Get Legend</button>
     <div id="geocoreLegendsId-table-div"></div>
     <button type="button" class="collapsible">Get Feature Info</button>
@@ -999,43 +1116,34 @@
       cgpv.init(function (mapId) {
         console.log(`api is ready for ${mapId}`);
 
-      if (['LYR3', 'LYR4', 'LYR5', 'LYR6', 'LYR7', 'LYR9'].includes(mapId)) {
-        var layerButtons = document.getElementsByClassName(`layer${mapId.slice(3)}-buttons-div`)[0];
-        if (mapId !== 'LYR5') layerButtons.appendChild(document.createElement("hr"));
-        else {
-          var table = document.createElement("table");
-          table.style.width = '100%';
-          table.border = '1px solid black';
-          layerButtons.appendChild(table);
-          layerButtons = document.createElement("td");
-          layerButtons.style.width = '16.66%';
-          layerButtons.style.padding = '15px';
-          layerButtons.border = '1px solid black';
-          table.appendChild(layerButtons);
-        }
+      if (['LYR3', 'LYR4', 'LYR5', 'LYR6', 'LYR7', 'LYR8', 'LYR9'].includes(mapId)) {
+        var mapButtonsDiv = document.getElementsByClassName(`layer${mapId.slice(3)}-buttons-div`)[0];
+        var tableElement = document.createElement("table");
+        tableElement.style.width = '100%';
+        tableElement.border = '1px solid black';
+        mapButtonsDiv.appendChild(tableElement);
+        Object.keys(cgpv.api.maps[mapId].layer.geoviewLayers).forEach((geoviewLayerId) => {
+          const geoviewLayer = cgpv.api.maps[mapId].layer.geoviewLayers[geoviewLayerId];
+          Object.keys(cgpv.api.maps[mapId].layer.registeredLayers).forEach((layerPath) => {
+            if (layerPath.startsWith(geoviewLayerId)) {
+              const layerConfig = cgpv.api.maps[mapId].layer.registeredLayers[layerPath];
+              const { geoviewRenderer } = cgpv.api.maps[mapId];
+              geoviewRenderer.getLegendStyles(layerConfig.style).then((legendStyle) => {
 
-          const geoviewLayers = cgpv.api.maps[mapId].layer.geoviewLayers;
-          Object.keys(geoviewLayers).forEach((geoviewLayerId) => {
-            const geoviewLayer = geoviewLayers[geoviewLayerId];
-            if (mapId === 'LYR5') {
-              const geoviewLayerText = document.createElement('h1');
-              geoviewLayerText.innerText = geoviewLayer.geoviewLayerName.en;
-              layerButtons.appendChild(geoviewLayerText);
-            }
-            const registeredLayers = cgpv.api.maps[mapId].layer.registeredLayers;
-            Object.keys(registeredLayers).forEach((layerPath) => {
-              if (mapId === 'LYR5') {
-                layerButtons = document.createElement('td');
-                layerButtons.style.width = '16.66%';
-                layerButtons.style.padding = '15px';
-                layerButtons.border = '1px solid black';
-                table.appendChild(layerButtons);
-              }
-              if (layerPath.startsWith(geoviewLayerId)) {
-                const layerConfig = registeredLayers[layerPath];
-                const layerConfigH2 = document.createElement('h2');
+                mapButtonsDiv = document.createElement('td');
+                mapButtonsDiv.style.width = '16.66%';
+                mapButtonsDiv.border = '1px solid black';
+                tableElement.appendChild(mapButtonsDiv);
+
+                const geoviewLayerH1 = document.createElement('h1');
+                geoviewLayerH1.innerText = geoviewLayer.geoviewLayerName.en;
+                mapButtonsDiv.appendChild(geoviewLayerH1);
+
+                  const layerConfigH2 = document.createElement('h2');
                 layerConfigH2.innerText = `${layerConfig.layerName.en}  `;
-                layerButtons.appendChild(layerConfigH2);
+                layerConfigH2.style.height = '15px';
+                mapButtonsDiv.appendChild(layerConfigH2);
+
                 const toggleLayerVisibility = document.createElement('button');
                 const visibilityFlag = geoviewLayer.getVisible(layerConfig);
                 if (visibilityFlag) toggleLayerVisibility.innerText = 'Hide';
@@ -1048,135 +1156,207 @@
                 });
                 layerConfigH2.appendChild(toggleLayerVisibility);
 
-              if (layerConfig.style) {
-                Object.keys(layerConfig.style).forEach((geometry) => {
-                  const geometryText = document.createElement("p");
-                  geometryText.innerText = `Geometry = ${geometry}`;
-                  layerButtons.appendChild(geometryText);
-                  if (layerConfig.style[geometry].styleType === 'uniqueValue') {
-                    const toggleUniqueValueDefault = document.createElement("button");
-                    if (layerConfig.style[geometry].defaultVisible)
-                      toggleUniqueValueDefault.innerText = `Hide ${layerConfig.style[geometry].defaultLabel}`;
-                    else
-                      toggleUniqueValueDefault.innerText =  `Show ${layerConfig.style[geometry].defaultLabel}`;
-                    toggleUniqueValueDefault.addEventListener('click', function (e) {
-                      layerConfig.style[geometry].defaultVisible = !layerConfig.style[geometry].defaultVisible;
-                      if (layerConfig.style[geometry].defaultVisible)
-                        toggleUniqueValueDefault.innerText = `Hide ${layerConfig.style[geometry].defaultLabel}`;
-                      else
-                        toggleUniqueValueDefault.innerText = `Show ${layerConfig.style[geometry].defaultLabel}`;
-                      const checkbox = document.getElementById(`checkbox-${mapId}`);
-                      const filterInput = document.getElementById(`filter-input-${mapId}`);
-                      const filter = checkbox.value === 'true' ? filterInput.value : '';
-                      geoviewLayer.applyViewFilter(layerConfig, filter);
-                    });
-                    layerButtons.appendChild(toggleUniqueValueDefault);
-                    if (mapId === 'LYR5') layerButtons.appendChild(document.createElement("p"));
-
-                    for (let i = 0; i < layerConfig.style[geometry].uniqueValueStyleInfo.length; i++) {
-                      const toggleUniqueValueFeature = document.createElement("button");
-                      if (layerConfig.style[geometry].uniqueValueStyleInfo[i].visible)
-                        toggleUniqueValueFeature.innerText = `Hide ${layerConfig.style[geometry].uniqueValueStyleInfo[i].label}`;
-                      else
-                        toggleUniqueValueFeature.innerText = `Show ${layerConfig.style[geometry].uniqueValueStyleInfo[i].label}`;
-                      toggleUniqueValueFeature.addEventListener('click', function (e) {
-                        const uniqueValueStyleInfoEntry = layerConfig.style[geometry].uniqueValueStyleInfo[i];
-                        uniqueValueStyleInfoEntry.visible = !uniqueValueStyleInfoEntry.visible;
-                        if (uniqueValueStyleInfoEntry.visible)
-                          toggleUniqueValueFeature.innerText = `Hide ${uniqueValueStyleInfoEntry.label}`;
-                        else
-                          toggleUniqueValueFeature.innerText = `Show ${uniqueValueStyleInfoEntry.label}`;
-                        const checkbox = document.getElementById(`checkbox-${mapId}`);
-                        const filterInput = document.getElementById(`filter-input-${mapId}`);
-                        const filter = checkbox.value === 'true' ? filterInput.value : '';
-                        geoviewLayer.applyViewFilter(layerConfig, filter);
-                      });
-                      layerButtons.appendChild(toggleUniqueValueFeature);
-                      if (mapId === 'LYR5') layerButtons.appendChild(document.createElement("p"));
-                    }
-                  } if (layerConfig.style[geometry].styleType === 'classBreaks') {
-                    const toggleClassBreakDefault = document.createElement("button");
-                    if (layerConfig.style[geometry].defaultVisible)
-                      toggleClassBreakDefault.innerText = `Hide ${layerConfig.style[geometry].defaultLabel}`;
-                    else
-                      toggleClassBreakDefault.innerText = `Show ${layerConfig.style[geometry].defaultLabel}`;
-                    toggleClassBreakDefault.addEventListener('click', function (e) {
-                      layerConfig.style[geometry].defaultVisible = !layerConfig.style[geometry].defaultVisible;
-                      if (layerConfig.style[geometry].defaultVisible)
-                        toggleClassBreakDefault.innerText = `Hide ${layerConfig.style[geometry].defaultLabel}`;
-                      else
-                        toggleClassBreakDefault.innerText = `Show ${layerConfig.style[geometry].defaultLabel}`;
-                      const checkbox = document.getElementById(`checkbox-${mapId}`);
-                      const filterInput = document.getElementById(`filter-input-${mapId}`);
-                      const filter = checkbox.value === 'true' ? filterInput.value : '';
-                      geoviewLayer.applyViewFilter(layerConfig, filter);
-                    });
-                    layerButtons.appendChild(toggleClassBreakDefault);
-
-                    for (let i = 0; i < layerConfig.style[geometry].classBreakStyleInfo.length; i++) {
-                      const toggleClassBreakFeature = document.createElement("button");
-                      if (layerConfig.style[geometry].classBreakStyleInfo[i].visible)
-                        toggleClassBreakFeature.innerText = `Hide ${layerConfig.style[geometry].classBreakStyleInfo[i].label}`;
-                      else
-                        toggleClassBreakFeature.innerText = `Show ${layerConfig.style[geometry].classBreakStyleInfo[i].label}`;
-                      toggleClassBreakFeature.addEventListener('click', function (e) {
-                        const classBreakStyleInfoEntry = layerConfig.style[geometry].classBreakStyleInfo[i];
-                        classBreakStyleInfoEntry.visible = !classBreakStyleInfoEntry.visible;
-                        if (classBreakStyleInfoEntry.visible)
-                          toggleClassBreakFeature.innerText = `Hide ${classBreakStyleInfoEntry.label}`;
-                        else
-                          toggleClassBreakFeature.innerText = `Show ${classBreakStyleInfoEntry.label}`;
-                        const checkbox = document.getElementById(`checkbox-${mapId}`);
-                        const filterInput = document.getElementById(`filter-input-${mapId}`);
-                        const filter = checkbox.value === 'true' ? filterInput.value : '';
-                        geoviewLayer.applyViewFilter(layerConfig, filter);
-                      });
-                      layerButtons.appendChild(toggleClassBreakFeature);
-                    }
-                  }
-                  if (geoviewLayer.getLayerFilter) {
-                    const layerFilterText = document.createElement("p");
-                    layerFilterText.innerText = `Extra filter: `;
-                    layerButtons.appendChild(layerFilterText);
-                    const layerFilterInput = document.createElement("input");
-                    layerFilterInput.id = `filter-input-${mapId}`;
-                    layerFilterInput.style.width = '50%';
-                    layerFilterText.appendChild(layerFilterInput);
-                    layerFilterInput.value = geoviewLayer.getLayerFilter(layerConfig) || '';
-                    const layerFilterButton = document.createElement("button");
-                    layerFilterButton.addEventListener('click', function (e) {
-                      const checkbox = document.getElementById(`checkbox-${mapId}`);
-                      if (checkbox.value === 'true')
-                        geoviewLayer.applyViewFilter(layerConfig, layerFilterInput.value);
-                      else {
-                        geoviewLayer.setLayerFilter(layerFilterInput.value, layerConfig);
-                        geoviewLayer.applyViewFilter(layerConfig);
+                if (layerConfig.style) {
+                  Object.keys(layerConfig.style).forEach((geometry) => {
+                    const geometryText = document.createElement("p");
+                    geometryText.innerText = `Geometry = ${geometry}`;
+                    geometryText.style.height = '15px';
+                    mapButtonsDiv.appendChild(geometryText);
+                    if (layerConfig.style[geometry].styleType === 'uniqueValue') {
+                      if (layerConfig.style[geometry].defaultSettings) {
+                        if (layerConfig.style[geometry].defaultVisible === 'always') {
+                          const alwaysDefaultLabel = document.createElement("label");
+                          alwaysDefaultLabel.innerText =  `Always show `;
+                          alwaysDefaultLabel.style.fontSize = '15px';
+                          alwaysDefaultLabel.style.height = '15px';
+                          mapButtonsDiv.appendChild(alwaysDefaultLabel);
+                          mapButtonsDiv.appendChild(legendStyle[geometry].defaultCanvas);
+                          const br = document.createElement("br");
+                          br.style.height = '1px';
+                          mapButtonsDiv.appendChild(br);
+                        } else {
+                          const toggleUniqueValueDefault = document.createElement("button");
+                          if (layerConfig.style[geometry].defaultVisible === 'yes')
+                            toggleUniqueValueDefault.innerText = `Hide ${layerConfig.style[geometry].defaultLabel}`;
+                          else if (layerConfig.style[geometry].defaultVisible === 'no')
+                            toggleUniqueValueDefault.innerText =  `Show ${layerConfig.style[geometry].defaultLabel}`;
+                          toggleUniqueValueDefault.addEventListener('click', function (e) {
+                            if (layerConfig.style[geometry].defaultVisible === 'yes') {
+                              layerConfig.style[geometry].defaultVisible = 'no';
+                              toggleUniqueValueDefault.innerText = `Show ${layerConfig.style[geometry].defaultLabel}`;
+                            } else if (layerConfig.style[geometry].defaultVisible === 'no') {
+                              layerConfig.style[geometry].defaultVisible = 'yes';
+                              toggleUniqueValueDefault.innerText = `Hide ${layerConfig.style[geometry].defaultLabel}`;
+                            }
+                            const checkbox = document.getElementById(`checkbox-${mapId}`);
+                            const filterInput = document.getElementById(`filter-input-${mapId}`);
+                            const filter = checkbox.value === 'true' ? filterInput.value : '';
+                            geoviewLayer.applyViewFilter(layerConfig, filter);
+                          });
+                          mapButtonsDiv.appendChild(toggleUniqueValueDefault);
+                          const br = document.createElement("br");
+                          br.style.height = '1px';
+                          mapButtonsDiv.appendChild(br);
+                        }
                       }
-                    });
-                    layerFilterButton.innerText = 'Apply';
-                    layerFilterText.appendChild(layerFilterButton);
+                      for (let i = 0; i < layerConfig.style[geometry].uniqueValueStyleInfo.length; i++) {
+                        if (layerConfig.style[geometry].uniqueValueStyleInfo[i].visible === 'always') {
+                          const alwaysEntry = document.createElement("label");
+                          alwaysEntry.innerText =  `Always show `;
+                          alwaysEntry.style.fontSize = '15px';
+                          mapButtonsDiv.appendChild(alwaysEntry);
+                          mapButtonsDiv.appendChild(legendStyle[geometry].arrayOfCanvas[i]);
 
-                    const checkboxInput = document.createElement("input");
-                    checkboxInput.type='checkbox';
-                    checkboxInput.value = 'false';
-                    checkboxInput.id = `checkbox-${mapId}`;
-                    checkboxInput.addEventListener('click', function (e) {
-                      checkboxInput.value =checkboxInput.value === 'true' ? 'false' : 'true';
-                      if (checkboxInput.value === 'true')
-                        geoviewLayer.applyViewFilter(layerConfig, layerFilterInput.value);
-                      else {
-                        geoviewLayer.setLayerFilter(layerFilterInput.value, layerConfig);
-                        geoviewLayer.applyViewFilter(layerConfig);
+                          const br = document.createElement("br");
+                          br.style.height = '1px';
+                          mapButtonsDiv.appendChild(br);
+                        } else {
+                          const toggleUniqueValueFeature = document.createElement("button");
+                          if (layerConfig.style[geometry].uniqueValueStyleInfo[i].visible === 'yes')
+                            toggleUniqueValueFeature.innerText = `Hide ${layerConfig.style[geometry].uniqueValueStyleInfo[i].label}`;
+                          else if (layerConfig.style[geometry].uniqueValueStyleInfo[i].visible === 'no')
+                            toggleUniqueValueFeature.innerText = `Show ${layerConfig.style[geometry].uniqueValueStyleInfo[i].label}`;
+                          toggleUniqueValueFeature.addEventListener('click', function (e) {
+                            const uniqueValueStyleInfoEntry = layerConfig.style[geometry].uniqueValueStyleInfo[i];
+                            if (uniqueValueStyleInfoEntry.visible === 'yes') {
+                              uniqueValueStyleInfoEntry.visible = 'no';
+                              toggleUniqueValueFeature.innerText = `Show ${uniqueValueStyleInfoEntry.label}`;
+                            } else if (uniqueValueStyleInfoEntry.visible === 'no') {
+                              uniqueValueStyleInfoEntry.visible = 'yes';
+                              toggleUniqueValueFeature.innerText = `Hide ${uniqueValueStyleInfoEntry.label}`;
+                            }
+                            const checkbox = document.getElementById(`checkbox-${mapId}`);
+                            const filterInput = document.getElementById(`filter-input-${mapId}`);
+                            const filter = checkbox.value === 'true' ? filterInput.value : '';
+                            geoviewLayer.applyViewFilter(layerConfig, filter);
+                          });
+                          mapButtonsDiv.appendChild(toggleUniqueValueFeature);
+                          mapButtonsDiv.appendChild(legendStyle[geometry].arrayOfCanvas[i]);
+
+                          const br = document.createElement("br");
+                          br.style.height = '1px';
+                          mapButtonsDiv.appendChild(br);
+                        }
                       }
-                    });
-                    layerButtons.appendChild(checkboxInput);
-                    const checkboxText = document.createElement("label");
-                    checkboxText.innerText = `apply only the extra filter`;
-                    layerButtons.appendChild(checkboxText);
-                  }
-                  if (mapId !== 'LYR5') layerButtons.appendChild(document.createElement("hr"));
-                });
-              }
+                    } else if (layerConfig.style[geometry].styleType === 'classBreaks') {
+                      if (layerConfig.style[geometry].defaultSettings) {
+                        if (layerConfig.style[geometry].defaultVisible === 'always') {
+                          const alwaysDefaultLabel = document.createElement("label");
+                          alwaysDefaultLabel.innerText =  `Always show `;
+                          alwaysDefaultLabel.style.fontSize = '15px';
+                          mapButtonsDiv.appendChild(alwaysDefaultLabel);
+                          mapButtonsDiv.appendChild(legendStyle[geometry].defaultCanvas);
+                          const br = document.createElement("br");
+                          br.style.height = '1px';
+                          mapButtonsDiv.appendChild(br);
+                        } else {
+                          const toggleClassBreakDefault = document.createElement("button");
+                          if (layerConfig.style[geometry].defaultVisible === 'yes')
+                            toggleClassBreakDefault.innerText = `Hide ${layerConfig.style[geometry].defaultLabel}`;
+                          else if (layerConfig.style[geometry].defaultVisible === 'no')
+                            toggleClassBreakDefault.innerText = `Show ${layerConfig.style[geometry].defaultLabel}`;
+                          toggleClassBreakDefault.addEventListener('click', function (e) {
+                          if (layerConfig.style[geometry].defaultVisible === 'yes') {
+                            layerConfig.style[geometry].defaultVisible = 'no';
+                            toggleClassBreakDefault.innerText = `Show ${layerConfig.style[geometry].defaultLabel}`;
+                          } else if (layerConfig.style[geometry].defaultVisible === 'no') {
+                            layerConfig.style[geometry].defaultVisible = 'yes';
+                            toggleClassBreakDefault.innerText = `Hide ${layerConfig.style[geometry].defaultLabel}`;
+                          }
+                            const checkbox = document.getElementById(`checkbox-${mapId}`);
+                            const filterInput = document.getElementById(`filter-input-${mapId}`);
+                            const filter = checkbox.value === 'true' ? filterInput.value : '';
+                            geoviewLayer.applyViewFilter(layerConfig, filter);
+                          });
+                          mapButtonsDiv.appendChild(toggleClassBreakDefault);
+                          const br = document.createElement("br");
+                          br.style.height = '1px';
+                          mapButtonsDiv.appendChild(br);
+                        }
+                      }
+                      for (let i = 0; i < layerConfig.style[geometry].classBreakStyleInfo.length; i++) {
+                        if (layerConfig.style[geometry].classBreakStyleInfo[i].visible === 'always') {
+                          const alwaysEntry = document.createElement("label");
+                          alwaysEntry.innerText =  `Always show `;
+                          alwaysEntry.style.fontSize = '15px';
+                          mapButtonsDiv.appendChild(alwaysEntry);
+                          mapButtonsDiv.appendChild(legendStyle[geometry].arrayOfCanvas[i]);
+
+                          const br = document.createElement("br");
+                          br.style.height = '1px';
+                          mapButtonsDiv.appendChild(br);
+                        } else {
+                          const toggleClassBreakFeature = document.createElement("button");
+                          if (layerConfig.style[geometry].classBreakStyleInfo[i].visible === 'yes')
+                            toggleClassBreakFeature.innerText = `Hide ${layerConfig.style[geometry].classBreakStyleInfo[i].label}`;
+                          else if (layerConfig.style[geometry].classBreakStyleInfo[i].visible === 'no')
+                            toggleClassBreakFeature.innerText = `Show ${layerConfig.style[geometry].classBreakStyleInfo[i].label}`;
+                          toggleClassBreakFeature.addEventListener('click', function (e) {
+                            const classBreakStyleInfoEntry = layerConfig.style[geometry].classBreakStyleInfo[i];
+                            if (classBreakStyleInfoEntry.visible === 'yes') {
+                              classBreakStyleInfoEntry.visible = 'no';
+                              toggleClassBreakFeature.innerText = `Show ${classBreakStyleInfoEntry.label}`;
+                            } else if (classBreakStyleInfoEntry.visible === 'no') {
+                              classBreakStyleInfoEntry.visible = 'yes';
+                              toggleClassBreakFeature.innerText = `Hide ${classBreakStyleInfoEntry.label}`;
+                            }
+                            const checkbox = document.getElementById(`checkbox-${mapId}`);
+                            const filterInput = document.getElementById(`filter-input-${mapId}`);
+                            const filter = checkbox.value === 'true' ? filterInput.value : '';
+                            geoviewLayer.applyViewFilter(layerConfig, filter);
+                          });
+                          mapButtonsDiv.appendChild(toggleClassBreakFeature);
+                          mapButtonsDiv.appendChild(legendStyle[geometry].arrayOfCanvas[i]);
+
+                          const br = document.createElement("br");
+                          br.style.height = '1px';
+                          mapButtonsDiv.appendChild(br);
+                        }
+                      }
+                    }
+                    if (geoviewLayer.getLayerFilter) {
+                      const layerFilterText = document.createElement("p");
+                      layerFilterText.innerText = `Extra filter: `;
+                      mapButtonsDiv.appendChild(layerFilterText);
+                      const layerFilterInput = document.createElement("input");
+                      layerFilterInput.id = `filter-input-${mapId}`;
+                      layerFilterInput.style.width = '50%';
+                      layerFilterText.appendChild(layerFilterInput);
+                      layerFilterInput.value = geoviewLayer.getLayerFilter(layerConfig) || '';
+                      const layerFilterButton = document.createElement("button");
+                      layerFilterButton.addEventListener('click', function (e) {
+                        const checkbox = document.getElementById(`checkbox-${mapId}`);
+                        if (checkbox.value === 'true')
+                          geoviewLayer.applyViewFilter(layerConfig, layerFilterInput.value);
+                        else {
+                          geoviewLayer.setLayerFilter(layerFilterInput.value, layerConfig);
+                          geoviewLayer.applyViewFilter(layerConfig);
+                        }
+                      });
+                      layerFilterButton.innerText = 'Apply';
+                      layerFilterText.appendChild(layerFilterButton);
+
+                      const checkboxInput = document.createElement("input");
+                      checkboxInput.type='checkbox';
+                      checkboxInput.value = 'false';
+                      checkboxInput.id = `checkbox-${mapId}`;
+                      checkboxInput.addEventListener('click', function (e) {
+                        checkboxInput.value =checkboxInput.value === 'true' ? 'false' : 'true';
+                        if (checkboxInput.value === 'true')
+                          geoviewLayer.applyViewFilter(layerConfig, layerFilterInput.value);
+                        else {
+                          geoviewLayer.setLayerFilter(layerFilterInput.value, layerConfig);
+                          geoviewLayer.applyViewFilter(layerConfig);
+                        }
+                      });
+                      mapButtonsDiv.appendChild(checkboxInput);
+                      const checkboxText = document.createElement("label");
+                      checkboxText.innerText = `apply only the extra filter`;
+                      mapButtonsDiv.appendChild(checkboxText);
+                    }
+                  });
+                }
+              });
             }
           });
         });

--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -234,8 +234,8 @@
           "description": "Label used if field/value association is not found."
         },
         "defaultVisible": {
-          "type": "boolean",
-          "description": "Flag used to show/hide features associated to the default label (default true)."
+          "enum": ["yes", "no", "always"],
+          "description": "Flag used to show/hide features associated to the default label (default: yes)."
         },
         "defaultSettings": {
           "$ref": "#/definitions/TypeKindOfVectorSettings",
@@ -263,8 +263,8 @@
             "type": "string"
           },
           "visible": {
-            "type": "boolean",
-            "description": "Flag used to show/hide features associated to the label (default true)."
+            "enum": ["yes", "no", "always"],
+            "description": "Flag used to show/hide features associated to the label (default: yes)."
           },
           "values": {
             "type": "array",
@@ -295,8 +295,8 @@
           "description": "Label used if field/value association is not found."
         },
         "defaultVisible": {
-          "type": "boolean",
-          "description": "Flag used to show/hide features associated to the default label (default true)."
+          "enum": ["yes", "no", "always"],
+          "description": "Flag used to show/hide features associated to the default label (default: yes)."
         },
         "defaultSettings": {
           "$ref": "#/definitions/TypeKindOfVectorSettings",
@@ -321,8 +321,8 @@
             "type": "string"
           },
           "visible": {
-            "type": "boolean",
-            "description": "Flag used to show/hide features associated to the label (default true)."
+            "enum": ["yes", "no", "always"],
+            "description": "Flag used to show/hide features associated to the label (default: yes)."
           },
           "minValue": {
             "type": "number"
@@ -793,11 +793,19 @@
           "type": "string",
           "description": "The id of the layer to display on the map."
         },
-        "layerName": {
+        "geocoreLayerName": {
           "$ref": "#/definitions/TypeLocalizedString",
           "description": "The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
         },
-        "source": { "$ref": "#/definitions/TypeSourceGeocoreConfig" }
+        "initialSettings": {
+          "$ref": "#/definitions/TypeLayerInitialSettings",
+          "description": "Initial settings to apply to the layer entry at creation time. Initial settings are inherited from the parent in the configuration tree."
+        },
+        "source": { "$ref": "#/definitions/TypeSourceGeocoreConfig" },
+        "listOfLayerEntryConfig": {
+          "$ref": "#/definitions/TypeListOfLayerEntryConfig",
+          "description": "The list of layer entry configurations to use from the GeoView layer group."
+        }
       },
       "required": ["layerId"]
     },
@@ -951,7 +959,7 @@
           "description": "The layer entries to use from the GeoView layer."
         }
       },
-      "required": ["geoviewLayerId", "geoviewLayerType", "listOfLayerEntryConfig"]
+      "required": ["geoviewLayerType", "listOfLayerEntryConfig"]
     },
 
     "TypeGeoviewLayerType": {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -391,10 +391,11 @@ export class WMS extends AbstractGeoViewRaster {
         return true;
       }
 
-      layerEntryConfig.layerName = {
-        en: layerFound.Title as string,
-        fr: layerFound.Title as string,
-      };
+      if (!layerEntryConfig.layerName)
+        layerEntryConfig.layerName = {
+          en: layerFound.Title as string,
+          fr: layerFound.Title as string,
+        };
 
       api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);
       return true;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -95,6 +95,9 @@ export const geoviewEntryIsEsriFeature = (
  */
 // ******************************************************************************************************************************
 export class EsriFeature extends AbstractGeoViewVector {
+  /** Layer metadata */
+  layerMetadata: Record<string, TypeJsonObject> = {};
+
   /** ***************************************************************************************************************************
    * Initialize layer.
    *
@@ -245,6 +248,7 @@ export class EsriFeature extends AbstractGeoViewVector {
             // layers must have a fields attribute except if it is an metadata layer group.
             if (!response.data.fields && !(layerEntryConfig as TypeLayerGroupEntryConfig).isMetadataLayerGroup)
               throw new Error(`Despite a return code of 200, an error was detected with this query (${queryUrl}?f=pjson)`);
+            this.layerMetadata[Layer.getLayerPath(layerEntryConfig)] = response.data;
             if (geoviewEntryIsEsriFeature(layerEntryConfig)) {
               if (!layerEntryConfig.style) {
                 const renderer = Cast<EsriBaseRenderer>(response.data.drawingInfo?.renderer);

--- a/packages/geoview-core/src/geo/layer/other/geocore.ts
+++ b/packages/geoview-core/src/geo/layer/other/geocore.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-param-reassign */
+import defaultsDeep from 'lodash/defaultsDeep';
 import { api } from '../../../app';
 import { catalogUrl } from '../../../core/utils/config/config';
 import {
@@ -5,6 +7,9 @@ import {
   TypeGeoviewLayerConfig,
   TypeGeocoreLayerEntryConfig,
   TypeListOfGeoviewLayerConfig,
+  TypeLocalizedString,
+  layerEntryIsGroupLayer,
+  TypeListOfLayerEntryConfig,
 } from '../../map/map-schema-types';
 import { CONST_LAYER_TYPES } from '../geoview-layers/abstract-geoview-layers';
 import { UUIDmapConfigReader } from '../../../core/utils/config/reader/uuid-config-reader';
@@ -77,15 +82,72 @@ export class GeoCore {
         promiseOfLayerConfigs.push(UUIDmapConfigReader.getGVlayersConfigFromUUID(this.mapId, requestUrl));
       });
       Promise.all(promiseOfLayerConfigs).then((listOfLayerCreated) => {
-        listOfLayerCreated.forEach((listeOfGeoviewLayerConfig) => {
+        listOfLayerCreated.forEach((listOfGeoviewLayerConfig, index) => {
+          listOfGeoviewLayerConfig.forEach((geoviewLayerConfig) => {
+            this.copyConfigSettingsOverGeocoreSettings(geocoreLayerConfig.listOfLayerEntryConfig[index], geoviewLayerConfig);
+          });
           this.configValidation.validateListOfGeoviewLayerConfig(
             api.map(this.mapId).mapFeaturesConfig.suportedLanguages,
-            listeOfGeoviewLayerConfig
+            listOfGeoviewLayerConfig
           );
         });
         resolve(listOfLayerCreated);
       });
     });
     return arrayOfListOfGeoviewLayerConfig;
+  }
+
+  /**
+   * Copy the config settings over the geocore values (config values have priority).
+   *
+   * @param {TypeGeocoreLayerEntryConfig} geocoreLayerEntryConfig The config file settings
+   * @param {TypeGeoviewLayerConfig} geoviewLayerConfig The settings returned by the geocore service
+   */
+  private copyConfigSettingsOverGeocoreSettings(
+    geocoreLayerEntryConfig: TypeGeocoreLayerEntryConfig,
+    geoviewLayerConfig: TypeGeoviewLayerConfig
+  ) {
+    if (geocoreLayerEntryConfig.geocoreLayerName)
+      geoviewLayerConfig.geoviewLayerName = {
+        ...geocoreLayerEntryConfig.geocoreLayerName,
+      } as TypeLocalizedString;
+
+    if (geocoreLayerEntryConfig.listOfLayerEntryConfig?.length) {
+      const defaultDeepFoundEntry = (
+        layerArrayFromConfig: TypeListOfLayerEntryConfig,
+        layerArrayFromService: TypeListOfLayerEntryConfig
+      ) => {
+        layerArrayFromService.forEach((layerEntryFromService, i, arrayFromService) => {
+          const entryFound = layerArrayFromConfig.find((layerEntryFromConfig) => {
+            if (layerEntryFromConfig.layerId === layerEntryFromService.layerId) {
+              if (layerEntryIsGroupLayer(layerEntryFromService)) {
+                if (layerEntryIsGroupLayer(layerEntryFromConfig)) {
+                  defaultDeepFoundEntry(layerEntryFromConfig.listOfLayerEntryConfig!, layerEntryFromService.listOfLayerEntryConfig);
+                } else
+                  throw new Error(`Geocore group id ${layerEntryFromService.layerId} should be defined as a group in the configuration`);
+              } else {
+                arrayFromService[i] = defaultsDeep(layerEntryFromConfig, layerEntryFromService);
+                // Force a found property to the layerEntryFromConfig object
+                Object.assign(layerEntryFromConfig, { found: true });
+              }
+              return true;
+            }
+            return false;
+          });
+          if (!entryFound) arrayFromService[i].layerId = '';
+        });
+        for (let i = layerArrayFromService.length - 1; i >= 0; i--)
+          if (!layerArrayFromService[i].layerId) layerArrayFromService.splice(i, 1);
+      };
+      defaultDeepFoundEntry(geocoreLayerEntryConfig.listOfLayerEntryConfig, geoviewLayerConfig.listOfLayerEntryConfig);
+      const validateConfig = (layerArrayFromConfig: TypeListOfLayerEntryConfig) => {
+        for (let i = 0; i < layerArrayFromConfig.length; i++) {
+          if (!('found' in layerArrayFromConfig[i]))
+            throw new Error(`Layer ${layerArrayFromConfig[i].layerId} from the configuration does not exist on the geocore service`);
+          if (layerEntryIsGroupLayer(layerArrayFromConfig[i])) validateConfig(layerArrayFromConfig[i].listOfLayerEntryConfig!);
+        }
+      };
+      validateConfig(geocoreLayerEntryConfig.listOfLayerEntryConfig);
+    }
   }
 }

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -366,8 +366,8 @@ export type TypeUniqueValueStyleInfo = {
   /** Label used by the style. */
   label: string;
   /** Values associated to the style. */
-  visible?: boolean;
-  /** Flag used to show/hide features associated to the label (default true). */
+  visible?: 'yes' | 'no' | 'always';
+  /** Flag used to show/hide features associated to the label (default: yes). */
   values: string[];
   /** options associated to the style. */
   settings: TypeKindOfVectorSettings;
@@ -400,8 +400,8 @@ export interface TypeUniqueValueStyleConfig extends TypeBaseStyleConfig {
   /** Label used if field/value association is not found. */
   defaultLabel?: string;
   /** Options used if field/value association is not found. */
-  defaultVisible?: boolean;
-  /** Flag used to show/hide features associated to the default label (default true). */
+  defaultVisible?: 'yes' | 'no' | 'always';
+  /** Flag used to show/hide features associated to the default label (default: yes). */
   defaultSettings?: TypeKindOfVectorSettings;
   /** Fields used by the style. */
   fields: string[];
@@ -416,8 +416,8 @@ export type TypeClassBreakStyleInfo = {
   /** Label used by the style. */
   label: string;
   /** Minimum values associated to the style. */
-  visible?: boolean;
-  /** Flag used to show/hide features associated to the label (default true). */
+  visible?: 'yes' | 'no' | 'always';
+  /** Flag used to show/hide features associated to the label (default: yes). */
   minValue: number | undefined | null;
   /** Maximum values associated to the style. */
   maxValue: number;
@@ -452,8 +452,8 @@ export interface TypeClassBreakStyleConfig extends TypeBaseStyleConfig {
   /** Label used if field/value association is not found. */
   defaultLabel?: string;
   /** Options used if field/value association is not found. */
-  defaultVisible?: boolean;
-  /** Flag used to show/hide features associated to the default label (default true). */
+  defaultVisible?: 'yes' | 'no' | 'always';
+  /** Flag used to show/hide features associated to the default label (default: yes). */
   defaultSettings?: TypeKindOfVectorSettings;
   /** Field used by the style. */
   field: string;
@@ -586,7 +586,7 @@ export type TypeBaseLayerEntryConfig = {
   initialSettings?: TypeLayerInitialSettings;
   /** Source settings to apply to the GeoView vector layer source at creation time. */
   source?: TypeBaseSourceVectorInitialConfig | TypeSourceImageInitialConfig | TypeSourceTileInitialConfig;
-  /** The listOfLayerEntryConfig attribute is used only on group entry and on GeoView layer configurations. */
+  /** The listOfLayerEntryConfig attribute is not used by child of TypeBaseLayerEntryConfig. */
   listOfLayerEntryConfig?: never;
 };
 
@@ -781,18 +781,21 @@ export type TypeGeocoreLayerEntryConfig = {
   gvLayer?: BaseLayer;
   /** Layer entry data type. */
   entryType?: 'geocore';
-  /** Basic information used to identify the GeoView layer. The GeoCore catalog uuid of the layer is stored in the layerId
-   * attribute. The id will have the language extension (id-'lang').
-   */
-  layerId: string;
+  /** The layerId is not used by geocore layers. */
+  layerId: never;
+  /** The display name of a geocore layer is in geocoreLayerName. */
+  layerName?: never;
   /** The display name of the layer (English/French). */
-  layerName?: TypeLocalizedString;
+  geocoreLayerName?: TypeLocalizedString;
   /** The access path to the geoCore endpoint (optional, this value should be embeded in the GeoView API). */
   source?: TypeSourceGeocoreConfig;
-  /** Attribute initialSettings is never used by GeoCore layer entry. */
-  initialSettings?: never;
-  /** The listOfLayerEntryConfig attribute is used only on group entry and on GeoView layer configurations. */
-  listOfLayerEntryConfig?: never;
+  /**
+   * Initial settings to apply to the GeoView layer entry at creation time. Initial settings are inherited from the parent in the
+   * configuration tree.
+   */
+  initialSettings?: TypeLayerInitialSettings;
+  /** The list of layer entry configurations to use from the Geocore layer. */
+  listOfLayerEntryConfig?: TypeListOfLayerEntryConfig;
 };
 
 /** ******************************************************************************************************************************

--- a/packages/geoview-core/src/geo/renderer/esri-renderer.ts
+++ b/packages/geoview-core/src/geo/renderer/esri-renderer.ts
@@ -446,7 +446,7 @@ function processUniqueValueRenderer(styleId: string, renderer: EsriUniqueValueRe
   const style: TypeStyleConfig = {};
   const styleType = 'uniqueValue';
   const defaultLabel = renderer.defaultLabel === null ? undefined : renderer.defaultLabel;
-  const defaultVisible = true;
+  const defaultVisible = 'yes';
   const defaultSettings = convertSymbol(renderer.defaultSymbol);
   const fields = [renderer.field1];
   if (renderer.field2) fields.push(renderer.field2);
@@ -459,7 +459,7 @@ function processUniqueValueRenderer(styleId: string, renderer: EsriUniqueValueRe
         settings.rotation = Math.PI / 2 - settings.rotation!;
       uniqueValueStyleInfo.push({
         label: symbolInfo.label,
-        visible: true,
+        visible: 'yes',
         values: symbolInfo.value.split(renderer.fieldDelimiter),
         settings,
       });
@@ -520,7 +520,7 @@ function processClassBreakRenderer(styleId: string, EsriRenderer: EsriClassBreak
   const styleType = 'classBreaks';
   const defaultLabel = EsriRenderer.defaultLabel === null ? undefined : EsriRenderer.defaultLabel;
   const defaultSettings = convertSymbol(EsriRenderer.defaultSymbol);
-  const defaultVisible = true;
+  const defaultVisible = 'yes';
   const { field } = EsriRenderer;
   const classBreakStyleInfo: TypeClassBreakStyleInfo[] = [];
   for (let i = 0; i < EsriRenderer.classBreakInfos.length; i++) {
@@ -530,7 +530,7 @@ function processClassBreakRenderer(styleId: string, EsriRenderer: EsriClassBreak
         settings.rotation = Math.PI / 2 - settings.rotation!;
       const geoviewClassBreakInfo: TypeClassBreakStyleInfo = {
         label: EsriRenderer.classBreakInfos[i].label,
-        visible: true,
+        visible: 'yes',
         minValue: EsriRenderer.classBreakInfos[i].classMinValue,
         maxValue: EsriRenderer.classBreakInfos[i].classMaxValue,
         settings,

--- a/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
@@ -409,6 +409,7 @@ export class GeoviewRenderer {
   getLegendStyles(styleConfig: TypeStyleConfig): Promise<TypeLayerStyle> {
     const promisedLayerStyle = new Promise<TypeLayerStyle>((resolve) => {
       const layerStyle: TypeLayerStyle = {};
+      if (!styleConfig) resolve(layerStyle);
 
       if (styleConfig.Point) {
         // ======================================================================================================================
@@ -1209,9 +1210,9 @@ export class GeoviewRenderer {
     if (isUniqueValueStyleConfig(styleSettings)) {
       const { defaultSettings, fields, uniqueValueStyleInfo } = styleSettings;
       const i = this.searchUniqueValueEntry(fields, uniqueValueStyleInfo, feature!);
-      if (i !== undefined && (legendFilterIsOff || uniqueValueStyleInfo[i].visible))
+      if (i !== undefined && (legendFilterIsOff || uniqueValueStyleInfo[i].visible !== 'no'))
         return this.processSimplePoint(uniqueValueStyleInfo[i].settings);
-      if (i === undefined && defaultSettings !== undefined && (legendFilterIsOff || styleSettings.defaultVisible))
+      if (i === undefined && defaultSettings !== undefined && (legendFilterIsOff || styleSettings.defaultVisible !== 'no'))
         return this.processSimplePoint(defaultSettings);
     }
     return undefined;
@@ -1239,9 +1240,9 @@ export class GeoviewRenderer {
     if (isUniqueValueStyleConfig(styleSettings)) {
       const { defaultSettings, fields, uniqueValueStyleInfo } = styleSettings;
       const i = this.searchUniqueValueEntry(fields, uniqueValueStyleInfo, feature!);
-      if (i !== undefined && (legendFilterIsOff || uniqueValueStyleInfo[i].visible))
+      if (i !== undefined && (legendFilterIsOff || uniqueValueStyleInfo[i].visible !== 'no'))
         return this.processSimpleLineString(uniqueValueStyleInfo[i].settings, feature);
-      if (i === undefined && defaultSettings !== undefined && (legendFilterIsOff || styleSettings.defaultVisible))
+      if (i === undefined && defaultSettings !== undefined && (legendFilterIsOff || styleSettings.defaultVisible !== 'no'))
         return this.processSimpleLineString(defaultSettings, feature);
     }
     return undefined;
@@ -1269,9 +1270,9 @@ export class GeoviewRenderer {
     if (isUniqueValueStyleConfig(styleSettings)) {
       const { defaultSettings, fields, uniqueValueStyleInfo } = styleSettings;
       const i = this.searchUniqueValueEntry(fields, uniqueValueStyleInfo, feature!);
-      if (i !== undefined && (legendFilterIsOff || uniqueValueStyleInfo[i].visible))
+      if (i !== undefined && (legendFilterIsOff || uniqueValueStyleInfo[i].visible !== 'no'))
         return this.processSimplePolygon(uniqueValueStyleInfo[i].settings, feature);
-      if (i === undefined && defaultSettings !== undefined && (legendFilterIsOff || styleSettings.defaultVisible))
+      if (i === undefined && defaultSettings !== undefined && (legendFilterIsOff || styleSettings.defaultVisible !== 'no'))
         return this.processSimplePolygon(defaultSettings, feature);
     }
     return undefined;
@@ -1326,8 +1327,10 @@ export class GeoviewRenderer {
     if (isClassBreakStyleConfig(styleSettings)) {
       const { defaultSettings, field, classBreakStyleInfo } = styleSettings;
       const i = this.searchClassBreakEntry(field, classBreakStyleInfo, feature!);
-      if (i !== undefined && classBreakStyleInfo[i].visible) return this.processSimplePoint(classBreakStyleInfo[i].settings);
-      if (defaultSettings !== undefined && styleSettings.defaultVisible && i === undefined) return this.processSimplePoint(defaultSettings);
+      if (i !== undefined && (legendFilterIsOff || classBreakStyleInfo[i].visible !== 'no'))
+        return this.processSimplePoint(classBreakStyleInfo[i].settings);
+      if (i === undefined && defaultSettings !== undefined && (legendFilterIsOff || styleSettings.defaultVisible !== 'no'))
+        return this.processSimplePoint(defaultSettings);
     }
     return undefined;
   }
@@ -1354,8 +1357,9 @@ export class GeoviewRenderer {
     if (isClassBreakStyleConfig(styleSettings)) {
       const { defaultSettings, field, classBreakStyleInfo } = styleSettings;
       const i = this.searchClassBreakEntry(field, classBreakStyleInfo, feature!);
-      if (i !== undefined && classBreakStyleInfo[i].visible) return this.processSimpleLineString(classBreakStyleInfo[i].settings, feature);
-      if (defaultSettings !== undefined && styleSettings.defaultVisible && i === undefined)
+      if (i !== undefined && (legendFilterIsOff || classBreakStyleInfo[i].visible !== 'no'))
+        return this.processSimpleLineString(classBreakStyleInfo[i].settings, feature);
+      if (i === undefined && defaultSettings !== undefined && (legendFilterIsOff || styleSettings.defaultVisible !== 'no'))
         return this.processSimpleLineString(defaultSettings, feature);
     }
     return undefined;
@@ -1383,8 +1387,9 @@ export class GeoviewRenderer {
     if (isClassBreakStyleConfig(styleSettings)) {
       const { defaultSettings, field, classBreakStyleInfo } = styleSettings;
       const i = this.searchClassBreakEntry(field, classBreakStyleInfo, feature!);
-      if (i !== undefined && classBreakStyleInfo[i].visible) return this.processSimplePolygon(classBreakStyleInfo[i].settings, feature);
-      if (defaultSettings !== undefined && styleSettings.defaultVisible && i === undefined)
+      if (i !== undefined && (legendFilterIsOff || classBreakStyleInfo[i].visible !== 'no'))
+        return this.processSimplePolygon(classBreakStyleInfo[i].settings, feature);
+      if (i === undefined && defaultSettings !== undefined && (legendFilterIsOff || styleSettings.defaultVisible !== 'no'))
         return this.processSimplePolygon(defaultSettings, feature);
     }
     return undefined;


### PR DESCRIPTION
# Description

The values that can be assigned to the visible flag of unique value and class break are now 'always', 'yes' and 'no'.
GeoCore layer names can now be specified in the layer configuration.
Esri layers now keep layer's metadata in the geoview layer object.
Unique value now verify the type of the fields (string / number) and adapt the filter accordingly

Fixes # 538 and 668

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?
Using the Layers template and verifying that the show/hide and always show behave as expexted.
Edit the config file many times.

# Checklist:

- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/878)
<!-- Reviewable:end -->
