### PR TITLE
887-getAllFeatureInfo_and_getFeatureInfo_result_formatting

### DIFF
--- a/packages/geoview-core/public/geojson/metadata.json
+++ b/packages/geoview-core/public/geojson/metadata.json
@@ -7,9 +7,10 @@
       "source": {
         "featureInfo": {
           "queryable": "true",
-          "nameField": { "en": "number", "fr": "number" },
-          "outfields": { "en": "number", "fr": "number" },
-          "aliasFields": { "en": "number", "fr": "nombre" }
+          "nameField": { "en": "Province", "fr": "Province" },
+          "outfields": { "en": "Province", "fr": "Province" },
+          "fieldTypes": "string",
+          "aliasFields": { "en": "Province", "fr": "Province" }
         }
       },
       "initialSettings": {
@@ -77,8 +78,9 @@
       "source": {
         "featureInfo": {
           "queryable": "true",
-          "nameField": { "en": "Road Number", "fr": "Road Number" },
-          "outfields": { "en": "Road Number,Province", "fr": "Road Number,Province" },
+          "nameField": { "en": "Road_Number", "fr": "Road_Number" },
+          "outfields": { "en": "Road_Number,Province", "fr": "Road_Number,Province" },
+          "fieldTypes": "number,string",
           "aliasFields": { "en": "Road Number,Province", "fr": "Numéro de route,Province" }
         }
       },
@@ -106,7 +108,8 @@
         "featureInfo": {
           "queryable": "true",
           "nameField": { "en": "data", "fr": "data" },
-          "outfields": { "en": "data,label", "fr": "data, label" },
+          "outfields": { "en": "data,label", "fr": "data,label" },
+          "fieldTypes": "string,string",
           "aliasFields": { "en": "data,label", "fr": "données,étiquette" }
         }
       },
@@ -135,6 +138,7 @@
           "queryable": "true",
           "nameField": { "en": "Red", "fr": "Red" },
           "outfields": { "en": "Red,Green,Blue,Yellow,Orange", "fr": "Red,Green,Blue,Yellow,Orange" },
+          "fieldTypes": "number,number,number,number,number",
           "aliasFields": { "en": "Red,Green,Blue,Yellow,Orange", "fr": "Rouge,Vert,Bleu,Jaune,Orange" }
         }
       },

--- a/packages/geoview-core/public/templates/codedoc.js
+++ b/packages/geoview-core/public/templates/codedoc.js
@@ -26,9 +26,21 @@ function createConfigSnippet() {
     // check if JSON can be parsed, if not do nothing
     try {
       if (configSnippet !== undefined && el !== null) {
+        // Erase comments in the configSnippet.
+        const uncommentedConfigSnippet = configSnippet.value
+          .split(/(?<!\\)'/gm)
+          .map((fragment, index) => {
+            if (index % 2) return fragment.replaceAll(/\/\*/gm, String.fromCharCode(1)).replaceAll(/\*\//gm, String.fromCharCode(2));
+            return fragment; // .replaceAll(/\/\*(?<=\/\*)((?:.|\n|\r)*?)(?=\*\/)\*\//gm, '');
+          })
+          .join("'")
+          .replaceAll(/\/\*(?<=\/\*)((?:.|\n|\r)*?)(?=\*\/)\*\//gm, '')
+          .replaceAll(String.fromCharCode(1), '/*')
+          .replaceAll(String.fromCharCode(2), '*/');
+
         el.textContent = JSON.stringify(
           JSON.parse(
-            configSnippet.value
+            uncommentedConfigSnippet
               // remove CR and LF from the map config
               .replace(/(\r\n|\n|\r)/gm, '')
               // replace apostrophes not preceded by a backslash with quotes

--- a/packages/geoview-core/public/templates/layers.html
+++ b/packages/geoview-core/public/templates/layers.html
@@ -13,6 +13,20 @@
     <link href="https://fonts.googleapis.com/css?family=Roboto|Montserrat:200,300,400,900|Merriweather" rel="stylesheet" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" href="css/style.css" />
+    <style>
+      table.info, th.info, td.info, th.infoCol1, td.infoCol1 {
+        border: 1px solid black;
+      }
+      th.info, td.info, th.infoCol1, td.infoCol1 {
+        padding: 15px;
+        width: 15%;
+      }
+      th.info, th.infoCol1, td.infoCol1 {
+        text-align: left;
+        font-weight: bold;
+        font-size: 15px;
+      }
+      </style>
   </head>
 
   <body>
@@ -62,6 +76,7 @@
     <div
       id="LYR1"
       class="llwp-map"
+      triggerReadyCallback="true"
       data-lang="en"
       data-config="{
             'map': {
@@ -79,7 +94,7 @@
               'listOfGeoviewLayerConfig': [
                 {
                   'geoviewLayerId': 'wmsLYR1-Root',
-                  'geoviewLayerName': { 'en': 'Root' },
+                  'geoviewLayerName': { 'en': 'Weather Group' },
                   'metadataAccessPath': { 'en': 'https://geo.weather.gc.ca/geomet' },
                   'geoviewLayerType': 'ogcWms',
                   'initialSettings': { 'visible': true },
@@ -90,13 +105,20 @@
                       'layerName': { 'en': 'Group' },
                       'listOfLayerEntryConfig': [
                         {
-                          'layerId': 'CURRENT_CONDITIONS'
+                          'layerId': 'CURRENT_CONDITIONS',
+                          'source': {
+                            'featureInfo': {
+                              'queryable': true,
+                              'nameField': { 'en': 'plain_text', 'fr': 'plain_texte' },
+                              'fieldTypes': 'string',
+                              'outfields': { 'en': 'plain_text', 'fr': 'plain_texte' },
+                              'aliasFields':  { 'en': 'Forcast', 'fr': 'Prévision' }
+                            }
+                          }
                         },
                         {
-                          'layerId': 'METNOTES'
-                        },
-                        {
-                          'layerId': 'CGSL.ETA_ICEC'
+                          'layerId': 'CGSL.ETA_ICEC',
+                          'layerName': { 'en': 'Ice Cover' }
                         }
                       ]
                     }
@@ -110,10 +132,13 @@
                   'listOfLayerEntryConfig': [
                     {
                       'layerId': 'msi-94-or-more',
+                      'layerName': { 'en': 'Permanent Snow' },
                       'source': {
+                        'style': 'msi-binary',
                         'featureInfo': {
                           'queryable': true,
                           'nameField': { 'en': 'band-0-pixel-value', 'fr': 'band-0-pixel-value' },
+                          'fieldTypes': 'number',
                           'outfields': { 'en': 'band-0-pixel-value', 'fr': 'band-0-pixel-value' },
                           'aliasFields':  { 'en': 'Pixel value', 'fr': 'Valeur du pixel' }
                         }
@@ -129,8 +154,10 @@
             'suportedLanguages': ['en']
           }"
     ></div>
-    <button class="Get-wms-Legend">Get Legend</button>
-    <div id="wmsLegendsId-table-div"></div>
+    <button type="button" class="collapsible">Visibility and filters</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="layer1-buttons-div" class="panel"></pre>
+    <button class="collapsible">Get Legend</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="wmsLegendsId-table-div" class="panel"></pre>
     <button type="button" class="collapsible">Get Feature Info</button>
     <pre style="height: 20pc; overflow-y: scroll" id="wmsResultSetId" class="panel">Click on feature on the map</pre>
     <hr />
@@ -208,7 +235,7 @@
             'viewSettings': {
               'zoom': 4,
               'center': [-100, 60],
-              'projection': 3978
+              'projection': 3857
             },
             'basemapOptions': {
               'basemapId': 'transport',
@@ -216,6 +243,17 @@
               'labeled': true
             },
             'listOfGeoviewLayerConfig': [
+              {
+                'geoviewLayerId': 'HistoricalFlood',
+                'geoviewLayerName': { 'en': 'Historical Flood' },
+                'metadataAccessPath': { 'en': 'https://euclgis.reg.rw/server/rest/services/Electrical_Trans_Distr_Network/MapServer' },
+                'geoviewLayerType': 'esriDynamic',
+                'listOfLayerEntryConfig': [
+                  {
+                    'layerId': '1'
+                  }
+                ]
+              },
               {
                 'geoviewLayerId': 'uniqueValueId',
                 'geoviewLayerName': { 'en': 'uniqueValue' },
@@ -399,13 +437,14 @@
                 'listOfLayerEntryConfig': [
                   {
                     'layerId': '8',
+                    'layerName': { 'en': 'CSO volume 2020' },
                     'layerFilter': 'Total_CSO_Volume > 5000000',
                     'initialSettings': { 'visible': true },
                     'style': {
                       'Point': {
                         'styleId': 'classBreaksId',
                         'styleType': 'classBreaks',
-                        'defaultLabel': 'Pas de données de volume / No volume data',
+                        'defaultLabel': 'No volume data',
                         'defaultSettings': {
                           'symbol': 'square',
                           'type': 'simpleSymbol',
@@ -607,11 +646,12 @@
           'suportedLanguages': ['en']
         }"
     ></div>
-    <div class="layer3-buttons-div"></div>
-    <button class="Get-esri-dynamic-Legend">Get Legend</button>
-    <div id="esriDynamicLegendsId-table-div"></div>
+    <button type="button" class="collapsible">Visibility and filters</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="layer3-buttons-div" class="panel"></pre>
+    <button class="collapsible">Get Legend</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="esriDynamicLegendsId-table-div" class="panel"></pre>
     <button type="button" class="collapsible">Get Feature Info</button>
-    <pre style="height: 20pc; overflow-y: scroll" id="esriDynamicResultSetId" class="panel">Click on feature on the map</pre>
+    <pre style="height: 20pc; overflow-y: scroll; overflow-x: scroll;" id="esriDynamicResultSetId" class="panel">Click on feature on the map</pre>
     <hr />
     <p>This map has an Esri dynamic layer added from configuration.</p>
     <button type="button" class="collapsible">Configuration Snippet</button>
@@ -633,7 +673,7 @@
             'viewSettings': {
               'zoom': 4,
               'center': [-100, 60],
-              'projection': 3978
+              'projection': 3857
             },
             'basemapOptions': {
               'basemapId': 'transport',
@@ -642,16 +682,26 @@
             },
             'listOfGeoviewLayerConfig': [
               {
+                'geoviewLayerId': 'uniqueValueId',
+                'geoviewLayerName': { 'en': 'uniqueValue' },
+                'metadataAccessPath': { 'en': 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/' },
+                'geoviewLayerType': 'esriDynamic',
+                'listOfLayerEntryConfig': [
+                  {
+                    'layerId': '1'
+                  }
+                ]
+              },
+              {
                 'geoviewLayerId': 'esriFeatureLYR4.1',
-                'geoviewLayerName': { 'en': 'Water quality at monitoring sites' },
+                'geoviewLayerName': { 'en': 'Electrical Network' },
                 'metadataAccessPath': {
-                  'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/900A_and_top_100_en/MapServer'
+                  'en': 'https://euclgis.reg.rw/server/rest/services/Electrical_Trans_Distr_Network/MapServer'
                 },
                 'geoviewLayerType': 'esriFeature',
                 'listOfLayerEntryConfig': [
                   {
-                    'layerId': '4',
-                    'layerFilter': 'province_territoire like \'British%bi_\' OR province_territoire = \'Ontario\' OR province_territoire = \'Nunavut\''
+                    'layerId': '1'
                   }
                 ]
               }
@@ -663,9 +713,10 @@
           'suportedLanguages': ['en']
         }"
     ></div>
-    <div class="layer4-buttons-div"></div>
-    <button class="Get-esri-feature-Legend">Get Legend</button>
-    <div id="esriFeatureLegendsId-table-div"></div>
+    <button type="button" class="collapsible">Visibility and filters</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="layer4-buttons-div" class="panel"></pre>
+    <button class="collapsible">Get Legend</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="esriFeatureLegendsId-table-div" class="panel"></pre>
     <button type="button" class="collapsible">Get Feature Info</button>
     <pre style="height: 20pc; overflow-y: scroll" id="esriFeatureResultSetId" class="panel">Click on feature on the map</pre>
     <hr />
@@ -740,11 +791,13 @@
     'suportedLanguages': ['en']
     }"
     ></div>
-    <div class="layer5-buttons-div"></div>
-    <button class="Get-geojson-Legend">Get Legend</button>
-    <div id="geojsonLegendsId-table-div"></div>
-    <button id="add-geojson">Add GeoJSON Layer</button><button id="remove-geojson">Remove GeoJSON Layer</button> <br />
-    <label> Added Layer ID : </label><label id="new-layer-id-label"></label>
+    <button type="button" class="collapsible">Visibility and filters</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="layer5-buttons-div" class="panel"></pre>
+    <button class="collapsible">Get Legend</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="geojsonLegendsId-table-div" class="panel">
+      <button id="add-geojson">Add GeoJSON Layer</button><button id="remove-geojson">Remove GeoJSON Layer</button> <br />
+      <label> Added Layer ID : </label><label id="new-layer-id-label"></label>
+    </pre>
     <button type="button" class="collapsible">Get Feature Info</button>
     <pre style="height: 20pc; overflow-y: scroll" id="geoJsonResultSetId" class="panel">Click on feature on the map</pre>
     <hr />
@@ -801,9 +854,10 @@
         'suportedLanguages': ['en']
       }"
     ></div>
-    <div class="layer6-buttons-div"></div>
-    <button class="Get-wfs-Legend">Get Legend</button>
-    <div id="wfsLegendsId-table-div"></div>
+    <button type="button" class="collapsible">Visibility and filters</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="layer6-buttons-div" class="panel"></pre>
+    <button class="collapsible">Get Legend</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="wfsLegendsId-table-div" class="panel"></pre>
     <button type="button" class="collapsible">Get Feature Info</button>
     <pre style="height: 20pc; overflow-y: scroll" id="wfsResultSetId" class="panel">Click on feature on the map</pre>
     <hr />
@@ -859,9 +913,10 @@
           'suportedLanguages': ['en']
         }"
     ></div>
-    <div class="layer7-buttons-div"></div>
-    <button class="Get-ogcApi-Legend">Get Legend</button>
-    <div id="ogcApiLegendsId-table-div"></div>
+    <button type="button" class="collapsible">Visibility and filters</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="layer7-buttons-div" class="panel"></pre>
+    <button class="collapsible">Get Legend</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="ogcApiLegendsId-table-div" class="panel"></pre>
     <button type="button" class="collapsible">Get Feature Info</button>
     <pre style="height: 20pc; overflow-y: scroll" id="ogcFeatureResultSetId" class="panel">Click on feature on the map</pre>
     <hr />
@@ -1040,9 +1095,10 @@
           'suportedLanguages': ['en']
         }"
     ></div>
-    <div class="layer8-buttons-div"></div>
-    <button class="Get-geocore-Legend">Get Legend</button>
-    <div id="geocoreLegendsId-table-div"></div>
+    <button type="button" class="collapsible">Visibility and filters</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="layer8-buttons-div" class="panel"></pre>
+    <button class="collapsible">Get Legend</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="geocoreLegendsId-table-div" class="panel"></pre>
     <button type="button" class="collapsible">Get Feature Info</button>
     <pre style="height: 20pc; overflow-y: scroll" id="geocoreResultSetId" class="panel">Click on feature on the map</pre>
     <hr />
@@ -1102,9 +1158,12 @@
     'suportedLanguages': ['en']
   }"
     ></div>
-    <div class="layer9-buttons-div"></div>
-    <button class="Get-Geopackage-Legend">Get Legend</button>
-    <div id="geopackageLegendsId-table-div"></div>
+    <button type="button" class="collapsible">Visibility and filters</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="layer9-buttons-div" class="panel"></pre>
+    <button class="collapsible">Get Legend</button>
+    <pre style="height: 20pc; overflow-y: scroll" id="geopackageLegendsId-table-div" class="panel">
+      <button id="Get-Geopackage-Legend">Get Legend</button>
+    </pre>
     <button type="button" class="collapsible">Get Feature Info</button>
     <pre style="height: 20pc; overflow-y: scroll" id="geopackageResultSetId" class="panel">Click on feature on the map</pre>
     <hr />
@@ -1118,8 +1177,151 @@
 
     <script src="codedoc.js"></script>
     <script>
+      const createInfoTable = (mapId, resultSetsId, resultSets) => {
+        var infoTable = document.getElementById(resultSetsId);
+        infoTable.textContent = '';
+        var oldContent = document.getElementById(`layer${mapId.slice(3)}-info`);
+        if (oldContent) oldContent.remove();
+        var content = document.createElement("div");
+        content.id = `layer${mapId.slice(3)}-info`;
+        infoTable.appendChild(content);
+        Object.keys(resultSets).forEach((layerPath) => {
+          const layerData = resultSets[layerPath];
+
+          // Header of the layer
+          infoH1 = document.createElement('h1');
+          infoH1.innerText = layerData.length ? layerPath : `${layerPath} (empty)`;
+          content.appendChild(infoH1);
+
+          if (layerData.length) {
+            infoH2 = document.createElement('h2');
+            infoH2.innerText = 'Aliases and types';
+            content.appendChild(infoH2);
+
+            // Header of the layer table that describe the aliases and the types
+            tableElement = document.createElement('table');
+            tableElement.classList.add('info');
+            content.appendChild(tableElement);
+
+            tableRow = document.createElement('tr');
+            tableRow.classList.add('info');
+            tableElement.appendChild(tableRow);
+            tableData = document.createElement('th');
+            tableData.classList.add('infoCol1');
+            tableRow.appendChild(tableData);
+            Object.keys(layerData[0].fieldInfo).forEach((fieldName) => {
+              tableData = document.createElement('th');
+              tableData.classList.add('info');
+              tableData.innerText = fieldName;
+              tableRow.appendChild(tableData);
+            });
+
+            // Row describing the aliases
+            tableRow = document.createElement('tr');
+            tableRow.classList.add('info');
+            tableElement.appendChild(tableRow);
+            tableData = document.createElement('td');
+            tableData.classList.add('infoCol1');
+            tableData.innerText = 'Aliases =>';
+            tableRow.appendChild(tableData);
+            Object.keys(layerData[0].fieldInfo).forEach((fieldName) => {
+              tableData = document.createElement('td');
+              tableData.classList.add('info');
+              tableData.innerText = layerData[0].fieldInfo[fieldName].alias;
+              tableRow.appendChild(tableData);
+            });
+
+            // Row describing the types
+            tableRow = document.createElement('tr');
+            tableRow.classList.add('infoCol1');
+            tableElement.appendChild(tableRow);
+            tableData = document.createElement('td');
+            tableData.classList.add('infoCol1');
+            tableData.innerText = 'Types =>';
+            tableRow.appendChild(tableData);
+            Object.keys(layerData[0].fieldInfo).forEach((fieldName) => {
+              tableData = document.createElement('td');
+              tableData.classList.add('info');
+              tableData.innerText = layerData[0].fieldInfo[fieldName].dataType;
+              tableRow.appendChild(tableData);
+            });
+
+            // Header of the data section
+            infoH2 = document.createElement('h2');
+            infoH2.innerText = 'Data';
+            content.appendChild(infoH2);
+
+            tableElement = document.createElement('table');
+            tableElement.classList.add('info');
+            content.appendChild(tableElement);
+            createHeaders = true;
+
+            layerData.forEach((row) => {
+            // Header of the data table
+            if (createHeaders) {
+                tableRow = document.createElement('tr');
+                tableRow.classList.add('info');
+                tableElement.appendChild(tableRow);
+
+                tableData = document.createElement('th');
+                tableData.classList.add('infoCol1');
+                tableData.innerText = 'Symbology';
+                tableRow.appendChild(tableData);
+
+                tableData = document.createElement('th');
+                tableData.classList.add('infoCol1');
+                tableData.innerText = 'Zoom To';
+                tableRow.appendChild(tableData);
+
+                Object.keys(row.fieldInfo).forEach((fieldName) => {
+                  tableData = document.createElement('th');
+                  tableData.classList.add('info');
+                  tableData.innerText = fieldName;
+                  tableRow.appendChild(tableData);
+                });
+                createHeaders = false;
+              }
+
+            // Data row (feature information)
+            tableRow = document.createElement('tr');
+              tableRow.classList.add('info');
+              tableElement.appendChild(tableRow);
+
+              // Feature icon
+              tableData = document.createElement('td');
+              tableData.classList.add('info');
+              tableData.appendChild(row.featureIcon);
+              tableRow.appendChild(tableData);
+
+              // Zoom to button
+              tableData = document.createElement('td');
+              tableData.classList.add('info');
+              tableRow.appendChild(tableData);
+              tableZoomTo = document.createElement('button');
+              tableZoomTo.innerText = 'Zoom To Feature';
+              tableZoomTo.addEventListener('click', function (e) {
+                cgpv.api.map(mapId).zoomToExtent(row.extent);
+              });
+              tableData.appendChild(tableZoomTo);
+
+              // feature fields
+              Object.keys(row.fieldInfo).forEach((fieldName) => {
+                tableData = document.createElement('td');
+                tableData.classList.add('info');
+                tableData.innerText = row.fieldInfo[fieldName].value;
+                tableRow.appendChild(tableData);
+              });
+            });
+          } else {
+            content.appendChild(document.createElement('hr'));
+
+          }
+        });
+      };
+    </script>
+    <script>
       const createTableOfFilter = (mapId) => {
-        var mapButtonsDiv = document.getElementsByClassName(`layer${mapId.slice(3)}-buttons-div`)[0];
+        var mapButtonsDiv = document.getElementById(`layer${mapId.slice(3)}-buttons-div`);
         var oldTable = document.getElementById(`layer${mapId.slice(3)}-buttons-table`);
         if (oldTable) oldTable.remove();
         var tableElement = document.createElement("table");
@@ -1193,7 +1395,7 @@
                               layerConfig.style[geometry].defaultVisible = 'yes';
                               toggleUniqueValueDefault.innerText = `Hide ${layerConfig.style[geometry].defaultLabel}`;
                             }
-                            const checkbox = document.getElementById(`checkbox-${mapId}`);
+                            const checkbox = document.getElementById(`checkbox-${mapId}-${geoviewLayer.geoviewLayerId}`);
                             const filterInput = document.getElementById(`filter-input-${mapId}`);
                             const filter = checkbox.value === 'true' ? filterInput.value : '';
                             geoviewLayer.applyViewFilter(layerConfig, filter);
@@ -1230,7 +1432,7 @@
                               uniqueValueStyleInfoEntry.visible = 'yes';
                               toggleUniqueValueFeature.innerText = `Hide ${uniqueValueStyleInfoEntry.label}`;
                             }
-                            const checkbox = document.getElementById(`checkbox-${mapId}`);
+                            const checkbox = document.getElementById(`checkbox-${mapId}-${geoviewLayer.geoviewLayerId}`);
                             const filterInput = document.getElementById(`filter-input-${mapId}`);
                             const filter = checkbox.value === 'true' ? filterInput.value : '';
                             geoviewLayer.applyViewFilter(layerConfig, filter);
@@ -1268,7 +1470,7 @@
                             layerConfig.style[geometry].defaultVisible = 'yes';
                             toggleClassBreakDefault.innerText = `Hide ${layerConfig.style[geometry].defaultLabel}`;
                           }
-                            const checkbox = document.getElementById(`checkbox-${mapId}`);
+                            const checkbox = document.getElementById(`checkbox-${mapId}-${geoviewLayer.geoviewLayerId}`);
                             const filterInput = document.getElementById(`filter-input-${mapId}`);
                             const filter = checkbox.value === 'true' ? filterInput.value : '';
                             geoviewLayer.applyViewFilter(layerConfig, filter);
@@ -1305,7 +1507,7 @@
                               classBreakStyleInfoEntry.visible = 'yes';
                               toggleClassBreakFeature.innerText = `Hide ${classBreakStyleInfoEntry.label}`;
                             }
-                            const checkbox = document.getElementById(`checkbox-${mapId}`);
+                            const checkbox = document.getElementById(`checkbox-${mapId}-${geoviewLayer.geoviewLayerId}`);
                             const filterInput = document.getElementById(`filter-input-${mapId}`);
                             const filter = checkbox.value === 'true' ? filterInput.value : '';
                             geoviewLayer.applyViewFilter(layerConfig, filter);
@@ -1330,7 +1532,7 @@
                       layerFilterInput.value = geoviewLayer.getLayerFilter(layerConfig) || '';
                       const layerFilterButton = document.createElement("button");
                       layerFilterButton.addEventListener('click', function (e) {
-                        const checkbox = document.getElementById(`checkbox-${mapId}`);
+                        const checkbox = document.getElementById(`checkbox-${mapId}-${geoviewLayer.geoviewLayerId}`);
                         if (checkbox.value === 'true')
                           geoviewLayer.applyViewFilter(layerConfig, layerFilterInput.value);
                         else {
@@ -1344,7 +1546,7 @@
                       const checkboxInput = document.createElement("input");
                       checkboxInput.type='checkbox';
                       checkboxInput.value = 'false';
-                      checkboxInput.id = `checkbox-${mapId}`;
+                      checkboxInput.id = `checkbox-${mapId}-${geoviewLayer.geoviewLayerId}`;
                       checkboxInput.addEventListener('click', function (e) {
                         checkboxInput.value =checkboxInput.value === 'true' ? 'false' : 'true';
                         if (checkboxInput.value === 'true')
@@ -1372,12 +1574,20 @@
       cgpv.init(function (mapId) {
         console.log(`api is ready for ${mapId}`);
 
-      if (['LYR3', 'LYR4', 'LYR5', 'LYR6', 'LYR7', 'LYR8', 'LYR9'].includes(mapId)) createTableOfFilter(mapId);
+      if (['LYR1', 'LYR3', 'LYR4', 'LYR5', 'LYR6', 'LYR7', 'LYR8', 'LYR9'].includes(mapId)) createTableOfFilter(mapId);
 
         if (mapId === 'allMaps') {
           //create snippets
           createCodeSnippet();
           createConfigSnippet();
+          cgpv.api.event.emit({ handlerName: 'LYR1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'wmsLegendsId');
+          cgpv.api.event.emit({ handlerName: 'LYR3', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'esriDynamicLegendsId');
+          cgpv.api.event.emit({ handlerName: 'LYR4', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'esriFeatureLegendsId');
+          cgpv.api.event.emit({ handlerName: 'LYR5', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'geojsonLegendsId');
+          cgpv.api.event.emit({ handlerName: 'LYR6', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'wfsLegendsId');
+          cgpv.api.event.emit({ handlerName: 'LYR7', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'ogcApiLegendsId');
+          cgpv.api.event.emit({ handlerName: 'LYR8', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'geocoreLegendsId');
+          cgpv.api.event.emit({ handlerName: 'LYR9', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'geopackageLegendsId');
         }
       });
 
@@ -1447,7 +1657,7 @@
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
-          document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
+          createInfoTable('LYR1', 'wmsResultSetId', resultSets);
         },
         'LYR1',
         'wmsResultSetId'
@@ -1464,18 +1674,13 @@
         'wmsLegendsId'
       );
 
-      var addGeoJsonLegendButton = document.getElementsByClassName('Get-wms-Legend')[0];
-      addGeoJsonLegendButton.addEventListener('click', function (e) {
-        cgpv.api.event.emit({ handlerName: 'LYR1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'wmsLegendsId');
-      });
-
       // ESRI Dynamic =============================================================================================================
       const featureInfoEsriDynamicLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR3', 'esriDynamicResultSetId');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
-          document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
+          createInfoTable('LYR3', 'esriDynamicResultSetId', resultSets);
         },
         'LYR3',
         'esriDynamicResultSetId'
@@ -1492,18 +1697,13 @@
         'esriDynamicLegendsId'
       );
 
-      var addGeoJsonLegendButton = document.getElementsByClassName('Get-esri-dynamic-Legend')[0];
-      addGeoJsonLegendButton.addEventListener('click', function (e) {
-        cgpv.api.event.emit({ handlerName: 'LYR3', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'esriDynamicLegendsId');
-      });
-
       // ESRI Feature =============================================================================================================
       const featureInfoEsriFeatureLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR4', 'esriFeatureResultSetId');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
-          document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
+          createInfoTable('LYR4', 'esriFeatureResultSetId', resultSets);
         },
         'LYR4',
         'esriFeatureResultSetId'
@@ -1520,18 +1720,13 @@
         'esriFeatureLegendsId'
       );
 
-      var addGeoJsonLegendButton = document.getElementsByClassName('Get-esri-feature-Legend')[0];
-      addGeoJsonLegendButton.addEventListener('click', function (e) {
-        cgpv.api.event.emit({ handlerName: 'LYR4', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'esriFeatureLegendsId');
-      });
-
       // GeoJson ==================================================================================================================
       const featureInfoGeoJsonLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR5', 'geoJsonResultSetId');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
-          document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
+          createInfoTable('LYR5', 'geoJsonResultSetId', resultSets);
         },
         'LYR5',
         'geoJsonResultSetId'
@@ -1548,18 +1743,13 @@
         'geojsonLegendsId'
       );
 
-      var addGeoJsonLegendButton = document.getElementsByClassName('Get-geojson-Legend')[0];
-      addGeoJsonLegendButton.addEventListener('click', function (e) {
-        cgpv.api.event.emit({ handlerName: 'LYR5', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'geojsonLegendsId');
-      });
-
       // WFS ======================================================================================================================
       const featureInfoWfsLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR6', 'wfsResultSetId');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
-          document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
+          createInfoTable('LYR6', 'wfsResultSetId', resultSets);
         },
         'LYR6',
         'wfsResultSetId'
@@ -1576,18 +1766,13 @@
         'wfsLegendsId'
       );
 
-      var addGeoJsonLegendButton = document.getElementsByClassName('Get-wfs-Legend')[0];
-      addGeoJsonLegendButton.addEventListener('click', function (e) {
-        cgpv.api.event.emit({ handlerName: 'LYR6', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'wfsLegendsId');
-      });
-
       // OGC Feature API ==========================================================================================================
       const featureInfoOgcFeatureLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR7', 'ogcFeatureResultSetId');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
-          document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
+          createInfoTable('LYR7', 'ogcFeatureResultSetId', resultSets);
         },
         'LYR7',
         'ogcFeatureResultSetId'
@@ -1604,18 +1789,13 @@
         'ogcApiLegendsId'
       );
 
-      var addGeoJsonLegendButton = document.getElementsByClassName('Get-ogcApi-Legend')[0];
-      addGeoJsonLegendButton.addEventListener('click', function (e) {
-        cgpv.api.event.emit({ handlerName: 'LYR7', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'ogcApiLegendsId');
-      });
-
       // GeoCore ==================================================================================================================
       const featureInfoGeocoreFeatureLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR8', 'geocoreResultSetId');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
-          document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
+          createInfoTable('LYR8', 'geocoreResultSetId', resultSets);
         },
         'LYR8',
         'geocoreResultSetId'
@@ -1632,18 +1812,13 @@
         'geocoreLegendsId'
       );
 
-      var addGeoJsonLegendButton = document.getElementsByClassName('Get-geocore-Legend')[0];
-      addGeoJsonLegendButton.addEventListener('click', function (e) {
-        cgpv.api.event.emit({ handlerName: 'LYR8', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'geocoreLegendsId');
-      });
-
       // GeoPackage =============================================================================================================
       const featureInfoGeopackageLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR9', 'geopackageResultSetId');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
-          document.getElementById(layerSetId).textContent = JSON.stringify(resultSets, undefined, 2);
+          createInfoTable('LYR9', 'geopackageResultSetId', resultSets);
         },
         'LYR9',
         'geopackageResultSetId'
@@ -1659,11 +1834,6 @@
         'LYR9',
         'geopackageLegendsId'
       );
-
-      var addGeoJsonLegendButton = document.getElementsByClassName('Get-Geopackage-Legend')[0];
-      addGeoJsonLegendButton.addEventListener('click', function (e) {
-        cgpv.api.event.emit({ handlerName: 'LYR9', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER }, 'geopackageLegendsId');
-      });
 
       // ==========================================================================================================================
       // Test a refresh WMS from projection change
@@ -1696,8 +1866,10 @@
           const tableData = document.createElement('td');
           tableData.style.verticalAlign = 'middle';
           tableData.style.textAlign = 'center';
-          if (typeof data === 'string') tableData.innerHTML = data.replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-          else tableData.appendChild(data);
+          if (data)
+            if (typeof data === 'string') tableData.innerHTML = data.replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+            else tableData.appendChild(data);
+          else tableData.innerHTML = 'NO LEGEND';
           container.appendChild(tableData);
         };
         var oldTable = document.getElementById(`${layerSetId}-table`);
@@ -1765,7 +1937,7 @@
                     for (let i = 0; i < resultSets[layerPath].legend[geometryKey].arrayOfCanvas.length; i++) {
                       addRow(
                         layerPath,
-                        resultSets[layerPath].styleConfig[geometryKey].classBreakStyleInfos[i].label,
+                        resultSets[layerPath].styleConfig[geometryKey].classBreakStyleInfo[i].label,
                         resultSets[layerPath].legend[geometryKey].arrayOfCanvas[i]
                       );
                     }

--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -58,6 +58,10 @@
           "$ref": "#/definitions/TypeLocalizedString",
           "description": "A comma separated list of attribute names (English/French) that should be requested on query (all by default)."
         },
+        "fieldTypes": {
+          "type": "string",
+          "description": "A comma separated list of types. Type at index i is associated to the variable at index i."
+        },
         "aliasFields": {
           "$ref": "#/definitions/TypeLocalizedString",
           "description": "A comma separated list of attribute names (English/French) that should be use for alias. If empty, no alias will be set if not found."

--- a/packages/geoview-core/src/api/events/payloads/get-feature-info-payload.ts
+++ b/packages/geoview-core/src/api/events/payloads/get-feature-info-payload.ts
@@ -1,9 +1,12 @@
+import { Extent } from 'ol/extent';
 import { Coordinate } from 'ol/coordinate';
+import { FeatureLike } from 'ol/Feature';
 import { Pixel } from 'ol/pixel';
 
 import { PayloadBaseClass } from './payload-base-class';
 
 import { EventStringId, EVENT_NAMES } from '../event-types';
+import { TypeGeoviewLayerType } from '../../../geo/layer/geoview-layers/abstract-geoview-layers';
 
 /** Valid events that can create GetFeatureInfoPayload */
 const validEvents: EventStringId[] = [
@@ -14,10 +17,41 @@ const validEvents: EventStringId[] = [
 
 export type TypeQueryType = 'at pixel' | 'at coordinate' | 'at long lat' | 'using a bounding box' | 'using a polygon';
 
+export type codeValueEntryType = {
+  name: string;
+  code: unknown;
+};
+
+export type codedValueType = {
+  type: 'codedValue';
+  name: string;
+  description: string;
+  codedValues: codeValueEntryType[];
+};
+
+export type rangeDomainType = {
+  type: 'range';
+  name: string;
+  range: [minValue: unknown, maxValue: unknown];
+};
+
+export type TypeFieldEntry = {
+  fieldKey: number;
+  value: unknown;
+  dataType: 'string' | 'date' | 'number';
+  alias: string;
+  domain: null | codedValueType | rangeDomainType;
+};
+
 export type TypeFeatureInfoEntry = {
   featureKey: number;
-  featureInfo: Record<string, string | number | null>;
+  geoviewLayerType: TypeGeoviewLayerType;
+  extent: Extent;
+  geometry: FeatureLike | null;
+  featureIcon: HTMLCanvasElement;
+  fieldInfo: Partial<Record<string, TypeFieldEntry>>;
 };
+
 export type TypeArrayOfFeatureInfoEntries = TypeFeatureInfoEntry[];
 export type TypeFeatureInfoResultSets = { [layerPath: string]: TypeArrayOfFeatureInfoEntries | undefined };
 

--- a/packages/geoview-core/src/core/components/data-grid/data-grid-api.ts
+++ b/packages/geoview-core/src/core/components/data-grid/data-grid-api.ts
@@ -1,10 +1,9 @@
 import { createElement, ReactElement } from 'react';
 
 import { AbstractGeoViewVector, api } from '../../../app';
-// import { getLocalizedValue } from '../../utils/utilities';
 
 import { LayerDataGrid } from './layer-data-grid';
-import { TypeDisplayLanguage, TypeListOfLayerEntryConfig } from '../../../geo/map/map-schema-types';
+import { TypeDisplayLanguage } from '../../../geo/map/map-schema-types';
 
 export interface TypeLayerDataGridProps {
   layerId: string;
@@ -40,95 +39,49 @@ export class DataGridAPI {
    */
   createDataGrid = (layerDataGridProps: TypeLayerDataGridProps): ReactElement => {
     const { layerId } = layerDataGridProps;
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    let values: {}[] = [];
-    const groupKeys: string[] = [];
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    let groupValues: { layerValues: {}[] }[] = [];
-    const geoviewLayerInstance = api.map(this.mapId).layer.geoviewLayers[layerId];
-    if (geoviewLayerInstance.listOfLayerEntryConfig.length > 1) {
-      const setGroupKeys = (listOfLayerEntryConfig: TypeListOfLayerEntryConfig, parentLayerId: string) => {
-        listOfLayerEntryConfig.forEach((LayerEntryConfig) => {
-          if (
-            LayerEntryConfig.entryType === 'group' &&
-            LayerEntryConfig.listOfLayerEntryConfig !== undefined &&
-            LayerEntryConfig.listOfLayerEntryConfig.length > 1
-          ) {
-            setGroupKeys(LayerEntryConfig.listOfLayerEntryConfig, `${parentLayerId}/${LayerEntryConfig.layerId}`);
-          } else if (LayerEntryConfig.entryType !== 'group') {
-            groupKeys.push(`${parentLayerId}/${LayerEntryConfig.layerId}`);
-          }
+    const geoviewLayerInstance = api.map(this.mapId).layer.geoviewLayers[layerId] as AbstractGeoViewVector;
+    geoviewLayerInstance?.getAllFeatureInfo().then((arrayOfFeatureInfoEntries) => {
+      if (arrayOfFeatureInfoEntries?.length) {
+        // set values
+        const values = arrayOfFeatureInfoEntries.map((feature) => {
+          const { featureKey, fieldInfo } = feature;
+          return { featureKey, ...fieldInfo };
         });
-      };
-      setGroupKeys(geoviewLayerInstance.listOfLayerEntryConfig, layerId);
 
-      groupValues = groupKeys.map((layerkey) => {
-        const layerValues = (geoviewLayerInstance as AbstractGeoViewVector)?.getAllFeatureInfo(layerkey).map((feature) => {
-          const { featureKey, featureInfo } = feature;
-          return { featureKey, ...featureInfo };
+        // set columns
+        const columnHeader = Object.keys(arrayOfFeatureInfoEntries[0].fieldInfo).map<string>((fieldName): string => {
+          return arrayOfFeatureInfoEntries[0].fieldInfo[fieldName]!.alias;
         });
-        return { layerkey, layerValues };
-      });
-    } else {
-      const allFetureInfo = (geoviewLayerInstance as AbstractGeoViewVector)?.getAllFeatureInfo();
-      if (Array.isArray(allFetureInfo)) {
-        values = allFetureInfo.map((feature) => {
-          const { featureKey, featureInfo } = feature;
-          return { featureKey, ...featureInfo };
-        });
+
+        const columns = [];
+        for (let i = 0; i < columnHeader.length; i++) {
+          columns.push({
+            field: columnHeader[i],
+            headerName: columnHeader[i],
+            width: 150,
+            type: 'string',
+            hide: columnHeader[i] === 'fieldKey',
+          });
+        }
+
+        // set rows
+        const rows = values;
+
+        return createElement('div', {}, [
+          createElement(LayerDataGrid, {
+            key: `${layerId}-datagrid`,
+            columns,
+            rows,
+            pageSize: 50,
+            rowsPerPageOptions: [25, 50, 100],
+            autoHeight: true,
+            rowId: 'featureKey',
+            displayLanguage: this.displayLanguage,
+          }),
+        ]);
       }
-    }
-
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    const setLayerDataGridProps = (layerValues: {}[]) => {
-      // set columns
-      const columnHeader = Object.keys(layerValues[0]);
-
-      const columns = [];
-      for (let i = 0; i < columnHeader.length; i++) {
-        columns.push({
-          field: columnHeader[i],
-          headerName: columnHeader[i],
-          width: 150,
-          type: 'string',
-          hide: columnHeader.length > 1 && columnHeader[i] === 'featureKey',
-        });
-      }
-
-      // set rows
-      const rows = layerValues;
-
-      return {
-        key: `${layerId}-datagrid`,
-        columns,
-        rows,
-        pageSize: 50,
-        rowsPerPageOptions: [25, 50, 100],
-        autoHeight: true,
-        rowId: 'featureKey',
-        displayLanguage: this.displayLanguage,
-      };
-    };
-
-    return createElement('div', {}, [
-      groupKeys.length > 0 && [
-        createElement(
-          'select',
-          { id: `${layerId}-groupLayerSelection`, style: { fontSize: '1em', margin: '1em', padding: '0.3em' } },
-          groupKeys.map((layerkey) => {
-            return createElement('option', {}, [layerkey]);
-          })
-        ),
-        groupValues.map((groupValue, index) => {
-          return createElement(
-            'div',
-            { class: `${layerId}-layer-datagrid-table`, style: { display: index === 0 ? 'block' : 'none' } },
-            createElement(LayerDataGrid, setLayerDataGridProps(groupValue.layerValues))
-          );
-        }),
-      ],
-      values.length > 0 &&
-        createElement('div', { id: `${layerId}-layer-datagrid-table` }, [createElement(LayerDataGrid, setLayerDataGridProps(values))]),
-    ]);
+      return createElement('div', {}, []);
+    });
+    return createElement('div', {}, []);
   };
 }

--- a/packages/geoview-core/src/core/components/details/details-api.ts
+++ b/packages/geoview-core/src/core/components/details/details-api.ts
@@ -1,14 +1,8 @@
 import { createElement, ReactElement } from 'react';
-import { TypeArrayOfFeatureInfoEntries } from '../../../api/events/payloads/get-feature-info-payload';
 import { FeatureInfoLayerSet } from '../../../geo/utils/feature-info-layer-set';
 import { api } from '../../../app';
 
 import { Details, TypeArrayOfLayerData, DetailsProps } from './details';
-
-export interface TypeLayerDetailsProps {
-  layerPath: string;
-  features: TypeArrayOfFeatureInfoEntries;
-}
 
 /**
  * API to manage details component
@@ -34,7 +28,10 @@ export class DetailsAPI {
   /**
    * Create a details as as an element
    *
-   * @param {TypeLayerDetailsProps} layerDetailsProps the properties of the details to be created
+   * @param {TypeLayerDetailsProps} mapId the map identifier
+   * @param {TypeArrayOfLayerData} detailsElements the data to display in the Details element
+   * @param {detailsSettings} DetailsProps the properties of the details to be created
+   *
    * @return {ReactElement} the details react element
    *
    */

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -76,8 +76,8 @@ export function FeatureInfo(props: TypeFeatureProps): JSX.Element {
   const { feature, startOpen, backgroundStyle } = props;
   const featureId = `Feature Info ${feature.featureKey}`;
   const [isOpen, setOpen] = useState<boolean>(false);
-  const featureInfoList = Object.keys(feature.featureInfo).map((featureKey) => {
-    return { key: featureKey, value: feature.featureInfo[featureKey] };
+  const featureInfoList = Object.keys(feature.fieldInfo).map((fieldName) => {
+    return { key: fieldName, value: feature.fieldInfo[fieldName]!.value };
   });
   const fontColor = backgroundStyle === 'dark' ? { color: '#fff' } : {};
 

--- a/packages/geoview-core/src/core/components/legend/legend.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend.tsx
@@ -26,6 +26,7 @@ export function Legend(): JSX.Element | null {
       const newLayer = api.map(mapId).layer.geoviewLayers[geoviewLayerId];
       setOrderedMapLayers((orderedLayers) => [newLayer, ...orderedLayers]);
     } else {
+      // eslint-disable-next-line no-console
       console.error('geoviewLayerId is not in the layers list');
     }
   };

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -5,16 +5,16 @@ import { Pixel } from 'ol/pixel';
 import { Extent } from 'ol/extent';
 import LayerGroup, { Options as LayerGroupOptions } from 'ol/layer/Group';
 import { transformExtent } from 'ol/proj';
+import Feature from 'ol/Feature';
+import Geometry from 'ol/geom/Geometry';
 
-import { generateId } from '../../../core/utils/utilities';
+import { generateId, getLocalizedValue } from '../../../core/utils/utilities';
 import {
   TypeGeoviewLayerConfig,
   TypeListOfLayerEntryConfig,
   TypeLocalizedString,
   TypeLayerEntryConfig,
   TypeBaseLayerEntryConfig,
-  TypeBaseSourceImageInitialConfig,
-  TypeBaseSourceVectorInitialConfig,
   layerEntryIsGroupLayer,
   TypeStyleConfig,
   TypeLayerGroupEntryConfig,
@@ -23,9 +23,12 @@ import {
   TypeStyleGeometry,
 } from '../../map/map-schema-types';
 import {
+  codedValueType,
   GetFeatureInfoPayload,
   payloadIsQueryLayer,
+  rangeDomainType,
   TypeArrayOfFeatureInfoEntries,
+  TypeFeatureInfoEntry,
   TypeQueryType,
 } from '../../../api/events/payloads/get-feature-info-payload';
 import { snackbarMessagePayload } from '../../../api/events/payloads/snackbar-message-payload';
@@ -41,7 +44,7 @@ export type TypeLegend = {
   layerName?: TypeLocalizedString;
   type: TypeGeoviewLayerType;
   styleConfig?: TypeStyleConfig;
-  legend: TypeLayerStyle | HTMLCanvasElement;
+  legend: TypeLayerStyles | HTMLCanvasElement | null;
 };
 
 /**
@@ -74,7 +77,7 @@ export const isVectorLegend = (verifyIfLegend: TypeLegend): verifyIfLegend is Ty
 };
 
 export interface TypeVectorLegend extends TypeLegend {
-  legend: TypeLayerStyle;
+  legend: TypeLayerStyles;
 }
 
 export type TypeStyleRepresentation = {
@@ -85,7 +88,7 @@ export type TypeStyleRepresentation = {
   /** The arrayOfCanvas property is used by unique value and class break styles. */
   arrayOfCanvas?: (HTMLCanvasElement | null)[];
 };
-export type TypeLayerStyle = Partial<Record<TypeStyleGeometry, TypeStyleRepresentation>>;
+export type TypeLayerStyles = Partial<Record<TypeStyleGeometry, TypeStyleRepresentation>>;
 
 /** ******************************************************************************************************************************
  * GeoViewAbstractLayers types
@@ -192,6 +195,9 @@ export abstract class AbstractGeoViewLayer {
 
   // The service metadata.
   metadata: TypeJsonObject | null = null;
+
+  /** Layer metadata */
+  layerMetadata: Record<string, TypeJsonObject> = {};
 
   /** Attribution used in the OpenLayer source. */
   attributions: string[] = [];
@@ -703,6 +709,26 @@ export abstract class AbstractGeoViewLayer {
   }
 
   /** ***************************************************************************************************************************
+   * Return the type of the specified field.
+   *
+   * @param {string} fieldName field name for which we want to get the type.
+   * @param {TypeLayerEntryConfig} layeConfig layer configuration.
+   *
+   * @returns {null | codedValueType | rangeDomainType} The domain of the field.
+   */
+  protected abstract getFieldDomain(fieldName: string, layerConfig: TypeLayerEntryConfig): null | codedValueType | rangeDomainType;
+
+  /** ***************************************************************************************************************************
+   * Return the domain of the specified field. If the type can not be found, return 'string'.
+   *
+   * @param {string} fieldName field name for which we want to get the domain.
+   * @param {TypeLayerEntryConfig} layeConfig layer configuration.
+   *
+   * @returns {'string' | 'date' | 'number'} The type of the field.
+   */
+  protected abstract getFieldType(fieldName: string, layerConfig: TypeLayerEntryConfig): 'string' | 'date' | 'number';
+
+  /** ***************************************************************************************************************************
    * set the extent of the layer. Use undefined if it will be visible regardless of extent. The layer extent is an array of
    * numbers representing an extent: [minx, miny, maxx, maxy]. If layerPathOrConfig is undefined, the activeLayer of the class
    * will be used. This routine does nothing when no layerPathOrConfig is specified and the active layer is null.
@@ -844,12 +870,19 @@ export abstract class AbstractGeoViewLayer {
         style: TypeStyleConfig;
       };
 
-      if (!layerConfig?.style) resolve(null);
+      if (!layerConfig?.style)
+        resolve({
+          type: this.type,
+          layerPath: Layer.getLayerPath(layerConfig),
+          layerName: layerConfig.layerName!,
+          styleConfig: layerConfig?.style,
+          legend: null,
+        } as TypeLegend);
       else {
         const { geoviewRenderer } = api.map(this.mapId);
         geoviewRenderer.getLegendStyles(layerConfig.style as TypeStyleConfig).then((legendStyle) => {
           const legend: TypeLegend = {
-            type: layerConfig.geoviewRootLayer!.geoviewLayerType,
+            type: this.type,
             layerPath: Layer.getLayerPath(layerConfig),
             layerName: layerConfig.layerName!,
             styleConfig: layerConfig?.style,
@@ -863,23 +896,94 @@ export abstract class AbstractGeoViewLayer {
   }
 
   /** ***************************************************************************************************************************
-   * Utility method use to add an entry to the outfields or aliasFields attribute of the layerEntryConfig.source.featureInfo.
+   * Convert the feature information to an array of TypeArrayOfFeatureInfoEntries.
    *
-   * @param {TypeLayerEntryConfig} layerEntryConfig The layer entry configuration that contains the source.featureInfo.
-   * @param {outfields' | 'aliasFields} fieldName The field name to update.
-   * @param {string} fieldValue The value to append to the field name.
-   * @param {number} prefixEntryWithComa flag (0 = false) indicating that we must prefix the entry with a ','
+   * @param {Feature<Geometry>[]} features The array of features to convert.
+   * @param {TypeImageLayerEntryConfig | TypeVectorLayerEntryConfig} layerEntryConfig The layer configuration.
+   *
+   * @returns {TypeArrayOfFeatureInfoEntries} The Array of feature information.
    */
-  protected addFieldEntryToSourceFeatureInfo = (
-    layerEntryConfig: TypeLayerEntryConfig,
-    fieldName: 'outfields' | 'aliasFields',
-    fieldValue: string,
-    prefixEntryWithComa: number
-  ) => {
-    const layerEntrySourceConfig = layerEntryConfig.source as TypeBaseSourceVectorInitialConfig | TypeBaseSourceImageInitialConfig;
-    if (prefixEntryWithComa) {
-      layerEntrySourceConfig.featureInfo![fieldName]!.en = `${layerEntrySourceConfig.featureInfo![fieldName]!.en},`;
-    }
-    layerEntrySourceConfig.featureInfo![fieldName]!.en = `${layerEntrySourceConfig.featureInfo![fieldName]!.en}${fieldValue}`;
-  };
+  protected formatFeatureInfoResult(
+    features: Feature<Geometry>[],
+    layerEntryConfig?: TypeImageLayerEntryConfig | TypeVectorLayerEntryConfig
+  ): Promise<TypeArrayOfFeatureInfoEntries> {
+    const promisedArrayOfFeatureInfo = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
+      if (!features.length) resolve([]);
+      else {
+        const featureInfo = layerEntryConfig?.source?.featureInfo;
+        const fieldTypes = featureInfo?.fieldTypes?.split(',');
+        const outfields = getLocalizedValue(featureInfo?.outfields, this.mapId)?.split(',');
+        const aliasFields = getLocalizedValue(featureInfo?.aliasFields, this.mapId)?.split(',');
+        const queryResult: TypeArrayOfFeatureInfoEntries = [];
+        let featureKeyCounter = 0;
+        let fieldKeyCounter = 0;
+        const promisedAllCanvasFound: Promise<{ feature: Feature<Geometry>; canvas: HTMLCanvasElement | undefined }>[] = [];
+        features.forEach((featureNeedingItsCanvas) => {
+          promisedAllCanvasFound.push(
+            new Promise<{ feature: Feature<Geometry>; canvas: HTMLCanvasElement | undefined }>((resolveCanvas) => {
+              api
+                .map(this.mapId)
+                .geoviewRenderer.getFeatureCanvas(featureNeedingItsCanvas, layerEntryConfig as TypeVectorLayerEntryConfig)
+                .then((canvas) => {
+                  resolveCanvas({ feature: featureNeedingItsCanvas, canvas });
+                });
+            })
+          );
+        });
+        Promise.all(promisedAllCanvasFound).then((arrayOfFeatureInfo) => {
+          arrayOfFeatureInfo.forEach(({ canvas, feature }) => {
+            if (canvas) {
+              const clusterFeatures = feature.get('features');
+              if (clusterFeatures) {
+                this.formatFeatureInfoResult(clusterFeatures, layerEntryConfig).then((clusterFeatureInfo) => {
+                  clusterFeatureInfo.forEach((element) => {
+                    // eslint-disable-next-line no-param-reassign
+                    element.featureKey = featureKeyCounter++;
+                  });
+                  queryResult.push(...clusterFeatureInfo);
+                });
+              } else {
+                const featureInfoEntry: TypeFeatureInfoEntry = {
+                  // feature key for building the data-grid
+                  // eslint-disable-next-line no-param-reassign
+                  featureKey: featureKeyCounter++,
+                  geoviewLayerType: this.type,
+                  extent: feature.getGeometry()!.getExtent(),
+                  geometry: feature,
+                  featureIcon: canvas,
+                  fieldInfo: {},
+                };
+                const featureFields = feature.getKeys();
+                featureFields.forEach((fieldName) => {
+                  if (fieldName !== 'geometry') {
+                    if (outfields?.includes(fieldName)) {
+                      const fieldIndex = outfields.indexOf(fieldName);
+                      featureInfoEntry.fieldInfo[fieldName] = {
+                        fieldKey: fieldKeyCounter++,
+                        value: feature.get(fieldName),
+                        dataType: fieldTypes![fieldIndex] as 'string' | 'date' | 'number',
+                        alias: aliasFields![fieldIndex],
+                        domain: this.getFieldDomain(fieldName, layerEntryConfig!),
+                      };
+                    } else if (!outfields) {
+                      featureInfoEntry.fieldInfo[fieldName] = {
+                        fieldKey: fieldKeyCounter++,
+                        value: feature.get(fieldName),
+                        dataType: this.getFieldType(fieldName, layerEntryConfig!),
+                        alias: fieldName,
+                        domain: this.getFieldDomain(fieldName, layerEntryConfig!),
+                      };
+                    }
+                  }
+                });
+                queryResult.push(featureInfoEntry);
+              }
+            }
+          });
+          resolve(queryResult);
+        });
+      }
+    });
+    return promisedArrayOfFeatureInfo;
+  }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-param-reassign */
-import axios from 'axios';
 import { ImageArcGISRest } from 'ol/source';
 import { Options as SourceOptions } from 'ol/source/ImageArcGISRest';
 import { Options as ImageOptions } from 'ol/layer/BaseImage';
@@ -8,36 +7,48 @@ import { Image as ImageLayer } from 'ol/layer';
 import { Coordinate } from 'ol/coordinate';
 import { Pixel } from 'ol/pixel';
 import { transform, transformExtent } from 'ol/proj';
-import { Extent } from 'ol/extent';
+import { EsriJSON } from 'ol/format';
+import Feature from 'ol/Feature';
+import Geometry from 'ol/geom/Geometry';
 
-import cloneDeep from 'lodash/cloneDeep';
-import { Cast, TypeJsonArray, TypeJsonObject } from '../../../../core/types/global-types';
-import { getLocalizedValue, getXMLHttpRequest } from '../../../../core/utils/utilities';
-import { AbstractGeoViewLayer, CONST_LAYER_TYPES } from '../abstract-geoview-layers';
+import { getLocalizedValue } from '../../../../core/utils/utilities';
+import { AbstractGeoViewLayer, CONST_LAYER_TYPES, TypeLayerStyles } from '../abstract-geoview-layers';
 import { AbstractGeoViewRaster, TypeBaseRasterLayer } from './abstract-geoview-raster';
-import { EsriBaseRenderer, getStyleFromEsriRenderer } from '../../../renderer/esri-renderer';
 import {
   TypeImageLayerEntryConfig,
   TypeLayerEntryConfig,
   TypeSourceImageEsriInitialConfig,
   TypeGeoviewLayerConfig,
-  TypeListOfLayerEntryConfig,
-  TypeLayerGroupEntryConfig,
-  layerEntryIsGroupLayer,
-  TypeFeatureInfoLayerConfig,
   TypeStyleGeometry,
   isUniqueValueStyleConfig,
   isClassBreakStyleConfig,
   TypeUniqueValueStyleConfig,
   TypeClassBreakStyleConfig,
   isSimpleStyleConfig,
-  TypeBaseStyleConfig,
+  TypeListOfLayerEntryConfig,
 } from '../../../map/map-schema-types';
-import { TypeFeatureInfoEntry, TypeArrayOfFeatureInfoEntries } from '../../../../api/events/payloads/get-feature-info-payload';
+import {
+  TypeFeatureInfoEntry,
+  TypeArrayOfFeatureInfoEntries,
+  codedValueType,
+  rangeDomainType,
+} from '../../../../api/events/payloads/get-feature-info-payload';
 import { api } from '../../../../app';
 import { Layer } from '../../layer';
-import { TimeDimension, TimeDimensionESRI } from '../../../../core/utils/date-mgt';
+import { TimeDimension } from '../../../../core/utils/date-mgt';
 import { EVENT_NAMES } from '../../../../api/events/event-types';
+import {
+  commonGetFieldDomain,
+  commonGetFieldType,
+  commonGetServiceMetadata,
+  commonProcessFeatureInfoConfig,
+  commonProcessInitialSettings,
+  commonProcessLayerMetadata,
+  commonProcessTemporalDimension,
+  commonValidateListOfLayerEntryConfig,
+} from '../esri-layer-common';
+import { TypeJsonArray, TypeJsonObject } from '../../../../core/types/global-types';
+import { TypeEsriFeatureLayerEntryConfig } from '../vector/esri-feature';
 
 export interface TypeEsriDynamicLayerEntryConfig extends Omit<TypeImageLayerEntryConfig, 'source'> {
   source: TypeSourceImageEsriInitialConfig;
@@ -101,12 +112,6 @@ export const geoviewEntryIsEsriDynamic = (
  */
 // ******************************************************************************************************************************
 export class EsriDynamic extends AbstractGeoViewRaster {
-  /** Service metadata */
-  metadata: TypeJsonObject = {};
-
-  /** Layer metadata */
-  layerMetadata: Record<string, TypeJsonObject> = {};
-
   /** ****************************************************************************************************************************
    * Initialize layer.
    * @param {string} mapId The id of the map.
@@ -121,21 +126,9 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    *
    * @returns {Promise<void>} A promise that the execution is completed.
    */
-  protected getServiceMetadata(): Promise<void> {
+  getServiceMetadata(): Promise<void> {
     const promisedExecution = new Promise<void>((resolve) => {
-      const metadataUrl = getLocalizedValue(this.metadataAccessPath, this.mapId);
-      if (metadataUrl) {
-        getXMLHttpRequest(`${metadataUrl}?f=json`).then((metadataString) => {
-          if (metadataString === '{}')
-            throw new Error(`Cant't read service metadata for layer ${this.geoviewLayerId} of map ${this.mapId}.`);
-          else {
-            this.metadata = JSON.parse(metadataString) as TypeJsonObject;
-            const { copyrightText } = this.metadata;
-            if (copyrightText) this.attributions.push(copyrightText as string);
-            resolve();
-          }
-        });
-      } else throw new Error(`Cant't read service metadata for layer ${this.geoviewLayerId} of map ${this.mapId}.`);
+      commonGetServiceMetadata.call(this, resolve);
     });
     return promisedExecution;
   }
@@ -148,92 +141,101 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    *
    * @returns {TypeListOfLayerEntryConfig} A new list of layer entries configuration with deleted error layers.
    */
-  protected validateListOfLayerEntryConfig(listOfLayerEntryConfig: TypeListOfLayerEntryConfig): TypeListOfLayerEntryConfig {
-    return listOfLayerEntryConfig.filter((layerEntryConfig: TypeLayerEntryConfig) => {
-      if (api.map(this.mapId).layer.isRegistered(layerEntryConfig)) {
-        this.layerLoadError.push({
-          layer: Layer.getLayerPath(layerEntryConfig),
-          consoleMessage: `Duplicate layerPath (mapId: ${this.mapId}, layerPath: ${Layer.getLayerPath(layerEntryConfig)})`,
-        });
-        return false;
-      }
+  validateListOfLayerEntryConfig(listOfLayerEntryConfig: TypeListOfLayerEntryConfig): TypeListOfLayerEntryConfig {
+    return commonValidateListOfLayerEntryConfig.call(this, listOfLayerEntryConfig);
+  }
 
-      if (!this.metadata!.supportsDynamicLayers) {
-        this.layerLoadError.push({
-          layer: Layer.getLayerPath(layerEntryConfig),
-          consoleMessage: `Layer ${Layer.getLayerPath(layerEntryConfig)} of map ${this.mapId} does not support dynamic layers.`,
-        });
-        return false;
-      }
-
-      if (layerEntryIsGroupLayer(layerEntryConfig)) {
-        layerEntryConfig.listOfLayerEntryConfig = this.validateListOfLayerEntryConfig(layerEntryConfig.listOfLayerEntryConfig!);
-        if (layerEntryConfig.listOfLayerEntryConfig.length) {
-          api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);
-          return true;
-        }
-        this.layerLoadError.push({
-          layer: Layer.getLayerPath(layerEntryConfig),
-          consoleMessage: `Empty layer group (mapId:  ${this.mapId}, layerPath: ${Layer.getLayerPath(layerEntryConfig)})`,
-        });
-        return false;
-      }
-
-      let esriIndex = Number(layerEntryConfig.layerId);
-      if (Number.isNaN(esriIndex)) {
-        this.layerLoadError.push({
-          layer: Layer.getLayerPath(layerEntryConfig),
-          consoleMessage: `ESRI layerId must be a number (mapId:  ${this.mapId}, layerPath: ${Layer.getLayerPath(layerEntryConfig)})`,
-        });
-        return false;
-      }
-
-      esriIndex = this.metadata?.layers
-        ? (this.metadata.layers as TypeJsonArray).findIndex((layerInfo: TypeJsonObject) => layerInfo.id === esriIndex)
-        : -1;
-
-      if (esriIndex === -1) {
-        this.layerLoadError.push({
-          layer: Layer.getLayerPath(layerEntryConfig),
-          consoleMessage: `ESRI layerId not found (mapId:  ${this.mapId}, layerPath: ${Layer.getLayerPath(layerEntryConfig)})`,
-        });
-        return false;
-      }
-
-      if (this.metadata!.layers[esriIndex].type === 'Group Layer') {
-        const newListOfLayerEntryConfig: TypeListOfLayerEntryConfig = [];
-        (this.metadata!.layers[esriIndex].subLayerIds as TypeJsonArray).forEach((layerId) => {
-          const subLayerEntryConfig: TypeLayerEntryConfig = cloneDeep(layerEntryConfig);
-          subLayerEntryConfig.parentLayerConfig = Cast<TypeLayerGroupEntryConfig>(layerEntryConfig);
-          subLayerEntryConfig.layerId = `${layerId}`;
-          subLayerEntryConfig.layerName = {
-            en: this.metadata!.layers[layerId as number].name as string,
-            fr: this.metadata!.layers[layerId as number].name as string,
-          };
-          newListOfLayerEntryConfig.push(subLayerEntryConfig);
-        });
-        const switchToGroupLayer = Cast<TypeLayerGroupEntryConfig>(layerEntryConfig);
-        switchToGroupLayer.entryType = 'group';
-        switchToGroupLayer.layerName = {
-          en: this.metadata!.layers[esriIndex].name as string,
-          fr: this.metadata!.layers[esriIndex].name as string,
-        };
-        switchToGroupLayer.isMetadataLayerGroup = true;
-        switchToGroupLayer.listOfLayerEntryConfig = newListOfLayerEntryConfig;
-        api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);
-        this.validateListOfLayerEntryConfig(newListOfLayerEntryConfig);
-        return true;
-      }
-
-      if (!layerEntryConfig.layerName)
-        layerEntryConfig.layerName = {
-          en: this.metadata!.layers[esriIndex].name as string,
-          fr: this.metadata!.layers[esriIndex].name as string,
-        };
-
-      api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);
+  /** ***************************************************************************************************************************
+   * This method perform specific validation that can only be done by the child of the AbstractGeoViewEsriLayer class.
+   *
+   * @param {number} esriIndex The index of the current layer in the metadata.
+   *
+   * @returns {boolean} true if an error is detected.
+   */
+  esriChildHasDetectedAnError(layerEntryConfig: TypeLayerEntryConfig, esriIndex: number): boolean {
+    if (!this.metadata!.supportsDynamicLayers) {
+      this.layerLoadError.push({
+        layer: Layer.getLayerPath(layerEntryConfig),
+        consoleMessage: `Layer ${Layer.getLayerPath(layerEntryConfig)} of map ${this.mapId} does not support dynamic layers.`,
+      });
       return true;
-    });
+    }
+    return false;
+  }
+
+  /** ***************************************************************************************************************************
+   * Extract the type of the specified field from the metadata. If the type can not be found, return 'string'.
+   *
+   * @param {string} fieldName field name for which we want to get the type.
+   * @param {TypeLayerEntryConfig} layeConfig layer configuration.
+   *
+   * @returns {'string' | 'date' | 'number'} The type of the field.
+   */
+  getFieldType(fieldName: string, layerConfig: TypeLayerEntryConfig): 'string' | 'date' | 'number' {
+    return commonGetFieldType.call(this, fieldName, layerConfig);
+  }
+
+  /** ***************************************************************************************************************************
+   * Return the domain of the specified field.
+   *
+   * @param {string} fieldName field name for which we want to get the domain.
+   * @param {TypeLayerEntryConfig} layeConfig layer configuration.
+   *
+   * @returns {null | codedValueType | rangeDomainType} The domain of the field.
+   */
+  getFieldDomain(fieldName: string, layerConfig: TypeLayerEntryConfig): null | codedValueType | rangeDomainType {
+    return commonGetFieldDomain.call(this, fieldName, layerConfig);
+  }
+
+  /** ***************************************************************************************************************************
+   * This method will create a Geoview temporal dimension if it exist in the service metadata
+   * @param {TypeJsonObject} esriTimeDimension The ESRI time dimension object
+   * @param {TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig} layerEntryConfig The layer entry to configure
+   */
+  processTemporalDimension(
+    esriTimeDimension: TypeJsonObject,
+    layerEntryConfig: TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig
+  ) {
+    return commonProcessTemporalDimension.call(this, esriTimeDimension, layerEntryConfig);
+  }
+
+  /** ***************************************************************************************************************************
+   * This method verifies if the layer is queryable and sets the outfields and aliasFields of the source feature info.
+   *
+   * @param {string} capabilities The capabilities that will say if the layer is queryable.
+   * @param {string} nameField The display field associated to the layer.
+   * @param {string} geometryFieldName The field name of the geometry property.
+   * @param {TypeJsonArray} fields An array of field names and its aliases.
+   * @param {TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig} layerEntryConfig The layer entry to configure.
+   */
+  processFeatureInfoConfig = (
+    capabilities: string,
+    nameField: string,
+    geometryFieldName: string,
+    fields: TypeJsonArray,
+    layerEntryConfig: TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig
+  ) => {
+    return commonProcessFeatureInfoConfig.call(this, capabilities, nameField, geometryFieldName, fields, layerEntryConfig);
+  };
+
+  /** ***************************************************************************************************************************
+   * This method set the initial settings based on the service metadata. Priority is given to the layer configuration.
+   *
+   * @param {string} mapId The map identifier.
+   * @param {boolean} visibility The metadata initial visibility of the layer.
+   * @param {number} minScale The metadata minScale of the layer.
+   * @param {number} maxScale The metadata maxScale of the layer.
+   * @param {TypeJsonObject} extent The metadata layer extent.
+   * @param {TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig} layerEntryConfig The layer entry to configure.
+   */
+  processInitialSettings(
+    visibility: boolean,
+    minScale: number,
+    maxScale: number,
+    extent: TypeJsonObject,
+    layerEntryConfig: TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig
+  ) {
+    return commonProcessInitialSettings.call(this, visibility, minScale, maxScale, extent, layerEntryConfig);
   }
 
   /** ***************************************************************************************************************************
@@ -246,152 +248,9 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    */
   protected processLayerMetadata(layerEntryConfig: TypeLayerEntryConfig): Promise<void> {
     const promiseOfExecution = new Promise<void>((resolve) => {
-      // User-defined groups do not have metadata provided by the service endpoint.
-      if (layerEntryIsGroupLayer(layerEntryConfig) && !layerEntryConfig.isMetadataLayerGroup) resolve();
-      else {
-        let queryUrl = getLocalizedValue(this.metadataAccessPath, this.mapId);
-        if (queryUrl) {
-          queryUrl = queryUrl.endsWith('/') ? `${queryUrl}${layerEntryConfig.layerId}` : `${queryUrl}/${layerEntryConfig.layerId}`;
-          const queryResult = axios.get<TypeJsonObject>(`${queryUrl}?f=pjson`);
-          queryResult.then((response) => {
-            // layers must have a fields attribute except if it is an metadata layer group.
-            if (!response.data.fields && !(layerEntryConfig as TypeLayerGroupEntryConfig).isMetadataLayerGroup)
-              throw new Error(`Despite a return code of 200, an error was detected with this query (${queryUrl}?f=pjson)`);
-            this.layerMetadata[Layer.getLayerPath(layerEntryConfig)] = response.data;
-            if (geoviewEntryIsEsriDynamic(layerEntryConfig)) {
-              if (!(layerEntryConfig as TypeImageLayerEntryConfig).style) {
-                const renderer = Cast<EsriBaseRenderer>(response.data.drawingInfo?.renderer);
-                if (renderer) layerEntryConfig.style = getStyleFromEsriRenderer(this.mapId, layerEntryConfig, renderer);
-              } else {
-                // Replace all ` with ' in the styleFilter provided in the configuration because SQL string are between apostrophes
-                layerEntryConfig.layerFilter = layerEntryConfig.layerFilter?.split('`').join("'");
-              }
-              this.processFeatureInfoConfig(
-                response.data.capabilities as string,
-                response.data.displayField as string,
-                response.data.geometryField.name as string,
-                response.data.fields as TypeJsonArray,
-                layerEntryConfig
-              );
-              this.processInitialSettings(
-                response.data.defaultVisibility as boolean,
-                response.data.minScale as number,
-                response.data.maxScale as number,
-                response.data.extent,
-                layerEntryConfig
-              );
-              this.processTemporalDimension(response.data.timeInfo as TypeJsonObject, layerEntryConfig);
-            }
-            resolve();
-          });
-        } else resolve();
-      }
+      commonProcessLayerMetadata.call(this, resolve, layerEntryConfig);
     });
     return promiseOfExecution;
-  }
-
-  /** ***************************************************************************************************************************
-   * This method set the initial settings based on the service metadata. Priority is given to the layer configuration.
-   *
-   * @param {boolean} visibility The metadata initial visibility of the layer.
-   * @param {number} minScale The metadata minScale of the layer.
-   * @param {number} maxScale The metadata maxScale of the layer.
-   * @param {TypeJsonObject} extent The metadata layer extent.
-   * @param {TypeEsriDynamicLayerEntryConfig} layerEntryConfig The vector layer entry to configure.
-   */
-  private processInitialSettings(
-    visibility: boolean,
-    minScale: number,
-    maxScale: number,
-    extent: TypeJsonObject,
-    layerEntryConfig: TypeEsriDynamicLayerEntryConfig
-  ) {
-    if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
-    if (layerEntryConfig.initialSettings?.visible === undefined) layerEntryConfig.initialSettings.visible = visibility;
-    // ! TODO: The solution implemented in the following two lines is not right. scale and zoom are not the same things.
-    // ! if (layerEntryConfig.initialSettings?.minZoom === undefined && minScale !== 0) layerEntryConfig.initialSettings.minZoom = minScale;
-    // ! if (layerEntryConfig.initialSettings?.maxZoom === undefined && maxScale !== 0) layerEntryConfig.initialSettings.maxZoom = maxScale;
-    if (layerEntryConfig.initialSettings?.extent)
-      layerEntryConfig.initialSettings.extent = transformExtent(
-        layerEntryConfig.initialSettings.extent,
-        'EPSG:4326',
-        `EPSG:${api.map(this.mapId).currentProjection}`
-      );
-
-    if (layerEntryConfig.initialSettings?.bounds)
-      layerEntryConfig.initialSettings.bounds = transformExtent(
-        layerEntryConfig.initialSettings.bounds,
-        'EPSG:4326',
-        `EPSG:${api.map(this.mapId).currentProjection}`
-      );
-    else {
-      if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
-      const layerExtent = [extent.xmin, extent.ymin, extent.xmax, extent.ymax] as Extent;
-      layerEntryConfig.initialSettings.bounds = transformExtent(
-        layerExtent,
-        `EPSG:${extent.spatialReference.wkid as number}`,
-        `EPSG:${api.map(this.mapId).currentProjection}`
-      );
-    }
-  }
-
-  /** ***************************************************************************************************************************
-   * This method verifies if the layer is queryable and sets the outfields and aliasFields of the source feature info.
-   *
-   * @param {string} capabilities The capabilities that will say if the layer is queryable.
-   * @param {string} nameField The display field associated to the layer.
-   * @param {string} geometryFieldName The field name of the geometry property.
-   * @param {TypeJsonArray} fields An array of field names and its aliases.
-   * @param {TypeEsriDynamicLayerEntryConfig} layerEntryConfig The vector layer entry to configure.
-   */
-  private processFeatureInfoConfig(
-    capabilities: string,
-    nameField: string,
-    geometryFieldName: string,
-    fields: TypeJsonArray,
-    layerEntryConfig: TypeEsriDynamicLayerEntryConfig
-  ) {
-    if (!layerEntryConfig.source.featureInfo) layerEntryConfig.source.featureInfo = { queryable: capabilities.includes('Query') };
-    // metadata layer group doesn't have fields definition
-    if (!layerEntryConfig.isMetadataLayerGroup) {
-      if (!layerEntryConfig.source.featureInfo.nameField)
-        layerEntryConfig.source.featureInfo.nameField = {
-          en: nameField,
-          fr: nameField,
-        };
-
-      // Process undefined outfields or aliasFields ('' = false and !'' = true)
-      if (!layerEntryConfig.source.featureInfo.outfields?.en || !layerEntryConfig.source.featureInfo.aliasFields?.en) {
-        const processOutField = !layerEntryConfig.source.featureInfo.outfields?.en;
-        const processAliasFields = !layerEntryConfig.source.featureInfo.aliasFields?.en;
-        if (processOutField) layerEntryConfig.source.featureInfo.outfields = { en: '' };
-        if (processAliasFields) layerEntryConfig.source.featureInfo.aliasFields = { en: '' };
-        fields.forEach((fieldEntry, i) => {
-          if (fieldEntry.name === geometryFieldName) return;
-          if (processOutField) this.addFieldEntryToSourceFeatureInfo(layerEntryConfig, 'outfields', fieldEntry.name as string, i);
-          if (processAliasFields)
-            this.addFieldEntryToSourceFeatureInfo(
-              layerEntryConfig,
-              'aliasFields',
-              (fieldEntry.alias ? fieldEntry.alias : fieldEntry.name) as string,
-              i
-            );
-        });
-        layerEntryConfig.source.featureInfo!.outfields!.fr = layerEntryConfig.source.featureInfo!.outfields?.en;
-        layerEntryConfig.source.featureInfo!.aliasFields!.fr = layerEntryConfig.source.featureInfo!.aliasFields?.en;
-      }
-    }
-  }
-
-  /** ***************************************************************************************************************************
-   * This method will create a Geoview temporal dimension if it exist in the service metadata
-   * @param {TypeJsonObject} esriTimeDimension The ESRI time dimension object
-   * @param {TypeEsriDynamicLayerEntryConfig} layerEntryConfig The layer entry to configure
-   */
-  private processTemporalDimension(esriTimeDimension: TypeJsonObject, layerEntryConfig: TypeEsriDynamicLayerEntryConfig) {
-    if (esriTimeDimension !== undefined) {
-      layerEntryConfig.temporalDimension = api.dateUtilities.createDimensionFromESRI(esriTimeDimension as unknown as TimeDimensionESRI);
-    }
   }
 
   /** ****************************************************************************************************************************
@@ -404,7 +263,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
   processOneLayerEntry(layerEntryConfig: TypeEsriDynamicLayerEntryConfig): Promise<TypeBaseRasterLayer | null> {
     const promisedVectorLayer = new Promise<TypeBaseRasterLayer | null>((resolve) => {
       const sourceOptions: SourceOptions = {};
-      sourceOptions.attributions = [(this.metadata.copyrightText ? this.metadata.copyrightText : '') as string];
+      sourceOptions.attributions = [(this.metadata!.copyrightText ? this.metadata!.copyrightText : '') as string];
       sourceOptions.url = getLocalizedValue(layerEntryConfig.source.dataAccessPath!, this.mapId);
       sourceOptions.params = { LAYERS: `show:${layerEntryConfig.layerId}` };
       if (layerEntryConfig.source.transparent)
@@ -432,6 +291,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
       // postpone the setVisible action until all layers have been loaded on the map.
       api.event.once(
         EVENT_NAMES.LAYER.EVENT_IF_CONDITION,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         (payload) => {
           this.setVisible(layerEntryConfig.initialSettings!.visible!, layerEntryConfig);
         },
@@ -448,41 +308,6 @@ export class EsriDynamic extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Translate the get feature information at coordinate result set to the TypeArrayOfFeatureInfoEntries used by GeoView.
-   *
-   * @param {TypeJsonArray} features An array of found features formatted using the query syntax.
-   * @param {TypeFeatureInfoLayerConfig} featureInfo Feature information describing the user's desired output format.
-   *
-   * @returns {TypeArrayOfFeatureInfoEntries} The feature info table.
-   */
-  private formatFeatureInfoAtCoordinateResult(
-    features: TypeJsonArray,
-    featureInfo?: TypeFeatureInfoLayerConfig
-  ): TypeArrayOfFeatureInfoEntries {
-    if (!features.length) return [];
-    const outfields = getLocalizedValue(featureInfo?.outfields, this.mapId)?.split(',');
-    const aliasFields = getLocalizedValue(featureInfo?.aliasFields, this.mapId)?.split(',');
-    const queryResult: TypeArrayOfFeatureInfoEntries = [];
-    let keyCounter = 0;
-    features.forEach((feature) => {
-      const featureFields = Object.keys(feature.attributes);
-      const featureInfoEntry: TypeFeatureInfoEntry = {
-        // feature key for building the data-grid
-        featureKey: keyCounter++,
-        featureInfo: {},
-      };
-      featureFields.forEach((fieldName) => {
-        if (outfields?.includes(fieldName)) {
-          const aliasfieldIndex = outfields.indexOf(fieldName);
-          featureInfoEntry.featureInfo[aliasFields![aliasfieldIndex]] = feature.attributes[fieldName] as string | number | null;
-        } else if (!outfields) featureInfoEntry.featureInfo[fieldName] = feature.attributes[fieldName] as string | number | null;
-      });
-      queryResult.push(featureInfoEntry);
-    });
-    return queryResult;
-  }
-
-  /** ***************************************************************************************************************************
    * Return feature information for all the features around the provided Pixel.
    *
    * @param {Coordinate} location The pixel coordinate that will be used by the query.
@@ -491,11 +316,8 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
    */
   protected getFeatureInfoAtPixel(location: Pixel, layerConfig: TypeEsriDynamicLayerEntryConfig): Promise<TypeArrayOfFeatureInfoEntries> {
-    const promisedQueryResult = new Promise<TypeArrayOfFeatureInfoEntries>((resolve) => {
-      const { map } = api.map(this.mapId);
-      resolve(this.getFeatureInfoAtCoordinate(map.getCoordinateFromPixel(location), layerConfig));
-    });
-    return promisedQueryResult;
+    const { map } = api.map(this.mapId);
+    return this.getFeatureInfoAtCoordinate(map.getCoordinateFromPixel(location), layerConfig);
   }
 
   /** ***************************************************************************************************************************
@@ -552,12 +374,13 @@ export class EsriDynamic extends AbstractGeoViewRaster {
 
           fetch(identifyUrl).then((response) => {
             response.json().then((jsonResponse) => {
-              resolve(
-                this.formatFeatureInfoAtCoordinateResult(
-                  jsonResponse.results as TypeJsonArray,
-                  (layerConfig as TypeEsriDynamicLayerEntryConfig).source.featureInfo
-                )
+              const features = new EsriJSON().readFeatures(
+                { features: jsonResponse.results },
+                { dataProjection: 'EPSG:4326', featureProjection: `EPSG:${currentProjection}` }
               );
+              this.formatFeatureInfoResult(features, layerConfig).then((arrayOfFeatureInfoEntries) => {
+                resolve(arrayOfFeatureInfoEntries);
+              });
             });
           });
         }
@@ -761,6 +584,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
     if (layerEntryConfig) {
       const source = (layerEntryConfig.gvLayer as ImageLayer<ImageArcGISRest>).getSource()!;
       source.updateParams({ layerDefs: `{"${layerEntryConfig.layerId}": "${filter || this.getViewFilter(layerEntryConfig)}"}` });
+      layerEntryConfig.gvLayer!.set('legendFilterIsOff', !!filter);
       layerEntryConfig.gvLayer!.changed();
     }
   }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -29,7 +29,12 @@ import {
   TypeFeatureInfoLayerConfig,
   TypeSourceImageInitialConfig,
 } from '../../../map/map-schema-types';
-import { TypeFeatureInfoEntry, TypeArrayOfFeatureInfoEntries } from '../../../../api/events/payloads/get-feature-info-payload';
+import {
+  TypeFeatureInfoEntry,
+  TypeArrayOfFeatureInfoEntries,
+  rangeDomainType,
+  codedValueType,
+} from '../../../../api/events/payloads/get-feature-info-payload';
 import { getLocalizedValue, xmlToJson } from '../../../../core/utils/utilities';
 import { snackbarMessagePayload } from '../../../../api/events/payloads/snackbar-message-payload';
 import { EVENT_NAMES } from '../../../../api/events/event-types';
@@ -102,6 +107,30 @@ export class WMS extends AbstractGeoViewRaster {
    */
   constructor(mapId: string, layerConfig: TypeWMSLayerConfig) {
     super(CONST_LAYER_TYPES.WMS, layerConfig, mapId);
+  }
+
+  /** ***************************************************************************************************************************
+   * Extract the type of the specified field from the metadata. If the type can not be found, return 'string'.
+   *
+   * @param {string} fieldName field name for which we want to get the type.
+   * @param {TypeLayerEntryConfig} layeConfig layer configuration.
+   *
+   * @returns {'string' | 'date' | 'number'} The type of the field.
+   */
+  protected getFieldType(fieldName: string, layerConfig: TypeLayerEntryConfig): 'string' | 'date' | 'number' {
+    return 'string';
+  }
+
+  /** ***************************************************************************************************************************
+   * Returns null. WMS services don't have domains.
+   *
+   * @param {string} fieldName field name for which we want to get the domain.
+   * @param {TypeLayerEntryConfig} layeConfig layer configuration.
+   *
+   * @returns {null | codedValueType | rangeDomainType} The domain of the field.
+   */
+  protected getFieldDomain(fieldName: string, layerConfig: TypeLayerEntryConfig): null | codedValueType | rangeDomainType {
+    return null;
   }
 
   /** ***************************************************************************************************************************
@@ -530,12 +559,13 @@ export class WMS extends AbstractGeoViewRaster {
   protected processLayerMetadata(layerEntryConfig: TypeLayerEntryConfig): Promise<void> {
     const promiseOfExecution = new Promise<void>((resolve) => {
       if (geoviewEntryIsWMS(layerEntryConfig)) {
-        const layerCapabilities = this.getLayerMetadataEntry(layerEntryConfig.layerId);
+        const layerCapabilities = this.getLayerMetadataEntry(layerEntryConfig.layerId)!;
+        this.layerMetadata[Layer.getLayerPath(layerEntryConfig)] = layerCapabilities;
         if (layerCapabilities) {
           if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
           if (layerCapabilities.Attribution) this.attributions.push(layerCapabilities.Attribution as string);
           if (!layerEntryConfig.source.featureInfo) layerEntryConfig.source.featureInfo = { queryable: !!layerCapabilities.queryable };
-          // ! TODO: The solution implemented in the following 5 lines is not right. scale and zoom are not the same things.
+          // ! TODO: The solution implemented in the following lines is not right. scale and zoom are not the same things.
           // if (layerEntryConfig.initialSettings?.minZoom === undefined && layerCapabilities.MinScaleDenominator !== undefined)
           //   layerEntryConfig.initialSettings.minZoom = layerCapabilities.MinScaleDenominator as number;
           // if (layerEntryConfig.initialSettings?.maxZoom === undefined && layerCapabilities.MaxScaleDenominator !== undefined)
@@ -656,7 +686,11 @@ export class WMS extends AbstractGeoViewRaster {
                 const featureCollection = this.getAttribute(jsonResponse, 'FeatureCollection');
                 if (featureCollection) featureMember = this.getAttribute(featureCollection, 'featureMember');
               } else featureMember = { plain_text: { '#text': response.data } };
-              if (featureMember) resolve(this.formatFeatureInfoAtCoordinateResult(featureMember, layerConfig.source.featureInfo));
+              if (featureMember) {
+                const featureInfoResult = this.formatWmsFeatureInfoResult(featureMember, layerConfig);
+                featureInfoResult[0].extent = [clickCoordinate[0], clickCoordinate[1], clickCoordinate[0], clickCoordinate[1]];
+                resolve(featureInfoResult);
+          }
             });
           } else resolve([]);
         }
@@ -717,7 +751,7 @@ export class WMS extends AbstractGeoViewRaster {
           if (urlEntry.Format === 'image/png') return true;
           return false;
         });
-        if (legendUrl) return legendUrl;
+        return legendUrl || null;
       }
     }
     return null;
@@ -737,22 +771,27 @@ export class WMS extends AbstractGeoViewRaster {
         new Promise((resolve, reject) => {
           const reader = new FileReader();
           reader.onloadend = () => resolve(reader.result);
-          reader.onerror = reject;
+          reader.onerror = () => resolve(null);
           reader.readAsDataURL(blob);
         });
 
+      let queryUrl: string | undefined;
       const legendUrlFromCapabilities = this.getLegendUrlFromCapabilities(layerConfig);
-      let queryUrl: string;
       if (legendUrlFromCapabilities) queryUrl = legendUrlFromCapabilities.OnlineResource as string;
-      else
+      else if (Object.keys(this.metadata!.Capability.Request).includes('GetLegendGraphic'))
         queryUrl = `${getLocalizedValue(
           this.metadataAccessPath,
           this.mapId
         )!}service=WMS&version=1.3.0&request=GetLegendGraphic&FORMAT=image/png&layer=${layerConfig.layerId}`;
 
-      axios.get<TypeJsonObject>(queryUrl, { responseType: 'blob' }).then((response) => {
-        resolve(readImage(Cast<Blob>(response.data)));
-      });
+      if (queryUrl)
+        axios
+          .get<TypeJsonObject>(queryUrl, { responseType: 'blob' })
+          .then((response) => {
+            resolve(readImage(Cast<Blob>(response.data)));
+          })
+          .catch((error) => resolve(null));
+      else resolve(null);
     });
     return promisedImage;
   }
@@ -774,7 +813,13 @@ export class WMS extends AbstractGeoViewRaster {
       if (!layerConfig) resolve(null);
 
       this.getLegendImage(layerConfig!).then((legendImage) => {
-        if (!legendImage) resolve(null);
+        if (!legendImage)
+          resolve({
+            type: this.type,
+            layerPath: Layer.getLayerPath(layerConfig!),
+            layerName: layerConfig!.layerName,
+            legend: null,
+          });
         else {
           api
             .map(this.mapId)
@@ -793,7 +838,13 @@ export class WMS extends AbstractGeoViewRaster {
                   legend: drawingCanvas,
                 };
                 resolve(legend);
-              } else resolve(null);
+              } else
+                resolve({
+                  type: this.type,
+                  layerPath: Layer.getLayerPath(layerConfig!),
+                  layerName: layerConfig!.layerName,
+                  legend: null,
+                });
             });
         }
       });
@@ -802,25 +853,30 @@ export class WMS extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Translate the get feature information at coordinate result set to the TypeArrayOfFeatureInfoEntries used by GeoView.
+   * Translate the get feature information result set to the TypeArrayOfFeatureInfoEntries used by GeoView.
    *
    * @param {TypeJsonObject} featureMember An object formatted using the query syntax.
-   * @param {TypeFeatureInfoLayerConfig} featureInfo Feature information describing the user's desired output format.
+   * @param {TypeWmsLayerEntryConfig} layerEntryConfig The layer configuration.
    *
    * @returns {TypeArrayOfFeatureInfoEntries} The feature info table.
    */
-  private formatFeatureInfoAtCoordinateResult(
-    featureMember: TypeJsonObject,
-    featureInfo?: TypeFeatureInfoLayerConfig
-  ): TypeArrayOfFeatureInfoEntries {
+  formatWmsFeatureInfoResult(featureMember: TypeJsonObject, layerEntryConfig: TypeWmsLayerEntryConfig): TypeArrayOfFeatureInfoEntries {
+    const featureInfo = layerEntryConfig?.source?.featureInfo;
     const outfields = getLocalizedValue(featureInfo?.outfields, this.mapId)?.split(',');
+    const fieldTypes = featureInfo?.fieldTypes?.split(',');
     const aliasFields = getLocalizedValue(featureInfo?.aliasFields, this.mapId)?.split(',');
     const queryResult: TypeArrayOfFeatureInfoEntries = [];
 
+    let featureKeyCounter = 0;
+    let fieldKeyCounter = 0;
     const featureInfoEntry: TypeFeatureInfoEntry = {
       // feature key for building the data-grid
-      featureKey: 0,
-      featureInfo: {},
+      featureKey: featureKeyCounter++,
+      geoviewLayerType: this.type,
+      extent: [0, 0, 0, 0],
+      geometry: null,
+      featureIcon: document.createElement('canvas'),
+      fieldInfo: {},
     };
     const createFieldEntries = (entry: TypeJsonObject, prefix = '') => {
       const keys = Object.keys(entry);
@@ -829,7 +885,13 @@ export class WMS extends AbstractGeoViewRaster {
           const splitedKey = key.split(':');
           const fieldName = splitedKey[splitedKey.length - 1];
           if ('#text' in entry[key])
-            featureInfoEntry.featureInfo[`${prefix}${prefix ? '.' : ''}${fieldName}`] = entry[key]['#text'] as string;
+            featureInfoEntry.fieldInfo[`${prefix}${prefix ? '.' : ''}${fieldName}`] = {
+              fieldKey: fieldKeyCounter++,
+              value: entry[key]['#text'] as string,
+              dataType: 'string',
+              alias: `${prefix}${prefix ? '.' : ''}${fieldName}`,
+              domain: null,
+            };
           else createFieldEntries(entry[key], fieldName);
         }
       });
@@ -838,18 +900,21 @@ export class WMS extends AbstractGeoViewRaster {
 
     if (!outfields) queryResult.push(featureInfoEntry);
     else {
-      const filteredFeatureInfoEntry: TypeFeatureInfoEntry = {
-        // feature key for building the data-grid
-        featureKey: 0,
-        featureInfo: {},
-      };
-      Object.keys(featureInfoEntry.featureInfo).forEach((fieldName) => {
+      fieldKeyCounter = 0;
+      const fieldsToDelete = Object.keys(featureInfoEntry.fieldInfo).filter((fieldName) => {
         if (outfields?.includes(fieldName)) {
-          const aliasfieldIndex = outfields.indexOf(fieldName);
-          filteredFeatureInfoEntry.featureInfo[aliasFields![aliasfieldIndex]] = featureInfoEntry.featureInfo[fieldName];
+          const fieldIndex = outfields.indexOf(fieldName);
+          featureInfoEntry.fieldInfo[fieldName]!.fieldKey = fieldKeyCounter++;
+          featureInfoEntry.fieldInfo[fieldName]!.alias = aliasFields![fieldIndex];
+          featureInfoEntry.fieldInfo[fieldName]!.dataType = fieldTypes![fieldIndex] as 'string' | 'date' | 'number';
+          return false; // keep this entry
         }
+        return true; // delete this entry
       });
-      queryResult.push(filteredFeatureInfoEntry);
+      fieldsToDelete.forEach((entryToDelete) => {
+        delete featureInfoEntry.fieldInfo[entryToDelete];
+      });
+      queryResult.push(featureInfoEntry);
     }
     return queryResult;
   }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -1,8 +1,4 @@
 /* eslint-disable no-param-reassign */
-import axios from 'axios';
-import cloneDeep from 'lodash/cloneDeep';
-import { Extent } from 'ol/extent';
-import { transformExtent } from 'ol/proj';
 import { Vector as VectorSource } from 'ol/source';
 import { Geometry } from 'ol/geom';
 import { Options as SourceOptions } from 'ol/source/Vector';
@@ -10,9 +6,7 @@ import { all } from 'ol/loadingstrategy';
 import { EsriJSON } from 'ol/format';
 import { ReadOptions } from 'ol/format/Feature';
 
-import { Cast, toJsonObject, TypeJsonArray, TypeJsonObject } from '../../../../core/types/global-types';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES } from '../abstract-geoview-layers';
-import { AbstractGeoViewVector } from './abstract-geoview-vector';
 
 import {
   TypeLayerEntryConfig,
@@ -20,13 +14,24 @@ import {
   TypeVectorSourceInitialConfig,
   TypeGeoviewLayerConfig,
   TypeListOfLayerEntryConfig,
-  TypeLayerGroupEntryConfig,
-  layerEntryIsGroupLayer,
 } from '../../../map/map-schema-types';
 
-import { getLocalizedValue, getXMLHttpRequest } from '../../../../core/utils/utilities';
-import { EsriBaseRenderer, getStyleFromEsriRenderer } from '../../../renderer/esri-renderer';
-import { api, TimeDimension, TimeDimensionESRI } from '../../../../app';
+import { getLocalizedValue } from '../../../../core/utils/utilities';
+import {
+  commonGetFieldDomain,
+  commonGetFieldType,
+  commonGetServiceMetadata,
+  commonProcessFeatureInfoConfig,
+  commonProcessInitialSettings,
+  commonProcessLayerMetadata,
+  commonProcessTemporalDimension,
+  commonValidateListOfLayerEntryConfig,
+} from '../esri-layer-common';
+import { TimeDimension } from '../../../../core/utils/date-mgt';
+import { AbstractGeoViewVector } from './abstract-geoview-vector';
+import { TypeJsonArray, TypeJsonObject } from '../../../../core/types/global-types';
+import { TypeEsriDynamicLayerEntryConfig } from '../raster/esri-dynamic';
+import { codedValueType, rangeDomainType } from '../../../../api/events/payloads/get-feature-info-payload';
 import { Layer } from '../../layer';
 
 export interface TypeSourceEsriFeatureInitialConfig extends Omit<TypeVectorSourceInitialConfig, 'format'> {
@@ -95,9 +100,6 @@ export const geoviewEntryIsEsriFeature = (
  */
 // ******************************************************************************************************************************
 export class EsriFeature extends AbstractGeoViewVector {
-  /** Layer metadata */
-  layerMetadata: Record<string, TypeJsonObject> = {};
-
   /** ***************************************************************************************************************************
    * Initialize layer.
    *
@@ -113,21 +115,9 @@ export class EsriFeature extends AbstractGeoViewVector {
    *
    * @returns {Promise<void>} A promise that the execution is completed.
    */
-  protected getServiceMetadata(): Promise<void> {
+  getServiceMetadata(): Promise<void> {
     const promisedExecution = new Promise<void>((resolve) => {
-      const metadataUrl = getLocalizedValue(this.metadataAccessPath, this.mapId);
-      if (metadataUrl) {
-        getXMLHttpRequest(`${metadataUrl}?f=json`).then((metadataString) => {
-          if (metadataString === '{}')
-            throw new Error(`Cant't read service metadata for layer ${this.geoviewLayerId} of map ${this.mapId}.`);
-          else {
-            this.metadata = toJsonObject(JSON.parse(metadataString));
-            const { copyrightText } = this.metadata;
-            if (copyrightText) this.attributions.push(copyrightText as string);
-            resolve();
-          }
-        });
-      } else throw new Error(`Cant't read service metadata for layer ${this.geoviewLayerId} of map ${this.mapId}.`);
+      commonGetServiceMetadata.call(this, resolve);
     });
     return promisedExecution;
   }
@@ -140,186 +130,62 @@ export class EsriFeature extends AbstractGeoViewVector {
    *
    * @returns {TypeListOfLayerEntryConfig} A new list of layer entries configuration with deleted error layers.
    */
-  protected validateListOfLayerEntryConfig(listOfLayerEntryConfig: TypeListOfLayerEntryConfig): TypeListOfLayerEntryConfig {
-    return listOfLayerEntryConfig.filter((layerEntryConfig: TypeLayerEntryConfig) => {
-      if (api.map(this.mapId).layer.isRegistered(layerEntryConfig)) {
-        this.layerLoadError.push({
-          layer: Layer.getLayerPath(layerEntryConfig),
-          consoleMessage: `Duplicate layerPath (mapId:  ${this.mapId}, layerPath: ${Layer.getLayerPath(layerEntryConfig)})`,
-        });
-        return false;
-      }
+  validateListOfLayerEntryConfig(listOfLayerEntryConfig: TypeListOfLayerEntryConfig): TypeListOfLayerEntryConfig {
+    return commonValidateListOfLayerEntryConfig.call(this, listOfLayerEntryConfig);
+  }
 
-      if (layerEntryIsGroupLayer(layerEntryConfig)) {
-        layerEntryConfig.listOfLayerEntryConfig = this.validateListOfLayerEntryConfig(layerEntryConfig.listOfLayerEntryConfig!);
-        if (layerEntryConfig.listOfLayerEntryConfig.length) {
-          api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);
-          return true;
-        }
-        this.layerLoadError.push({
-          layer: Layer.getLayerPath(layerEntryConfig),
-          consoleMessage: `Empty layer group (mapId:  ${this.mapId}, layerPath: ${Layer.getLayerPath(layerEntryConfig)})`,
-        });
-        return false;
-      }
-
-      let esriIndex = Number(layerEntryConfig.layerId);
-      if (Number.isNaN(esriIndex)) {
-        this.layerLoadError.push({
-          layer: Layer.getLayerPath(layerEntryConfig),
-          consoleMessage: `ESRI layerId must be a number (mapId:  ${this.mapId}, layerPath: ${Layer.getLayerPath(layerEntryConfig)})`,
-        });
-        return false;
-      }
-
-      esriIndex = this.metadata?.layers
-        ? (this.metadata.layers as TypeJsonArray).findIndex((layerInfo: TypeJsonObject) => layerInfo.id === esriIndex)
-        : -1;
-
-      if (esriIndex === -1) {
-        this.layerLoadError.push({
-          layer: Layer.getLayerPath(layerEntryConfig),
-          consoleMessage: `ESRI layerId not found (mapId:  ${this.mapId}, layerPath: ${Layer.getLayerPath(layerEntryConfig)})`,
-        });
-        return false;
-      }
-
-      if (this.metadata!.layers[esriIndex].type === 'Group Layer') {
-        const newListOfLayerEntryConfig: TypeListOfLayerEntryConfig = [];
-        (this.metadata!.layers[esriIndex].subLayerIds as TypeJsonArray).forEach((layerId) => {
-          const subLayerEntryConfig: TypeLayerEntryConfig = cloneDeep(layerEntryConfig);
-          subLayerEntryConfig.parentLayerConfig = Cast<TypeLayerGroupEntryConfig>(layerEntryConfig);
-          subLayerEntryConfig.layerId = `${layerId}`;
-          subLayerEntryConfig.layerName = {
-            en: this.metadata!.layers[layerId as number].name as string,
-            fr: this.metadata!.layers[layerId as number].name as string,
-          };
-          newListOfLayerEntryConfig.push(subLayerEntryConfig);
-        });
-        const switchToGroupLayer = Cast<TypeLayerGroupEntryConfig>(layerEntryConfig);
-        switchToGroupLayer.entryType = 'group';
-        switchToGroupLayer.layerName = {
-          en: this.metadata!.layers[esriIndex].name as string,
-          fr: this.metadata!.layers[esriIndex].name as string,
-        };
-        switchToGroupLayer.isMetadataLayerGroup = true;
-        switchToGroupLayer.listOfLayerEntryConfig = newListOfLayerEntryConfig;
-        api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);
-        this.validateListOfLayerEntryConfig(newListOfLayerEntryConfig);
-        return true;
-      }
-
-      if (this.metadata!.layers[esriIndex].type !== 'Feature Layer') {
-        this.layerLoadError.push({
-          layer: Layer.getLayerPath(layerEntryConfig),
-          consoleMessage: `LayerId ${Layer.getLayerPath(layerEntryConfig)} of map ${this.mapId} is not a feature layer`,
-        });
-        return false;
-      }
-
-      layerEntryConfig.layerName = {
-        en: this.metadata!.layers[esriIndex].name as string,
-        fr: this.metadata!.layers[esriIndex].name as string,
-      };
-
-      api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);
+  /** ***************************************************************************************************************************
+   * This method perform specific validation that can only be done by the child of the AbstractGeoViewEsriLayer class.
+   *
+   * @param {number} esriIndex The index of the current layer in the metadata.
+   *
+   * @returns {boolean} true if an error is detected.
+   */
+  esriChildHasDetectedAnError(layerEntryConfig: TypeLayerEntryConfig, esriIndex: number): boolean {
+    if (this.metadata!.layers[esriIndex].type !== 'Feature Layer') {
+      this.layerLoadError.push({
+        layer: Layer.getLayerPath(layerEntryConfig),
+        consoleMessage: `LayerId ${Layer.getLayerPath(layerEntryConfig)} of map ${this.mapId} is not a feature layer`,
+      });
       return true;
-    });
-  }
-
-  /** ***************************************************************************************************************************
-   * This method is used to process the layer's metadata. It will fill the empty fields of the layer's configuration (renderer,
-   * initial settings, fields and aliases).
-   *
-   * @param {TypeLayerEntryConfig} layerEntryConfig The layer entry configuration to process.
-   *
-   * @returns {Promise<void>} A promise that the vector layer configuration has its metadata processed.
-   */
-  protected processLayerMetadata(layerEntryConfig: TypeLayerEntryConfig): Promise<void> {
-    const promiseOfExecution = new Promise<void>((resolve) => {
-      // User-defined groups do not have metadata provided by the service endpoint.
-      if (layerEntryIsGroupLayer(layerEntryConfig) && !layerEntryConfig.isMetadataLayerGroup) resolve();
-      else {
-        let queryUrl = getLocalizedValue(this.metadataAccessPath, this.mapId);
-        if (queryUrl) {
-          queryUrl = queryUrl.endsWith('/') ? `${queryUrl}${layerEntryConfig.layerId}` : `${queryUrl}/${layerEntryConfig.layerId}`;
-          const queryResult = axios.get<TypeJsonObject>(`${queryUrl}?f=pjson`);
-          queryResult.then((response) => {
-            // layers must have a fields attribute except if it is an metadata layer group.
-            if (!response.data.fields && !(layerEntryConfig as TypeLayerGroupEntryConfig).isMetadataLayerGroup)
-              throw new Error(`Despite a return code of 200, an error was detected with this query (${queryUrl}?f=pjson)`);
-            this.layerMetadata[Layer.getLayerPath(layerEntryConfig)] = response.data;
-            if (geoviewEntryIsEsriFeature(layerEntryConfig)) {
-              if (!layerEntryConfig.style) {
-                const renderer = Cast<EsriBaseRenderer>(response.data.drawingInfo?.renderer);
-                if (renderer) layerEntryConfig.style = getStyleFromEsriRenderer(this.mapId, layerEntryConfig, renderer);
-              }
-              this.processFeatureInfoConfig(
-                response.data.capabilities as string,
-                response.data.displayField as string,
-                response.data.geometryField?.name as string,
-                response.data.fields as TypeJsonArray,
-                layerEntryConfig
-              );
-              this.processInitialSettings(
-                response.data.defaultVisibility as boolean,
-                response.data.minScale as number,
-                response.data.maxScale as number,
-                response.data.extent,
-                layerEntryConfig
-              );
-              this.processTemporalDimension(response.data.timeInfo as TypeJsonObject, layerEntryConfig);
-            }
-            resolve();
-          });
-        } else resolve();
-      }
-    });
-    return promiseOfExecution;
-  }
-
-  /** ***************************************************************************************************************************
-   * This method set the initial settings based on the service metadata. Priority is given to the layer configuration.
-   *
-   * @param {boolean} visibility The metadata initial visibility of the layer.
-   * @param {number} minScale The metadata minScale of the layer.
-   * @param {number} maxScale The metadata maxScale of the layer.
-   * @param {TypeJsonObject} extent The metadata layer extent.
-   * @param {TypeEsriFeatureLayerEntryConfig} layerEntryConfig The vector layer entry to configure.
-   */
-  private processInitialSettings(
-    visibility: boolean,
-    minScale: number,
-    maxScale: number,
-    extent: TypeJsonObject,
-    layerEntryConfig: TypeEsriFeatureLayerEntryConfig
-  ) {
-    if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
-    // ! TODO: TThe solution implemented in the following two lines is not right. scale and zoom are not the same things.
-    // ! if (layerEntryConfig.initialSettings?.minZoom === undefined && minScale !== 0) layerEntryConfig.initialSettings.minZoom = minScale;
-    // ! if (layerEntryConfig.initialSettings?.maxZoom === undefined && maxScale !== 0) layerEntryConfig.initialSettings.maxZoom = maxScale;
-    if (layerEntryConfig.initialSettings?.visible === undefined) layerEntryConfig.initialSettings.visible = visibility;
-
-    if (layerEntryConfig.initialSettings?.extent)
-      layerEntryConfig.initialSettings.extent = transformExtent(
-        layerEntryConfig.initialSettings.extent,
-        'EPSG:4326',
-        `EPSG:${api.map(this.mapId).currentProjection}`
-      );
-    if (layerEntryConfig.initialSettings?.bounds)
-      layerEntryConfig.initialSettings.bounds = transformExtent(
-        layerEntryConfig.initialSettings.bounds,
-        'EPSG:4326',
-        `EPSG:${api.map(this.mapId).currentProjection}`
-      );
-    else {
-      const layerExtent: Extent = [extent.xmin as number, extent.ymin as number, extent.xmax as number, extent.ymax as number];
-      layerEntryConfig.initialSettings.bounds = transformExtent(
-        layerExtent,
-        `EPSG:${extent.spatialReference.wkid as number}`,
-        `EPSG:${api.map(this.mapId).currentProjection}`
-      );
     }
+    return false;
+  }
+
+  /** ***************************************************************************************************************************
+   * Extract the type of the specified field from the metadata. If the type can not be found, return 'string'.
+   *
+   * @param {string} fieldName field name for which we want to get the type.
+   * @param {TypeLayerEntryConfig} layeConfig layer configuration.
+   *
+   * @returns {'string' | 'date' | 'number'} The type of the field.
+   */
+  getFieldType(fieldName: string, layerConfig: TypeLayerEntryConfig): 'string' | 'date' | 'number' {
+    return commonGetFieldType.call(this, fieldName, layerConfig);
+  }
+
+  /** ***************************************************************************************************************************
+   * Return the domain of the specified field.
+   *
+   * @param {string} fieldName field name for which we want to get the domain.
+   * @param {TypeLayerEntryConfig} layeConfig layer configuration.
+   *
+   * @returns {null | codedValueType | rangeDomainType} The domain of the field.
+   */
+  getFieldDomain(fieldName: string, layerConfig: TypeLayerEntryConfig): null | codedValueType | rangeDomainType {
+    return commonGetFieldDomain.call(this, fieldName, layerConfig);
+  }
+
+  /** ***************************************************************************************************************************
+   * This method will create a Geoview temporal dimension if it exist in the service metadata
+   * @param {TypeJsonObject} esriTimeDimension The ESRI time dimension object
+   * @param {TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig} layerEntryConfig The layer entry to configure
+   */
+  processTemporalDimension(
+    esriTimeDimension: TypeJsonObject,
+    layerEntryConfig: TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig
+  ) {
+    return commonProcessTemporalDimension.call(this, esriTimeDimension, layerEntryConfig);
   }
 
   /** ***************************************************************************************************************************
@@ -329,56 +195,51 @@ export class EsriFeature extends AbstractGeoViewVector {
    * @param {string} nameField The display field associated to the layer.
    * @param {string} geometryFieldName The field name of the geometry property.
    * @param {TypeJsonArray} fields An array of field names and its aliases.
-   * @param {TypeEsriFeatureLayerEntryConfig} layerEntryConfig The vector layer entry to configure.
+   * @param {TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig} layerEntryConfig The layer entry to configure.
    */
-  private processFeatureInfoConfig(
+  processFeatureInfoConfig = (
     capabilities: string,
     nameField: string,
     geometryFieldName: string,
     fields: TypeJsonArray,
-    layerEntryConfig: TypeEsriFeatureLayerEntryConfig
-  ) {
-    if (!layerEntryConfig.source.featureInfo) layerEntryConfig.source.featureInfo = { queryable: capabilities.includes('Query') };
-    // dynamic group layer doesn't have fields definition
-    if (!layerEntryConfig.isMetadataLayerGroup) {
-      if (!layerEntryConfig.source.featureInfo.nameField)
-        layerEntryConfig.source.featureInfo.nameField = {
-          en: nameField,
-          fr: nameField,
-        };
+    layerEntryConfig: TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig
+  ) => {
+    return commonProcessFeatureInfoConfig.call(this, capabilities, nameField, geometryFieldName, fields, layerEntryConfig);
+  };
 
-      // Process undefined outfields or aliasFields ('' = false and !'' = true)
-      if (!layerEntryConfig.source.featureInfo.outfields?.en || !layerEntryConfig.source.featureInfo.aliasFields?.en) {
-        const processOutField = !layerEntryConfig.source.featureInfo.outfields?.en;
-        const processAliasFields = !layerEntryConfig.source.featureInfo.aliasFields?.en;
-        if (processOutField) layerEntryConfig.source.featureInfo.outfields = { en: '' };
-        if (processAliasFields) layerEntryConfig.source.featureInfo.aliasFields = { en: '' };
-        fields.forEach((fieldEntry, i) => {
-          if (fieldEntry.name === geometryFieldName) return;
-          if (processOutField) this.addFieldEntryToSourceFeatureInfo(layerEntryConfig, 'outfields', fieldEntry.name as string, i);
-          if (processAliasFields)
-            this.addFieldEntryToSourceFeatureInfo(
-              layerEntryConfig,
-              'aliasFields',
-              (fieldEntry.alias ? fieldEntry.alias : fieldEntry.name) as string,
-              i
-            );
-        });
-        layerEntryConfig.source.featureInfo!.outfields!.fr = layerEntryConfig.source.featureInfo!.outfields?.en;
-        layerEntryConfig.source.featureInfo!.aliasFields!.fr = layerEntryConfig.source.featureInfo!.aliasFields?.en;
-      }
-    }
+  /** ***************************************************************************************************************************
+   * This method set the initial settings based on the service metadata. Priority is given to the layer configuration.
+   *
+   * @param {string} mapId The map identifier.
+   * @param {boolean} visibility The metadata initial visibility of the layer.
+   * @param {number} minScale The metadata minScale of the layer.
+   * @param {number} maxScale The metadata maxScale of the layer.
+   * @param {TypeJsonObject} extent The metadata layer extent.
+   * @param {TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig} layerEntryConfig The layer entry to configure.
+   */
+  processInitialSettings(
+    visibility: boolean,
+    minScale: number,
+    maxScale: number,
+    extent: TypeJsonObject,
+    layerEntryConfig: TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig
+  ) {
+    return commonProcessInitialSettings.call(this, visibility, minScale, maxScale, extent, layerEntryConfig);
   }
 
   /** ***************************************************************************************************************************
-   * This method will create a Geoview temporal dimension if it exist in the service metadata
-   * @param {TypeJsonObject} esriTimeDimension The ESRI time dimension object
-   * @param {TypeEsriFeatureLayerEntryConfig} layerEntryConfig The layer entry to configure
+   * This method is used to process the layer's metadata. It will fill the empty fields of the layer's configuration (renderer,
+   * initial settings, fields and aliases).
+   *
+   * @param {TypeLayerEntryConfig} layerEntryConfig The layer entry configuration to process.
+   *
+   * @returns {Promise<void>} A promise that the layer configuration has its metadata processed.
    */
-  private processTemporalDimension(esriTimeDimension: TypeJsonObject, layerEntryConfig: TypeEsriFeatureLayerEntryConfig) {
-    if (esriTimeDimension !== undefined) {
-      layerEntryConfig.temporalDimension = api.dateUtilities.createDimensionFromESRI(esriTimeDimension as unknown as TimeDimensionESRI);
-    }
+  protected processLayerMetadata(layerEntryConfig: TypeLayerEntryConfig): Promise<void> {
+    const promiseOfExecution = new Promise<void>((resolve) => {
+      commonProcessLayerMetadata.call(this, resolve, layerEntryConfig);
+    });
+    return promiseOfExecution;
   }
 
   /** ***************************************************************************************************************************

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
@@ -27,6 +27,7 @@ import { getLocalizedValue, getXMLHttpRequest } from '../../../../core/utils/uti
 
 import { api } from '../../../../app';
 import { Layer } from '../../layer';
+import { codedValueType, rangeDomainType } from '../../../../api/events/payloads/get-feature-info-payload';
 
 export interface TypeSourceGeoPackageInitialConfig extends TypeVectorSourceInitialConfig {
   format: 'GeoPackage';
@@ -102,6 +103,32 @@ export class GeoPackage extends AbstractGeoViewVector {
    */
   constructor(mapId: string, layerConfig: TypeGeoPackageLayerConfig) {
     super(CONST_LAYER_TYPES.GEOPACKAGE, layerConfig, mapId);
+  }
+
+  /** ***************************************************************************************************************************
+   * Extract the type of the specified field from the metadata. If the type can not be found, return 'string'.
+   *
+   * @param {string} fieldName field name for which we want to get the type.
+   * @param {TypeLayerEntryConfig} layeConfig layer configuration.
+   *
+   * @returns {'string' | 'date' | 'number'} The type of the field.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected getFieldType(fieldName: string, layerConfig: TypeLayerEntryConfig): 'string' | 'date' | 'number' {
+    return 'string';
+  }
+
+  /** ***************************************************************************************************************************
+   * Returns null. Geo package services don't have domains.
+   *
+   * @param {string} fieldName field name for which we want to get the domain.
+   * @param {TypeLayerEntryConfig} layeConfig layer configuration.
+   *
+   * @returns {null | codedValueType | rangeDomainType} The domain of the field.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected getFieldDomain(fieldName: string, layerConfig: TypeLayerEntryConfig): null | codedValueType | rangeDomainType {
+    return null;
   }
 
   /** ***************************************************************************************************************************

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -95,6 +95,8 @@ export type TypeFeatureInfoLayerConfig = {
   nameField?: TypeLocalizedString;
   /** A comma separated list of attribute names (English/French) that should be requested on query (all by default). */
   outfields?: TypeLocalizedString;
+  /** A comma separated list of types. Type at index i is associated to the variable at index i. */
+  fieldTypes?: string;
   /** A comma separated list of attribute names (English/French) that should be use for alias. If empty, no alias will be set */
   aliasFields?: TypeLocalizedString;
 };

--- a/packages/geoview-core/src/geo/map/map.ts
+++ b/packages/geoview-core/src/geo/map/map.ts
@@ -3,7 +3,7 @@ import { i18n } from 'i18next';
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 import OLMap from 'ol/Map';
-import View, { ViewOptions } from 'ol/View';
+import View, { FitOptions, ViewOptions } from 'ol/View';
 import { fromLonLat, ProjectionLike, toLonLat, transform as olTransform, transformExtent as olTransformExtent } from 'ol/proj';
 import { Coordinate } from 'ol/coordinate';
 import { Extent } from 'ol/extent';
@@ -386,6 +386,16 @@ export class MapViewer {
   getView = (): View => {
     return this.map.getView();
   };
+
+  /**
+   * Zoom to the specified extent.
+   *
+   * @param {Extent} extent The extent to zoom to.
+   * @param {FitOptions} zoomOptions The options to configure the zoomToExtent (default: { padding: [100, 100, 100, 100], maxZoom: 11 }).
+   */
+  zoomToExtent(extent: Extent, options: FitOptions = { padding: [100, 100, 100, 100], maxZoom: 11 }) {
+    this.map.getView().fit(extent, options);
+  }
 
   /**
    * Function called when the map has been rendered and ready to be customized


### PR DESCRIPTION
# Description

Correction to a bug found in the unique value find routine in geoviewRenderer.
The values returned by the get feature info call have a new type. It contains the field names, the field types, the field values, the field aliases, the feature with its style set to the right value, the extent, the domain for esri featuresand an entry key.

Fixes # 877

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
The tests were done using the layers template.

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/914)
<!-- Reviewable:end -->
