### PR TITLE
bug(legend): Fixed issue with ESRI dynamic legend load

### DIFF
--- a/packages/geoview-core/src/core/components/legend/legend-icon-list.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-icon-list.tsx
@@ -86,27 +86,22 @@ export function LegendIconList(props: TypeLegendIconListProps): JSX.Element {
       const geometryStyle = layerConfig.style[geometryKey as TypeStyleGeometry];
       if (geometryStyle !== undefined) {
         isChecked.forEach((checked, i) => {
-          if (i < isChecked.length - 1) {
-            if (geometryStyle.styleType === 'classBreaks') {
+          if (geometryStyle.styleType === 'classBreaks') {
+            if (i < (geometryStyle as TypeClassBreakStyleConfig).classBreakStyleInfo.length - 1) {
               (geometryStyle as TypeClassBreakStyleConfig).classBreakStyleInfo[i].visible = checked === true ? 'yes' : 'no';
+            } else if ((geometryStyle as TypeClassBreakStyleConfig).classBreakStyleInfo.length === isChecked.length) {
+              (geometryStyle as TypeClassBreakStyleConfig).classBreakStyleInfo[i].visible = checked === true ? 'yes' : 'no';
+            } else {
+              (geometryStyle as TypeUniqueValueStyleConfig).defaultVisible = checked === true ? 'yes' : 'no';
             }
-            if (geometryStyle.styleType === 'uniqueValue') {
+          }
+          if (geometryStyle.styleType === 'uniqueValue') {
+            if (i < (geometryStyle as TypeUniqueValueStyleConfig).uniqueValueStyleInfo.length - 1) {
               (geometryStyle as TypeUniqueValueStyleConfig).uniqueValueStyleInfo[i].visible = checked === true ? 'yes' : 'no';
-            }
-          } else {
-            if (geometryStyle.styleType === 'classBreaks') {
-              if ((geometryStyle as TypeClassBreakStyleConfig).classBreakStyleInfo.length === isChecked.length) {
-                (geometryStyle as TypeClassBreakStyleConfig).classBreakStyleInfo[i].visible = checked === true ? 'yes' : 'no';
-              } else {
-                (geometryStyle as TypeUniqueValueStyleConfig).defaultVisible = checked === true ? 'yes' : 'no';
-              }
-            }
-            if (geometryStyle.styleType === 'uniqueValue') {
-              if ((geometryStyle as TypeUniqueValueStyleConfig).uniqueValueStyleInfo.length === isChecked.length) {
-                (geometryStyle as TypeUniqueValueStyleConfig).uniqueValueStyleInfo[i].visible = checked === true ? 'yes' : 'no';
-              } else {
-                (geometryStyle as TypeUniqueValueStyleConfig).defaultVisible = checked === true ? 'yes' : 'no';
-              }
+            } else if ((geometryStyle as TypeUniqueValueStyleConfig).uniqueValueStyleInfo.length === isChecked.length) {
+              (geometryStyle as TypeUniqueValueStyleConfig).uniqueValueStyleInfo[i].visible = checked === true ? 'yes' : 'no';
+            } else {
+              (geometryStyle as TypeUniqueValueStyleConfig).defaultVisible = checked === true ? 'yes' : 'no';
             }
           }
         });

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -581,7 +581,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
     const layerEntryConfig = (
       typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig) : layerPathOrConfig
     ) as TypeEsriDynamicLayerEntryConfig;
-    if (layerEntryConfig) {
+    if ((layerEntryConfig.gvLayer as ImageLayer<ImageArcGISRest>).getSource()) {
       const source = (layerEntryConfig.gvLayer as ImageLayer<ImageArcGISRest>).getSource()!;
       source.updateParams({ layerDefs: `{"${layerEntryConfig.layerId}": "${filter || this.getViewFilter(layerEntryConfig)}"}` });
       layerEntryConfig.gvLayer!.set('legendFilterIsOff', !!filter);


### PR DESCRIPTION
Closes #920
Closes #927

# Description

Fixes issue with ESRI dynamic nested groups loading a legend. Also fixes issue with removing ESRI Dynamic layers from legend.

Fixes #920 
Fixes #927 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with three sources, and a source for each other supported layer type, both loading and removing the layer.

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
