### PR TITLE
861-[BUG]_qgis_wms_getFeatureInfo

### DIFF
--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -392,7 +392,7 @@
           "items": {
             "type": "number"
           },
-          "description": "The bounding box that contains all the layer's features."
+          "description": "The geographic bounding box that contains all the layer's features."
         },
         "extent": {
           "type": "array",

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -689,8 +689,7 @@ export abstract class AbstractGeoViewLayer {
     if (layerConfig) {
       if (Array.isArray(layerConfig)) processGroupLayerBounds(layerConfig);
       else processGroupLayerBounds([layerConfig]);
-      if (projectionCode && bounds)
-        return transformExtent(bounds, `EPSG:${api.map(this.mapId).currentProjection}`, `EPSG:${projectionCode}`);
+      if (projectionCode && bounds) return transformExtent(bounds, `EPSG:4326`, `EPSG:${projectionCode}`);
     }
     return bounds;
   }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -280,19 +280,9 @@ export function commonProcessInitialSettings(
       `EPSG:${api.map(this.mapId).currentProjection}`
     );
 
-  if (layerEntryConfig.initialSettings?.bounds)
-    layerEntryConfig.initialSettings.bounds = transformExtent(
-      layerEntryConfig.initialSettings.bounds,
-      'EPSG:4326',
-      `EPSG:${api.map(this.mapId).currentProjection}`
-    );
-  else {
+  if (!layerEntryConfig.initialSettings?.bounds) {
     const layerExtent = [extent.xmin, extent.ymin, extent.xmax, extent.ymax] as Extent;
-    layerEntryConfig.initialSettings.bounds = transformExtent(
-      layerExtent,
-      `EPSG:${extent.spatialReference.wkid as number}`,
-      `EPSG:${api.map(this.mapId).currentProjection}`
-    );
+    layerEntryConfig.initialSettings = { bounds: layerExtent };
   }
 }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -15,7 +15,7 @@ import { transform, transformExtent } from 'ol/proj';
 
 import cloneDeep from 'lodash/cloneDeep';
 
-import { Cast, TypeJsonArray, TypeJsonObject } from '../../../../core/types/global-types';
+import { Cast, toJsonObject, TypeJsonArray, TypeJsonObject } from '../../../../core/types/global-types';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES, TypeLegend } from '../abstract-geoview-layers';
 import { AbstractGeoViewRaster, TypeBaseRasterLayer } from './abstract-geoview-raster';
 import {
@@ -577,18 +577,8 @@ export class WMS extends AbstractGeoViewRaster {
               `EPSG:${api.map(this.mapId).currentProjection}`
             );
 
-          if (layerEntryConfig.initialSettings?.bounds)
-            layerEntryConfig.initialSettings.bounds = transformExtent(
-              layerEntryConfig.initialSettings.bounds,
-              'EPSG:4326',
-              `EPSG:${api.map(this.mapId).currentProjection}`
-            );
-          else if (layerCapabilities.EX_GeographicBoundingBox) {
-            layerEntryConfig.initialSettings.bounds = transformExtent(
-              layerCapabilities.EX_GeographicBoundingBox as Extent,
-              'EPSG:4326',
-              `EPSG:${api.map(this.mapId).currentProjection}`
-            );
+          if (!layerEntryConfig.initialSettings?.bounds && layerCapabilities.EX_GeographicBoundingBox) {
+            layerEntryConfig.initialSettings = { bounds: layerCapabilities.EX_GeographicBoundingBox as Extent };
           }
 
           if (layerCapabilities.Dimension) {
@@ -660,10 +650,10 @@ export class WMS extends AbstractGeoViewRaster {
         const crs = `EPSG:${api.map(this.mapId).currentProjection}`;
         const clickCoordinate = transform(lnglat, 'EPSG:4326', crs);
         if (
-          clickCoordinate[0] < layerConfig.initialSettings!.bounds![0] ||
-          layerConfig.initialSettings!.bounds![2] < clickCoordinate[0] ||
-          clickCoordinate[1] < layerConfig.initialSettings!.bounds![1] ||
-          layerConfig.initialSettings!.bounds![3] < clickCoordinate[1]
+          lnglat[0] < layerConfig.initialSettings!.bounds![0] ||
+          layerConfig.initialSettings!.bounds![2] < lnglat[0] ||
+          lnglat[1] < layerConfig.initialSettings!.bounds![1] ||
+          layerConfig.initialSettings!.bounds![3] < lnglat[1]
         )
           resolve([]);
         else {
@@ -678,17 +668,38 @@ export class WMS extends AbstractGeoViewRaster {
             INFO_FORMAT: infoFormat,
           });
           if (featureInfoUrl) {
-            let featureMember: TypeJsonObject | null;
+            let featureMember: TypeJsonObject | undefined;
             axios(featureInfoUrl).then((response) => {
               if (infoFormat === 'text/xml') {
                 const xmlDomResponse = new DOMParser().parseFromString(response.data, 'text/xml');
                 const jsonResponse = xmlToJson(xmlDomResponse);
+                // ! TODO: We should use a WMS format setting in the schema to decide what feature info response interpreter to use
+                // ! For the moment, we try to guess the response format based on properties returned from the query
                 const featureCollection = this.getAttribute(jsonResponse, 'FeatureCollection');
                 if (featureCollection) featureMember = this.getAttribute(featureCollection, 'featureMember');
+                else {
+                  const featureInfoResponse = this.getAttribute(jsonResponse, 'GetFeatureInfoResponse');
+                  if (featureInfoResponse?.Layer) {
+                    featureMember = {};
+                    const layerName =
+                      featureInfoResponse.Layer['@attributes'] && featureInfoResponse.Layer['@attributes'].name
+                        ? (featureInfoResponse.Layer['@attributes'].name as string)
+                        : 'undefined';
+                    featureMember['Layer name'] = toJsonObject({ '#text': layerName });
+                    if (featureInfoResponse.Layer.Attribute && featureInfoResponse.Layer.Attribute['@attributes']) {
+                      const fieldName = featureInfoResponse.Layer.Attribute['@attributes'].name
+                        ? (featureInfoResponse.Layer.Attribute['@attributes'].name as string)
+                        : 'undefined';
+                      const fieldValue = featureInfoResponse.Layer.Attribute['@attributes'].value
+                        ? (featureInfoResponse.Layer.Attribute['@attributes'].value as string)
+                        : 'undefined';
+                      featureMember[fieldName] = toJsonObject({ '#text': fieldValue });
+                    }
+                  }
+                }
               } else featureMember = { plain_text: { '#text': response.data } };
               if (featureMember) {
-                const featureInfoResult = this.formatWmsFeatureInfoResult(featureMember, layerConfig);
-                featureInfoResult[0].extent = [clickCoordinate[0], clickCoordinate[1], clickCoordinate[0], clickCoordinate[1]];
+                const featureInfoResult = this.formatWmsFeatureInfoResult(featureMember, layerConfig, clickCoordinate);
                 resolve(featureInfoResult);
               }
             });
@@ -857,10 +868,15 @@ export class WMS extends AbstractGeoViewRaster {
    *
    * @param {TypeJsonObject} featureMember An object formatted using the query syntax.
    * @param {TypeWmsLayerEntryConfig} layerEntryConfig The layer configuration.
+   * @param {Coordinate} clickCoordinate The coordinate where the user has clicked.
    *
    * @returns {TypeArrayOfFeatureInfoEntries} The feature info table.
    */
-  formatWmsFeatureInfoResult(featureMember: TypeJsonObject, layerEntryConfig: TypeWmsLayerEntryConfig): TypeArrayOfFeatureInfoEntries {
+  formatWmsFeatureInfoResult(
+    featureMember: TypeJsonObject,
+    layerEntryConfig: TypeWmsLayerEntryConfig,
+    clickCoordinate: Coordinate
+  ): TypeArrayOfFeatureInfoEntries {
     const featureInfo = layerEntryConfig?.source?.featureInfo;
     const outfields = getLocalizedValue(featureInfo?.outfields, this.mapId)?.split(',');
     const fieldTypes = featureInfo?.fieldTypes?.split(',');
@@ -873,7 +889,7 @@ export class WMS extends AbstractGeoViewRaster {
       // feature key for building the data-grid
       featureKey: featureKeyCounter++,
       geoviewLayerType: this.type,
-      extent: [0, 0, 0, 0],
+      extent: [clickCoordinate[0], clickCoordinate[1], clickCoordinate[0], clickCoordinate[1]],
       geometry: null,
       featureIcon: document.createElement('canvas'),
       fieldInfo: {},
@@ -883,7 +899,7 @@ export class WMS extends AbstractGeoViewRaster {
       keys.forEach((key) => {
         if (!key.endsWith('Geometry') && !key.startsWith('@')) {
           const splitedKey = key.split(':');
-          const fieldName = splitedKey[splitedKey.length - 1];
+          const fieldName = splitedKey.slice(-1)[0];
           if ('#text' in entry[key])
             featureInfoEntry.fieldInfo[`${prefix}${prefix ? '.' : ''}${fieldName}`] = {
               fieldKey: fieldKeyCounter++,
@@ -925,11 +941,10 @@ export class WMS extends AbstractGeoViewRaster {
    * @param {TypeJsonObject} jsonObject The object that is supposed to have the needed attribute.
    * @param {string} attribute The attribute searched.
    *
-   * @returns {TypeJsonObject | null} The promised feature info table.
+   * @returns {TypeJsonObject | undefined} The promised feature info table.
    */
-  private getAttribute(jsonObject: TypeJsonObject, attributeEnding: string): TypeJsonObject | null {
-    const keys = Object.keys(jsonObject);
-    for (let i = 0; i < keys.length; i++) if (keys[i].endsWith(attributeEnding)) return jsonObject[keys[i]];
-    return null;
+  private getAttribute(jsonObject: TypeJsonObject, attributeEnding: string): TypeJsonObject | undefined {
+    const keyFound = Object.keys(jsonObject).find((key) => key.endsWith(attributeEnding));
+    return keyFound ? jsonObject[keyFound] : undefined;
   }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -291,12 +291,6 @@ export class XYZTiles extends AbstractGeoViewRaster {
             `EPSG:${api.map(this.mapId).currentProjection}`
           );
 
-        if (layerEntryConfig.initialSettings?.bounds)
-          layerEntryConfig.initialSettings!.bounds = transformExtent(
-            layerEntryConfig.initialSettings.bounds,
-            'EPSG:4326',
-            `EPSG:${api.map(this.mapId).currentProjection}`
-          );
         resolve();
       }
     });

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -244,13 +244,6 @@ export class GeoJSON extends AbstractGeoViewVector {
             `EPSG:${api.map(this.mapId).currentProjection}`
           );
 
-        if (layerEntryConfig.initialSettings?.bounds) {
-          layerEntryConfig.initialSettings.bounds = transformExtent(
-            layerEntryConfig.initialSettings.bounds,
-            'EPSG:4326',
-            `EPSG:${api.map(this.mapId).currentProjection}`
-          );
-        }
         resolve();
       }
     });

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
@@ -220,21 +220,18 @@ export class GeoPackage extends AbstractGeoViewVector {
             `EPSG:${api.map(this.mapId).currentProjection}`
           );
 
-        if (layerEntryConfig.initialSettings?.bounds)
-          layerEntryConfig.initialSettings.bounds = transformExtent(
-            layerEntryConfig.initialSettings.bounds,
-            'EPSG:4326',
-            `EPSG:${api.map(this.mapId).currentProjection}`
-          );
-        else {
-          if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
-          if (this.metadata?.collections[i].extent?.spatial?.bbox && this.metadata?.collections[i].extent?.spatial?.crs) {
-            layerEntryConfig.initialSettings.bounds = transformExtent(
+        if (
+          !layerEntryConfig.initialSettings?.bounds &&
+          this.metadata?.collections[i].extent?.spatial?.bbox &&
+          this.metadata?.collections[i].extent?.spatial?.crs
+        ) {
+          layerEntryConfig.initialSettings = {
+            bounds: transformExtent(
               this.metadata.collections[i].extent.spatial.bbox[0] as number[],
               get(this.metadata.collections[i].extent.spatial.crs as string)!,
               `EPSG:${api.map(this.mapId).currentProjection}`
-            );
-          }
+            ),
+          };
         }
 
         api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
@@ -213,21 +213,18 @@ export class OgcFeature extends AbstractGeoViewVector {
             `EPSG:${api.map(this.mapId).currentProjection}`
           );
 
-        if (layerEntryConfig.initialSettings?.bounds)
-          layerEntryConfig.initialSettings.bounds = transformExtent(
-            layerEntryConfig.initialSettings.bounds,
-            'EPSG:4326',
-            `EPSG:${api.map(this.mapId).currentProjection}`
-          );
-        else {
-          if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
-          if (this.metadata?.collections[i].extent?.spatial?.bbox && this.metadata?.collections[i].extent?.spatial?.crs) {
-            layerEntryConfig.initialSettings.bounds = transformExtent(
+        if (
+          !layerEntryConfig.initialSettings?.bounds &&
+          this.metadata?.collections[i].extent?.spatial?.bbox &&
+          this.metadata?.collections[i].extent?.spatial?.crs
+        ) {
+          layerEntryConfig.initialSettings = {
+            bounds: transformExtent(
               this.metadata.collections[i].extent.spatial.bbox[0] as number[],
               get(this.metadata.collections[i].extent.spatial.crs as string)!,
               `EPSG:${api.map(this.mapId).currentProjection}`
-            );
-          }
+            ),
+          };
         }
 
         api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -213,20 +213,13 @@ export class WFS extends AbstractGeoViewVector {
             `EPSG:${api.map(this.mapId).currentProjection}`
           );
 
-        if (layerEntryConfig.initialSettings?.bounds)
-          layerEntryConfig.initialSettings.bounds = transformExtent(
-            layerEntryConfig.initialSettings.bounds,
-            'EPSG:4326',
-            `EPSG:${api.map(this.mapId).currentProjection}`
-          );
-        else {
-          if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
-          if (metadataLayerList[i]['ows:WGS84BoundingBox']) {
-            const lowerCorner = (metadataLayerList[i]['ows:WGS84BoundingBox']['ows:LowerCorner']['#text'] as string).split(' ');
-            const upperCorner = (metadataLayerList[i]['ows:WGS84BoundingBox']['ows:UpperCorner']['#text'] as string).split(' ');
-            const bounds = [Number(lowerCorner[0]), Number(lowerCorner[1]), Number(upperCorner[0]), Number(upperCorner[1])];
-            layerEntryConfig.initialSettings.bounds = transformExtent(bounds, 'EPSG:4326', `EPSG:${api.map(this.mapId).currentProjection}`);
-          }
+        if (!layerEntryConfig.initialSettings?.bounds && metadataLayerList[i]['ows:WGS84BoundingBox']) {
+          const lowerCorner = (metadataLayerList[i]['ows:WGS84BoundingBox']['ows:LowerCorner']['#text'] as string).split(' ');
+          const upperCorner = (metadataLayerList[i]['ows:WGS84BoundingBox']['ows:UpperCorner']['#text'] as string).split(' ');
+          const bounds = [Number(lowerCorner[0]), Number(lowerCorner[1]), Number(upperCorner[0]), Number(upperCorner[1])];
+          layerEntryConfig.initialSettings = {
+            bounds: transformExtent(bounds, 'EPSG:4326', `EPSG:${api.map(this.mapId).currentProjection}`),
+          };
         }
 
         api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -31,7 +31,7 @@ export type TypeLayerInitialSettings = {
   opacity?: number;
   /** Initial visibility setting. Default = true. */
   visible?: boolean;
-  /** The bounding box that contains all the layer's features. */
+  /** The geographic bounding box that contains all the layer's features. */
   bounds?: Extent;
   /** The extent that constrains the view. Called with [minX, minY, maxX, maxY] extent coordinates. */
   extent?: Extent;


### PR DESCRIPTION
# Description

The bounds, when translated from geographic to map projection, does not end up to an equivalent bounding polygon. GeoView WMS layers verify that the queries are done inside this polygon to avoid errors with some WMS services. Since the bounds in the map projection does not correspond to the original geographic one (can not use transformExtent back and forth), the test say that the click is outside the bounds and get feature info returns nothing.

The solution is to keep the bounds using geographic coordinates and do the test using the geographic click position.

Fixes #861

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using the method described in the issue #861 to reproduce the bug and confirming that the problem is not there anymore.

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
