### PR TITLE
fix(zoom): Zoom changed from int to number

### DIFF
--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -1049,11 +1049,11 @@
           "description": "The initial rotation for the view in degree (positive rotation clockwise, 0 means North). Will be converted to radiant by the viewer."
         },
         "zoom": {
-          "type": "integer",
+          "type": "number",
           "minimum": 0,
           "maximum": 28,
           "default": 12,
-          "description": "Initial map zoom level. Zoom level are define by the basemap zoom levels."
+          "description": "Initial map zoom level. Zoom level are define by the basemap zoom levels. Levels between whole numbers are supported to fine tune initial view."
         }
       },
       "required": ["zoom", "center"]


### PR DESCRIPTION
Closes #844

# Description

Changed zoom to number in schema as openlayers allows for non integer values.

Fixes #844 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Checked codebase for anywhere zoom was required to be an integer, tested maps with non integer zoom valuees.

# Checklist:

- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/895)
<!-- Reviewable:end -->
