### PR TITLE
986 remove zoom out in data and details

### DIFF
--- a/packages/geoview-core/src/core/components/data-grid/layer-data-grid.tsx
+++ b/packages/geoview-core/src/core/components/data-grid/layer-data-grid.tsx
@@ -30,9 +30,8 @@ import {
 import { useTheme, Theme } from '@mui/material/styles';
 import Button, { ButtonProps } from '@mui/material/Button';
 import { Extent } from 'ol/extent';
-import { fromLonLat } from 'ol/proj';
 import { TypeLayerEntryConfig, AbstractGeoViewVector, EsriDynamic, api, TypeDisplayLanguage } from '../../../app';
-import { Tooltip, MenuItem, Switch, ZoomInSearchIcon, ZoomOutSearchIcon, IconButton } from '../../../ui';
+import { Tooltip, MenuItem, Switch, ZoomInSearchIcon, IconButton } from '../../../ui';
 
 /**
  * Create a data grid (table) component for a lyer features all request
@@ -111,12 +110,6 @@ export function LayerDataGrid(props: CustomDataGridProps) {
 
   const [filterString, setFilterString] = useState<string>('');
   const [mapfiltered, setMapFiltered] = useState<boolean>(false);
-
-  const { currentProjection } = api.map(mapId);
-  const { zoom, center } = api.map(mapId).mapFeaturesConfig.map.viewSettings;
-  const projectionConfig = api.projection.projections[currentProjection];
-  let currentZoomId = -1;
-
   /**
    * Convert the filter string from the Filter Model
    *
@@ -239,7 +232,6 @@ export function LayerDataGrid(props: CustomDataGridProps) {
    */
 
   const handleZoomIn = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, zoomid: number, extent: Extent) => {
-    currentZoomId = currentZoomId !== zoomid ? zoomid : -1;
     api.map(mapId).zoomToExtent(extent);
   };
 

--- a/packages/geoview-core/src/core/components/data-grid/layer-data-grid.tsx
+++ b/packages/geoview-core/src/core/components/data-grid/layer-data-grid.tsx
@@ -233,35 +233,14 @@ export function LayerDataGrid(props: CustomDataGridProps) {
    * featureinfo data grid Zoom in/out handling
    *
    * @param {React.MouseEvent<HTMLButtonElement, MouseEvent>} e mouse clicking event
-   * @param {number} zoomid in of zoom incon button clicking
+   *  @param {number} zoomid in of zoom incon button clicking
    * @param {Extent} extent feature exten
    *
    */
 
   const handleZoomIn = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, zoomid: number, extent: Extent) => {
     currentZoomId = currentZoomId !== zoomid ? zoomid : -1;
-    document.querySelectorAll('svg.MuiSvgIcon-root>path').forEach((path) => {
-      (path as HTMLElement).style.display = 'block';
-    });
-
-    const zoomButtonElement = e.target as HTMLElement;
-    const zoomInIconElement = zoomButtonElement.parentElement?.children[0] as HTMLElement;
-    const zoomOutIconElement = zoomButtonElement.parentElement?.children[1] as HTMLElement;
-    zoomInIconElement.style.display = currentZoomId !== zoomid ? 'block' : 'none';
-    zoomOutIconElement.style.display = currentZoomId === zoomid ? 'block' : 'none';
-
-    if (currentZoomId === zoomid) {
-      api.map(mapId).zoomToExtent(extent);
-    } else {
-      api
-        .map(mapId)
-        .map.getView()
-        .animate({
-          center: fromLonLat(center, projectionConfig),
-          duration: 500,
-          zoom,
-        });
-    }
+    api.map(mapId).zoomToExtent(extent);
   };
 
   /**
@@ -338,8 +317,7 @@ export function LayerDataGrid(props: CustomDataGridProps) {
       if (column.field === 'featureActions') {
         return (
           <IconButton color="primary" onClick={(e) => handleZoomIn(e, params.id as number, rows[params.id as number].extent)}>
-            <ZoomInSearchIcon style={{ display: currentZoomId !== Number(params.id) ? 'block' : 'none' }} />
-            <ZoomOutSearchIcon style={{ display: currentZoomId === Number(params.id) ? 'block' : 'none' }} />
+            <ZoomInSearchIcon />
           </IconButton>
         );
       }

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/require-default-props */
 import React, { useEffect, useState } from 'react';
 import { useTheme, Theme } from '@mui/material/styles';
-import { fromLonLat } from 'ol/proj';
 import {
   Collapse,
   List,
@@ -12,7 +11,6 @@ import {
   ExpandMoreIcon,
   ExpandLessIcon,
   ZoomInSearchIcon,
-  ZoomOutSearchIcon,
   Tooltip,
   IconButton,
   Box,
@@ -72,7 +70,6 @@ export function FeatureInfo(props: TypeFeatureProps): JSX.Element {
   const featureId = `Feature Info ${feature.featureKey}`;
   const featureIconSrc = feature.featureIcon.toDataURL();
   const [isOpen, setOpen] = useState<boolean>(false);
-  const [currentZoom, setCurrentZoom] = useState<boolean>(false);
   const featureInfoList = Object.keys(feature.fieldInfo).map((fieldName) => {
     return {
       key: feature.fieldInfo[fieldName]!.alias ? feature.fieldInfo[fieldName]!.alias : fieldName,
@@ -80,10 +77,6 @@ export function FeatureInfo(props: TypeFeatureProps): JSX.Element {
       value: feature.fieldInfo[fieldName]!.value,
     };
   });
-
-  const { currentProjection } = api.map(mapId);
-  const { zoom, center } = api.map(mapId).mapFeaturesConfig.map.viewSettings;
-  const projectionConfig = api.projection.projections[currentProjection];
 
   const theme: Theme & {
     iconImg: React.CSSProperties;
@@ -93,7 +86,6 @@ export function FeatureInfo(props: TypeFeatureProps): JSX.Element {
     e.stopPropagation();
     api.map(mapId).zoomToExtent(feature.extent);
     setOpen(true);
-    setCurrentZoom(!currentZoom);
   }
 
   useEffect(() => {

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -91,19 +91,8 @@ export function FeatureInfo(props: TypeFeatureProps): JSX.Element {
 
   function handleZoomIn(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) {
     e.stopPropagation();
-    if (!currentZoom) {
-      api.map(mapId).zoomToExtent(feature.extent);
-      setOpen(true);
-    } else {
-      api
-        .map(mapId)
-        .map.getView()
-        .animate({
-          center: fromLonLat(center, projectionConfig),
-          duration: 500,
-          zoom,
-        });
-    }
+    api.map(mapId).zoomToExtent(feature.extent);
+    setOpen(true);
     setCurrentZoom(!currentZoom);
   }
 
@@ -135,7 +124,7 @@ export function FeatureInfo(props: TypeFeatureProps): JSX.Element {
           </Tooltip>
           <ListItemIcon>
             <IconButton color="primary" onClick={(e) => handleZoomIn(e)}>
-              {!currentZoom ? <ZoomInSearchIcon /> : <ZoomOutSearchIcon />}
+              <ZoomInSearchIcon />
             </IconButton>
           </ListItemIcon>
         </ListItemButton>

--- a/packages/geoview-footer-panel/src/data-item.tsx
+++ b/packages/geoview-footer-panel/src/data-item.tsx
@@ -41,7 +41,7 @@ export function DataItem({ mapId }: Props): JSX.Element {
         });
       }
     });
-  }, 3000);
+  }, 3500);
   return (
     <Tabs
       tabsProps={{

--- a/packages/geoview-footer-panel/src/data-item.tsx
+++ b/packages/geoview-footer-panel/src/data-item.tsx
@@ -41,7 +41,7 @@ export function DataItem({ mapId }: Props): JSX.Element {
         });
       }
     });
-  }, 2000);
+  }, 3000);
   return (
     <Tabs
       tabsProps={{


### PR DESCRIPTION
# Description

remove the zoom out toggling in details and data grid components

Fixes # 986

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

got footer panel, details and data tab, click the zoomin icon, it won't toggle to zoom out icon

# Checklist:

- [ X ] I have connected the issues(s) to this PR
- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
