### PR TITLE
feat(layers): Layers follow config order and can be moved

### DIFF
--- a/packages/geoview-core/src/core/components/legend/legend.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend.tsx
@@ -16,7 +16,7 @@ export function Legend(): JSX.Element | null {
   const mapConfig = useContext(MapContext);
   const { mapId } = mapConfig;
 
-  const configLayerIds = api.map(mapId).mapFeaturesConfig.map.listOfGeoviewLayerConfig?.map((element) => element.geoviewLayerId) || [];
+  const configLayerIds = api.map(mapId).layer.layerOrder || [];
 
   const [mapLayers, setMapLayers] = useState<{ [geoviewLayerId: string]: AbstractGeoViewLayer }>({});
   const [orderedMapLayers, setOrderedMapLayers] = useState<AbstractGeoViewLayer[]>([]);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -178,6 +178,9 @@ export abstract class AbstractGeoViewLayer {
   /** The GeoView layer metadataAccessPath. The name attribute is optional */
   metadataAccessPath: TypeLocalizedString = { en: '', fr: '' };
 
+  // order to load layers
+  layerOrder: string[];
+
   /**
    * An array of layer settings. In the schema, this attribute is optional. However, we define it as mandatory and if the
    * configuration does not provide a value, we use an empty array instead of an undefined attribute.
@@ -218,6 +221,7 @@ export abstract class AbstractGeoViewLayer {
   constructor(type: TypeGeoviewLayerType, mapLayerConfig: TypeGeoviewLayerConfig, mapId: string) {
     this.mapId = mapId;
     this.type = type;
+    this.layerOrder = [];
     this.geoviewLayerId = mapLayerConfig.geoviewLayerId || generateId('');
     this.geoviewLayerName.en = mapLayerConfig?.geoviewLayerName?.en ? mapLayerConfig.geoviewLayerName.en : DEFAULT_LAYER_NAMES[type];
     this.geoviewLayerName.fr = mapLayerConfig?.geoviewLayerName?.fr ? mapLayerConfig.geoviewLayerName.fr : DEFAULT_LAYER_NAMES[type];

--- a/packages/geoview-core/src/geo/map/map.ts
+++ b/packages/geoview-core/src/geo/map/map.ts
@@ -216,6 +216,8 @@ export class MapViewer {
             (payload) => {
               if (payloadIsGeoViewLayerAdded(payload)) {
                 const { geoviewLayer } = payload;
+                geoviewLayer.layerOrder = this.layer.orderSubLayers(geoviewLayer.listOfLayerEntryConfig);
+                this.layer.setLayerZIndices(geoviewLayer);
                 geoviewLayer!.isLoaded = true;
                 if (this.remainingLayersThatNeedToBeLoadedIsDecrementedToZero4TheFirstTime()) {
                   clearTimeout(this.layerLoadedTimeoutId[geoviewLayerConfig.geoviewLayerId]);

--- a/packages/geoview-layers-panel/src/layer-stepper.tsx
+++ b/packages/geoview-layers-panel/src/layer-stepper.tsx
@@ -693,6 +693,15 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
           setAddLayerVisible(false);
         }, 3000);
       }
+
+      if (layerConfig.geoviewLayerId) {
+        api.map(mapId).layer.layerOrder.push(layerConfig.geoviewLayerId);
+      } else if (layerConfig.listOfLayerEntryConfig !== undefined) {
+        layerConfig.listOfLayerEntryConfig.forEach((subLayer) => {
+          if (subLayer.layerId) api.map(mapId).layer.layerOrder.unshift(subLayer.layerId);
+        });
+      }
+
       api.map(mapId).layer.addGeoviewLayer(layerConfig);
     }
   };

--- a/packages/geoview-layers-panel/src/panel-content.tsx
+++ b/packages/geoview-layers-panel/src/panel-content.tsx
@@ -110,7 +110,7 @@ function PanelContent(props: TypePanelContentProps): JSX.Element {
   };
 
   useEffect(() => {
-    if (api.map(mapId!).layer !== undefined) setMapLayers(Object.keys(api.map(mapId!).layer.geoviewLayers));
+    if (api.map(mapId!).layer?.layerOrder !== undefined) setMapLayers([...api.map(mapId!).layer.layerOrder].reverse());
     api.event.on(
       api.eventNames.LAYER.EVENT_REMOVE_LAYER,
       (payload) => {

--- a/packages/geoview-layers-panel/src/reorder-layers-list.tsx
+++ b/packages/geoview-layers-panel/src/reorder-layers-list.tsx
@@ -57,7 +57,7 @@ function ReorderLayersList({ mapId, title, layerIds, setReorderLayersVisible, se
     const reorderedLayerIds = [...layerIds];
     const [removed] = reorderedLayerIds.splice(source.index, 1);
     reorderedLayerIds.splice(destination.index, 0, removed);
-    // TODO waiting on issue #736, need to emit an event or api call here to make the map change the layer order
+    api.map(mapId).layer.moveLayer(removed, destination.index);
     setMapLayers(reorderedLayerIds);
   };
 


### PR DESCRIPTION
Closes #629
Closes #736

# Description

Layers now follow the order specified in the config, with the first layer being on the top. Layers can now be reordered in the layers panel.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Checked layers on the layers page for correct orders, enabled layers panel on WMS layer map to move layers around. Also added and moved layers on layers-panel page.

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/950)
<!-- Reviewable:end -->
