### PR TITLE
add background to mini map button and tooltip

### DIFF
--- a/packages/geoview-core/src/core/components/overview-map/overview-map-toggle.tsx
+++ b/packages/geoview-core/src/core/components/overview-map/overview-map-toggle.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { OverviewMap as OLOverviewMap } from 'ol/control';
+import { useTranslation } from 'react-i18next';
 
 import makeStyles from '@mui/styles/makeStyles';
 
-import { ChevronLeftIcon } from '../../../ui';
+import { ChevronLeftIcon, Tooltip } from '../../../ui';
 
 const useStyles = makeStyles((theme) => ({
   toggleBtn: {
@@ -49,6 +50,7 @@ export function OverviewMapToggle(props: OverviewMapToggleProps): JSX.Element {
   const { overviewMap } = props;
 
   const [status, setStatus] = useState(true);
+  const { t } = useTranslation<string>();
 
   const divRef = useRef<HTMLDivElement>(null);
 
@@ -86,18 +88,20 @@ export function OverviewMapToggle(props: OverviewMapToggleProps): JSX.Element {
   }, []);
 
   return (
-    <div ref={divRef} className={`${classes.toggleBtnContainer}`}>
-      <div
-        className={`${classes.toggleBtn} ${!status ? classes.minimapOpen : classes.minimapClosed}`}
-        style={{
-          margin: 0,
-          padding: 0,
-          height: 'initial',
-          minWidth: 'initial',
-        }}
-      >
-        <ChevronLeftIcon />
+    <Tooltip title={t('mapctrl.overviewmap.toggle')}>
+      <div ref={divRef} className={`${classes.toggleBtnContainer}`}>
+        <div
+          className={`${classes.toggleBtn} ${!status ? classes.minimapOpen : classes.minimapClosed}`}
+          style={{
+            margin: 0,
+            padding: 0,
+            height: 'initial',
+            minWidth: 'initial',
+          }}
+        >
+          <ChevronLeftIcon />
+        </div>
       </div>
-    </div>
+    </Tooltip>
   );
 }

--- a/packages/geoview-core/src/core/components/overview-map/overview-map.tsx
+++ b/packages/geoview-core/src/core/components/overview-map/overview-map.tsx
@@ -67,12 +67,9 @@ const useStyles = makeStyles((theme) => ({
       right: 0,
       left: 'auto !important',
       bottom: 'auto !important',
-      backgroundColor: 'transparent',
-      '&:hover': {
-        backgroundColor: 'transparent',
-      },
+      backgroundColor: '#cccccc',
       '&:focus': {
-        backgroundColor: 'transparent',
+        outline: 'none',
       },
     },
     '&::before': {
@@ -81,15 +78,12 @@ const useStyles = makeStyles((theme) => ({
       position: 'absolute',
       width: 0,
       height: 0,
-      borderTop: '28px solid rgba(0, 0, 0, 0.2)',
-      borderLeft: '28px solid rgba(0, 0, 0, 0.2)',
       borderRadius: 2,
       zIndex: theme.zIndex.appBar,
       right: 0,
       top: 0,
     },
     '& .ol-overviewmap-box': {
-      border: '1px solid black',
       backgroundColor: 'rgba(0, 0, 0, 0.2)',
     },
     '& .ol-viewport': {
@@ -229,6 +223,7 @@ export function OverviewMap(): JSX.Element {
       label: toggleButton,
       collapsed: false,
       rotateWithView: true,
+      tipLabel: '',
     });
 
     map.addControl(overviewMapControl);


### PR DESCRIPTION
# Description

Add solid background and tooltip to minimap toggle button

Fixes # (847)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
![image](https://user-images.githubusercontent.com/7388956/217322848-34b5312a-dcd9-4f44-9a89-f3649c9ac810.png)
![image](https://user-images.githubusercontent.com/7388956/217322908-11e438e2-299e-41d4-941f-d67b354c1307.png)


# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/883)
<!-- Reviewable:end -->
