### PR TITLE
932-Cluster_template_correction

### DIFF
--- a/packages/geoview-core/public/configs/cluster-config.json
+++ b/packages/geoview-core/public/configs/cluster-config.json
@@ -15,8 +15,7 @@
       {
         "geoviewLayerId": "flood_cluster",
         "geoviewLayerName": {
-          "en": "Cluster test",
-          "fr": ""
+          "en": "Cluster test"
         },
         "geoviewLayerType": "GeoJSON",
         "listOfLayerEntryConfig": [
@@ -24,8 +23,7 @@
             "layerId": "lines.json",
             "source": {
               "dataAccessPath": {
-                "en": "./geojson/",
-                "fr": "./geojson/"
+                "en": "./geojson/"
               },
               "cluster": {
                 "enable": true,
@@ -37,8 +35,7 @@
             "layerId": "polygons.json",
             "source": {
               "dataAccessPath": {
-                "en": "./geojson/",
-                "fr": "./geojson/"
+                "en": "./geojson/"
               },
               "cluster": {
                 "enable": true

--- a/packages/geoview-core/public/geojson/lines.json
+++ b/packages/geoview-core/public/geojson/lines.json
@@ -10,6 +10,20 @@
       "geometry": {
         "type": "LineString",
         "coordinates": [
+          [-79, 49],
+          [-78, 46]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Road_Number": 55,
+        "Province": "Quebec"
+      },
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
           [-78, 49],
           [-76, 46],
           [-77, 49]

--- a/packages/geoview-core/public/geojson/polygons.json
+++ b/packages/geoview-core/public/geojson/polygons.json
@@ -8,6 +8,22 @@
         "type": "Polygon",
         "coordinates": [
           [
+            [-89, 54],
+            [-85, 55],
+            [-85, 52],
+            [-89, 52],
+            [-89, 54]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": { "Province": "Ontario" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
             [-90, 52],
             [-84, 53],
             [-84, 50],

--- a/packages/geoview-core/src/core/utils/config/config.ts
+++ b/packages/geoview-core/src/core/utils/config/config.ts
@@ -166,6 +166,10 @@ export class Config {
     if (urlParamsConfig && shared === 'true') mapFeaturesConfig = { ...urlParamsConfig };
 
     // NOTE: URL config has precedence on JSON file config that has precedence on inline config
+    if (!mapFeaturesConfig) {
+      console.log(`- Map: ${mapId} - Empty JSON configuration object, using default -`);
+    }
+
     return this.configValidation.validateMapConfigAgainstSchema(mapFeaturesConfig);
   }
 }

--- a/packages/geoview-core/src/core/utils/config/reader/div-config-reader.ts
+++ b/packages/geoview-core/src/core/utils/config/reader/div-config-reader.ts
@@ -31,7 +31,7 @@ export class InlineDivConfigReader {
 
     let configObjStr = mapElement.getAttribute('data-config');
 
-    if (configObjStr && configObjStr !== '') {
+    if (configObjStr) {
       // Erase comments in the config file.
       configObjStr = configObjStr
         .split(/(?<!\\)'/gm)
@@ -51,12 +51,10 @@ export class InlineDivConfigReader {
       configObjStr = configObjStr.replace(/\\'/gm, "'");
 
       if (!isJsonString(configObjStr)) {
-        console.log(`- Map: ${mapId} - Invalid JSON configuration object, using default -`);
+        console.log(`- Map: ${mapId} - Invalid JSON configuration object in div, a fallback strategy will be used -`);
       } else {
         mapConfig = { ...JSON.parse(configObjStr) };
       }
-    } else {
-      console.log(`- Map: ${mapId} - Empty JSON configuration object, using default -`);
     }
 
     return mapConfig;

--- a/packages/geoview-core/src/core/utils/config/reader/json-config-reader.ts
+++ b/packages/geoview-core/src/core/utils/config/reader/json-config-reader.ts
@@ -24,7 +24,7 @@ export class JsonConfigReader {
     const configUrl = mapElement.getAttribute('data-config-url');
 
     // check config url
-    if (configUrl && configUrl !== '') {
+    if (configUrl) {
       try {
         const res = await fetch(configUrl);
 

--- a/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
@@ -661,12 +661,7 @@ export class GeoviewRenderer {
       const originalFeature = clusterSize ? feature!.get('features')[0] : feature;
       const originalGeometryType = getGeometryType(originalFeature);
 
-      // If style does not exist for the geometryType, create it.
-      if (layerEntryConfig.style![originalGeometryType] === undefined) {
-        const defaultStyle = this.createDefaultStyle(originalGeometryType, layerEntryConfig);
-        if (defaultStyle) layerEntryConfig.style![originalGeometryType] = defaultStyle[originalGeometryType];
-      }
-
+      // If style does not exist for the geometryType, getFeatureStyle will create it.
       return this.getFeatureStyle(originalFeature, layerEntryConfig);
     }
 


### PR DESCRIPTION
# Description

This PR is to correct a bug introduced in PR Legend filtering does not cover clustering #869 and merged with https://github.com/Canadian-Geospatial-Platform/geoview/pull/930.

Fixes #869
Fixes #930

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Open the cluster template and look in the console. The stack dump displayed at load time is not supposed to be there anymore. Look at the first map, you will see two cluster with a different color. One is for Polygons and the other for LineStrings. Zoom in and the clusters will be replaced by the clustered geometry.

# Checklist:

- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/933)
<!-- Reviewable:end -->
