### PR TITLE
fix(demo): default config url and switch projection for layers package

### DIFF
--- a/packages/geoview-core/public/templates/default-config.html
+++ b/packages/geoview-core/public/templates/default-config.html
@@ -13,6 +13,23 @@
     <link href="https://fonts.googleapis.com/css?family=Roboto|Montserrat:200,300,400,900|Merriweather" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" href="css/style.css" />
+
+    <script>
+      // add url params
+      if (document.location.search.length === 0)
+        // reload page with new params
+        document.location.search =
+          '?' +
+          'p=3857&' +
+          'z=4&' +
+          'c=-100,40&' +
+          'l=en&' +
+          't=dark&' +
+          'b={basemapId:transport,shaded:false,labeled:true}&' +
+          'i=dynamic&' +
+          'cc=overview-map&' +
+          'keys=12acd145-626a-49eb-b850-0a59c9bc7506,ccc75c12-5acc-4a6a-959f-ef6f621147b9';
+    </script>
   </head>
 
   <body>
@@ -207,7 +224,7 @@
           'map': {
             'interaction': 'dynamic',
             'viewSettings': {
-              'zoom': 4,
+              'zoom': 10,
               'center': [-100, 60],
               'projection': 3978
             },
@@ -218,7 +235,7 @@
             },
             'listOfGeoviewLayerConfig': []
           },
-          'components': ['overview-map', 'nav-bar', 'footer-bar'],
+          'components': ['app-bar', 'overview-map', 'nav-bar', 'footer-bar'],
           'corePackages': [],
           'theme': 'dark',
           'suportedLanguages': ['en']

--- a/packages/geoview-core/public/templates/package-layers-panel.html
+++ b/packages/geoview-core/public/templates/package-layers-panel.html
@@ -45,32 +45,14 @@
       <h4 id="HUC1">1. Default Configuration</h4>
       <a class="ref-link" href="#top">Top</a>
     </div>
-    <div
-      id="mapWM"
-      class="llwp-map"
-      data-lang="en"
-      data-config="{
-          'map': {
-            'interaction': 'dynamic',
-            'viewSettings': {
-              'zoom': 4,
-              'center': [-100, 60],
-              'projection': 3857
-            },
-            'basemapOptions': {
-              'basemapId': 'transport',
-              'shaded': true,
-              'labeled': true
-            },
-            'listOfGeoviewLayerConfig': [
-            ]
-          },
-          'theme': 'dark',
-          'components': ['app-bar', 'footer-bar'],
-          'corePackages': ['layers-panel'],
-          'suportedLanguages': ['en']
-        }"
-    ></div>
+
+    <select name="projections" id="projections">
+      <option value="3857">Web Mercator (3857)</option>
+      <option value="3978">LCC (3978)</option>
+    </select>
+    <button type="button" onclick="reloadMap()">Set Projection</button>
+
+    <div id="mapWM" class="llwp-map" data-lang="en"></div>
     <h4>Add Layer Examples</h4>
     <div style="font-size: smaller">
       <div>
@@ -132,13 +114,58 @@
     <pre id="mapWMCS" class="panel"></pre>
     <script src="codedoc.js"></script>
     <script>
+      function reloadMap() {
+        cgpv.api.map('mapWM').loadMapConfig(`{
+          'map': {
+            'interaction': 'dynamic',
+            'viewSettings': {
+              'zoom': 4,
+              'center': [-100, 60],
+              'projection': ${Number(document.getElementById('projections').value)}
+            },
+            'basemapOptions': {
+              'basemapId': 'transport',
+              'shaded': true,
+              'labeled': true
+            },
+            'listOfGeoviewLayerConfig': [
+            ]
+          },
+          'theme': 'dark',
+          'components': ['app-bar', 'footer-bar'],
+          'corePackages': ['layers-panel', 'details-panel'],
+          'suportedLanguages': ['en']
+        }`);
+      }
       // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
       cgpv.init(function () {
         console.log('api is ready');
 
+        cgpv.api.map('mapWM').loadMapConfig(`{
+          'map': {
+            'interaction': 'dynamic',
+            'viewSettings': {
+              'zoom': 4,
+              'center': [-100, 60],
+              'projection': 3857
+            },
+            'basemapOptions': {
+              'basemapId': 'transport',
+              'shaded': true,
+              'labeled': true
+            },
+            'listOfGeoviewLayerConfig': [
+            ]
+          },
+          'theme': 'dark',
+          'components': ['app-bar', 'footer-bar'],
+          'corePackages': ['layers-panel', 'details-panel'],
+          'suportedLanguages': ['en']
+        }`);
+
         //create snippets
         createConfigSnippet();
-        // createCodeSnippet();
+        createCodeSnippet();
       });
     </script>
   </body>

--- a/packages/geoview-core/src/app.tsx
+++ b/packages/geoview-core/src/app.tsx
@@ -29,39 +29,41 @@ export const api = new API();
 // TODO look for a better place to put this when working on issue #8
 
 // listen to map reload event
-// TODO: Fix: because handler name is not know at registration, never trigger. Plus if we put default name, it triggers all the time.
-// break map 7 load default config
-api.event.on(EVENT_NAMES.MAP.EVENT_MAP_RELOAD, (payload) => {
-  if (payloadIsAmapFeaturesConfig(payload)) {
-    if (payload.mapFeaturesConfig && payload.mapFeaturesConfig.mapId) {
-      // unsubscribe from all events registered on this map
-      api.event.offAll(payload.mapFeaturesConfig.mapId);
+api.event.on(
+  EVENT_NAMES.MAP.EVENT_MAP_RELOAD,
+  (payload) => {
+    if (payloadIsAmapFeaturesConfig(payload)) {
+      if (payload.mapFeaturesConfig && payload.mapFeaturesConfig.mapId) {
+        // unsubscribe from all events registered on this map
+        api.event.offAll(payload.mapFeaturesConfig.mapId);
 
-      // unload all loaded plugins on the map
-      api.plugin.removePlugins(payload.mapFeaturesConfig.mapId);
+        // unload all loaded plugins on the map
+        api.plugin.removePlugins(payload.mapFeaturesConfig.mapId);
 
-      // get the map container
-      const map = document.getElementById(payload.mapFeaturesConfig.mapId);
+        // get the map container
+        const map = document.getElementById(payload.mapFeaturesConfig.mapId);
 
-      if (map) {
-        // remove the dom element (remove rendered map)
-        ReactDOM.unmountComponentAtNode(map);
+        if (map) {
+          // remove the dom element (remove rendered map)
+          ReactDOM.unmountComponentAtNode(map);
 
-        // delete the map instance from the maps array
-        delete api.maps[payload.mapFeaturesConfig.mapId];
+          // delete the map instance from the maps array
+          delete api.maps[payload.mapFeaturesConfig.mapId];
 
-        // delete plugins that were loaded on the map
-        delete api.plugin.plugins[payload.mapFeaturesConfig.mapId];
+          // delete plugins that were loaded on the map
+          delete api.plugin.plugins[payload.mapFeaturesConfig.mapId];
 
-        // set plugin's loaded to false
-        api.plugin.pluginsLoaded = false;
+          // set plugin's loaded to false
+          api.plugin.pluginsLoaded = false;
 
-        // re-render map with updated config keeping previous values if unchanged
-        ReactDOM.render(<AppStart mapFeaturesConfig={payload.mapFeaturesConfig} />, map);
+          // re-render map with updated config keeping previous values if unchanged
+          ReactDOM.render(<AppStart mapFeaturesConfig={payload.mapFeaturesConfig} />, map);
+        }
       }
     }
-  }
-});
+  },
+  'all'
+);
 
 /**
  * Initialize the cgpv and render it to root element

--- a/packages/geoview-layers-panel/src/panel-content.tsx
+++ b/packages/geoview-layers-panel/src/panel-content.tsx
@@ -100,6 +100,7 @@ function PanelContent(props: TypePanelContentProps): JSX.Element {
     if (Object.keys(api.map(mapId).layer.geoviewLayers).includes(addGeoviewLayerId)) {
       setMapLayers((orderedLayers) => [addGeoviewLayerId, ...orderedLayers]);
     } else {
+      // eslint-disable-next-line no-console
       console.error('geoviewLayerId is not in the layers list');
     }
   };
@@ -109,7 +110,7 @@ function PanelContent(props: TypePanelContentProps): JSX.Element {
   };
 
   useEffect(() => {
-    setMapLayers(Object.keys(api.map(mapId!).layer.geoviewLayers));
+    if (api.map(mapId!).layer !== undefined) setMapLayers(Object.keys(api.map(mapId!).layer.geoviewLayers));
     api.event.on(
       api.eventNames.LAYER.EVENT_REMOVE_LAYER,
       (payload) => {


### PR DESCRIPTION
closes #856

# Description

Re enable the EVENT EVENT_MAP_RELOAD with the all handler name to allow the map to be reloaded. This is use to switch projection in layers-package demo file. At the same repair the load by url in default config demo page.

Fixes # (856)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run package-layers-panel.html and switch projection
Run default-config.html and look at map 5

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/888)
<!-- Reviewable:end -->
