### PR TITLE
870-Implement_WMS_style_filtering

### DIFF
--- a/packages/geoview-core/public/configs/my-config.json
+++ b/packages/geoview-core/public/configs/my-config.json
@@ -45,8 +45,8 @@
           "fr": "GeoJSON Line"
         },
         "metadataAccessPath": {
-          "en": "./geojson/",
-          "fr": "./geojson/"
+          "en": "./geojson/metadata.json",
+          "fr": "./geojson/metadata.json"
         },
         "geoviewLayerType": "GeoJSON",
         "listOfLayerEntryConfig": [{ "layerId": "points.json" }, { "layerId": "lines.json" }, { "layerId": "polygons.json" }]

--- a/packages/geoview-core/public/templates/codedoc.js
+++ b/packages/geoview-core/public/templates/codedoc.js
@@ -42,7 +42,7 @@ function createConfigSnippet() {
       }
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.log('Error trapped');
+      console.log('Error trapped in createConfigSnippet');
     }
   }
 

--- a/packages/geoview-core/public/templates/layers.html
+++ b/packages/geoview-core/public/templates/layers.html
@@ -896,16 +896,22 @@
               {
                 'geoviewLayerType': 'geoCore',
                 'listOfLayerEntryConfig': [
+                  /*===========================================================================
+                  Temporarilly deactivate this entry because the service has a legend problem
                   {
                     'layerId': '0fe65119-e96e-4a57-8bfe-9d9245fba06b',
                     'geocoreLayerName': { 'en': 'HRDEM Mosaic Hillshade' },
                     'listOfLayerEntryConfig': [
                       {
                         'layerId': 'dsm-hillshade',
-                        'layerName': { 'en': 'Map' }
+                        'layerName': { 'en': 'Map' },
+                        'source': {
+                          'style': 'hillshade'
+                        }
                       }
                     ]
                   },
+                  /*===========================================================================*/
                   {
                     'layerId': 'ccc75c12-5acc-4a6a-959f-ef6f621147b9',
                     'geocoreLayerName': { 'en': 'Commemorative Map' },
@@ -1112,13 +1118,12 @@
 
     <script src="codedoc.js"></script>
     <script>
-      // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
-      cgpv.init(function (mapId) {
-        console.log(`api is ready for ${mapId}`);
-
-      if (['LYR3', 'LYR4', 'LYR5', 'LYR6', 'LYR7', 'LYR8', 'LYR9'].includes(mapId)) {
+      const createTableOfFilter = (mapId) => {
         var mapButtonsDiv = document.getElementsByClassName(`layer${mapId.slice(3)}-buttons-div`)[0];
+        var oldTable = document.getElementById(`layer${mapId.slice(3)}-buttons-table`);
+        if (oldTable) oldTable.remove();
         var tableElement = document.createElement("table");
+        tableElement.id = `layer${mapId.slice(3)}-buttons-table`;
         tableElement.style.width = '100%';
         tableElement.border = '1px solid black';
         mapButtonsDiv.appendChild(tableElement);
@@ -1361,6 +1366,13 @@
           });
         });
       }
+    </script>
+    <script>
+      // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
+      cgpv.init(function (mapId) {
+        console.log(`api is ready for ${mapId}`);
+
+      if (['LYR3', 'LYR4', 'LYR5', 'LYR6', 'LYR7', 'LYR8', 'LYR9'].includes(mapId)) createTableOfFilter(mapId);
 
         if (mapId === 'allMaps') {
           //create snippets
@@ -1379,13 +1391,14 @@
           {
             geoviewLayerId: 'geoJsonSample',
             geoviewLayerName: {
-              en: 'geojson sample',
-              fr: 'exemple geojson',
+              en: 'Historical Flood',
+              fr: 'Inondation Historique',
             },
             geoviewLayerType: 'GeoJSON',
             listOfLayerEntryConfig: [
               {
                 layerId: 'historical_flood_0.geojson',
+                layerName: { en: 'Map', fr: 'Carte' },
                 source: {
                   dataAccessPath: {
                     en: './geojson/',
@@ -1394,8 +1407,8 @@
                   featureInfo: {
                     queryable: true,
                     nameField: { en: 'comment_en', fr: 'comment_fr' },
-                    outfields: { en: 'comment_en,death_en_1,end_date', fr: 'comment_fr,death_fr_1,end_date' },
-                    aliasFields: { en: 'comment_en,death_en_1,end_date', fr: 'comment_fr,death_fr_1,end_date' },
+                    outfields: { en: 'comment_en,death_en_1,end_date,death_en_1', fr: 'comment_fr,death_fr_1,end_date,death_en_1' },
+                    aliasFields: { en: 'comment_en,death_en_1,end_date,death_en_1', fr: 'comment_fr,death_fr_1,end_date,death_en_1' },
                   },
                 },
               },
@@ -1404,6 +1417,15 @@
           ['en', 'fr']
         );
         document.getElementById('new-layer-id-label').innerText = layerID;
+        cgpv.api.event.once(
+          cgpv.api.eventNames.LAYER.EVENT_LAYER_ADDED,
+            (payload) => {
+              createTableOfFilter('LYR5');
+            },
+            'LYR5',
+            'geoJsonSample'
+          );
+
       });
 
       // find the button element by ID
@@ -1415,6 +1437,8 @@
         const layerPath = document.getElementById('new-layer-id-label').innerText;
         if (layerPath) cgpv.api.map('LYR5').layer.removeLayersUsingPath(layerPath);
         document.getElementById('new-layer-id-label').innerText = '';
+        createTableOfFilter('LYR5');
+
       });
 
       // WMS ======================================================================================================================

--- a/packages/geoview-core/public/templates/test.html
+++ b/packages/geoview-core/public/templates/test.html
@@ -35,23 +35,143 @@
         'listOfGeoviewLayerConfig': [
           {
             'geoviewLayerId': 'wmsLYR1-Root',
-            'geoviewLayerName': { 'en': '900A' },
-            'metadataAccessPath': { 'en': 'https://services.arcgis.com/V6ZHFr6zdgNZuVG0/ArcGIS/rest/services/U2/FeatureServer/' },
-            'geoviewLayerType': 'esriFeature',
-            'listOfLayerEntryConfig': [
-              {
-                'layerId': '0'
-              }
-            ]
-          },
-          {
-            'geoviewLayerId': 'wmsLYR1-aerial',
-            'geoviewLayerName': { 'en': 'aerial' },
-            'metadataAccessPath': { 'en': 'https://datacube.services.geo.ca/web/aerial.xml' },
+            'geoviewLayerName': { 'en': 'QGis Test' },
+            'metadataAccessPath': { 'en': 'https://qgis-stage.services.geo.ca/dev/nrcan/landcover_2010_15_20_en' },
             'geoviewLayerType': 'ogcWms',
             'listOfLayerEntryConfig': [
               {
-                'layerId': 'regina'
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=1',
+                'source': {
+                  'style': '1',
+                  'serverType': 'qgis'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=2',
+                'source': {
+                  'style': '2'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=3',
+                'source': {
+                  'style': '3'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=4',
+                'source': {
+                  'style': '4'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=5',
+                'source': {
+                  'style': '5'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=6',
+                'source': {
+                  'style': '6'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=7',
+                'source': {
+                  'style': '7'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=8',
+                'source': {
+                  'style': '8'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=9',
+                'source': {
+                  'style': '9'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=10',
+                'source': {
+                  'style': '10'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=11',
+                'source': {
+                  'style': '11'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=12',
+                'source': {
+                  'style': '12'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=13',
+                'source': {
+                  'style': '13'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=14',
+                'source': {
+                  'style': '14'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=15',
+                'source': {
+                  'style': '15'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=16',
+                'source': {
+                  'style': '16'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=17',
+                'source': {
+                  'style': '17'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=18',
+                'source': {
+                  'style': '18'
+                }
+              },
+              {
+                'layerId': 'landcover_2015_19classes',
+                'layerPathEnding': 'style=19',
+                'source': {
+                  'style': '19'
+                }
               }
             ]
           }
@@ -64,9 +184,6 @@
     }"
     ></div>
     <button class="Get-Legend">Get Legend</button>
-    <button class="Show-Bounds-wms">Show Bounds</button>
-    <button class="Show-MultiPolygons">Find multi-polygons</button>
-    <button class="Show-MultiPoints">Find multi-points</button>
     <div id="legend-table-div"></div>
     <button type="button" class="collapsible">Get Feature Info</button>
     <pre style="height: 20pc; overflow-y: scroll" id="wmsResultSetId" class="panel">Click on feature on the map</pre>
@@ -76,34 +193,13 @@
     <hr />
     <script src="codedoc.js"></script>
     <script>
-      const showBoundsFunction = () => {
-        cgpv.api.map('LYR1').layer.vector.deleteGeometryGroup();
-        var allBounds;
-        Object.keys(cgpv.api.map('LYR1').layer.geoviewLayers).forEach((geoviewLayerId) => {
-          Object.keys(cgpv.api.map('LYR1').layer.registeredLayers).forEach((layerPath) => {
-            if (layerPath.startsWith(geoviewLayerId)) {
-              const bbox = cgpv.api.map('LYR1').layer.geoviewLayers[geoviewLayerId].calculateBounds(layerPath, 4326);
-              addBoundsPolygon(bbox, 4326, 4326);
-              if (!allBounds) allBounds = bbox;
-              else
-                allBounds = [
-                  Math.min(allBounds[0], bbox[0]),
-                  Math.min(allBounds[1], bbox[1]),
-                  Math.max(allBounds[2], bbox[2]),
-                  Math.max(allBounds[3], bbox[3]),
-                ];
-            }
-          });
-        });
-        cgpv.api.map('LYR1').fitBounds(allBounds, 4326);
-      };
       // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
       cgpv.init(function () {
         console.log('api is ready');
         //create snippets
         createCodeSnippet();
         createConfigSnippet();
-        showBoundsFunction();
+        // showBoundsFunction();
       });
       // WMS ======================================================================================================================
       const featureInfoWmsLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR1', 'wmsResultSetId');
@@ -132,101 +228,6 @@
       addGeoJsonLegendButton.addEventListener('click', function (e) {
         cgpv.api.event.emit({ handlerName: 'LYR1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'wmsLegendsId');
       });
-
-      var showBoundsButton = document.getElementsByClassName('Show-Bounds-wms')[0];
-      showBoundsButton.addEventListener('click', function (e) {
-        showBoundsFunction();
-      });
-
-      // WFS ======================================================================================================================
-      const featureInfoWfsLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR6', 'wfsResultSetId');
-      cgpv.api.event.on(
-        cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-        (payload) => {
-          const { layerSetId, resultSets } = payload;
-          document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
-        },
-        'LYR6',
-        'wfsResultSetId'
-      );
-
-      const LegendsWfsLayerSet = cgpv.api.createLegendsLayerSet('LYR6', 'wfsLegendsId');
-      cgpv.api.event.on(
-        cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
-        (payload) => {
-          const { resultSets } = payload;
-          displayLegend('wfsLegendsId', resultSets);
-        },
-        'LYR6',
-        'wfsLegendsId'
-      );
-
-      var addGeoJsonLegendButton = document.getElementsByClassName('Get-wfs-Legend')[0];
-      addGeoJsonLegendButton.addEventListener('click', function (e) {
-        cgpv.api.event.emit({ handlerName: 'LYR6', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'wfsLegendsId');
-      });
-
-      var showMultiPoints = document.getElementsByClassName('Show-MultiPoints')[0];
-      showMultiPoints.addEventListener('click', function (e) {
-        cgpv.api.map('LYR1').layer.vector.deleteGeometryGroup();
-        cycleThroughAllMultiPoints('LYR1');
-      });
-
-      // ==========================================================================================================================
-      function addBoundsPolygon(bbox, source, destination) {
-        const newBbox = cgpv.api.map('LYR1').transformAndDensifyExtent(bbox, `EPSG:${source}`, `EPSG:${destination}`);
-
-        cgpv.api.map('LYR1').layer.vector.setActiveGeometryGroup();
-
-        const polygon = cgpv.api.map('LYR1').layer.vector.addPolygon([newBbox], {
-          style: {
-            strokeColor: '#000',
-            strokeWidth: 5,
-            strokeOpacity: 0.8,
-          },
-        });
-      }
-
-      // ==========================================================================================================================
-      let i = 0;
-      let polygons = [];
-      function cycleThroughAllMultiPolygons(map) {
-        if (polygons.length === 0) {
-          cgpv.api
-            .map(map)
-            .layer.registeredLayers['LYR1-MultiPolygon/9'].gvLayer.getSource()
-            .forEachFeature((feature) => {
-              if (feature.getGeometry()?.getType() === 'MultiPolygon') polygons.push(feature);
-            });
-        }
-        if (i === polygons.length) i = 0;
-        if (polygons.length) {
-          const extent = polygons[i++].getGeometry()?.getExtent();
-          addBoundsPolygon(extent, cgpv.api.map('LYR1').currentProjection, 4326);
-          cgpv.api.map(map).fitBounds(extent);
-        }
-      }
-
-      // ==========================================================================================================================
-      let j = 0;
-      let points = [];
-      function cycleThroughAllMultiPoints(map) {
-        if (points.length === 0) {
-          cgpv.api
-            .map(map)
-            .layer.registeredLayers['LYR1-MultiPoint/0'].gvLayer.getSource()
-            .forEachFeature((feature) => {
-              if (feature.getGeometry()?.getType() === 'MultiPoint' && feature.getGeometry()?.flatCoordinates.length !== 2)
-                points.push(feature);
-            });
-        }
-        if (j === points.length) j = 0;
-        if (points.length) {
-          const extent = points[j++].getGeometry()?.getExtent();
-          addBoundsPolygon(extent, cgpv.api.map('LYR1').currentProjection, 4326);
-          cgpv.api.map(map).fitBounds(extent);
-        }
-      }
 
       // ==========================================================================================================================
       function displayLegend(layerSetId, resultSets) {
@@ -261,10 +262,21 @@
               table.appendChild(tableRow1);
               addHeader('Layer Path', tableRow1);
               addHeader('Symbology', tableRow1);
+              addHeader('Action', tableRow1);
             }
             const tableRow = document.createElement('tr');
             addData(resultSets[layerPath].layerPath, tableRow);
             addData(resultSets[layerPath].legend, tableRow);
+            const showHideButton = document.createElement('button');
+            const visibilityFlag = true;
+            showHideButton.innerText = 'Hide';
+            showHideButton.addEventListener('click', function (e) {
+              const visibilityFlag = !cgpv.api.maps.LYR1.layer.geoviewLayers['wmsLYR1-Root'].getVisible(layerPath);
+              if (visibilityFlag) showHideButton.innerText = 'Hide';
+              else showHideButton.innerText = 'Show';
+              cgpv.api.maps.LYR1.layer.geoviewLayers['wmsLYR1-Root'].setVisible(visibilityFlag, layerPath);
+            });
+            addData(showHideButton, tableRow);
             table.appendChild(tableRow);
           } else {
             const addRow = (layerPath, label, canvas) => {

--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -615,6 +615,10 @@
       "type": "object",
       "properties": {
         "entryType": { "enum": ["vectorHeatmap"] },
+        "layerPathEnding": {
+          "type": "string",
+          "description": "The ending element of the layer configuration path."
+        },
         "layerId": {
           "type": "string",
           "description": "The id of the layer to display on the map."
@@ -659,6 +663,10 @@
       "type": "object",
       "properties": {
         "entryType": { "enum": ["vector"] },
+        "layerPathEnding": {
+          "type": "string",
+          "description": "The ending element of the layer configuration path."
+        },
         "layerId": {
           "type": "string",
           "description": "The id of the layer to display on the map."
@@ -687,6 +695,10 @@
       "description": "Layer sources providing vector data divided into a tile grid.",
       "properties": {
         "entryType": { "enum": ["vectorTile"] },
+        "layerPathEnding": {
+          "type": "string",
+          "description": "The ending element of the layer configuration path."
+        },
         "layerId": {
           "type": "string",
           "description": "The id of the layer to display on the map."
@@ -739,6 +751,10 @@
       "type": "object",
       "properties": {
         "entryType": { "enum": ["raster"] },
+        "layerPathEnding": {
+          "type": "string",
+          "description": "The ending element of the layer configuration path."
+        },
         "layerId": {
           "type": "string",
           "description": "The id of the layer to display on the map."
@@ -766,6 +782,10 @@
       "type": "object",
       "properties": {
         "entryType": { "enum": ["raster"] },
+        "layerPathEnding": {
+          "type": "string",
+          "description": "The ending element of the layer configuration path."
+        },
         "layerId": {
           "type": "string",
           "description": "The id of the layer to display on the map."

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -27,6 +27,7 @@ import {
   layerEntryIsGroupLayer,
   TypeLayerGroupEntryConfig,
   TypeFeatureInfoLayerConfig,
+  TypeSourceImageInitialConfig,
 } from '../../../map/map-schema-types';
 import { TypeFeatureInfoEntry, TypeArrayOfFeatureInfoEntries } from '../../../../api/events/payloads/get-feature-info-payload';
 import { getLocalizedValue, xmlToJson } from '../../../../core/utils/utilities';
@@ -202,6 +203,9 @@ export class WMS extends AbstractGeoViewRaster {
           this.metadata = parser.read(capabilitiesString);
           if (this.metadata) {
             this.processMetadataInheritance();
+            const metadataAccessPath = this.metadata.Capability.Request.GetMap.DCPType[0].HTTP.Get.OnlineResource as string;
+            this.metadataAccessPath.en = metadataAccessPath;
+            this.metadataAccessPath.fr = metadataAccessPath;
             const dataAccessPath = this.metadata.Capability.Request.GetMap.DCPType[0].HTTP.Get.OnlineResource as string;
             const setDataAccessPath = (listOfLayerEntryConfig: TypeListOfLayerEntryConfig) => {
               listOfLayerEntryConfig.forEach((layerEntryConfig) => {
@@ -473,7 +477,7 @@ export class WMS extends AbstractGeoViewRaster {
         const dataAccessPath = getLocalizedValue(layerEntryConfig.source.dataAccessPath!, this.mapId)!;
         const sourceOptions: SourceOptions = {
           url: dataAccessPath.endsWith('?') ? dataAccessPath : `${dataAccessPath}?`,
-          params: { LAYERS: layerEntryConfig.layerId },
+          params: { LAYERS: layerEntryConfig.layerId, STYLES: layerEntryConfig.source?.style ? layerEntryConfig.source.style : '' },
         };
         sourceOptions.attributions = this.attributions;
         sourceOptions.serverType = layerEntryConfig.source.serverType;
@@ -697,19 +701,23 @@ export class WMS extends AbstractGeoViewRaster {
   /** ***************************************************************************************************************************
    * Get the legend image URL of a layer from the capabilities. Return null if it does not exist.
    *
-   * @param {string} layerId The layer identifier for which we are looking for the legend URL.
+   * @param {TypeWmsLayerEntryConfig} layerConfig layer configuration.
    *
    * @returns {TypeJsonObject | null} URL of a Legend image in png format or null
    */
-  private getLegendUrlFromCapabilities(layerId: string): TypeJsonObject | null {
-    const layerCapabilities = this.getLayerMetadataEntry(layerId);
-    if (layerCapabilities?.Style) {
-      for (let i = 0; i < layerCapabilities.Style.length; i++) {
-        if (layerCapabilities.Style[i].LegendURL) {
-          for (let j = 0; j < layerCapabilities.Style[i].LegendURL.length; j++) {
-            if (layerCapabilities.Style[i].LegendURL[j].Format === 'image/png') return layerCapabilities.Style[i].LegendURL[j];
-          }
-        }
+  private getLegendUrlFromCapabilities(layerConfig: TypeWmsLayerEntryConfig): TypeJsonObject | null {
+    const layerCapabilities = this.getLayerMetadataEntry(layerConfig.layerId);
+    if (Array.isArray(layerCapabilities?.Style)) {
+      const legendStyle = layerCapabilities?.Style.find((style) => {
+        if (layerConfig?.source?.style) return layerConfig.source.style === style.Name;
+        return style.Name === 'default';
+      });
+      if (Array.isArray(legendStyle?.LegendURL)) {
+        const legendUrl = legendStyle!.LegendURL.find((urlEntry) => {
+          if (urlEntry.Format === 'image/png') return true;
+          return false;
+        });
+        if (legendUrl) return legendUrl;
       }
     }
     return null;
@@ -718,11 +726,11 @@ export class WMS extends AbstractGeoViewRaster {
   /** ***************************************************************************************************************************
    * Get the legend image of a layer.
    *
-   * @param {string} layerId The layer identifier for which we are looking for the legend.
+   * @param {TypeWmsLayerEntryConfig} layerConfig layer configuration.
    *
    * @returns {blob} image blob
    */
-  private getLegendImage(layerId: string): Promise<string | ArrayBuffer | null> {
+  private getLegendImage(layerConfig: TypeWmsLayerEntryConfig): Promise<string | ArrayBuffer | null> {
     const promisedImage = new Promise<string | ArrayBuffer | null>((resolve) => {
       const readImage = (blob: Blob): Promise<string | ArrayBuffer | null> =>
         // eslint-disable-next-line @typescript-eslint/no-shadow
@@ -733,10 +741,14 @@ export class WMS extends AbstractGeoViewRaster {
           reader.readAsDataURL(blob);
         });
 
-      const legendUrlFromCapabilities = this.getLegendUrlFromCapabilities(layerId);
+      const legendUrlFromCapabilities = this.getLegendUrlFromCapabilities(layerConfig);
       let queryUrl: string;
       if (legendUrlFromCapabilities) queryUrl = legendUrlFromCapabilities.OnlineResource as string;
-      else queryUrl = `${this.metadataAccessPath}service=WMS&version=1.3.0&request=GetLegendGraphic&FORMAT=image/png&layer=${layerId}`;
+      else
+        queryUrl = `${getLocalizedValue(
+          this.metadataAccessPath,
+          this.mapId
+        )!}service=WMS&version=1.3.0&request=GetLegendGraphic&FORMAT=image/png&layer=${layerConfig.layerId}`;
 
       axios.get<TypeJsonObject>(queryUrl, { responseType: 'blob' }).then((response) => {
         resolve(readImage(Cast<Blob>(response.data)));
@@ -756,10 +768,12 @@ export class WMS extends AbstractGeoViewRaster {
    */
   getLegend(layerPathOrConfig: string | TypeLayerEntryConfig | null = this.activeLayer): Promise<TypeLegend | null> {
     const promisedLegend = new Promise<TypeLegend | null>((resolve) => {
-      const layerConfig = typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig) : layerPathOrConfig;
+      const layerConfig = Cast<TypeWmsLayerEntryConfig | undefined | null>(
+        typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig) : layerPathOrConfig
+      );
       if (!layerConfig) resolve(null);
 
-      this.getLegendImage(layerConfig!.layerId).then((legendImage) => {
+      this.getLegendImage(layerConfig!).then((legendImage) => {
         if (!legendImage) resolve(null);
         else {
           api

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -193,11 +193,17 @@ export class Layer {
   /**
    * Get the layer Path of the layer configuration parameter.
    * @param {TypeLayerEntryConfig} layerEntryConfig The layer configuration for wich we want to get the layer path.
+   * @param {string} layerPath Internal parameter used to build the layer path (should not be used by the user).
    *
    * @returns {string} Returns the layer path.
    */
   static getLayerPath(layerEntryConfig: TypeLayerEntryConfig, layerPath?: string): string {
-    const pathEnding = typeof layerPath === 'undefined' ? layerEntryConfig.layerId : layerPath;
+    let pathEnding = layerPath;
+    if (pathEnding === undefined)
+      pathEnding =
+        layerEntryConfig.layerPathEnding === undefined
+          ? layerEntryConfig.layerId
+          : `${layerEntryConfig.layerId}/${layerEntryConfig.layerPathEnding}`;
     if (layerEntryConfig.geoviewRootLayer === layerEntryConfig.parentLayerConfig)
       return `${layerEntryConfig.geoviewRootLayer!.geoviewLayerId!}/${pathEnding}`;
     return this.getLayerPath(

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -575,6 +575,8 @@ export type TypeBaseLayerEntryConfig = {
   isMetadataLayerGroup?: boolean;
   /** Layer entry data type. */
   entryType?: 'vector' | 'vectorTile' | 'vectorHeatmap' | 'raster' | 'group';
+  /** The ending element of the layer configuration path. */
+  layerPathEnding?: string;
   /** The id of the layer to display on the map. */
   layerId: string;
   /** The display name of the layer (English/French). */
@@ -689,13 +691,13 @@ export type TypeTileGrid = {
  * Initial settings for tile image sources.
  */
 export type TypeSourceTileInitialConfig = {
-  /** The service endpoint of the layer (English/French). */
+  /** The path (English/French) to reach the data to display. If not specified, metadatAccessPath will be assigne dto it. */
   dataAccessPath: TypeLocalizedString;
   /** The crossOrigin attribute for loaded images. Note that you must provide a crossOrigin value if you want to access pixel data
    * with the Canvas renderer.
    */
   crossOrigin?: string;
-  /** The source type for the tile layer. Default = XYZ. */
+  /** Spatial Reference EPSG code supported (https://epsg.io/). We support Web Mercator and Lambert Conical Conform Canada. */
   projection?: TypeValidMapProjectionCodes;
   /** Tile grid parameters to use. */
   tileGrid?: TypeTileGrid;
@@ -783,6 +785,8 @@ export type TypeGeocoreLayerEntryConfig = {
   entryType?: 'geocore';
   /** The layerId is not used by geocore layers. */
   layerId: never;
+  /** The layerPathEnding is not used by geocore layers. */
+  layerPathEnding: never;
   /** The display name of a geocore layer is in geocoreLayerName. */
   layerName?: never;
   /** The display name of the layer (English/French). */

--- a/packages/geoview-core/src/geo/map/map.ts
+++ b/packages/geoview-core/src/geo/map/map.ts
@@ -432,9 +432,21 @@ export class MapViewer {
    * @param {string} mapConfig a new config passed in from the function call
    */
   loadMapConfig = (mapConfig: string) => {
+    // Erase comments in the config file.
+    const configObjStr = mapConfig
+      .split(/(?<!\\)'/gm)
+      .map((fragment, index) => {
+        if (index % 2) return fragment.replaceAll(/\/\*/gm, String.fromCharCode(1)).replaceAll(/\*\//gm, String.fromCharCode(2));
+        return fragment; // .replaceAll(/\/\*(?<=\/\*)((?:.|\n|\r)*?)(?=\*\/)\*\//gm, '');
+      })
+      .join("'")
+      .replaceAll(/\/\*(?<=\/\*)((?:.|\n|\r)*?)(?=\*\/)\*\//gm, '')
+      .replaceAll(String.fromCharCode(1), '/*')
+      .replaceAll(String.fromCharCode(2), '*/');
+
     // parse the config
     const parsedMapConfig = JSON.parse(
-      mapConfig
+      configObjStr
         // remove CR and LF from the map config
         .replace(/(\r\n|\n|\r)/gm, '')
         // replace apostrophes not preceded by a backslash with quotes

--- a/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
@@ -1545,23 +1545,23 @@ export class GeoviewRenderer {
             dataStack.push({ nodeType: NodeType.variable, nodeValue: operande1.nodeValue === operande2.nodeValue });
             break;
           case '<':
-            if (typeof operande1.nodeValue !== typeof operande2.nodeValue) throw new Error(`= operator error, must compare same types`);
+            if (typeof operande1.nodeValue !== typeof operande2.nodeValue) throw new Error(`< operator error, must compare same types`);
             dataStack.push({ nodeType: NodeType.variable, nodeValue: operande1.nodeValue < operande2.nodeValue });
             break;
           case '>':
-            if (typeof operande1.nodeValue !== typeof operande2.nodeValue) throw new Error(`= operator error, must compare same types`);
+            if (typeof operande1.nodeValue !== typeof operande2.nodeValue) throw new Error(`> operator error, must compare same types`);
             dataStack.push({ nodeType: NodeType.variable, nodeValue: operande1.nodeValue > operande2.nodeValue });
             break;
           case '<=':
-            if (typeof operande1.nodeValue !== typeof operande2.nodeValue) throw new Error(`= operator error, must compare same types`);
+            if (typeof operande1.nodeValue !== typeof operande2.nodeValue) throw new Error(`<= operator error, must compare same types`);
             dataStack.push({ nodeType: NodeType.variable, nodeValue: operande1.nodeValue <= operande2.nodeValue });
             break;
           case '>=':
-            if (typeof operande1.nodeValue !== typeof operande2.nodeValue) throw new Error(`= operator error, must compare same types`);
+            if (typeof operande1.nodeValue !== typeof operande2.nodeValue) throw new Error(`>= operator error, must compare same types`);
             dataStack.push({ nodeType: NodeType.variable, nodeValue: operande1.nodeValue >= operande2.nodeValue });
             break;
           case '!=':
-            if (typeof operande1.nodeValue !== typeof operande2.nodeValue) throw new Error(`= operator error, must compare same types`);
+            if (typeof operande1.nodeValue !== typeof operande2.nodeValue) throw new Error(`!= operator error, must compare same types`);
             dataStack.push({ nodeType: NodeType.variable, nodeValue: operande1.nodeValue !== operande2.nodeValue });
             break;
           case 'and':


### PR DESCRIPTION
# Description

Style filtering exploits the grouping capacity of the geoview WMS layers. We can now place the same layerId on the map many times and assign a style to each of them. The filtering is done by showing/hiding the layer associated to a style.

It is now possible to place comments in the config files using /* and */, but not with //.

Fixes only issue 870

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using the test.html template.

To test, click the Legend button and use the show/hide buttons associated to each entry in the table..

# Checklist:

- [ ] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/893)
<!-- Reviewable:end -->
