### PR TITLE
982-Visibility-settings-bug

### DIFF
--- a/packages/geoview-core/public/templates/layers.html
+++ b/packages/geoview-core/public/templates/layers.html
@@ -97,7 +97,6 @@
                   'geoviewLayerName': { 'en': 'Weather Group' },
                   'metadataAccessPath': { 'en': 'https://geo.weather.gc.ca/geomet' },
                   'geoviewLayerType': 'ogcWms',
-                  'initialSettings': { 'visible': true },
                   'listOfLayerEntryConfig': [
                     {
                       'entryType': 'group',
@@ -206,7 +205,6 @@
                   'en': 'statmen toner'
                 },
                 'geoviewLayerType': 'xyzTiles',
-                'initialSettings': { 'visible': true },
                 'listOfLayerEntryConfig': [
                   {
                     'layerId': 'toner',
@@ -275,7 +273,6 @@
                   {
                     'layerId': '1',
                     'layerFilter': 'E_Province = \'Alberta\' or E_Province = \'Manitoba\'',
-                    'initialSettings': { 'visible': true },
                     'style': {
                       'Point': {
                         'styleId': 'uniqueValueId',
@@ -451,7 +448,6 @@
                     'layerId': '8',
                     'layerName': { 'en': 'CSO volume 2020' },
                     'layerFilter': 'Total_CSO_Volume > 5000000',
-                    'initialSettings': { 'visible': true },
                     'style': {
                       'Point': {
                         'styleId': 'classBreaksId',
@@ -697,7 +693,7 @@
                 'geoviewLayerId': 'uniqueValueId',
                 'geoviewLayerName': { 'en': 'uniqueValue' },
                 'metadataAccessPath': { 'en': 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/' },
-                'geoviewLayerType': 'esriDynamic',
+                'geoviewLayerType': 'esriFeature',
                 'listOfLayerEntryConfig': [
                   {
                     'layerId': '1'

--- a/packages/geoview-core/src/core/utils/config/config-validation.ts
+++ b/packages/geoview-core/src/core/utils/config/config-validation.ts
@@ -680,8 +680,13 @@ export class ConfigValidation {
         if (typeof config === 'object') {
           Object.keys(config).forEach((key) => {
             if (typeof config[key] === 'object') {
-              if (('en' in config[key] || 'fr' in config[key]) && (!config[key].en || !config[key].fr))
-                throw new Error('When you support both languages, you must set all en and fr properties of localized strings.');
+              if ('en' in config[key] || 'fr' in config[key]) {
+                // delete empty localized strings
+                if (!config[key].en && !config[key].fr) delete config[key];
+                else if (!config[key].en || !config[key].fr) {
+                  throw new Error('When you support both languages, you must set all en and fr properties of localized strings.');
+                }
+              }
               // Avoid the 'geoviewRootLayer' and 'parentLayerConfig' properties because they loop on themself and cause a
               // stack overflow error.
               else if (!['geoviewRootLayer', 'parentLayerConfig'].includes(key)) validateLocalizedString(config[key]);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -655,6 +655,7 @@ export abstract class AbstractGeoViewLayer {
       layers: new Collection(),
       properties: { layerEntryConfig },
     };
+    // layerEntryConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
     if (layerEntryConfig.initialSettings?.extent !== undefined) layerGroupOptions.extent = layerEntryConfig.initialSettings?.extent;
     if (layerEntryConfig.initialSettings?.maxZoom !== undefined) layerGroupOptions.maxZoom = layerEntryConfig.initialSettings?.maxZoom;
     if (layerEntryConfig.initialSettings?.minZoom !== undefined) layerGroupOptions.minZoom = layerEntryConfig.initialSettings?.minZoom;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -278,8 +278,8 @@ export function commonProcessInitialSettings(
   extent: TypeJsonObject,
   layerEntryConfig: TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig
 ) {
-  if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
-  if (layerEntryConfig.initialSettings?.visible === undefined) layerEntryConfig.initialSettings.visible = visibility;
+  // layerEntryConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
+  if (layerEntryConfig.initialSettings?.visible === undefined) layerEntryConfig.initialSettings!.visible = visibility;
   // ! TODO: The solution implemented in the following two lines is not right. scale and zoom are not the same things.
   // ! if (layerEntryConfig.initialSettings?.minZoom === undefined && minScale !== 0) layerEntryConfig.initialSettings.minZoom = minScale;
   // ! if (layerEntryConfig.initialSettings?.maxZoom === undefined && maxScale !== 0) layerEntryConfig.initialSettings.maxZoom = maxScale;
@@ -292,7 +292,7 @@ export function commonProcessInitialSettings(
 
   if (!layerEntryConfig.initialSettings?.bounds) {
     const layerExtent = [extent.xmin, extent.ymin, extent.xmax, extent.ymax] as Extent;
-    layerEntryConfig.initialSettings = { bounds: layerExtent };
+    layerEntryConfig.initialSettings!.bounds = layerExtent;
   }
 }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -279,6 +279,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
         source: new ImageArcGISRest(sourceOptions),
         properties: { layerEntryConfig },
       };
+      // layerEntryConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
       if (layerEntryConfig.initialSettings?.className !== undefined)
         imageLayerOptions.className = layerEntryConfig.initialSettings?.className;
       if (layerEntryConfig.initialSettings?.extent !== undefined) imageLayerOptions.extent = layerEntryConfig.initialSettings?.extent;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -520,9 +520,7 @@ export class WMS extends AbstractGeoViewRaster {
           source: new ImageWMS(sourceOptions),
           properties: { layerCapabilities, layerEntryConfig },
         };
-        if (!layerEntryConfig.initialSettings && layerEntryConfig.geoviewRootLayer?.initialSettings)
-          // eslint-disable-next-line no-param-reassign
-          layerEntryConfig.initialSettings = layerEntryConfig.geoviewRootLayer?.initialSettings;
+        // layerEntryConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
         if (layerEntryConfig.initialSettings?.className !== undefined)
           imageLayerOptions.className = layerEntryConfig.initialSettings?.className;
         if (layerEntryConfig.initialSettings?.extent !== undefined) imageLayerOptions.extent = layerEntryConfig.initialSettings?.extent;
@@ -561,7 +559,6 @@ export class WMS extends AbstractGeoViewRaster {
         const layerCapabilities = this.getLayerMetadataEntry(layerEntryConfig.layerId)!;
         this.layerMetadata[Layer.getLayerPath(layerEntryConfig)] = layerCapabilities;
         if (layerCapabilities) {
-          if (!layerEntryConfig.initialSettings) layerEntryConfig.initialSettings = {};
           if (layerCapabilities.Attribution) this.attributions.push(layerCapabilities.Attribution as string);
           if (!layerEntryConfig.source.featureInfo) layerEntryConfig.source.featureInfo = { queryable: !!layerCapabilities.queryable };
           // ! TODO: The solution implemented in the following lines is not right. scale and zoom are not the same things.
@@ -577,7 +574,7 @@ export class WMS extends AbstractGeoViewRaster {
             );
 
           if (!layerEntryConfig.initialSettings?.bounds && layerCapabilities.EX_GeographicBoundingBox) {
-            layerEntryConfig.initialSettings = { bounds: layerCapabilities.EX_GeographicBoundingBox as Extent };
+            layerEntryConfig.initialSettings!.bounds = layerCapabilities.EX_GeographicBoundingBox as Extent;
           }
 
           if (layerCapabilities.Dimension) {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -250,6 +250,7 @@ export class XYZTiles extends AbstractGeoViewRaster {
       }
 
       const tileLayerOptions: TileOptions<XYZ> = { source: new XYZ(sourceOptions) };
+      // layerEntryConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
       if (layerEntryConfig.initialSettings?.className !== undefined)
         tileLayerOptions.className = layerEntryConfig.initialSettings?.className;
       if (layerEntryConfig.initialSettings?.extent !== undefined) tileLayerOptions.extent = layerEntryConfig.initialSettings?.extent;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
@@ -225,13 +225,12 @@ export class GeoPackage extends AbstractGeoViewVector {
           this.metadata?.collections[i].extent?.spatial?.bbox &&
           this.metadata?.collections[i].extent?.spatial?.crs
         ) {
-          layerEntryConfig.initialSettings = {
-            bounds: transformExtent(
-              this.metadata.collections[i].extent.spatial.bbox[0] as number[],
-              get(this.metadata.collections[i].extent.spatial.crs as string)!,
-              `EPSG:${api.map(this.mapId).currentProjection}`
-            ),
-          };
+          // layerEntryConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
+          layerEntryConfig.initialSettings!.bounds = transformExtent(
+            this.metadata.collections[i].extent.spatial.bbox[0] as number[],
+            get(this.metadata.collections[i].extent.spatial.crs as string)!,
+            `EPSG:${api.map(this.mapId).currentProjection}`
+          );
         }
 
         api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
@@ -218,13 +218,12 @@ export class OgcFeature extends AbstractGeoViewVector {
           this.metadata?.collections[i].extent?.spatial?.bbox &&
           this.metadata?.collections[i].extent?.spatial?.crs
         ) {
-          layerEntryConfig.initialSettings = {
-            bounds: transformExtent(
-              this.metadata.collections[i].extent.spatial.bbox[0] as number[],
-              get(this.metadata.collections[i].extent.spatial.crs as string)!,
-              `EPSG:${api.map(this.mapId).currentProjection}`
-            ),
-          };
+          // layerEntryConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
+          layerEntryConfig.initialSettings!.bounds = transformExtent(
+            this.metadata.collections[i].extent.spatial.bbox[0] as number[],
+            get(this.metadata.collections[i].extent.spatial.crs as string)!,
+            `EPSG:${api.map(this.mapId).currentProjection}`
+          );
         }
 
         api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -217,9 +217,8 @@ export class WFS extends AbstractGeoViewVector {
           const lowerCorner = (metadataLayerList[i]['ows:WGS84BoundingBox']['ows:LowerCorner']['#text'] as string).split(' ');
           const upperCorner = (metadataLayerList[i]['ows:WGS84BoundingBox']['ows:UpperCorner']['#text'] as string).split(' ');
           const bounds = [Number(lowerCorner[0]), Number(lowerCorner[1]), Number(upperCorner[0]), Number(upperCorner[1])];
-          layerEntryConfig.initialSettings = {
-            bounds: transformExtent(bounds, 'EPSG:4326', `EPSG:${api.map(this.mapId).currentProjection}`),
-          };
+          // layerEntryConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
+          layerEntryConfig.initialSettings!.bounds = transformExtent(bounds, 'EPSG:4326', `EPSG:${api.map(this.mapId).currentProjection}`);
         }
 
         api.map(this.mapId).layer.registerLayerConfig(layerEntryConfig);

--- a/packages/geoview-core/src/geo/renderer/geoview-renderer-types.ts
+++ b/packages/geoview-core/src/geo/renderer/geoview-renderer-types.ts
@@ -77,13 +77,14 @@ export enum NodeType {
   variable,
   string,
   number,
+  null,
   unary,
   binary,
   group,
 }
 export type FilterNodeType = { nodeType: NodeType; nodeValue: string | number | boolean | string[] | number[] };
 export type FilterNodeArrayType = FilterNodeType[];
-export const binaryKeywors = ['in', 'like', 'and', 'or', '<', '<=', '=', '!=', '>', '>=', '||', '/', '*', ','];
+export const binaryKeywors = ['is', 'is not', 'in', 'like', 'and', 'or', '<', '<=', '=', '<>', '>', '>=', '||', '/', '*', ','];
 export const unaryKeywords = ['not'];
 export const groupKeywords = ['(', ')'];
 export const operatorPriority = [
@@ -100,8 +101,9 @@ export const operatorPriority = [
   { key: '>', priority: 9 },
   { key: '<=', priority: 8 },
   { key: '>=', priority: 7 },
-  { key: '!=', priority: 6 },
-  { key: 'is null', priority: 5 },
+  { key: '<>', priority: 6 },
+  { key: 'is not', priority: 5 },
+  { key: 'is', priority: 5 },
   { key: 'like', priority: 4 },
   { key: 'in', priority: 3 },
   { key: 'not', priority: 2 },


### PR DESCRIPTION
# Description

This PR resolve three issues:
- The `initialSettings` visibility flag is not working properly;
- The `Package - Layers Panel` generate a stack dump when adding a GeoJSON layer;
- The query filter does not accept `is null` and `is not null` operations.

Fixes #982, #983 and #984

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using the devTools to trace and verify that the code behave as expected.

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/985)
<!-- Reviewable:end -->
