### PR TITLE
feat(cluster): Toggle for clustering added to legend

### DIFF
--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -44,7 +44,8 @@
     "unknown": "Unknown Layer Title",
     "remove_layer": "Remove Layer",
     "opacity": "Opacity",
-    "expand_legend": "Expand Legend"
+    "expand_legend": "Expand Legend",
+    "toggle_cluster": "Toggle Clustering"
   },
   "keyboardnav": {
     "start": "Skip after map element",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -44,7 +44,8 @@
     "unknown": "Titre de légende inconnu",
     "remove_layer": "Supprimer le calque",
     "opacity": "Opacité",
-    "expand_legend": "Développer la légende"
+    "expand_legend": "Développer la légende",
+    "toggle_cluster": "Basculer le groupement"
   },
   "keyboardnav": {
     "start": "Aller après l'élément carte",

--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
@@ -25,7 +25,7 @@ export const useStyles = makeStyles((theme) => ({
 export function FooterTabs(): JSX.Element | null {
   const [selectedTab, setSelectedTab] = useState<number | undefined>();
   const [footerTabs, setFooterTabs] = useState<TypeTabs[]>([]);
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(true);
 
   const [isFullscreen, setIsFullscreen] = useState(false);
 
@@ -67,15 +67,14 @@ export function FooterTabs(): JSX.Element | null {
   /**
    * Handle a collapse, expand event for the tabs component
    */
-  const handleCollapse = (open?: boolean) => {
+  const handleCollapse = () => {
     // check if tabs component is created
-    const collapseStatus = open !== undefined ? open : isCollapsed;
     if (tabsContainerRef && tabsContainerRef.current) {
       const tabsContainer = tabsContainerRef.current as HTMLDivElement;
       const mapContainer = tabsContainer.previousElementSibling as HTMLDivElement;
       mapContainer.style.transition = 'height 0.2s ease-out';
       // check if the tabs container is collapsed
-      if (!collapseStatus) {
+      if (!isCollapsed) {
         tabsContainer.style.height = '55px';
         mapContainer.style.height = 'calc( 100% - 55px)';
       } else {
@@ -84,7 +83,7 @@ export function FooterTabs(): JSX.Element | null {
       }
     }
     setIsFullscreen(false);
-    setIsCollapsed(!collapseStatus);
+    setIsCollapsed(!isCollapsed);
 
     // update map container size
     setTimeout(() => {
@@ -164,7 +163,7 @@ export function FooterTabs(): JSX.Element | null {
           if (payload.handlerName && payload.handlerName === mapId) {
             // for details tab, extand the tab
             if (payload.tab.value === 1) {
-              handleCollapse(true);
+              handleCollapse();
             }
             setSelectedTab(undefined); // this will always trigger the tab change, needed in case user changes selection
             setSelectedTab(payload.tab.value);
@@ -184,6 +183,7 @@ export function FooterTabs(): JSX.Element | null {
     <div ref={tabsContainerRef as MutableRefObject<HTMLDivElement>} className={classes.tabsContainer}>
       <Tabs
         isCollapsed={isCollapsed}
+        handleCollapse={handleCollapse}
         selectedTab={selectedTab}
         tabsProps={{ variant: 'scrollable' }}
         tabs={footerTabs.map((tab) => {
@@ -193,9 +193,7 @@ export function FooterTabs(): JSX.Element | null {
         })}
         rightButtons={
           <>
-            {!isFullscreen && (
-              <IconButton onClick={() => handleCollapse()}>{!isCollapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}</IconButton>
-            )}
+            {!isFullscreen && <IconButton onClick={handleCollapse}>{!isCollapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}</IconButton>}
             <IconButton onClick={handleFullscreen}>{isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}</IconButton>
           </>
         }

--- a/packages/geoview-core/src/core/components/legend/legend-item.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-item.tsx
@@ -32,6 +32,7 @@ import {
   TypeLayerEntryConfig,
   TypeDisplayLanguage,
   MapContext,
+  AbstractGeoViewVector,
 } from '../../../app';
 import { LegendIconList } from './legend-icon-list';
 import { isVectorLegend, isWmsLegend } from '../../../geo/layer/geoview-layers/abstract-geoview-layers';
@@ -146,11 +147,14 @@ export function LegendItem(props: TypeLegendItemProps): JSX.Element {
 
   const mapConfig = useContext(MapContext);
   const { mapId } = mapConfig;
+  // check if layer is a vectorlayer, so that clustering can be toggled
+  const vectorLayers = { esriFeature: '', GeoJSON: '', GeoPackage: '', ogcFeature: '', ogcWfs: '' };
+  const canCluster = geoviewLayerInstance.type in vectorLayers;
 
   const [isChecked, setChecked] = useState(true);
   const [isOpacityOpen, setOpacityOpen] = useState(false);
-  const [isGroupOpen, setGroupOpen] = useState(false);
-  const [isLegendOpen, setLegendOpen] = useState(false);
+  const [isGroupOpen, setGroupOpen] = useState(true);
+  const [isLegendOpen, setLegendOpen] = useState(true);
   const [groupItems, setGroupItems] = useState<TypeListOfLayerEntryConfig>([]);
   const [iconType, setIconType] = useState<string | null>(null);
   const [iconImg, setIconImg] = useState<string | null>(null);
@@ -324,6 +328,12 @@ export function LegendItem(props: TypeLegendItemProps): JSX.Element {
     if (subLayerId) geoviewLayerInstance.setOpacity((opacityValue as number) / 100, subLayerId);
     else geoviewLayerInstance.setOpacity((opacityValue as number) / 100);
   };
+  const handleClusterToggle = () => {
+    (geoviewLayerInstance as AbstractGeoViewVector).toggleCluster();
+    const layerConfig = api.map(mapId).layer.getGeoviewLayerById(layerId)?.activeLayer?.geoviewRootLayer;
+    api.map(mapId).layer.removeGeoviewLayer(geoviewLayerInstance);
+    api.map(mapId).layer.addGeoviewLayer(layerConfig!);
+  };
 
   return (
     <Grid item sm={12} md={subLayerId ? 12 : 6} lg={subLayerId ? 12 : 4}>
@@ -335,7 +345,7 @@ export function LegendItem(props: TypeLegendItemProps): JSX.Element {
                 {isGroupOpen ? <ExpandMoreIcon /> : <ExpandLessIcon />}
               </IconButton>
             )}
-            {isLegendOpen && (
+            {groupItems.length === 0 && isLegendOpen && (
               <IconButton sx={sxClasses.iconPreview} color="primary" size="small" onClick={handleLegendClick}>
                 <CloseIcon />
               </IconButton>
@@ -390,6 +400,7 @@ export function LegendItem(props: TypeLegendItemProps): JSX.Element {
         {/* Add more layer options here - zoom to, reorder */}
         {isRemoveable && <MenuItem onClick={handleRemoveLayer}>{t('legend.remove_layer')}</MenuItem>}
         {canSetOpacity && groupItems.length === 0 && <MenuItem onClick={handleOpacityOpen}>{t('legend.opacity')}</MenuItem>}
+        {canCluster && groupItems.length === 0 && <MenuItem onClick={handleClusterToggle}>{t('legend.toggle_cluster')}</MenuItem>}
       </Menu>
       <Collapse in={isOpacityOpen} timeout="auto">
         <Box sx={sxClasses.opacityMenu}>

--- a/packages/geoview-core/src/core/utils/config/config-validation.ts
+++ b/packages/geoview-core/src/core/utils/config/config-validation.ts
@@ -602,12 +602,14 @@ export class ConfigValidation {
           fr = fr!.split('/').length > 1 ? fr!.split('/').slice(0, -1).join('/') : './';
           layerEntryConfig.source.dataAccessPath = { en, fr } as TypeLocalizedString;
         }
-        layerEntryConfig.source.dataAccessPath!.en = layerEntryConfig.source.dataAccessPath!.en!.endsWith('/')
-          ? `${layerEntryConfig.source.dataAccessPath!.en}${layerEntryConfig.layerId}`
-          : `${layerEntryConfig.source.dataAccessPath!.en}/${layerEntryConfig.layerId}`;
-        layerEntryConfig.source.dataAccessPath!.fr = layerEntryConfig.source.dataAccessPath!.fr!.endsWith('/')
-          ? `${layerEntryConfig.source.dataAccessPath!.fr}${layerEntryConfig.layerId}`
-          : `${layerEntryConfig.source.dataAccessPath!.fr}/${layerEntryConfig.layerId}`;
+        if (!layerEntryConfig.source.dataAccessPath!.en?.endsWith('.json' || '.geojson' || '.JSON' || '.geoJSON' || '.GEOJSON')) {
+          layerEntryConfig.source.dataAccessPath!.en = layerEntryConfig.source.dataAccessPath!.en!.endsWith('/')
+            ? `${layerEntryConfig.source.dataAccessPath!.en}${layerEntryConfig.layerId}`
+            : `${layerEntryConfig.source.dataAccessPath!.en}/${layerEntryConfig.layerId}`;
+          layerEntryConfig.source.dataAccessPath!.fr = layerEntryConfig.source.dataAccessPath!.fr!.endsWith('/')
+            ? `${layerEntryConfig.source.dataAccessPath!.fr}${layerEntryConfig.layerId}`
+            : `${layerEntryConfig.source.dataAccessPath!.fr}/${layerEntryConfig.layerId}`;
+        }
         if (!layerEntryConfig?.source?.dataProjection) layerEntryConfig.source.dataProjection = 'EPSG:4326';
       }
     });

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -486,4 +486,12 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
     if (layerEntryConfig) return layerEntryConfig.gvLayer?.get('layerFilter');
     return undefined;
   }
+
+  /** ***************************************************************************************************************************
+   * Toggle cluster status.
+   */
+  toggleCluster() {
+    const config = this.activeLayer as TypeVectorLayerEntryConfig;
+    config.source!.cluster!.enable = !config.source!.cluster!.enable;
+  }
 }

--- a/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
@@ -36,7 +36,10 @@ export class FeatureInfoLayerSet {
   constructor(mapId: string, layerSetId: string) {
     const registrationConditionFunction = (layerPath: string): boolean => {
       const layerEntryConfig = api.map(this.mapId).layer.registeredLayers[layerPath];
-      return 'featureInfo' in layerEntryConfig.source! && !!layerEntryConfig.source.featureInfo?.queryable;
+      if (layerEntryConfig.source) {
+        return 'featureInfo' in layerEntryConfig.source! && !!layerEntryConfig.source.featureInfo?.queryable;
+      }
+      return false;
     };
     this.mapId = mapId;
     this.layerSetId = layerSetId;

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -62,8 +62,8 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
    * Handle a tab click
    * If the panel is collapsed when tab is clicked, expand the panel
    */
-  const handleClick = () => {
-    if (isCollapsed && handleCollapse !== undefined) handleCollapse();
+  const handleClick = (index: number) => {
+    if (handleCollapse !== undefined && (isCollapsed || value === index)) handleCollapse();
   };
 
   useEffect(() => {
@@ -93,7 +93,7 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
                 key={index}
                 {...props.tabProps}
                 id={`tab-${index}`}
-                onClick={handleClick}
+                onClick={() => handleClick(index)}
                 sx={{
                   fontSize: 16,
                   minWidth: 'min(4vw, 24px)',

--- a/packages/geoview-footer-panel/src/legend-item.tsx
+++ b/packages/geoview-footer-panel/src/legend-item.tsx
@@ -70,7 +70,7 @@ export function LegendItem({ mapId }: Props): JSX.Element {
   }, []);
 
   useEffect(() => {
-    setLegend(api.map(mapId).legend.createLegend({ layerIds: mapLayers }));
+    setLegend(api.map(mapId).legend.createLegend({ layerIds: mapLayers, isRemoveable: false, canSetOpacity: true }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mapLayers]);
 


### PR DESCRIPTION
Closes #778
Closes #890

# Description

Cluster toggle added to the legend menu. Legend items are now expanded by default, clicking on the open tab closes the panel. issues with footer panel tabs fixed.

Fixes #778
Fixes #890 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I added the cluster toggle to the footer panel for testing to test it on all layers in /package-footer-panel.html, and then tested it in the layer-panel menu after adding the esri dynamic layer to the map in package-layers-panel.html. Legend tab behaviour was tested throughout those tests.

# Checklist:

- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/894)
<!-- Reviewable:end -->
