### PR TITLE
fix(swiper): Fixed the division not being in the center of swiper bar

### DIFF
--- a/packages/geoview-swiper/src/swiper.tsx
+++ b/packages/geoview-swiper/src/swiper.tsx
@@ -115,6 +115,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
   const [layersIds] = useState<string[]>(config.layers);
   const [geoviewLayers] = useState(api.map(mapId).layer.geoviewLayers);
   const [olLayers, setOlLayers] = useState<BaseLayer[]>([]);
+  const [offset, setOffset] = useState(0);
 
   const [orientation] = useState(config.orientation);
   const swiperValue = useRef(50);
@@ -181,7 +182,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
         ? -map.getTargetElement().getBoundingClientRect().left + evt.clientX
         : -map.getTargetElement().getBoundingClientRect().top + evt.clientY;
     const size = orientation === 'vertical' ? mapSize.current[0] : mapSize.current[1];
-    swiperValue.current = (client / size) * 100;
+    swiperValue.current = ((client - offset) / size) * 100;
 
     // force VectorImage to refresh
     olLayers.forEach((layer: BaseLayer) => {
@@ -190,6 +191,21 @@ export function Swiper(props: SwiperProps): JSX.Element {
 
     map.render();
   }, 100);
+
+  /**
+   * On Click, calculate the offset between click location and swiper
+   * @param {MouseEvent} evt The mouse event to calculate the offset
+   */
+  const setMouseOffset = (evt: MouseEvent) => {
+    const position =
+      orientation === 'vertical'
+        ? -map.getTargetElement().getBoundingClientRect().left + evt.clientX
+        : -map.getTargetElement().getBoundingClientRect().top + evt.clientY;
+    mapSize.current = map.getSize() || [0, 0];
+    const size = orientation === 'vertical' ? mapSize.current[0] : mapSize.current[1];
+    const offSetOnClick = position - (size * swiperValue.current) / 100;
+    setOffset(offSetOnClick);
+  };
 
   useEffect(() => {
     // set listener for layers in config array
@@ -222,6 +238,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
         axis={`${orientation === 'vertical' ? 'x' : 'y'}`}
         bounds="parent"
         defaultPosition={{ x: orientation === 'vertical' ? defaultX : 0, y: orientation === 'vertical' ? 0 : defaultY }}
+        onMouseDown={(e) => setMouseOffset(e)}
         onStop={(e) => {
           onStop(e as MouseEvent);
         }}


### PR DESCRIPTION
Closes #901

# Description

Fixes swiper bar dividing map based on mouse pointer location rather than bar position.

Fixes # 901

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Lots of dragging with both vertical and horizontal alignments.

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/936)
<!-- Reviewable:end -->
