### PR TITLE
fix legend menu and export btn autofocus

### DIFF
--- a/packages/geoview-core/src/core/components/legend/legend-item.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-item.tsx
@@ -448,7 +448,7 @@ export function LegendItem(props: TypeLegendItemProps): JSX.Element {
         MenuListProps={{
           'aria-labelledby': 'setOpacityBtn',
         }}
-        autoFocus={menuOpen}
+        disablePortal
       >
         {/* Add more layer options here - zoom to, reorder */}
         {isRemoveable && <MenuItem onClick={handleRemoveLayer}>{t('legend.remove_layer')}</MenuItem>}

--- a/packages/geoview-core/src/core/components/legend/legend-item.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-item.tsx
@@ -448,6 +448,7 @@ export function LegendItem(props: TypeLegendItemProps): JSX.Element {
         MenuListProps={{
           'aria-labelledby': 'setOpacityBtn',
         }}
+        autoFocus={menuOpen}
       >
         {/* Add more layer options here - zoom to, reorder */}
         {isRemoveable && <MenuItem onClick={handleRemoveLayer}>{t('legend.remove_layer')}</MenuItem>}

--- a/packages/geoview-core/src/core/components/nav-bar/export-modal.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/export-modal.tsx
@@ -43,7 +43,7 @@ export default function ExportModal(props: ExportModalProps): JSX.Element {
       >
         <DialogTitle>Export Map as PNG</DialogTitle>
         <DialogActions>
-          <Button onClick={closeModal} size="small">
+          <Button onClick={closeModal} size="small" autoFocus>
             Cancel
           </Button>
           <Button type="submit" onClick={closeModal} size="small">


### PR DESCRIPTION
# Description
Fix the legend menu focus and export button dialog when dialog is shown.

Fixes # ([906](https://github.com/canadian-geospatial-platform/geoview/issues/906))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually tested

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/911)
<!-- Reviewable:end -->
