### PR TITLE
804 move temporal dimension on geoview instances

### DIFF
--- a/packages/geoview-core/public/templates/layers-temporal.html
+++ b/packages/geoview-core/public/templates/layers-temporal.html
@@ -79,13 +79,28 @@
                   'listOfLayerEntryConfig': [
                     {
                       'entryType': 'group',
-                      'layerId': 'wmsLYR1-Group',
-                      'layerName': { 'en': 'Group' },
+                      'layerId': 'wmsLYR1-Group1',
+                      'layerName': { 'en': 'Group1' },
                       'listOfLayerEntryConfig': [
+                      {
+                        'entryType': 'group',
+                        'layerId': 'wmsLYR1-Group2',
+                        'layerName': { 'en': 'Group2' },
+                        'listOfLayerEntryConfig': [
                         {
-                          'layerId': 'RADAR_1KM_RSNO'
+                          'entryType': 'group',
+                          'layerId': 'wmsLYR1-Group3',
+                          'layerName': { 'en': 'Group3' },
+                          'listOfLayerEntryConfig': [
+                            {
+                              'layerId': 'RADAR_1KM_RSNO',
+                              'layerPathEnding': 'ending'
+                            }
+                          ]
                         }
-                      ]
+                            ]
+                      }
+                        ]
                     }
                   ]
                 }
@@ -214,17 +229,17 @@
           var timeConsoleLyr2 = document.getElementById('LYR2TD');
           var timeConsoleLyr3 = document.getElementById('LYR3TD');
           timeConsoleLyr1.textContent = JSON.stringify(
-            cgpv.api.map('LYR1').layer.geoviewLayers['wmsLYR1-Root'].listOfLayerEntryConfig[0].listOfLayerEntryConfig[0].temporalDimension,
+            cgpv.api.map('LYR1').layer.geoviewLayers['wmsLYR1-Root'].layerTemporalDimension['wmsLYR1-Root/wmsLYR1-Group1/wmsLYR1-Group2/wmsLYR1-Group3/RADAR_1KM_RSNO/ending'],
             undefined,
             2
           );
           timeConsoleLyr2.textContent = JSON.stringify(
-            cgpv.api.map('LYR2').layer.geoviewLayers['esriDynamicLYR3'].listOfLayerEntryConfig[0].temporalDimension,
+            cgpv.api.map('LYR2').layer.geoviewLayers['esriDynamicLYR3'].layerTemporalDimension['esriDynamicLYR3/0'],
             undefined,
             2
           );
           timeConsoleLyr3.textContent = JSON.stringify(
-            cgpv.api.map('LYR3').layer.geoviewLayers['esriFeatureLYR4b'].listOfLayerEntryConfig[0].temporalDimension,
+            cgpv.api.map('LYR3').layer.geoviewLayers['esriFeatureLYR4b'].layerTemporalDimension['esriFeatureLYR4b/0'],
             undefined,
             2
           );

--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -392,7 +392,7 @@
           "items": {
             "type": "number"
           },
-          "description": "The bounding box that contains all the layer's features."
+          "description": "The geographic bounding box that contains all the layer's features."
         },
         "extent": {
           "type": "array",

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -689,8 +689,7 @@ export abstract class AbstractGeoViewLayer {
     if (layerConfig) {
       if (Array.isArray(layerConfig)) processGroupLayerBounds(layerConfig);
       else processGroupLayerBounds([layerConfig]);
-      if (projectionCode && bounds)
-        return transformExtent(bounds, `EPSG:${api.map(this.mapId).currentProjection}`, `EPSG:${projectionCode}`);
+      if (projectionCode && bounds) return transformExtent(bounds, `EPSG:4326`, `EPSG:${projectionCode}`);
     }
     return bounds;
   }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -38,6 +38,7 @@ import { TypeJsonObject } from '../../../core/types/global-types';
 import { Layer } from '../layer';
 import { LayerSetPayload, payloadIsRequestLayerInventory } from '../../../api/events/payloads/layer-set-payload';
 import { GetLegendsPayload, payloadIsQueryLegend } from '../../../api/events/payloads/get-legends-payload';
+import { TimeDimension } from '../../../core/utils/date-mgt';
 
 export type TypeLegend = {
   layerPath: string;
@@ -200,6 +201,9 @@ export abstract class AbstractGeoViewLayer {
 
   /** Layer metadata */
   layerMetadata: Record<string, TypeJsonObject> = {};
+
+  /** Layer temporal dimension */
+  layerTemporalDimension: Record<string, TimeDimension> = {};
 
   /** Attribution used in the OpenLayer source. */
   attributions: string[] = [];

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -190,7 +190,9 @@ export function commonProcessTemporalDimension(
   layerEntryConfig: TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig
 ) {
   if (esriTimeDimension !== undefined) {
-    layerEntryConfig.temporalDimension = api.dateUtilities.createDimensionFromESRI(Cast<TimeDimensionESRI>(esriTimeDimension));
+    this.layerTemporalDimension[Layer.getLayerPath(layerEntryConfig)] = api.dateUtilities.createDimensionFromESRI(
+      Cast<TimeDimensionESRI>(esriTimeDimension)
+    );
   }
 }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -280,19 +280,9 @@ export function commonProcessInitialSettings(
       `EPSG:${api.map(this.mapId).currentProjection}`
     );
 
-  if (layerEntryConfig.initialSettings?.bounds)
-    layerEntryConfig.initialSettings.bounds = transformExtent(
-      layerEntryConfig.initialSettings.bounds,
-      'EPSG:4326',
-      `EPSG:${api.map(this.mapId).currentProjection}`
-    );
-  else {
+  if (!layerEntryConfig.initialSettings?.bounds) {
     const layerExtent = [extent.xmin, extent.ymin, extent.xmax, extent.ymax] as Extent;
-    layerEntryConfig.initialSettings.bounds = transformExtent(
-      layerExtent,
-      `EPSG:${extent.spatialReference.wkid as number}`,
-      `EPSG:${api.map(this.mapId).currentProjection}`
-    );
+    layerEntryConfig.initialSettings = { bounds: layerExtent };
   }
 }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -52,7 +52,6 @@ import { TypeEsriFeatureLayerEntryConfig } from '../vector/esri-feature';
 
 export interface TypeEsriDynamicLayerEntryConfig extends Omit<TypeImageLayerEntryConfig, 'source'> {
   source: TypeSourceImageEsriInitialConfig;
-  temporalDimension?: TimeDimension;
 }
 
 export interface TypeEsriDynamicLayerConfig extends Omit<TypeGeoviewLayerConfig, 'listOfLayerEntryConfig'> {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -43,7 +43,6 @@ import { Layer } from '../../layer';
 
 export interface TypeWmsLayerEntryConfig extends Omit<TypeImageLayerEntryConfig, 'source'> {
   source: TypeSourceImageWmsInitialConfig;
-  temporalDimension?: TimeDimension;
 }
 
 export interface TypeWMSLayerConfig extends Omit<TypeGeoviewLayerConfig, 'listOfLayerEntryConfig'> {
@@ -601,7 +600,7 @@ export class WMS extends AbstractGeoViewRaster {
    */
   private processTemporalDimension(wmsTimeDimension: TypeJsonObject, layerEntryConfig: TypeWmsLayerEntryConfig) {
     if (wmsTimeDimension !== undefined) {
-      layerEntryConfig.temporalDimension = api.dateUtilities.createDimensionFromOGC(wmsTimeDimension);
+      this.layerTemporalDimension[Layer.getLayerPath(layerEntryConfig)] = api.dateUtilities.createDimensionFromOGC(wmsTimeDimension);
     }
   }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -15,7 +15,7 @@ import { transform, transformExtent } from 'ol/proj';
 
 import cloneDeep from 'lodash/cloneDeep';
 
-import { Cast, TypeJsonArray, TypeJsonObject } from '../../../../core/types/global-types';
+import { Cast, toJsonObject, TypeJsonArray, TypeJsonObject } from '../../../../core/types/global-types';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES, TypeLegend } from '../abstract-geoview-layers';
 import { AbstractGeoViewRaster, TypeBaseRasterLayer } from './abstract-geoview-raster';
 import {
@@ -577,18 +577,8 @@ export class WMS extends AbstractGeoViewRaster {
               `EPSG:${api.map(this.mapId).currentProjection}`
             );
 
-          if (layerEntryConfig.initialSettings?.bounds)
-            layerEntryConfig.initialSettings.bounds = transformExtent(
-              layerEntryConfig.initialSettings.bounds,
-              'EPSG:4326',
-              `EPSG:${api.map(this.mapId).currentProjection}`
-            );
-          else if (layerCapabilities.EX_GeographicBoundingBox) {
-            layerEntryConfig.initialSettings.bounds = transformExtent(
-              layerCapabilities.EX_GeographicBoundingBox as Extent,
-              'EPSG:4326',
-              `EPSG:${api.map(this.mapId).currentProjection}`
-            );
+          if (!layerEntryConfig.initialSettings?.bounds && layerCapabilities.EX_GeographicBoundingBox) {
+            layerEntryConfig.initialSettings = { bounds: layerCapabilities.EX_GeographicBoundingBox as Extent };
           }
 
           if (layerCapabilities.Dimension) {
@@ -660,10 +650,10 @@ export class WMS extends AbstractGeoViewRaster {
         const crs = `EPSG:${api.map(this.mapId).currentProjection}`;
         const clickCoordinate = transform(lnglat, 'EPSG:4326', crs);
         if (
-          clickCoordinate[0] < layerConfig.initialSettings!.bounds![0] ||
-          layerConfig.initialSettings!.bounds![2] < clickCoordinate[0] ||
-          clickCoordinate[1] < layerConfig.initialSettings!.bounds![1] ||
-          layerConfig.initialSettings!.bounds![3] < clickCoordinate[1]
+          lnglat[0] < layerConfig.initialSettings!.bounds![0] ||
+          layerConfig.initialSettings!.bounds![2] < lnglat[0] ||
+          lnglat[1] < layerConfig.initialSettings!.bounds![1] ||
+          layerConfig.initialSettings!.bounds![3] < lnglat[1]
         )
           resolve([]);
         else {
@@ -678,17 +668,38 @@ export class WMS extends AbstractGeoViewRaster {
             INFO_FORMAT: infoFormat,
           });
           if (featureInfoUrl) {
-            let featureMember: TypeJsonObject | null;
+            let featureMember: TypeJsonObject | undefined;
             axios(featureInfoUrl).then((response) => {
               if (infoFormat === 'text/xml') {
                 const xmlDomResponse = new DOMParser().parseFromString(response.data, 'text/xml');
                 const jsonResponse = xmlToJson(xmlDomResponse);
+                // ! TODO: We should use a WMS format setting in the schema to decide what feature info response interpreter to use
+                // ! For the moment, we try to guess the response format based on properties returned from the query
                 const featureCollection = this.getAttribute(jsonResponse, 'FeatureCollection');
                 if (featureCollection) featureMember = this.getAttribute(featureCollection, 'featureMember');
+                else {
+                  const featureInfoResponse = this.getAttribute(jsonResponse, 'GetFeatureInfoResponse');
+                  if (featureInfoResponse?.Layer) {
+                    featureMember = {};
+                    const layerName =
+                      featureInfoResponse.Layer['@attributes'] && featureInfoResponse.Layer['@attributes'].name
+                        ? (featureInfoResponse.Layer['@attributes'].name as string)
+                        : 'undefined';
+                    featureMember['Layer name'] = toJsonObject({ '#text': layerName });
+                    if (featureInfoResponse.Layer.Attribute && featureInfoResponse.Layer.Attribute['@attributes']) {
+                      const fieldName = featureInfoResponse.Layer.Attribute['@attributes'].name
+                        ? (featureInfoResponse.Layer.Attribute['@attributes'].name as string)
+                        : 'undefined';
+                      const fieldValue = featureInfoResponse.Layer.Attribute['@attributes'].value
+                        ? (featureInfoResponse.Layer.Attribute['@attributes'].value as string)
+                        : 'undefined';
+                      featureMember[fieldName] = toJsonObject({ '#text': fieldValue });
+                    }
+                  }
+                }
               } else featureMember = { plain_text: { '#text': response.data } };
               if (featureMember) {
-                const featureInfoResult = this.formatWmsFeatureInfoResult(featureMember, layerConfig);
-                featureInfoResult[0].extent = [clickCoordinate[0], clickCoordinate[1], clickCoordinate[0], clickCoordinate[1]];
+                const featureInfoResult = this.formatWmsFeatureInfoResult(featureMember, layerConfig, clickCoordinate);
                 resolve(featureInfoResult);
               }
             });
@@ -857,10 +868,15 @@ export class WMS extends AbstractGeoViewRaster {
    *
    * @param {TypeJsonObject} featureMember An object formatted using the query syntax.
    * @param {TypeWmsLayerEntryConfig} layerEntryConfig The layer configuration.
+   * @param {Coordinate} clickCoordinate The coordinate where the user has clicked.
    *
    * @returns {TypeArrayOfFeatureInfoEntries} The feature info table.
    */
-  formatWmsFeatureInfoResult(featureMember: TypeJsonObject, layerEntryConfig: TypeWmsLayerEntryConfig): TypeArrayOfFeatureInfoEntries {
+  formatWmsFeatureInfoResult(
+    featureMember: TypeJsonObject,
+    layerEntryConfig: TypeWmsLayerEntryConfig,
+    clickCoordinate: Coordinate
+  ): TypeArrayOfFeatureInfoEntries {
     const featureInfo = layerEntryConfig?.source?.featureInfo;
     const outfields = getLocalizedValue(featureInfo?.outfields, this.mapId)?.split(',');
     const fieldTypes = featureInfo?.fieldTypes?.split(',');
@@ -873,7 +889,7 @@ export class WMS extends AbstractGeoViewRaster {
       // feature key for building the data-grid
       featureKey: featureKeyCounter++,
       geoviewLayerType: this.type,
-      extent: [0, 0, 0, 0],
+      extent: [clickCoordinate[0], clickCoordinate[1], clickCoordinate[0], clickCoordinate[1]],
       geometry: null,
       featureIcon: document.createElement('canvas'),
       fieldInfo: {},
@@ -883,7 +899,7 @@ export class WMS extends AbstractGeoViewRaster {
       keys.forEach((key) => {
         if (!key.endsWith('Geometry') && !key.startsWith('@')) {
           const splitedKey = key.split(':');
-          const fieldName = splitedKey[splitedKey.length - 1];
+          const fieldName = splitedKey.slice(-1)[0];
           if ('#text' in entry[key])
             featureInfoEntry.fieldInfo[`${prefix}${prefix ? '.' : ''}${fieldName}`] = {
               fieldKey: fieldKeyCounter++,
@@ -925,11 +941,10 @@ export class WMS extends AbstractGeoViewRaster {
    * @param {TypeJsonObject} jsonObject The object that is supposed to have the needed attribute.
    * @param {string} attribute The attribute searched.
    *
-   * @returns {TypeJsonObject | null} The promised feature info table.
+   * @returns {TypeJsonObject | undefined} The promised feature info table.
    */
-  private getAttribute(jsonObject: TypeJsonObject, attributeEnding: string): TypeJsonObject | null {
-    const keys = Object.keys(jsonObject);
-    for (let i = 0; i < keys.length; i++) if (keys[i].endsWith(attributeEnding)) return jsonObject[keys[i]];
-    return null;
+  private getAttribute(jsonObject: TypeJsonObject, attributeEnding: string): TypeJsonObject | undefined {
+    const keyFound = Object.keys(jsonObject).find((key) => key.endsWith(attributeEnding));
+    return keyFound ? jsonObject[keyFound] : undefined;
   }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -291,12 +291,6 @@ export class XYZTiles extends AbstractGeoViewRaster {
             `EPSG:${api.map(this.mapId).currentProjection}`
           );
 
-        if (layerEntryConfig.initialSettings?.bounds)
-          layerEntryConfig.initialSettings!.bounds = transformExtent(
-            layerEntryConfig.initialSettings.bounds,
-            'EPSG:4326',
-            `EPSG:${api.map(this.mapId).currentProjection}`
-          );
         resolve();
       }
     });

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -27,7 +27,6 @@ import {
   commonProcessTemporalDimension,
   commonValidateListOfLayerEntryConfig,
 } from '../esri-layer-common';
-import { TimeDimension } from '../../../../core/utils/date-mgt';
 import { AbstractGeoViewVector } from './abstract-geoview-vector';
 import { TypeJsonArray, TypeJsonObject } from '../../../../core/types/global-types';
 import { TypeEsriDynamicLayerEntryConfig } from '../raster/esri-dynamic';
@@ -40,7 +39,6 @@ export interface TypeSourceEsriFeatureInitialConfig extends Omit<TypeVectorSourc
 
 export interface TypeEsriFeatureLayerEntryConfig extends Omit<TypeVectorLayerEntryConfig, 'source'> {
   source: TypeSourceEsriFeatureInitialConfig;
-  temporalDimension?: TimeDimension;
 }
 
 export interface TypeEsriFeatureLayerConfig extends Omit<TypeGeoviewLayerConfig, 'listOfLayerEntryConfig'> {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -244,13 +244,6 @@ export class GeoJSON extends AbstractGeoViewVector {
             `EPSG:${api.map(this.mapId).currentProjection}`
           );
 
-        if (layerEntryConfig.initialSettings?.bounds) {
-          layerEntryConfig.initialSettings.bounds = transformExtent(
-            layerEntryConfig.initialSettings.bounds,
-            'EPSG:4326',
-            `EPSG:${api.map(this.mapId).currentProjection}`
-          );
-        }
         resolve();
       }
     });

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
@@ -220,21 +220,18 @@ export class GeoPackage extends AbstractGeoViewVector {
             `EPSG:${api.map(this.mapId).currentProjection}`
           );
 
-        if (layerEntryConfig.initialSettings?.bounds)
-          layerEntryConfig.initialSettings.bounds = transformExtent(
-            layerEntryConfig.initialSettings.bounds,
-            'EPSG:4326',
-            `EPSG:${api.map(this.mapId).currentProjection}`
-          );
-        else {
-          if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
-          if (this.metadata?.collections[i].extent?.spatial?.bbox && this.metadata?.collections[i].extent?.spatial?.crs) {
-            layerEntryConfig.initialSettings.bounds = transformExtent(
+        if (
+          !layerEntryConfig.initialSettings?.bounds &&
+          this.metadata?.collections[i].extent?.spatial?.bbox &&
+          this.metadata?.collections[i].extent?.spatial?.crs
+        ) {
+          layerEntryConfig.initialSettings = {
+            bounds: transformExtent(
               this.metadata.collections[i].extent.spatial.bbox[0] as number[],
               get(this.metadata.collections[i].extent.spatial.crs as string)!,
               `EPSG:${api.map(this.mapId).currentProjection}`
-            );
-          }
+            ),
+          };
         }
 
         api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
@@ -213,21 +213,18 @@ export class OgcFeature extends AbstractGeoViewVector {
             `EPSG:${api.map(this.mapId).currentProjection}`
           );
 
-        if (layerEntryConfig.initialSettings?.bounds)
-          layerEntryConfig.initialSettings.bounds = transformExtent(
-            layerEntryConfig.initialSettings.bounds,
-            'EPSG:4326',
-            `EPSG:${api.map(this.mapId).currentProjection}`
-          );
-        else {
-          if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
-          if (this.metadata?.collections[i].extent?.spatial?.bbox && this.metadata?.collections[i].extent?.spatial?.crs) {
-            layerEntryConfig.initialSettings.bounds = transformExtent(
+        if (
+          !layerEntryConfig.initialSettings?.bounds &&
+          this.metadata?.collections[i].extent?.spatial?.bbox &&
+          this.metadata?.collections[i].extent?.spatial?.crs
+        ) {
+          layerEntryConfig.initialSettings = {
+            bounds: transformExtent(
               this.metadata.collections[i].extent.spatial.bbox[0] as number[],
               get(this.metadata.collections[i].extent.spatial.crs as string)!,
               `EPSG:${api.map(this.mapId).currentProjection}`
-            );
-          }
+            ),
+          };
         }
 
         api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -213,20 +213,13 @@ export class WFS extends AbstractGeoViewVector {
             `EPSG:${api.map(this.mapId).currentProjection}`
           );
 
-        if (layerEntryConfig.initialSettings?.bounds)
-          layerEntryConfig.initialSettings.bounds = transformExtent(
-            layerEntryConfig.initialSettings.bounds,
-            'EPSG:4326',
-            `EPSG:${api.map(this.mapId).currentProjection}`
-          );
-        else {
-          if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
-          if (metadataLayerList[i]['ows:WGS84BoundingBox']) {
-            const lowerCorner = (metadataLayerList[i]['ows:WGS84BoundingBox']['ows:LowerCorner']['#text'] as string).split(' ');
-            const upperCorner = (metadataLayerList[i]['ows:WGS84BoundingBox']['ows:UpperCorner']['#text'] as string).split(' ');
-            const bounds = [Number(lowerCorner[0]), Number(lowerCorner[1]), Number(upperCorner[0]), Number(upperCorner[1])];
-            layerEntryConfig.initialSettings.bounds = transformExtent(bounds, 'EPSG:4326', `EPSG:${api.map(this.mapId).currentProjection}`);
-          }
+        if (!layerEntryConfig.initialSettings?.bounds && metadataLayerList[i]['ows:WGS84BoundingBox']) {
+          const lowerCorner = (metadataLayerList[i]['ows:WGS84BoundingBox']['ows:LowerCorner']['#text'] as string).split(' ');
+          const upperCorner = (metadataLayerList[i]['ows:WGS84BoundingBox']['ows:UpperCorner']['#text'] as string).split(' ');
+          const bounds = [Number(lowerCorner[0]), Number(lowerCorner[1]), Number(upperCorner[0]), Number(upperCorner[1])];
+          layerEntryConfig.initialSettings = {
+            bounds: transformExtent(bounds, 'EPSG:4326', `EPSG:${api.map(this.mapId).currentProjection}`),
+          };
         }
 
         api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -31,7 +31,7 @@ export type TypeLayerInitialSettings = {
   opacity?: number;
   /** Initial visibility setting. Default = true. */
   visible?: boolean;
-  /** The bounding box that contains all the layer's features. */
+  /** The geographic bounding box that contains all the layer's features. */
   bounds?: Extent;
   /** The extent that constrains the view. Called with [minX, minY, maxX, maxY] extent coordinates. */
   extent?: Extent;

--- a/packages/geoview-swiper/src/swiper.tsx
+++ b/packages/geoview-swiper/src/swiper.tsx
@@ -115,6 +115,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
   const [layersIds] = useState<string[]>(config.layers);
   const [geoviewLayers] = useState(api.map(mapId).layer.geoviewLayers);
   const [olLayers, setOlLayers] = useState<BaseLayer[]>([]);
+  const [offset, setOffset] = useState(0);
 
   const [orientation] = useState(config.orientation);
   const swiperValue = useRef(50);
@@ -181,7 +182,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
         ? -map.getTargetElement().getBoundingClientRect().left + evt.clientX
         : -map.getTargetElement().getBoundingClientRect().top + evt.clientY;
     const size = orientation === 'vertical' ? mapSize.current[0] : mapSize.current[1];
-    swiperValue.current = (client / size) * 100;
+    swiperValue.current = ((client - offset) / size) * 100;
 
     // force VectorImage to refresh
     olLayers.forEach((layer: BaseLayer) => {
@@ -190,6 +191,21 @@ export function Swiper(props: SwiperProps): JSX.Element {
 
     map.render();
   }, 100);
+
+  /**
+   * On Click, calculate the offset between click location and swiper
+   * @param {MouseEvent} evt The mouse event to calculate the offset
+   */
+  const setMouseOffset = (evt: MouseEvent) => {
+    const position =
+      orientation === 'vertical'
+        ? -map.getTargetElement().getBoundingClientRect().left + evt.clientX
+        : -map.getTargetElement().getBoundingClientRect().top + evt.clientY;
+    mapSize.current = map.getSize() || [0, 0];
+    const size = orientation === 'vertical' ? mapSize.current[0] : mapSize.current[1];
+    const offSetOnClick = position - (size * swiperValue.current) / 100;
+    setOffset(offSetOnClick);
+  };
 
   useEffect(() => {
     // set listener for layers in config array
@@ -222,6 +238,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
         axis={`${orientation === 'vertical' ? 'x' : 'y'}`}
         bounds="parent"
         defaultPosition={{ x: orientation === 'vertical' ? defaultX : 0, y: orientation === 'vertical' ? 0 : defaultY }}
+        onMouseDown={(e) => setMouseOffset(e)}
         onStop={(e) => {
           onStop(e as MouseEvent);
         }}


### PR DESCRIPTION
# Description

Moved the time dimension from the layerEntryConfig instance to the geoviewLayer instance. The time dimension is now in this.layerTimeDimension[path to the layerEntryConfig]

Fixes #804

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Using the layers-temporal.html template and the DevTool debugger. Run the template and expand the Time Dimension section below the map. Set a breakpoint and look in cgpv.api.map('the_map_id').layer.geoviewLayers['the_geoview_layer_id'].layerTemporalDimension['the_layer_entry_path'] to confirm everything is set properly.

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/941)
<!-- Reviewable:end -->
