### PR TITLE
1017 reduce schema validation verbosity

### DIFF
--- a/packages/geoview-core/public/templates/layers/esri-dynamic.html
+++ b/packages/geoview-core/public/templates/layers/esri-dynamic.html
@@ -85,44 +85,209 @@
               'labeled': true
             },
             'listOfGeoviewLayerConfig': [
-            {
-              'geoviewLayerId': 'uniqueValueId',
-              'geoviewLayerName': { 'en': 'uniqueValue' },
-              'metadataAccessPath': { 'en': 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/' },
-              'geoviewLayerType': 'esriDynamic',
-              'listOfLayerEntryConfig': [
-                {
-                  'layerId': '1'
-                }
-              ]
-            },
-            {
-              'geoviewLayerId': 'historical-flood',
-              'geoviewLayerName': { 'en': 'Historical Flood Events (HFE)' },
-              'metadataAccessPath': {
-                'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/historical_flood_event_en/MapServer'
+              {
+                'geoviewLayerId': 'historical-flood',
+                'geoviewLayerName': { 'en': 'Historical Flood Events (HFE)' },
+                'metadataAccessPath': {
+                  'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/historical_flood_event_en/MapServer'
+                },
+                'geoviewLayerType': 'esriDynamic',
+                'listOfLayerEntryConfig': [
+                  {
+                    'layerId': '0',
+                    'layerFilter': 'source_1 = \'MSPQ\''
+                  }
+                ]
               },
-              'geoviewLayerType': 'esriDynamic',
-              'listOfLayerEntryConfig': [
-                {
-                  'layerId': '0'
-                }
-              ]
-            },
-            {
-              'geoviewLayerId': 'esriFeatureLYR4.1',
-              'geoviewLayerName': { 'en': 'Temporal_Test_Bed_en' },
-              'metadataAccessPath': {
-                'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/Temporal_Test_Bed_en/MapServer/'
+              {
+                'geoviewLayerId': 'uniqueValueId',
+                'geoviewLayerName': { 'en': 'uniqueValue' },
+                'metadataAccessPath': { 'en': 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/' },
+                'geoviewLayerType': 'esriDynamic',
+                'listOfLayerEntryConfig': [
+                  {
+                    'layerId': '1',
+                    'layerFilter': 'E_Province = \'Alberta\' or E_Province = \'Manitoba\'',
+                    'initialSettings': { 'visible': true },
+                    'style': {
+                      'Point': {
+                        'styleId': 'uniqueValueId',
+                        'defaultLabel': 'Regulated, Yearly, Normal',
+                        'styleType': 'uniqueValue',
+                        'defaultSettings': {
+                          'mimeType': 'image/png',
+                          'offset': [0, 0],
+                          'opacity': 1,
+                          'rotation': 0,
+                          'src': 'iVBORw0KGgoAAAANSUhEUgAAABIAAAAPCAYAAADphp8SAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAUhJREFUOI2d0z1Lw1AUBuD3hppCLSo4iLg6dFZBEYtZQgeFgB+jrSIEQXSxFUIFg1jTYhBHyWITEVwDOhXUSVz8Bf4DcahgBxtvrkNrIbamSd/tXM557llOBAGiGQtxRb779OuJdEOUm9UY+6o+6KYkZDN2rWdooF7dZ6BTdXzsATjqCSpaqTGXOblGxeVUc/JCzby8hYZc5pwAiDXLOM8GDwFsh4KOy8kJAGueRwK5cDl7nt94eg0MEdJ3BoC09XO8BmAlEFQwhSUCzHf8ANyyVhZnlPXKsy+0a4An4Er/bQoAjNBTAElfaCQq7gB03A8CMKdZgqSkH+2OUMmaHqaMHnRBGlsxrmgYuJVl0DboG/0qAYaCQAAS71FxE6gYHki7SiWY62wFRJqhqm5K19mMXWtBLnN0EuBk/mT093Rag/n0/WJIxJMfY79g/IvbH/IAAAAASUVORK5CYII=',
+                          'type': 'iconSymbol'
+                        },
+                        'defaultVisible': 'yes',
+                        'fields': ['E_Regulated', 'E_SampleType', 'E_Overall_Condition'],
+                        'uniqueValueStyleInfo': [
+                          {
+                            'label': 'Natural, Seasonal, High',
+                            'settings': {
+                              'mimeType': 'image/png',
+                              'offset': [0, 0],
+                              'opacity': 1,
+                              'rotation': 0,
+                              'src': 'iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAcNJREFUKJFjYSATsCBz/v//z/Tp8+fwO/cf273/+FmckZHxn6iQwBMVJbldXJyc27Bq/P//v8jVm3cmtUxf7rX+3nN+ZEVJ+srhd+8/3KikIFfMyMj4Fa7x////zBeu3JjuXDM55Ou//xjOmnfxrsS+8t7Uze1FLAwMDClwjU+fv0irmLzYH5smGHjw/TdTz7yVIe/ef9wiJMi/gYWBgYHhxp2HXgeev2dFVtjhb8Pw7dtPhqbdp+FiCy894E+4cz+IgYEBovHDp88qyJpmxngwxIf5wfnImt+9f68Ed+rff3/ZkTVycnDA2dxcHMhSDH/+/WeHa+Tm5HzJwMCgCJMsW7SZgYmZkeHHj18M5RsPo2jk4eJ+DdcoKSZyQoeX0+LK5+8MDAwMDC9+/WWImbkeI4D85MUZJMWED8A1qirKVjUlBvgETVqugqEa5mQmRoacKO9zWurKPXCNfHx8389evha5Njd8bfPCLXIXPn1F0eQgLshQGut7XUREOJCRkfEfXCMDAwODsa7WmQOnT+t150VMevn6ne33bz+kGBgZ/3FzcTyUEBXZxcb4p0RbTek3TD1KWnUwNf3IwMAQj8u5yAAAupehfivnXOEAAAAASUVORK5CYII=',
+                              'type': 'iconSymbol'
+                            },
+                            'values': ['Natural', 'Seasonal', 'High'],
+                            'visible': 'yes'
+                          },
+                          {
+                            'label': 'Natural, Seasonal, Low',
+                            'settings': {
+                              'mimeType': 'image/png',
+                              'offset': [0, 0],
+                              'opacity': 1,
+                              'rotation': 0,
+                              'src': 'iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAcNJREFUKJFjYSATsCBz/v//z/T986fw1w/u2n379EGckZHxH7eg8BMxRZVd7Jxc27Bq/P//v8izW9cmHZ/Z5vX14RF+ZEVC2j7hLx/c3Sgmr1TMyMj4Fa7x////zI+vXpp+oDE45P+/3xjOend1i8Su6hOprs3LWRgYGFLgGj88f5p2fFqNPzZNMPDvxxumU/MnhHx5/24Lj6DQBhYGBgaGF3dvev14eYkVWaGCVxHD7+/fGJ7unwEXe39tK/+re3FBDAwMEI3fP71XQdakEd7MYBYay8DAwMCwl4EBRfOXd2+UEH78958dJcQ4OeBsVi5uFCf///uXHa6RjYPrJQMDgyJM8trSRgZGJiaGPz9+MDzY2ouikZ2H9zVcI6+YxAkWHjmLP18eQQLi9xeGy/OKMQKIW86SgVdU/ABco5CiapVebKXPuemZKhiqoYCRiZVBLyzrnJSaVg9cIx8f3/cHly9EGmZMW3tlabfc78/3UTRxiOkx6EUWXOcVFg5kZGT8B9fIwMDAoKBrcObe6QN6ppnNkz6/fmn7+8d3KUYGhn+sXNwPeUUldnEzsJZIqmnDIxolrSqZOnxkYGCIx+VcZAAA8GKiZ9d12dAAAAAASUVORK5CYII=',
+                              'type': 'iconSymbol'
+                            },
+                            'values': ['Natural', 'Seasonal', 'Low'],
+                            'visible': 'no'
+                          },
+                          {
+                            'label': 'Natural, Seasonal, Normal',
+                            'settings': {
+                              'mimeType': 'image/png',
+                              'offset': [0, 0],
+                              'opacity': 1,
+                              'rotation': 0,
+                              'src': 'iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAcdJREFUKJFjYSATsCBz/v//z/Tt++fwZ6/v2X359lGckZHxHx+34BNJMZVdnOyc27Bq/P//v8iDZzcm7Tg+yev915v8yIokhMzCn768v1FKTKGYkZHxK1zj////me8+vjx99YHikP///2I468W7UxJLd11NjXTtZ2FgYEiBa3zz4WnaluO9/tg0wcCff1+Zdp+aFfLpy/stfDyCG1gYGBgYnry46/Xtx2NWZIW6CmEMP39/Y7j1dAvC5vdn+J+8uh3EwMAA0fjl+0cVZE1mGqkMzmYRDAwMDAxr9zKgaP785Z0Skh//siNrZGPhgLPZWblRnPz3/z92uEZ2Ns6XDAwMijDJo9dmMTAyMjH8/vOD4fKDlSgaOdm5X8M1CvJKnGBl4bf4/ecjAwMDA8P/fz8ZDl+eiBFAAtyqDIK84gfgGiWElKrs9TJ99pzrUMFQDQWMjMwMNnpx5+Sl1HvgGvn4+L7ffnA50tmwbO3hK7Plfv1+j6KJi0OawV4v+bogr2ggIyPjP7hGBgYGBlUF3TNX7x3QczMtnvTh82vb37+/STEwMv7jYOV+KMArtusbN1OJrKTab5h6lLSqreTwkYGBIR6Xc5EBAG+8pa3DWR79AAAAAElFTkSuQmCC',
+                              'type': 'iconSymbol'
+                            },
+                            'values': ['Natural', 'Seasonal', 'Normal'],
+                            'visible': 'no'
+                          },
+                          {
+                            'label': 'Natural, Yearly, High',
+                            'settings': {
+                              'mimeType': 'image/png',
+                              'offset': [0, 0],
+                              'opacity': 1,
+                              'rotation': 0,
+                              'src': 'iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAARhJREFUKJGNjzFLQlEYhp8OR45xaUgiIqcgEhpqb2toaFAbpTEuQTch15qD5ooEwR/QrnDr+gPammsMg7hgDsHBjtm5DXrFwbo948fzvnyvJKZUms305g/1gCKCLNABGxhHXXN71Y01CbBaPFppa3wNOcS4Yg3EltJfZfJewTSqD8OA66p2ONOEKMd0FiBqsuNu0qq/ykyYOtBE67/IMRnSqTPAkxoKCTIACvYMeBLI/icALAFCYulMDP2LLmAl2ADEdpLtwJ0BpOl/V1ValBNe+1R9ew4gadU/nN3jgpbWBxanyD2D3X+7rz0NA0DXv3kkf7KhbP/UCIoKloF3BxvMDcTFi197jtNy3NO4DA1UgIoZncxo6SQ//xRZVbXMk6kAAAAASUVORK5CYII=',
+                              'type': 'iconSymbol'
+                            },
+                            'values': ['Natural', 'Yearly', 'High'],
+                            'visible': 'yes'
+                          },
+                          {
+                            'label': 'Natural, Yearly, Low',
+                            'settings': {
+                              'mimeType': 'image/png',
+                              'offset': [0, 0],
+                              'opacity': 1,
+                              'rotation': 0,
+                              'src': 'iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAASFJREFUKJGNkb1KA0EURs8Mw0YRLUREDLgIYsBCezsLSxMbgwSUJYiFpLDVWvABBAsLiVaSYGUgIXkAO7E0vbAIyUaMouyQGQt3u/x44MKF73zc4ioirnYZd7R7KCQZDEkIW9ZQdxL+Re6OIPYUwE1maRGtq0AKE0fOspCsa+0WbrNj6f1S8xFA3R+Q+OzoCpCiPzO216sUs6k1r9R8Vd22mxeSlQFyhJ6WVp8CR0pI0sPlPyxsx4WkNSN9MMw1QCoLrf9cgDDYBKMEYd3ibIwuTNQAlHn3L8WUWwCSQ+wfKb/OAJTX4KO4000LM1kFZvvI31aGub2y/wLR47xy8HS9tbCqnM6JhQwwj6RtCevgnHtlvxm3VbzkH57fgONoBvILJileSF2zp2AAAAAASUVORK5CYII=',
+                              'type': 'iconSymbol'
+                            },
+                            'values': ['Natural', 'Yearly', 'Low'],
+                            'visible': 'no'
+                          },
+                          {
+                            'label': 'Natural, Yearly, Normal',
+                            'settings': {
+                              'mimeType': 'image/png',
+                              'offset': [0, 0],
+                              'opacity': 1,
+                              'rotation': 0,
+                              'src': 'iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAARxJREFUKJGNkS1IQ2EUQM/99u2vioj4ksWBQbuwoLDoZpSB8lgwyIJN3hBEnA6TQTAYZNpNDqZ7UdBm1m5QmQsqvjF57zNsr21uBy5cLuekq+mxe7aajMVeN0RUDgILVNOYoNGJdU728vet0NMABxfpaeG9DirVPSuAGRG1EP9NFA8vM9nSuvsAoI+viHvf0RqQoj/jGL9WqWbmHdt90d7XUgFhdoAcMmaUXwI2NUJ2iNzFsBIGFmakZBIXpTE0R9KhRYZAi9AwhsVhtsANgP4JIqdJ8YuA9Y/fRkXLAHrfdj/L1XRWSaIO/kQf2RMT5J212yfoPW7Hvns8Ol+eC3TbMcbPAVPAh5hIA3TFsevPYa3DZbtw/QZs9WYgf/xmWAwLz4rrAAAAAElFTkSuQmCC',
+                              'type': 'iconSymbol'
+                            },
+                            'values': ['Natural', 'Yearly', 'Normal'],
+                            'visible': 'no'
+                          },
+                          {
+                            'label': 'Regulated, Seasonal, High',
+                            'settings': {
+                              'mimeType': 'image/png',
+                              'offset': [0, 0],
+                              'opacity': 1,
+                              'rotation': 0,
+                              'src': 'iVBORw0KGgoAAAANSUhEUgAAABMAAAAQCAYAAAD0xERiAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAf5JREFUOI2t01tI02EYBvDnrT+EmC6KYCRBglFRmJ02VlgRSqAUHUCQZY68GQ2vJGdIkHiRdNE06DAG9u8gxoJpRxJ3EQqaMYpS2VAqaqsVxGyWOmXu6WoyXbFmPXffw8vve/ngU/Afo6QaICnR6Ox1RVlqFhH+EzY9M1P1qLunuKSosBKAumiMpGbIN1putLtyX67PrSDpFJHJRWE/Jybr6mw3DQDQcKVN33rhTA2AxrQxkhvdPf2F7mAoAwDuv/+S+XrYV0zyhogE0sJCY+Hak81tuxM7y6Xbhmf2PCuA6r/GSB5qaW0vCEVjkth7JyKKu3dgB0m9iAykxEgu838KGq2dvdu2ZGXgak0l1uZo0ed5A6PdBaPdZdhn2HkaQGpsNhYzn2tR9QBw3nQYuu35AIDjpUXwDI7A1jcER3tnPskyEXH+ESOZ82rQu/euz78OALKXZ867aPUqDQCgoetFwYmjB4+QfCgiU7/FpiLT1aeaHAfi51sP3Ni6eQM02VkYffcBl7uez83WN6u71CarGYAtCSO5597j7k3eH5EV8e7O8Ec8MZ2FTrsSTwPf5m3p9Pnzakfe6kiuEZHPcxjJJd/D4+UV9o6ShW8YisaSoHhMjdf296sXLQDqEzerCgS/ljotZSn/6oJox8Ljx0h2iIhHAQARcQBwpAkl5ReILNJbf8Z/egAAAABJRU5ErkJggg==',
+                              'type': 'iconSymbol'
+                            },
+                            'values': ['Regulated', 'Seasonal', 'High'],
+                            'visible': 'no'
+                          },
+                          {
+                            'label': 'Regulated, Seasonal, Low',
+                            'settings': {
+                              'mimeType': 'image/png',
+                              'offset': [0, 0],
+                              'opacity': 1,
+                              'rotation': 0,
+                              'src': 'iVBORw0KGgoAAAANSUhEUgAAABMAAAAQCAYAAAD0xERiAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAf1JREFUOI2t009Ik2EcB/Dvr15o/dOikNKIJA+KJZOwtaKQwkNWJB4KsfAg1SglcJFBhAeRCIqoJhivTA8eQpAOZhCMkQ4Ra2nN0mrQPzdrHZyTNt9qr99OjumKNet7e378+DxfHngU/McoyRZIih6NtixVFIuI8J8w/cf36hFHT0n+gYNVANoXjZFM9795VeGx12Vn5OSeJNkpIpFFYVokfKn/1hUzAAzcbTIdblStABpTxkjmjvU59mpfh5YDQPhj/0rf6IsSkm0i4ksJ+xacvOhurtkdPxu8fcG8sflhPYDav8ZIHnG124zUNYmfRyN+5a3LsYOkSUQGk2Ikl036xyvfP7heqKzaDPP5G1ibuQkfng3AY6+Dx241b91VfBZAcmx2Vrf02RpMALD9RD2yC4sAAMbScgReDiHwpANP76kFJI+JSOcfMZJZn0aG9017nVsAwLA6bd5FhnXrAQA+Z4sxWFZZRrJbRGZ+i/3UtFrXtZr9c+fR7g5k5RVgRVo6Au+8GHe0xnZ77zQUHW1qtQC4mYCR3PO8pytP1/xr5mah14/QdaoXhoxtmPnsntdy2uvMmfCO7SSZKSITMYzkknBoqsLTZi1d+IbUtQQo1u7q6eLj6uNzAC7HN6ue+uI7ZDxjS/pXF2RDOBQsJ3lfRNwKAIiICkBNEUrIL56h1pnX6ksDAAAAAElFTkSuQmCC',
+                              'type': 'iconSymbol'
+                            },
+                            'values': ['Regulated', 'Seasonal', 'Low'],
+                            'visible': 'no'
+                          },
+                          {
+                            'label': 'Regulated, Seasonal, Normal',
+                            'settings': {
+                              'mimeType': 'image/png',
+                              'offset': [0, 0],
+                              'opacity': 1,
+                              'rotation': 0,
+                              'src': 'iVBORw0KGgoAAAANSUhEUgAAABMAAAAQCAYAAAD0xERiAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAftJREFUOI2t011I01EYBvDnzX80a2UFRbWKRgVGGQvJsUZSgV2UUkQYEhFh0Ci8iOgDBt10YxG5ootgFwndlCGlq6CCaFsRfiA6RdMoXa7Bhtk+29iHT1eT6Yo167k7Dy+/83LgKPiPUfINkJR0OnWvqEgxiQj/CUukE/Wd/S+rKrbuPwmgec4YyZKxb0N1TpdFu27l5hMkW0Tk55ywWDx6xfb+ugEAXny4oz9VffMCgGsFYyRLe4be7o7Ex4sBIBAdXvTFM1BF8r6IeArCQpHJS6+6G3dld887Gg3rVzdfBtDw1xjJmmdOq45MSnafSgWVvhF7OUm9iHTkxUgu8E96jvePPtwxXylBtcGMFcs0+DjWBYfLAofLYijbaDwLID82NZU2tTlu6QGgsuwMSrXlAACjrgZunwtu3xu87nqwnWStiLT8ESOp+fTVVTkR6tsAAMWqxTMuUquWAwBGPO06/4+jh0naRCT2WyyRjDc8dV7dlzl3DrZCq9kG9cIl8Pg+Y3DcNj3bZr+x8/ShJhOAphyMpPFdb/uWVDq8NNP5g72421oLtWotwrHRGVtOhAY2ub3DFSTXiIh3GiM5LxwN1jldtw/MfkMymQNl8thu3nP+2KNzAMzZm9V/D3gP7tVdzPtXZ2VVJBo4QvKJiHQrACAiVgDWAqGc/ALxctoeg0TwJAAAAABJRU5ErkJggg==',
+                              'type': 'iconSymbol'
+                            },
+                            'values': ['Regulated', 'Seasonal', 'Normal'],
+                            'visible': 'no'
+                          },
+                          {
+                            'label': 'Regulated, Yearly, High',
+                            'settings': {
+                              'mimeType': 'image/png',
+                              'offset': [0, 0],
+                              'opacity': 1,
+                              'rotation': 0,
+                              'src': 'iVBORw0KGgoAAAANSUhEUgAAABIAAAAPCAYAAADphp8SAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAATxJREFUOI2d079LAnEYx/F3p9yFOMS1JK0NztHQUNQmYXHQr61JyPLIwTAIgqShHxQSghZBY3/AF3Ju7X9okLZoOAr6Uhf5vYYTyUo9/WzPl+f7ep7lCRMkyWyUaumtU0u4K7KyGzE+X+5cKzeLKMq+IePjdQeYMJDbLhz0ByXSo+Dl/ULLY6UuEdfPPUOmHjqUeJFGGUXp+4DdE2TO2eMStfbzzYD1kaR9/lgtPwSGpK6KKAZ+9z9p6ghYDgYtZBZR3kybGUumZU86onzfGcpmdWruCWjtlkUqdQpMd4SM2tcWaGNtFT9TWJsW4kL8D61mhnn39rog/kA4duEWqP+F3HoBtKEgEIq4aWVSjqhctUCxRDruKG0jENKIVF4BK3eDKMom5AyGzlBe99trTcxQ/uk0P7qiMt8j0pJvr8JggMSSoswAAAAASUVORK5CYII=',
+                              'type': 'iconSymbol'
+                            },
+                            'values': ['Regulated', 'Yearly', 'High'],
+                            'visible': 'no'
+                          },
+                          {
+                            'label': 'Regulated, Yearly, Low',
+                            'settings': {
+                              'mimeType': 'image/png',
+                              'offset': [0, 0],
+                              'opacity': 1,
+                              'rotation': 0,
+                              'src': 'iVBORw0KGgoAAAANSUhEUgAAABIAAAAPCAYAAADphp8SAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAURJREFUOI2d079LAmEcx/H3HfIIYhA1HQ0tBzpXUENRe8FBduGSFoEEUUvYFCQN/aCIxrglzwgEaTioubWlPyByEQclmiLBOrxrqKQ09fSzPQ/f5/V8lq8PDzFmCSZueWs34+uEZHUC7456Z2r5mbhFpWfoA3Ub7DFkZQtKez1BmWhoyLWrSQBkkTS10fO49fDcNeTar/sgAt/HoCtedoH1rqC0PjCCI5Z+30kOiYvo8NlKtvDkGZKcvlNAapyXbQ6ABU+QGVHmgekWf0TSWmhi2Xq8bwsZmwiK4gi5VVeQfNVjYKot5C8ObyCjtmYAmMzoihbLlax/oczi+KBbK+90QABwHXFowE0Cas2N7HIKmX4vEBD2R9RVrvPGH+hSV8KOw5pH5CuynTI1ruIWlTrkIk6aGnaKg/KzOvWHsVxhriukIZ8czlrxD/361gAAAABJRU5ErkJggg==',
+                              'type': 'iconSymbol'
+                            },
+                            'values': ['Regulated', 'Yearly', 'Low'],
+                            'visible': 'no'
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
               },
-              'geoviewLayerType': 'esriDynamic',
-              'listOfLayerEntryConfig': [
-                {
-                  'layerId': '0'
-                }
-              ]
-            }
-          ]
+              {
+                'geoviewLayerId': 'esriFeatureLYR4.1',
+                'geoviewLayerName': { 'en': 'Temporal_Test_Bed_en' },
+                'metadataAccessPath': {
+                  'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/Temporal_Test_Bed_en/MapServer/'
+                },
+                'geoviewLayerType': 'esriDynamic',
+                'listOfLayerEntryConfig': [
+                  {
+                    'layerId': '0'
+                  }
+                ]
+              }
+            ]
           },
           'components': ['overview-map', 'nav-bar', 'north-arrow', 'footer-bar'],
           'corePackages': [],

--- a/packages/geoview-core/public/templates/layers/layerlib.js
+++ b/packages/geoview-core/public/templates/layers/layerlib.js
@@ -153,7 +153,7 @@ const createInfoTable = (mapId, resultSetsId, resultSets) => {
           if (row.fieldInfo[fieldName].dataType === 'date') {
             const { dateUtilities } = cgpv.api;
             // tableData.innerText = dateUtilities.convertToDate(row.fieldInfo[fieldName].value);
-            tableData.innerText = dateUtilities.format(dateUtilities.convertToUTC(row.fieldInfo[fieldName].value), 'day', 'second');
+            tableData.innerText = dateUtilities.format(dateUtilities.convertToLocal(row.fieldInfo[fieldName].value), 'day', 'second');
           } else tableData.innerText = row.fieldInfo[fieldName].value;
           tableRow.appendChild(tableData);
         });
@@ -244,6 +244,7 @@ const createTableOfFilter = (mapId) => {
                       geoviewLayer.applyViewFilter(layerConfig, filter);
                     });
                     mapButtonsDiv.appendChild(toggleUniqueValueDefault);
+                    mapButtonsDiv.appendChild(legendStyle[geometry].defaultCanvas);
                     const br = document.createElement('br');
                     br.style.height = '1px';
                     mapButtonsDiv.appendChild(br);

--- a/packages/geoview-core/public/templates/layers/wms.html
+++ b/packages/geoview-core/public/templates/layers/wms.html
@@ -140,7 +140,7 @@
                       }
                     }
                   ]
-                }/*,
+                },
                 {
                   'geoviewLayerId': 'Hydro',
                   'geoviewLayerName': { 'en': 'Hydro' },
@@ -152,7 +152,7 @@
                       'layerName': { 'en': 'hydro_network' }
                     }
                   ]
-                }*/
+                }
               ]
             },
             'components': ['overview-map', 'nav-bar', 'footer-bar'],

--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://cgpv/schema",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "GeoView Core Config Schema",
   "type": "object",
@@ -65,6 +66,19 @@
         "aliasFields": {
           "$ref": "#/definitions/TypeLocalizedString",
           "description": "A comma separated list of attribute names (English/French) that should be use for alias. If empty, no alias will be set if not found."
+        }
+      },
+      "required": ["queryable"]
+    },
+
+    "TypeFeatureInfoNotQueryable": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "queryable": {
+          "type": "boolean",
+          "const": false,
+          "description": "Do not allow querying."
         }
       },
       "required": ["queryable"]
@@ -342,7 +356,7 @@
     },
 
     "TypeKindOfVectorSettings": {
-      "anyOf": [
+      "oneOf": [
         { "$ref": "#/definitions/TypeLineStringVectorConfig" },
         { "$ref": "#/definitions/TypePolygonVectorConfig" },
         { "$ref": "#/definitions/TypeSimpleSymbolVectorConfig" },
@@ -351,7 +365,7 @@
     },
 
     "TypeStyleSettings": {
-      "anyOf": [
+      "oneOf": [
         { "$ref": "#/definitions/TypeSimpleStyleConfig" },
         { "$ref": "#/definitions/TypeUniqueValueStyleConfig" },
         { "$ref": "#/definitions/TypeClassBreakStyleConfig" }
@@ -480,14 +494,6 @@
       }
     },
 
-    "TypeSourceImageInitialConfig": {
-      "anyOf": [
-        { "$ref": "#/definitions/TypeSourceImageWmsInitialConfig" },
-        { "$ref": "#/definitions/TypeSourceImageEsriInitialConfig" },
-        { "$ref": "#/definitions/TypeSourceImageStaticInitialConfig" }
-      ]
-    },
-
     "TypeSourceImageWmsInitialConfig": {
       "additionalProperties": false,
       "type": "object",
@@ -512,7 +518,7 @@
           "description": "The type of the remote WMS server. The default value is mapserver."
         },
         "style": {
-          "anyOf": [
+          "oneOf": [
             {
               "type": "string",
               "description": "Single style to apply"
@@ -532,6 +538,37 @@
     "TypeOfServer": {
       "enum": ["mapserver", "geoserver", "qgis"],
       "description": "The type of the remote WMS server. The default value is mapserver."
+    },
+
+    "TypeSourceImageStaticInitialConfig": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "dataAccessPath": {
+          "$ref": "#/definitions/TypeLocalizedString",
+          "description": "The path (English/French) to reach the data to display. If not specified, metadatAccessPath will be assigne dto it."
+        },
+        "crossOrigin": {
+          "type": "string",
+          "description": "The crossOrigin attribute for loaded images. Note that you must provide a crossOrigin value if you want to access pixel data with the Canvas renderer."
+        },
+        "projection": {
+          "type": "integer",
+          "description": "Spatial Reference EPSG code supported (https://epsg.io/). We support Web Mercator and Lambert Conical Conform Canada."
+        },
+        "featureInfo": {
+          "$ref": "#/definitions/TypeFeatureInfoNotQueryable"
+        },
+        "extent": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {
+            "type": "number"
+          },
+          "description": "The extent of the static image. Called with [minX, minY, maxX, maxY] extent coordinates."
+        }
+      }
     },
 
     "TypeSourceImageEsriInitialConfig": {
@@ -570,37 +607,6 @@
       "description": "The format of the exported image. The default format is png."
     },
 
-    "TypeSourceImageStaticInitialConfig": {
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "dataAccessPath": {
-          "$ref": "#/definitions/TypeLocalizedString",
-          "description": "The path (English/French) to reach the data to display. If not specified, metadatAccessPath will be assigne dto it."
-        },
-        "crossOrigin": {
-          "type": "string",
-          "description": "The crossOrigin attribute for loaded images. Note that you must provide a crossOrigin value if you want to access pixel data with the Canvas renderer."
-        },
-        "projection": {
-          "type": "integer",
-          "description": "Spatial Reference EPSG code supported (https://epsg.io/). We support Web Mercator and Lambert Conical Conform Canada."
-        },
-        "featureInfo": {
-          "$ref": "#/definitions/TypeFeatureInfoLayerConfig"
-        },
-        "extent": {
-          "type": "array",
-          "minItems": 4,
-          "maxItems": 4,
-          "items": {
-            "type": "number"
-          },
-          "description": "The extent of the static image. Called with [minX, minY, maxX, maxY] extent coordinates."
-        }
-      }
-    },
-
     "TypeSourceTileInitialConfig": {
       "additionalProperties": false,
       "properties": {
@@ -615,6 +621,9 @@
         "projection": {
           "type": "integer",
           "description": "Spatial Reference EPSG code supported (https://epsg.io/). We support Web Mercator and Lambert Conical Conform Canada."
+        },
+        "featureInfo": {
+          "$ref": "#/definitions/TypeFeatureInfoNotQueryable"
         },
         "tileGrid": { "$ref": "#/definitions/TypeTileGrid" }
       }
@@ -670,7 +679,8 @@
       "additionalProperties": false,
       "type": "object",
       "properties": {
-        "entryType": { "enum": ["vectorHeatmap"] },
+        "schemaTag": { "enum": ["not used yet"] },
+        "entryType": { "enum": ["vector-heatmap"] },
         "layerPathEnding": {
           "type": "string",
           "description": "The ending element of the layer configuration path."
@@ -709,15 +719,22 @@
         "weight": {
           "type": "string",
           "description": "Feature attribute to use for the weight or a function (ADD FORMAT) that returns a weight from a feature."
+        },
+        "not": {
+          "listOfLayerEntryConfig": {
+            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
+            "description": "The list of layer entry configurations to use from the GeoView layer group."
+          }
         }
       },
-      "required": ["layerId"]
+      "required": ["schemaTag", "entryType", "layerId"]
     },
 
     "TypeVectorLayerEntryConfig": {
       "additionalProperties": false,
       "type": "object",
       "properties": {
+        "schemaTag": { "enum": ["GeoJSON", "esriFeature", "ogcWfs", "ogcFeature", "GeoPackage"] },
         "entryType": { "enum": ["vector"] },
         "layerPathEnding": {
           "type": "string",
@@ -740,9 +757,15 @@
           "description": "Initial settings to apply to the layer entry at creation time. Initial settings are inherited from the parent in the configuration tree."
         },
         "source": { "$ref": "#/definitions/TypeVectorSourceInitialConfig" },
-        "style": { "$ref": "#/definitions/TypeStyleConfig" }
+        "style": { "$ref": "#/definitions/TypeStyleConfig" },
+        "not": {
+          "listOfLayerEntryConfig": {
+            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
+            "description": "The list of layer entry configurations to use from the GeoView layer group."
+          }
+        }
       },
-      "required": ["layerId"]
+      "required": ["schemaTag", "entryType", "layerId"]
     },
 
     "TypeVectorTileLayerEntryConfig": {
@@ -750,7 +773,8 @@
       "type": "object",
       "description": "Layer sources providing vector data divided into a tile grid.",
       "properties": {
-        "entryType": { "enum": ["vectorTile"] },
+        "schemaTag": { "enum": ["not used yet"] },
+        "entryType": { "enum": ["vector-tile"] },
         "layerPathEnding": {
           "type": "string",
           "description": "The ending element of the layer configuration path."
@@ -775,9 +799,15 @@
           "$ref": "#/definitions/TypeVectorTileSourceInitialConfig",
           "description": "Information used to configure the source of a vector tile layer."
         },
-        "style": { "$ref": "#/definitions/TypeStyleConfig" }
+        "style": { "$ref": "#/definitions/TypeStyleConfig" },
+        "not": {
+          "listOfLayerEntryConfig": {
+            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
+            "description": "The list of layer entry configurations to use from the GeoView layer group."
+          }
+        }
       },
-      "required": ["layerId"]
+      "required": ["schemaTag", "entryType", "layerId"]
     },
 
     "TypeVectorTileSourceInitialConfig": {
@@ -802,42 +832,116 @@
       }
     },
 
-    "TypeImageLayerEntryConfig": {
+    "TypeOgcWmsLayerEntryConfig": {
       "additionalProperties": false,
       "type": "object",
       "properties": {
-        "entryType": { "enum": ["raster"] },
-        "layerPathEnding": {
-          "type": "string",
-          "description": "The ending element of the layer configuration path."
-        },
+        "schemaTag": { "enum": ["ogcWms"] },
+        "entryType": { "enum": ["raster-image"] },
         "layerId": {
           "type": "string",
           "description": "The id of the layer to display on the map."
+        },
+        "layerPathEnding": {
+          "type": "string",
+          "description": "The ending element of the layer configuration path."
         },
         "layerName": {
           "$ref": "#/definitions/TypeLocalizedString",
           "description": "The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
         },
-        "styleFilter": {
+        "initialSettings": {
+          "$ref": "#/definitions/TypeLayerInitialSettings",
+          "description": "Initial settings to apply to the layer entry at creation time. Initial settings are inherited from the parent in the configuration tree."
+        },
+        "source": { "$ref": "#/definitions/TypeSourceImageWmsInitialConfig" },
+        "style": { "$ref": "#/definitions/TypeStyleConfig" },
+        "not": {
+          "listOfLayerEntryConfig": {
+            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
+            "description": "The list of layer entry configurations to use from the GeoView layer group."
+          }
+        }      },
+      "required": ["schemaTag", "entryType", "layerId"]
+    },
+
+    "TypeEsriDynamicLayerEntryConfig": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "schemaTag": { "enum": ["esriDynamic"] },
+        "entryType": { "enum": ["raster-image"] },
+        "layerId": {
           "type": "string",
-          "description": "Style filter to apply on feature of this style."
+          "description": "The id of the layer to display on the map."
+        },
+        "layerPathEnding": {
+          "type": "string",
+          "description": "The ending element of the layer configuration path."
+        },
+        "layerName": {
+          "$ref": "#/definitions/TypeLocalizedString",
+          "description": "The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
+        },
+        "layerFilter": {
+          "type": "string",
+          "description": "Filter to apply on feature of this layer."
         },
         "initialSettings": {
           "$ref": "#/definitions/TypeLayerInitialSettings",
           "description": "Initial settings to apply to the layer entry at creation time. Initial settings are inherited from the parent in the configuration tree."
         },
-        "source": { "$ref": "#/definitions/TypeSourceImageInitialConfig" },
-        "style": { "$ref": "#/definitions/TypeStyleConfig" }
+        "source": { "$ref": "#/definitions/TypeSourceImageEsriInitialConfig" },
+        "style": { "$ref": "#/definitions/TypeStyleConfig" },
+        "not": {
+          "listOfLayerEntryConfig": {
+            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
+            "description": "The list of layer entry configurations to use from the GeoView layer group."
+          }
+        }
       },
-      "required": ["layerId"]
+      "required": ["schemaTag", "entryType", "layerId"]
+    },
+
+    "TypeImageStaticLayerEntryConfig": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "schemaTag": { "enum": ["imageStatic"] },
+        "entryType": { "enum": ["raster-image"] },
+        "layerId": {
+          "type": "string",
+          "description": "The id of the layer to display on the map."
+        },
+        "layerPathEnding": {
+          "type": "string",
+          "description": "The ending element of the layer configuration path."
+        },
+        "layerName": {
+          "$ref": "#/definitions/TypeLocalizedString",
+          "description": "The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
+        },
+        "initialSettings": {
+          "$ref": "#/definitions/TypeLayerInitialSettings",
+          "description": "Initial settings to apply to the layer entry at creation time. Initial settings are inherited from the parent in the configuration tree."
+        },
+        "source": { "$ref": "#/definitions/TypeSourceImageStaticInitialConfig" },
+        "not": {
+          "listOfLayerEntryConfig": {
+            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
+            "description": "The list of layer entry configurations to use from the GeoView layer group."
+          }
+        }
+      },
+      "required": ["schemaTag", "entryType", "layerId"]
     },
 
     "TypeTileLayerEntryConfig": {
       "additionalProperties": false,
       "type": "object",
       "properties": {
-        "entryType": { "enum": ["raster"] },
+        "schemaTag": { "enum": ["ogcWms", "xyzTiles"] },
+        "entryType": { "enum": ["raster-tile"] },
         "layerPathEnding": {
           "type": "string",
           "description": "The ending element of the layer configuration path."
@@ -854,9 +958,15 @@
           "$ref": "#/definitions/TypeLayerInitialSettings",
           "description": "Initial settings to apply to the layer entry at creation time. Initial settings are inherited from the parent in the configuration tree."
         },
-        "source": { "$ref": "#/definitions/TypeSourceTileInitialConfig" }
+        "source": { "$ref": "#/definitions/TypeSourceTileInitialConfig" },
+        "not": {
+          "listOfLayerEntryConfig": {
+            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
+            "description": "The list of layer entry configurations to use from the GeoView layer group."
+          }
+        }
       },
-      "required": ["layerId"]
+      "required": ["schemaTag", "entryType", "layerId"]
     },
 
     "TypeGeocoreLayerEntryConfig": {
@@ -864,7 +974,8 @@
       "type": "object",
       "description": "Layer where configration is extracted by a configuration snippet stored on a server. The server configuration will handle bilangual informations.",
       "properties": {
-        "entryType": { "enum": ["geocore"] },
+        "schemaTag": { "enum": ["geoCore"] },
+        "entryType": { "enum": ["geoCore"] },
         "layerId": {
           "type": "string",
           "description": "The id of the layer to display on the map."
@@ -883,7 +994,7 @@
           "description": "The list of layer entry configurations to use from the GeoView layer group."
         }
       },
-      "required": ["layerId"]
+      "required": ["schemaTag", "entryType", "layerId"]
     },
 
     "TypeSourceGeocoreConfig": {
@@ -894,12 +1005,15 @@
         "dataAccessPath": {
           "$ref": "#/definitions/TypeLocalizedString",
           "description": "The url path to the geoCore endpoint (optional, this value should be embeded in the GeoView API)."
+        },
+        "featureInfo": {
+          "$ref": "#/definitions/TypeFeatureInfoNotQueryable"
         }
       }
     },
 
     "TypeLayerEntryType": {
-      "enum": ["vector", "vectorTile", "vectorHeatmap", "raster", "geocore"],
+      "enum": ["vector", "vector-tile", "vector-heatmap", "raster-tile", "raster-image", "geoCore"],
       "description": "Layer entry data type."
     },
 
@@ -912,6 +1026,12 @@
         "layerId": {
           "type": "string",
           "description": "The id of the layer group to display on the map."
+        },
+        "not": {
+          "layerPathEnding": {
+            "type": "string",
+            "description": "The ending element of the layer configuration path."
+          }
         },
         "layerName": {
           "$ref": "#/definitions/TypeLocalizedString",
@@ -935,19 +1055,126 @@
         { "$ref": "#/definitions/TypeVectorHeatmapLayerEntryConfig" },
         { "$ref": "#/definitions/TypeVectorTileLayerEntryConfig" },
         { "$ref": "#/definitions/TypeVectorLayerEntryConfig" },
-        { "$ref": "#/definitions/TypeImageLayerEntryConfig" },
+        { "$ref": "#/definitions/TypeOgcWmsLayerEntryConfig" },
+        { "$ref": "#/definitions/TypeEsriDynamicLayerEntryConfig" },
         { "$ref": "#/definitions/TypeTileLayerEntryConfig" },
         { "$ref": "#/definitions/TypeGeocoreLayerEntryConfig" }
       ]
     },
 
-    "TypeListOfLayerEntryConfig": {
+    "TypeListOfOgcWmsLayerEntryConfig": {
+      "description": "This type is used recursively by the IsValidTypeListOfLayerEntryConfig method coded in config-validation.ts file. It completes the validation of the list of layer entry config.",
       "type": "array",
       "minItems": 1,
       "additionalProperties": false,
-      "items": {
-        "$ref": "#/definitions/TypeLayerEntryConfig"
-      }
+      "items": {"anyOf": [
+        { "$ref": "#/definitions/TypeLayerGroupEntryConfig" },
+        { "$ref": "#/definitions/TypeOgcWmsLayerEntryConfig" }
+      ]}
+    },
+
+    "TypeListOfImageStaticLayerEntryConfig": {
+      "description": "This type is used recursively by the IsValidTypeListOfLayerEntryConfig method coded in config-validation.ts file. It completes the validation of the list of layer entry config.",
+      "type": "array",
+      "minItems": 1,
+      "additionalProperties": false,
+      "items": {"anyOf": [
+        { "$ref": "#/definitions/TypeLayerGroupEntryConfig" },
+        { "$ref": "#/definitions/TypeImageStaticLayerEntryConfig" }
+      ]}
+    },
+
+    "TypeListOfXyzTilesLayerEntryConfig": {
+      "description": "This type is used recursively by the IsValidTypeListOfLayerEntryConfig method coded in config-validation.ts file. It completes the validation of the list of layer entry config.",
+      "type": "array",
+      "minItems": 1,
+      "additionalProperties": false,
+      "items": {"anyOf": [
+        { "$ref": "#/definitions/TypeLayerGroupEntryConfig" },
+        { "$ref": "#/definitions/TypeTileLayerEntryConfig" }
+      ]}
+    },
+
+    "TypeListOfEsriDynamicLayerEntryConfig": {
+      "description": "This type is used recursively by the IsValidTypeListOfLayerEntryConfig method coded in config-validation.ts file. It completes the validation of the list of layer entry config.",
+      "type": "array",
+      "minItems": 1,
+      "additionalProperties": false,
+      "items": {"anyOf": [
+        { "$ref": "#/definitions/TypeLayerGroupEntryConfig" },
+        { "$ref": "#/definitions/TypeEsriDynamicLayerEntryConfig" }
+      ]}
+    },
+
+    "TypeListOfEsriFeatureLayerEntryConfig": {
+      "description": "This type is used recursively by the IsValidTypeListOfLayerEntryConfig method coded in config-validation.ts file. It completes the validation of the list of layer entry config.",
+      "type": "array",
+      "minItems": 1,
+      "additionalProperties": false,
+      "items": {"anyOf": [
+        { "$ref": "#/definitions/TypeLayerGroupEntryConfig" },
+        { "$ref": "#/definitions/TypeVectorLayerEntryConfig" }
+      ]}
+    },
+
+    "TypeListOfGeoJSONLayerEntryConfig": {
+      "description": "This type is used recursively by the IsValidTypeListOfLayerEntryConfig method coded in config-validation.ts file. It completes the validation of the list of layer entry config.",
+      "type": "array",
+      "minItems": 1,
+      "additionalProperties": false,
+      "items": {"anyOf": [
+        { "$ref": "#/definitions/TypeLayerGroupEntryConfig" },
+        { "$ref": "#/definitions/TypeVectorLayerEntryConfig" }
+      ]}
+    },
+
+    "TypeListOfOgcWfsLayerEntryConfig": {
+      "description": "This type is used recursively by the IsValidTypeListOfLayerEntryConfig method coded in config-validation.ts file. It completes the validation of the list of layer entry config.",
+      "type": "array",
+      "minItems": 1,
+      "additionalProperties": false,
+      "items": {"anyOf": [
+        { "$ref": "#/definitions/TypeLayerGroupEntryConfig" },
+        { "$ref": "#/definitions/TypeVectorLayerEntryConfig" }
+      ]}
+    },
+
+    "TypeListOfOgcFeatureLayerEntryConfig": {
+      "description": "This type is used recursively by the IsValidTypeListOfLayerEntryConfig method coded in config-validation.ts file. It completes the validation of the list of layer entry config.",
+      "type": "array",
+      "minItems": 1,
+      "additionalProperties": false,
+      "items": {"anyOf": [
+        { "$ref": "#/definitions/TypeLayerGroupEntryConfig" },
+        { "$ref": "#/definitions/TypeVectorLayerEntryConfig" }
+      ]}
+    },
+
+    "TypeListOfGeoPackageLayerEntryConfig": {
+      "description": "This type is used recursively by the IsValidTypeListOfLayerEntryConfig method coded in config-validation.ts file. It completes the validation of the list of layer entry config.",
+      "type": "array",
+      "minItems": 1,
+      "additionalProperties": false,
+      "items": {"anyOf": [
+        { "$ref": "#/definitions/TypeLayerGroupEntryConfig" },
+        { "$ref": "#/definitions/TypeVectorLayerEntryConfig" }
+      ]}
+    },
+
+    "TypeListOfGeoCoreLayerEntryConfig": {
+      "description": "This type is used recursively by the IsValidTypeListOfLayerEntryConfig method coded in config-validation.ts file. It completes the validation of the list of layer entry config.",
+      "type": "array",
+      "minItems": 1,
+      "additionalProperties": false,
+      "items": {"anyOf": [
+        { "$ref": "#/definitions/TypeLayerGroupEntryConfig" },
+        { "$ref": "#/definitions/TypeGeocoreLayerEntryConfig" }
+      ]}
+    },
+
+    "TypeListOfLayerEntryConfig": {
+      "type": "array",
+      "minItems": 1
     },
 
     "TypeMapConfig": {
@@ -1041,7 +1268,7 @@
     "TypeGeoviewLayerType": {
       "type": "string",
       "items": {
-        "enum": ["esriDynamic", "esriFeature", "imageStatic", "GeoJSON", "geoCore", "GeoPackage", "xyzTiles", "ogcFeature", "ogcWfs", "ogcWms"]
+        "enum": ["esriDynamic", "esriFeature", "GeoJSON", "geoCore", "GeoPackage", "xyzTiles", "ogcFeature", "ogcWfs", "ogcWms"]
       },
       "description": "Type of GeoView layer."
     },
@@ -1230,7 +1457,7 @@
     },
 
     "TypeMapFeaturesInstance": {
-      "description": "The map feature configuration.",
+      "description": "The map features configuration. This type is used by the IsValidTypeMapFeaturesInstance method coded in config-validation.ts file. It does the validation down to the list of layer entry config.",
       "additionalProperties": false,
       "type": "object",
       "properties": {
@@ -1251,23 +1478,5 @@
       },
       "required": ["map", "suportedLanguages"]
     }
-  },
-
-  "properties": {
-    "map": { "$ref": "#/definitions/TypeMapConfig" },
-    "theme": {
-      "enum": ["dark", "light"],
-      "default": "dark",
-      "description": "Theme style the viewer."
-    },
-    "appBar": { "$ref": "#/definitions/TypeAppBarProps" },
-    "navBar": { "$ref": "#/definitions/TypeNavBarProps" },
-    "components": { "$ref": "#/definitions/TypeMapComponents" },
-    "corePackages": { "$ref": "#/definitions/TypeMapCorePackages" },
-    "externalPackages": { "$ref": "#/definitions/TypeExternalPackages" },
-    "serviceUrls": { "$ref": "#/definitions/TypeServiceUrls" },
-    "suportedLanguages": { "$ref": "#/definitions/TypeListOfLocalizedLanguages" },
-    "schemaVersionUsed": { "$ref": "#/definitions/TypeValidVersions" }
-  },
-  "required": ["map", "suportedLanguages"]
+  }
 }

--- a/packages/geoview-core/src/core/utils/config/config-validation.ts
+++ b/packages/geoview-core/src/core/utils/config/config-validation.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console, no-underscore-dangle, no-param-reassign */
 import Ajv from 'ajv';
+import { AnyValidateFunction } from 'ajv/dist/types';
 
 import defaultsDeep from 'lodash/defaultsDeep';
 import { generateId } from '../utilities';
@@ -15,7 +16,6 @@ import { geoviewEntryIsWFS } from '../../../geo/layer/geoview-layers/vector/wfs'
 import { geoviewEntryIsOgcFeature } from '../../../geo/layer/geoview-layers/vector/ogc-feature';
 import { geoviewEntryIsGeoJSON } from '../../../geo/layer/geoview-layers/vector/geojson';
 import { geoviewEntryIsGeoPackage } from '../../../geo/layer/geoview-layers/vector/geopackage';
-import { geoviewEntryIsGeocore } from '../../../geo/layer/other/geocore';
 import {
   layerEntryIsGroupLayer,
   TypeGeoviewLayerConfig,
@@ -38,6 +38,7 @@ import { api } from '../../../app';
 import { snackbarMessagePayload } from '../../../api/events/payloads/snackbar-message-payload';
 import { EVENT_NAMES } from '../../../api/events/event-types';
 import { Layer } from '../../../geo/layer/layer';
+import { CONST_GEOVIEW_SCHEMA_BY_TYPE, TypeGeoviewLayerType } from '../../../geo/layer/geoview-layers/abstract-geoview-layers';
 
 // ******************************************************************************************************************************
 // ******************************************************************************************************************************
@@ -298,6 +299,127 @@ export class ConfigValidation {
   }
 
   /** ***************************************************************************************************************************
+   * Print a trace to help locate schema errors.
+   * @param {AnyValidateFunction<unknown>} validate The Ajv validator.
+   * @param {any} objectAffected Object that was validated.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private printSchemaError(validate: AnyValidateFunction<unknown>, objectAffected: any) {
+    for (let i = 0; i < validate.errors!.length; i += 1) {
+      const error = validate.errors![i];
+      const { instancePath } = error;
+      const path = instancePath.split('/');
+      let node = objectAffected;
+      for (let j = 1; j < path.length; j += 1) {
+        node = node[path[j]];
+      }
+      console.log(this.mapId, '='.repeat(200));
+      console.log('Schema error: ', this.mapId, error);
+      console.log('Object affected: ', this.mapId, node);
+    }
+
+    setTimeout(() => {
+      const errorMessage = `- Map ${this.mapId}: A schema error was found, check the console to see what is wrong.`;
+
+      api.event.emit(
+        snackbarMessagePayload(EVENT_NAMES.SNACKBAR.EVENT_SNACKBAR_OPEN, this.mapId, {
+          type: 'string',
+          value: errorMessage,
+        })
+      );
+    }, 2000);
+  }
+
+  /** ***************************************************************************************************************************
+   * Validate the configuration of the map features against the TypeMapFeaturesInstance defined in the schema..
+   * @param {TypeMapFeaturesConfig} mapFeaturesConfigToValidate The map features configuration to validate.
+   * @param {Ajv} validator The schema validator to use.
+   *
+   * @returns {TypeMapFeaturesConfig} A valid map features configuration.
+   */
+  private IsValidTypeMapFeaturesInstance(mapFeaturesConfigToValidate: TypeMapFeaturesConfig, validator: Ajv): boolean {
+    const schemaPath = 'https://cgpv/schema#/definitions/TypeMapFeaturesInstance';
+    const validate = validator.getSchema(schemaPath);
+
+    if (!validate) {
+      setTimeout(() => {
+        const errorMessage = `- Map ${this.mapId}: Cannot find schema "${schemaPath}".`;
+        console.log(errorMessage);
+
+        api.event.emit(
+          snackbarMessagePayload(EVENT_NAMES.SNACKBAR.EVENT_SNACKBAR_OPEN, this.mapId, {
+            type: 'string',
+            value: errorMessage,
+          })
+        );
+      }, 2000);
+      return false;
+    }
+
+    // validate configuration
+    const valid = validate({ ...mapFeaturesConfigToValidate });
+
+    if (!valid) {
+      this.printSchemaError(validate, mapFeaturesConfigToValidate);
+      return false;
+    }
+    return true;
+  }
+
+  /** ***************************************************************************************************************************
+   * Validate the configuration of the map features against the TypeMapFeaturesInstance defined in the schema.
+   * @param {TypeGeoviewLayerType} geoviewLayerType The GeoView layer type to validate.
+   * @param {TypeListOfLayerEntryConfig} listOfLayerEntryConfig The list of layer entry configurations to validate.
+   * @param {Ajv} validator The schema validator to use.
+   *
+   * @returns {TypeMapFeaturesConfig} A valid map features configuration.
+   */
+  private IsValidTypeListOfLayerEntryConfig(
+    geoviewLayerType: TypeGeoviewLayerType,
+    listOfLayerEntryConfig: TypeListOfLayerEntryConfig,
+    validator: Ajv
+  ): boolean {
+    const layerSchemaPath = `https://cgpv/schema#/definitions/${CONST_GEOVIEW_SCHEMA_BY_TYPE[geoviewLayerType]}`;
+    const groupSchemaPath = `https://cgpv/schema#/definitions/TypeLayerGroupEntryConfig`;
+
+    for (let i = 0; i < listOfLayerEntryConfig.length; i++) {
+      const schemaPath = layerEntryIsGroupLayer(listOfLayerEntryConfig[i]) ? groupSchemaPath : layerSchemaPath;
+      const validate = validator.getSchema(schemaPath);
+
+      if (!validate) {
+        setTimeout(() => {
+          const errorMessage = `- Map ${this.mapId}: Cannot find schema "${schemaPath}".`;
+          console.log(errorMessage);
+
+          api.event.emit(
+            snackbarMessagePayload(EVENT_NAMES.SNACKBAR.EVENT_SNACKBAR_OPEN, this.mapId, {
+              type: 'string',
+              value: errorMessage,
+            })
+          );
+        }, 2000);
+        return false;
+      }
+      // validate configuration
+      const valid = validate(listOfLayerEntryConfig[i]);
+
+      if (!valid) {
+        this.printSchemaError(validate, listOfLayerEntryConfig[i]);
+        return false;
+      }
+    }
+
+    for (let i = 0; i < listOfLayerEntryConfig.length; i++) {
+      if (
+        layerEntryIsGroupLayer(listOfLayerEntryConfig[i]) &&
+        !this.IsValidTypeListOfLayerEntryConfig(geoviewLayerType, listOfLayerEntryConfig[i].listOfLayerEntryConfig!, validator)
+      )
+        return false;
+    }
+    return true;
+  }
+
+  /** ***************************************************************************************************************************
    * Validate the map features configuration.
    * @param {TypeMapFeaturesConfig} mapFeaturesConfigToValidate The map features configuration to validate.
    *
@@ -315,40 +437,22 @@ export class ConfigValidation {
       // create a validator object
       const validator = new Ajv({
         strict: false,
-        allErrors: true,
+        allErrors: false,
       });
 
       // initialize validator with schema file
-      const validate = validator.compile(schema);
+      validator.compile(schema);
 
-      // validate configuration
-      const valid = validate({ ...mapFeaturesConfigToValidate });
+      let isValid = this.IsValidTypeMapFeaturesInstance(mapFeaturesConfigToValidate, validator);
+      for (let i = 0; i < mapFeaturesConfigToValidate.map.listOfGeoviewLayerConfig.length && isValid; i++) {
+        isValid = this.IsValidTypeListOfLayerEntryConfig(
+          mapFeaturesConfigToValidate.map.listOfGeoviewLayerConfig[i].geoviewLayerType,
+          mapFeaturesConfigToValidate.map.listOfGeoviewLayerConfig[i].listOfLayerEntryConfig,
+          validator
+        );
+      }
 
-      if (!valid && validate.errors && validate.errors.length) {
-        for (let j = 0; j < validate.errors.length; j += 1) {
-          const error = validate.errors[j];
-          const { instancePath } = error;
-          const path = instancePath.split('/');
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          let node: any = mapFeaturesConfigToValidate;
-          for (let i = 1; i < path.length; i += 1) {
-            node = node[path[i]];
-          }
-          console.log(this.mapId, error);
-          console.log(this.mapId, node);
-        }
-
-        setTimeout(() => {
-          const errorMessage = `- Map ${this.mapId}: A schema error was found, check the console to see what is wrong.`;
-
-          api.event.emit(
-            snackbarMessagePayload(EVENT_NAMES.SNACKBAR.EVENT_SNACKBAR_OPEN, this.mapId, {
-              type: 'string',
-              value: errorMessage,
-            })
-          );
-        }, 2000);
-
+      if (!isValid) {
         validMapFeaturesConfig = {
           ...this.adjustMapConfiguration(mapFeaturesConfigToValidate),
           mapId: this.mapId,
@@ -398,47 +502,22 @@ export class ConfigValidation {
       listOfGeoviewLayerConfig.forEach((geoviewLayerConfig) => {
         switch (geoviewLayerConfig.geoviewLayerType) {
           case 'GeoJSON':
+          case 'xyzTiles':
+          case 'GeoPackage':
+          case 'imageStatic':
             this.geoviewLayerIdIsMandatory(geoviewLayerConfig);
             this.processLayerEntryConfig(geoviewLayerConfig, geoviewLayerConfig, geoviewLayerConfig.listOfLayerEntryConfig);
             break;
           case 'esriDynamic':
-            this.geoviewLayerIdIsMandatory(geoviewLayerConfig);
-            this.metadataAccessPathIsMandatory(geoviewLayerConfig);
-            this.processLayerEntryConfig(geoviewLayerConfig, geoviewLayerConfig, geoviewLayerConfig.listOfLayerEntryConfig);
-            break;
           case 'esriFeature':
+          case 'ogcFeature':
+          case 'ogcWfs':
+          case 'ogcWms':
             this.geoviewLayerIdIsMandatory(geoviewLayerConfig);
             this.metadataAccessPathIsMandatory(geoviewLayerConfig);
             this.processLayerEntryConfig(geoviewLayerConfig, geoviewLayerConfig, geoviewLayerConfig.listOfLayerEntryConfig);
             break;
           case 'geoCore':
-            this.processLayerEntryConfig(geoviewLayerConfig, geoviewLayerConfig, geoviewLayerConfig.listOfLayerEntryConfig);
-            break;
-          case 'GeoPackage':
-            this.geoviewLayerIdIsMandatory(geoviewLayerConfig);
-            this.processLayerEntryConfig(geoviewLayerConfig, geoviewLayerConfig, geoviewLayerConfig.listOfLayerEntryConfig);
-            break;
-          case 'imageStatic':
-            this.geoviewLayerIdIsMandatory(geoviewLayerConfig);
-            this.processLayerEntryConfig(geoviewLayerConfig, geoviewLayerConfig, geoviewLayerConfig.listOfLayerEntryConfig);
-            break;
-          case 'xyzTiles':
-            this.geoviewLayerIdIsMandatory(geoviewLayerConfig);
-            this.processLayerEntryConfig(geoviewLayerConfig, geoviewLayerConfig, geoviewLayerConfig.listOfLayerEntryConfig);
-            break;
-          case 'ogcFeature':
-            this.geoviewLayerIdIsMandatory(geoviewLayerConfig);
-            this.metadataAccessPathIsMandatory(geoviewLayerConfig);
-            this.processLayerEntryConfig(geoviewLayerConfig, geoviewLayerConfig, geoviewLayerConfig.listOfLayerEntryConfig);
-            break;
-          case 'ogcWfs':
-            this.geoviewLayerIdIsMandatory(geoviewLayerConfig);
-            this.metadataAccessPathIsMandatory(geoviewLayerConfig);
-            this.processLayerEntryConfig(geoviewLayerConfig, geoviewLayerConfig, geoviewLayerConfig.listOfLayerEntryConfig);
-            break;
-          case 'ogcWms':
-            this.geoviewLayerIdIsMandatory(geoviewLayerConfig);
-            this.metadataAccessPathIsMandatory(geoviewLayerConfig);
             this.processLayerEntryConfig(geoviewLayerConfig, geoviewLayerConfig, geoviewLayerConfig.listOfLayerEntryConfig);
             break;
           default:
@@ -493,8 +572,6 @@ export class ConfigValidation {
       if (layerEntryIsGroupLayer(layerEntryConfig))
         this.processLayerEntryConfig(rootLayerConfig, layerEntryConfig, layerEntryConfig.listOfLayerEntryConfig);
       else if (geoviewEntryIsWMS(layerEntryConfig)) {
-        // Value for layerEntryConfig.entryType can only be raster
-        if (!layerEntryConfig.entryType) layerEntryConfig.entryType = 'raster';
         // if layerEntryConfig.source.dataAccessPath is undefined, the metadataAccessPath defined on the root is used.
         if (!layerEntryConfig.source) layerEntryConfig.source = {};
         if (!layerEntryConfig.source.dataAccessPath) {
@@ -514,7 +591,7 @@ export class ConfigValidation {
         if (!layerEntryConfig.source.serverType) layerEntryConfig.source.serverType = 'mapserver';
       } else if (geoviewEntryIsImageStatic(layerEntryConfig)) {
         // Value for layerEntryConfig.entryType can only be raster
-        if (!layerEntryConfig.entryType) layerEntryConfig.entryType = 'raster';
+        if (!layerEntryConfig.entryType) layerEntryConfig.entryType = 'raster-image';
 
         if (!layerEntryConfig.source.dataAccessPath) {
           throw new Error(
@@ -524,8 +601,6 @@ export class ConfigValidation {
           );
         }
       } else if (geoviewEntryIsXYZTiles(layerEntryConfig)) {
-        // Value for layerEntryConfig.entryType can only be raster
-        if (!layerEntryConfig.entryType) layerEntryConfig.entryType = 'raster';
         /** layerEntryConfig.source.dataAccessPath is mandatory. */
         if (!layerEntryConfig.source.dataAccessPath) {
           throw new Error(
@@ -538,8 +613,6 @@ export class ConfigValidation {
         if (Number.isNaN(layerEntryConfig.layerId)) {
           throw new Error(`The layer entry with layerId equal to ${Layer.getLayerPath(layerEntryConfig)} must be an integer string`);
         }
-        // Value for layerEntryConfig.entryType can only be raster
-        if (!layerEntryConfig.entryType) layerEntryConfig.entryType = 'raster';
         // if layerEntryConfig.source.dataAccessPath is undefined, we assign the metadataAccessPath of the GeoView layer to it.
         if (!layerEntryConfig.source) layerEntryConfig.source = {};
         if (!layerEntryConfig.source.dataAccessPath)
@@ -548,8 +621,6 @@ export class ConfigValidation {
         if (Number.isNaN(layerEntryConfig.layerId)) {
           throw new Error(`The layer entry with layerId equal to ${Layer.getLayerPath(layerEntryConfig)} must be an integer string`);
         }
-        // Default value for layerEntryConfig.entryType is vector
-        if (!layerEntryConfig.entryType) layerEntryConfig.entryType = 'vector';
         // Attribute 'style' must exist in layerEntryConfig even if it is undefined
         if (!('style' in layerEntryConfig)) layerEntryConfig.style = undefined;
         // if layerEntryConfig.source.dataAccessPath is undefined, we assign the metadataAccessPath of the GeoView layer to it
@@ -560,8 +631,6 @@ export class ConfigValidation {
         if (!layerEntryConfig.source.dataAccessPath)
           layerEntryConfig.source.dataAccessPath = { ...rootLayerConfig.metadataAccessPath } as TypeLocalizedString;
       } else if (geoviewEntryIsWFS(layerEntryConfig)) {
-        // Default value for layerEntryConfig.entryType is vector
-        if (!layerEntryConfig.entryType) layerEntryConfig.entryType = 'vector';
         // Attribute 'style' must exist in layerEntryConfig even if it is undefined
         if (!('style' in layerEntryConfig)) layerEntryConfig.style = undefined;
         // if layerEntryConfig.source.dataAccessPath is undefined, we assign the metadataAccessPath of the GeoView layer to it.
@@ -572,8 +641,6 @@ export class ConfigValidation {
           layerEntryConfig.source.dataAccessPath = { ...rootLayerConfig.metadataAccessPath } as TypeLocalizedString;
         if (!layerEntryConfig?.source?.dataProjection) layerEntryConfig.source.dataProjection = 'EPSG:4326';
       } else if (geoviewEntryIsOgcFeature(layerEntryConfig)) {
-        // Default value for layerEntryConfig.entryType is vector
-        if (!layerEntryConfig.entryType) layerEntryConfig.entryType = 'vector';
         // Attribute 'style' must exist in layerEntryConfig even if it is undefined
         if (!('style' in layerEntryConfig)) layerEntryConfig.style = undefined;
         // if layerEntryConfig.source.dataAccessPath is undefined, we assign the metadataAccessPath of the GeoView layer to it.
@@ -584,8 +651,6 @@ export class ConfigValidation {
           layerEntryConfig.source.dataAccessPath = { ...rootLayerConfig.metadataAccessPath } as TypeLocalizedString;
         if (!layerEntryConfig?.source?.dataProjection) layerEntryConfig.source.dataProjection = 'EPSG:4326';
       } else if (geoviewEntryIsGeoPackage(layerEntryConfig)) {
-        // Default value for layerEntryConfig.entryType is vector
-        if (!layerEntryConfig.entryType) layerEntryConfig.entryType = 'vector';
         // Attribute 'style' must exist in layerEntryConfig even if it is undefined
         if (!('style' in layerEntryConfig)) layerEntryConfig.style = undefined;
         // if layerEntryConfig.source.dataAccessPath is undefined, we assign the metadataAccessPath of the GeoView layer to it.
@@ -610,9 +675,6 @@ export class ConfigValidation {
             : `${layerEntryConfig.source.dataAccessPath!.fr}/${layerEntryConfig.layerId}`;
         }
         if (!layerEntryConfig?.source?.dataProjection) layerEntryConfig.source.dataProjection = 'EPSG:4326';
-      } else if (geoviewEntryIsGeocore(layerEntryConfig)) {
-        // Default value for layerEntryConfig.entryType is vector
-        if (!layerEntryConfig.entryType) layerEntryConfig.entryType = 'geocore';
       } else if (geoviewEntryIsGeoJSON(layerEntryConfig)) {
         if (!layerEntryConfig.geoviewRootLayer.metadataAccessPath && !layerEntryConfig.source?.dataAccessPath) {
           throw new Error(

--- a/packages/geoview-core/src/core/utils/config/config.ts
+++ b/packages/geoview-core/src/core/utils/config/config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
-import { TypeDisplayLanguage } from '../../../geo/map/map-schema-types';
+import { TypeDisplayLanguage, TypeListOfLayerEntryConfig } from '../../../geo/map/map-schema-types';
+import { CONST_LAYER_ENTRY_TYPE, TypeGeoviewLayerType } from '../../../geo/layer/geoview-layers/abstract-geoview-layers';
 import { TypeMapFeaturesConfig } from '../../types/global-types';
 import { ConfigValidation } from './config-validation';
 import { InlineDivConfigReader } from './reader/div-config-reader';
@@ -65,7 +66,7 @@ export class Config {
   }
 
   /** ***************************************************************************************************************************
-   * Set mapId value.
+   * Set triggerReadyCallback value.
    * @param {string} triggerReadyCallback The value to assign to the triggerReadyCallback flag for the Geoview map.
    */
   set triggerReadyCallback(triggerReadyCallback: boolean) {
@@ -115,7 +116,31 @@ export class Config {
     // update display language if provided in map element
     if (displayLanguage) this.displayLanguage = displayLanguage as TypeDisplayLanguage;
 
+    if (mapFeaturesConfig?.map?.listOfGeoviewLayerConfig) {
+      mapFeaturesConfig.map.listOfGeoviewLayerConfig.forEach((geoviewLayerEntry) => {
+        if (Object.keys(CONST_LAYER_ENTRY_TYPE).includes(geoviewLayerEntry.geoviewLayerType))
+          this.setLayerEntryType(geoviewLayerEntry.listOfLayerEntryConfig!, geoviewLayerEntry.geoviewLayerType);
+        else throw new Error(`Invalid GeoView Layer Type ${geoviewLayerEntry.geoviewLayerType}`);
+      });
+    }
     return this.configValidation.validateMapConfigAgainstSchema(mapFeaturesConfig);
+  }
+
+  /** ***************************************************************************************************************************
+   * Initialize all layer entry type fields accordingly to the GeoView layer type..
+   * @param {TypeListOfLayerEntryConfig} listOfLayerEntryConfig The list of layer entry configuration to adjust.
+   * @param {TypeGeoviewLayerType} geoviewLayerType The GeoView layer type.
+   */
+  private setLayerEntryType(listOfLayerEntryConfig: TypeListOfLayerEntryConfig, geoviewLayerType: TypeGeoviewLayerType): void {
+    listOfLayerEntryConfig?.forEach((layerEntryConfig) => {
+      if (layerEntryConfig.entryType === 'group') this.setLayerEntryType(layerEntryConfig.listOfLayerEntryConfig!, geoviewLayerType);
+      else {
+        // eslint-disable-next-line no-param-reassign
+        layerEntryConfig.schemaTag = geoviewLayerType;
+        // eslint-disable-next-line no-param-reassign
+        layerEntryConfig.entryType = CONST_LAYER_ENTRY_TYPE[geoviewLayerType];
+      }
+    });
   }
 
   /** ***************************************************************************************************************************
@@ -170,6 +195,13 @@ export class Config {
       console.log(`- Map: ${mapId} - Empty JSON configuration object, using default -`);
     }
 
+    if (mapFeaturesConfig?.map?.listOfGeoviewLayerConfig) {
+      mapFeaturesConfig.map.listOfGeoviewLayerConfig.forEach((geoviewLayerEntry) => {
+        if (Object.keys(CONST_LAYER_ENTRY_TYPE).includes(geoviewLayerEntry.geoviewLayerType))
+          this.setLayerEntryType(geoviewLayerEntry.listOfLayerEntryConfig!, geoviewLayerEntry.geoviewLayerType);
+        else throw new Error(`Invalid GeoView Layer Type ${geoviewLayerEntry.geoviewLayerType}`);
+      });
+    }
     return this.configValidation.validateMapConfigAgainstSchema(mapFeaturesConfig);
   }
 }

--- a/packages/geoview-core/src/core/utils/config/reader/uuid-config-reader.ts
+++ b/packages/geoview-core/src/core/utils/config/reader/uuid-config-reader.ts
@@ -2,12 +2,18 @@ import axios, { AxiosResponse } from 'axios';
 
 import { TypeJsonObject, TypeJsonArray, TypeJsonValue } from '../../../types/global-types';
 
-import { TypeListOfGeoviewLayerConfig, TypeOfServer } from '../../../../geo/map/map-schema-types';
+import {
+  TypeEsriDynamicLayerEntryConfig,
+  TypeImageStaticLayerEntryConfig,
+  TypeListOfGeoviewLayerConfig,
+  TypeOfServer,
+  TypeOgcWmsLayerEntryConfig,
+} from '../../../../geo/map/map-schema-types';
 import { CONST_LAYER_TYPES } from '../../../../geo/layer/geoview-layers/abstract-geoview-layers';
-import { TypeEsriDynamicLayerConfig, TypeEsriDynamicLayerEntryConfig } from '../../../../geo/layer/geoview-layers/raster/esri-dynamic';
+import { TypeEsriDynamicLayerConfig } from '../../../../geo/layer/geoview-layers/raster/esri-dynamic';
 import { TypeEsriFeatureLayerConfig, TypeEsriFeatureLayerEntryConfig } from '../../../../geo/layer/geoview-layers/vector/esri-feature';
-import { TypeImageStaticLayerConfig, TypeImageStaticLayerEntryConfig } from '../../../../geo/layer/geoview-layers/raster/image-static';
-import { TypeWMSLayerConfig, TypeWmsLayerEntryConfig } from '../../../../geo/layer/geoview-layers/raster/wms';
+import { TypeImageStaticLayerConfig } from '../../../../geo/layer/geoview-layers/raster/image-static';
+import { TypeWMSLayerConfig } from '../../../../geo/layer/geoview-layers/raster/wms';
 import { TypeWFSLayerConfig, TypeWfsLayerEntryConfig } from '../../../../geo/layer/geoview-layers/vector/wfs';
 import { TypeOgcFeatureLayerConfig, TypeOgcFeatureLayerEntryConfig } from '../../../../geo/layer/geoview-layers/vector/ogc-feature';
 import { TypeGeoJSONLayerConfig, TypeGeoJSONLayerEntryConfig } from '../../../../geo/layer/geoview-layers/vector/geojson';
@@ -35,11 +41,11 @@ export class UUIDmapConfigReader {
   private static getLayerConfigFromResponse(result: AxiosResponse<TypeJsonObject>): TypeListOfGeoviewLayerConfig {
     const listOfGeoviewLayerConfig: TypeListOfGeoviewLayerConfig = [];
 
-    if (result && result.data) {
-      for (let i = 0; i < result.data.length; i++) {
+    if (result?.data) {
+      for (let i = 0; i < (result.data as TypeJsonArray).length; i++) {
         const data = result.data[i];
 
-        if (data && data.layers && data.layers.length > 0) {
+        if (data?.layers && (data.layers as TypeJsonArray).length > 0) {
           const layer = data.layers[0];
 
           if (layer) {
@@ -61,7 +67,8 @@ export class UUIDmapConfigReader {
                 geoviewLayerType: 'esriDynamic',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeEsriDynamicLayerEntryConfig => {
                   const esriDynamicLayerEntryConfig: TypeEsriDynamicLayerEntryConfig = {
-                    entryType: 'raster',
+                    schemaTag: 'esriDynamic',
+                    entryType: 'raster-image',
                     layerId: `${item.index}`,
                     source: {
                       dataAccessPath: {
@@ -75,7 +82,7 @@ export class UUIDmapConfigReader {
               };
               listOfGeoviewLayerConfig.push(layerConfig);
             } else if (isFeature) {
-              for (let j = 0; j < layerEntries.length; j++) {
+              for (let j = 0; j < (layerEntries as TypeJsonArray).length; j++) {
                 const featureUrl = `${url}/${layerEntries[j].index}`;
                 const layerConfig: TypeEsriFeatureLayerConfig = {
                   geoviewLayerId: `${id}`,
@@ -90,6 +97,7 @@ export class UUIDmapConfigReader {
                   geoviewLayerType: 'esriFeature',
                   listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeEsriFeatureLayerEntryConfig => {
                     const esriFeatureLayerEntryConfig: TypeEsriFeatureLayerEntryConfig = {
+                      schemaTag: 'esriFeature',
                       entryType: 'vector',
                       layerId: `${item.index}`,
                       source: {
@@ -119,6 +127,7 @@ export class UUIDmapConfigReader {
                 geoviewLayerType: 'esriFeature',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeEsriFeatureLayerEntryConfig => {
                   const esriFeatureLayerEntryConfig: TypeEsriFeatureLayerEntryConfig = {
+                    schemaTag: 'esriFeature',
                     entryType: 'vector',
                     layerId: `${item.index}`,
                     source: {
@@ -145,9 +154,10 @@ export class UUIDmapConfigReader {
                   fr: url as string,
                 },
                 geoviewLayerType: 'ogcWms',
-                listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeWmsLayerEntryConfig => {
-                  const wmsLayerEntryConfig: TypeWmsLayerEntryConfig = {
-                    entryType: 'raster',
+                listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeOgcWmsLayerEntryConfig => {
+                  const wmsLayerEntryConfig: TypeOgcWmsLayerEntryConfig = {
+                    schemaTag: 'ogcWms',
+                    entryType: 'raster-image',
                     layerId: `${item.id}`,
                     source: {
                       dataAccessPath: {
@@ -175,6 +185,7 @@ export class UUIDmapConfigReader {
                 geoviewLayerType: 'ogcWfs',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeWfsLayerEntryConfig => {
                   const wfsLayerEntryConfig: TypeWfsLayerEntryConfig = {
+                    schemaTag: 'ogcWfs',
                     entryType: 'vector',
                     layerId: `${item.id}`,
                     source: {
@@ -203,6 +214,7 @@ export class UUIDmapConfigReader {
                 geoviewLayerType: 'ogcFeature',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeOgcFeatureLayerEntryConfig => {
                   const ogcFeatureLayerEntryConfig: TypeOgcFeatureLayerEntryConfig = {
+                    schemaTag: 'ogcFeature',
                     entryType: 'vector',
                     layerId: `${item.id}`,
                     source: {
@@ -231,6 +243,7 @@ export class UUIDmapConfigReader {
                 geoviewLayerType: 'GeoJSON',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeGeoJSONLayerEntryConfig => {
                   const geoJSONLayerEntryConfig: TypeGeoJSONLayerEntryConfig = {
+                    schemaTag: 'GeoJSON',
                     entryType: 'vector',
                     layerId: `${item.id}`,
                     source: {
@@ -259,7 +272,8 @@ export class UUIDmapConfigReader {
                 geoviewLayerType: 'xyzTiles',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeXYZTilesLayerEntryConfig => {
                   const xyzTilesLayerEntryConfig: TypeXYZTilesLayerEntryConfig = {
-                    entryType: 'raster',
+                    schemaTag: 'xyzTiles',
+                    entryType: 'raster-tile',
                     layerId: `${item.id}`,
                     source: {
                       dataAccessPath: {
@@ -286,6 +300,7 @@ export class UUIDmapConfigReader {
                 geoviewLayerType: 'GeoPackage',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeGeoPackageLayerEntryConfig => {
                   const geoPackageLayerEntryConfig: TypeGeoPackageLayerEntryConfig = {
+                    schemaTag: 'GeoPackage',
                     entryType: 'vector',
                     layerId: `${item.id}`,
                     source: {
@@ -314,7 +329,8 @@ export class UUIDmapConfigReader {
                 geoviewLayerType: 'imageStatic',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeImageStaticLayerEntryConfig => {
                   const imageStaticLayerEntryConfig: TypeImageStaticLayerEntryConfig = {
-                    entryType: 'raster',
+                    schemaTag: 'imageStatic',
+                    entryType: 'raster-image',
                     layerId: `${item.id}`,
                     source: {
                       dataAccessPath: {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -11,6 +11,7 @@ import { Cast, Coordinate, TypeJsonArray, TypeJsonObject } from '../../../core/t
 import { AbstractGeoViewLayer, TypeGeoviewLayerType } from './abstract-geoview-layers';
 import {
   layerEntryIsGroupLayer,
+  TypeEsriDynamicLayerEntryConfig,
   TypeLayerEntryConfig,
   TypeLayerGroupEntryConfig,
   TypeListOfLayerEntryConfig,
@@ -18,7 +19,7 @@ import {
 import { getLocalizedValue, getXMLHttpRequest } from '../../../core/utils/utilities';
 import { api } from '../../../app';
 import { Layer } from '../layer';
-import { EsriDynamic, geoviewEntryIsEsriDynamic, TypeEsriDynamicLayerConfig, TypeEsriDynamicLayerEntryConfig } from './raster/esri-dynamic';
+import { EsriDynamic, geoviewEntryIsEsriDynamic, TypeEsriDynamicLayerConfig } from './raster/esri-dynamic';
 import { EsriFeature, geoviewEntryIsEsriFeature, TypeEsriFeatureLayerConfig, TypeEsriFeatureLayerEntryConfig } from './vector/esri-feature';
 import { EsriBaseRenderer, getStyleFromEsriRenderer } from '../../renderer/esri-renderer';
 import { TimeDimensionESRI } from '../../../core/utils/date-mgt';

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -15,7 +15,6 @@ import { getLocalizedValue } from '../../../../core/utils/utilities';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES, TypeLayerStyles } from '../abstract-geoview-layers';
 import { AbstractGeoViewRaster, TypeBaseRasterLayer } from './abstract-geoview-raster';
 import {
-  TypeImageLayerEntryConfig,
   TypeLayerEntryConfig,
   TypeSourceImageEsriInitialConfig,
   TypeGeoviewLayerConfig,
@@ -26,6 +25,7 @@ import {
   TypeClassBreakStyleConfig,
   isSimpleStyleConfig,
   TypeListOfLayerEntryConfig,
+  TypeEsriDynamicLayerEntryConfig,
 } from '../../../map/map-schema-types';
 import {
   TypeFeatureInfoEntry,
@@ -49,10 +49,6 @@ import {
 } from '../esri-layer-common';
 import { TypeJsonArray, TypeJsonObject } from '../../../../core/types/global-types';
 import { TypeEsriFeatureLayerEntryConfig } from '../vector/esri-feature';
-
-export interface TypeEsriDynamicLayerEntryConfig extends Omit<TypeImageLayerEntryConfig, 'source'> {
-  source: TypeSourceImageEsriInitialConfig;
-}
 
 export interface TypeEsriDynamicLayerConfig extends Omit<TypeGeoviewLayerConfig, 'listOfLayerEntryConfig'> {
   geoviewLayerType: 'esriDynamic';

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
@@ -7,28 +7,21 @@ import Static, { Options as SourceOptions } from 'ol/source/ImageStatic';
 import { Options as ImageOptions } from 'ol/layer/BaseImage';
 import { Coordinate } from 'ol/coordinate';
 import { Pixel } from 'ol/pixel';
-import { transformExtent } from 'ol/proj';
 
-import defaultsDeep from 'lodash/defaultsDeep';
-import { Cast, toJsonObject, TypeJsonObject } from '../../../../core/types/global-types';
+import { Cast, TypeJsonObject } from '../../../../core/types/global-types';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES, TypeLegend } from '../abstract-geoview-layers';
 import { AbstractGeoViewRaster, TypeBaseRasterLayer } from './abstract-geoview-raster';
 import {
-  TypeImageLayerEntryConfig,
   TypeLayerEntryConfig,
-  TypeSourceImageStaticInitialConfig,
   TypeGeoviewLayerConfig,
   TypeListOfLayerEntryConfig,
   layerEntryIsGroupLayer,
+  TypeImageStaticLayerEntryConfig,
 } from '../../../map/map-schema-types';
 import { codedValueType, rangeDomainType, TypeArrayOfFeatureInfoEntries } from '../../../../api/events/payloads/get-feature-info-payload';
-import { getLocalizedValue, getXMLHttpRequest } from '../../../../core/utils/utilities';
+import { getLocalizedValue } from '../../../../core/utils/utilities';
 import { api } from '../../../../app';
 import { Layer } from '../../layer';
-
-export interface TypeImageStaticLayerEntryConfig extends Omit<TypeImageLayerEntryConfig, 'source'> {
-  source: TypeSourceImageStaticInitialConfig;
-}
 
 export interface TypeImageStaticLayerConfig extends Omit<TypeGeoviewLayerConfig, 'listOfLayerEntryConfig'> {
   geoviewLayerType: 'imageStatic';

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -14,6 +14,7 @@ import {
   TypeVectorSourceInitialConfig,
   TypeGeoviewLayerConfig,
   TypeListOfLayerEntryConfig,
+  TypeEsriDynamicLayerEntryConfig,
 } from '../../../map/map-schema-types';
 
 import { getLocalizedValue } from '../../../../core/utils/utilities';
@@ -29,7 +30,6 @@ import {
 } from '../esri-layer-common';
 import { AbstractGeoViewVector } from './abstract-geoview-vector';
 import { TypeJsonArray, TypeJsonObject } from '../../../../core/types/global-types';
-import { TypeEsriDynamicLayerEntryConfig } from '../raster/esri-dynamic';
 import { codedValueType, rangeDomainType } from '../../../../api/events/payloads/get-feature-info-payload';
 import { Layer } from '../../layer';
 

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -489,7 +489,7 @@ export type TypeStyleConfig = Partial<Record<TypeStyleGeometry, TypeStyleSetting
 /** ******************************************************************************************************************************
  * Type of Style to apply to the GeoView vector layer source at creation time.
  */
-export type TypeLayerEntryType = 'vector' | 'vectorTile' | 'vectorHeatmap' | 'raster' | 'geocore';
+export type TypeLayerEntryType = 'vector' | 'vector-tile' | 'vector-heatmap' | 'raster-tile' | 'raster-image' | 'geoCore';
 
 /** ******************************************************************************************************************************
  * type guard function that redefines a TypeLayerEntryConfig as a TypeLayerGroupEntryConfig if the entryType attribute of the
@@ -526,7 +526,7 @@ export const layerEntryIsVector = (verifyIfLayer: TypeLayerEntryConfig): verifyI
  * @returns {boolean} true if the type ascention is valid.
  */
 export const layerEntryIsVectorHeatmap = (verifyIfLayer: TypeLayerEntryConfig): verifyIfLayer is TypeVectorHeatmapLayerEntryConfig => {
-  return verifyIfLayer?.entryType === 'vectorHeatmap';
+  return verifyIfLayer?.entryType === 'vector-heatmap';
 };
 
 /** ******************************************************************************************************************************
@@ -539,22 +539,59 @@ export const layerEntryIsVectorHeatmap = (verifyIfLayer: TypeLayerEntryConfig): 
  * @returns {boolean} true if the type ascention is valid.
  */
 export const layerEntryIsVectorTile = (verifyIfLayer: TypeLayerEntryConfig): verifyIfLayer is TypeVectorTileLayerEntryConfig => {
-  return verifyIfLayer?.entryType === 'vectorTile';
+  return verifyIfLayer?.entryType === 'vector-tile';
 };
 
 /** ******************************************************************************************************************************
- * type guard function that redefines a TypeLayerEntryConfig as a TypeImageLayerEntryConfig | TypeTileLayerEntryConfig if the
- * entryType attribute of the verifyIfLayer parameter is 'raster'. The type ascention applies only to the true block of the if
- * clause that use this function.
+ * type guard function that redefines a TypeLayerEntryConfig as a TypeOgcWmsLayerEntryConfig if the schemaTag attribute of the
+ * verifyIfLayer parameter is 'ogcWms'. The type ascention applies only to the true block of the if clause that use this
+ * function.
  *
  * @param {TypeLayerEntryConfig} verifyIfLayer Polymorphic object to test in order to determine if the type ascention is valid.
  *
  * @returns {boolean} true if the type ascention is valid.
  */
-export const layerEntryIsRaster = (
-  verifyIfLayer: TypeLayerEntryConfig
-): verifyIfLayer is TypeImageLayerEntryConfig | TypeTileLayerEntryConfig => {
-  return verifyIfLayer?.entryType === 'raster';
+export const layerEntryIsOgcWms = (verifyIfLayer: TypeLayerEntryConfig): verifyIfLayer is TypeOgcWmsLayerEntryConfig => {
+  return verifyIfLayer?.schemaTag === 'ogcWms';
+};
+
+/** ******************************************************************************************************************************
+ * type guard function that redefines a TypeLayerEntryConfig as a TypeEsriDynamicLayerEntryConfig if the schemaTag attribute of
+ * the verifyIfLayer parameter is 'ogcWms'. The type ascention applies only to the true block of the if clause that use this
+ * function.
+ *
+ * @param {TypeLayerEntryConfig} verifyIfLayer Polymorphic object to test in order to determine if the type ascention is valid.
+ *
+ * @returns {boolean} true if the type ascention is valid.
+ */
+export const layerEntryIsEsriDynamic = (verifyIfLayer: TypeLayerEntryConfig): verifyIfLayer is TypeEsriDynamicLayerEntryConfig => {
+  return verifyIfLayer?.schemaTag === 'esriDynamic';
+};
+
+/** ******************************************************************************************************************************
+ * type guard function that redefines a TypeLayerEntryConfig as a TypeImageStaticLayerEntryConfig if the schemaTag attribute of
+ * the verifyIfLayer parameter is 'ogcWms'. The type ascention applies only to the true block of the if clause that use this
+ * function.
+ *
+ * @param {TypeLayerEntryConfig} verifyIfLayer Polymorphic object to test in order to determine if the type ascention is valid.
+ *
+ * @returns {boolean} true if the type ascention is valid.
+ */
+export const layerEntryIsImageStatic = (verifyIfLayer: TypeLayerEntryConfig): verifyIfLayer is TypeImageStaticLayerEntryConfig => {
+  return verifyIfLayer?.schemaTag === 'imageStatic';
+};
+
+/** ******************************************************************************************************************************
+ * type guard function that redefines a TypeLayerEntryConfig as a TypeTileLayerEntryConfig if the entryType attribute of the
+ * verifyIfLayer parameter is 'raster-tile'. The type ascention applies only to the true block of the if clause that use this
+ * function.
+ *
+ * @param {TypeLayerEntryConfig} verifyIfLayer Polymorphic object to test in order to determine if the type ascention is valid.
+ *
+ * @returns {boolean} true if the type ascention is valid.
+ */
+export const layerEntryIsRasterTile = (verifyIfLayer: TypeLayerEntryConfig): verifyIfLayer is TypeTileLayerEntryConfig => {
+  return verifyIfLayer?.entryType === 'raster-tile';
 };
 
 /** ******************************************************************************************************************************
@@ -567,7 +604,7 @@ export const layerEntryIsRaster = (
  * @returns {boolean} true if the type ascention is valid.
  */
 export const layerEntryIsGeocore = (verifyIfLayer: TypeLayerEntryConfig): verifyIfLayer is TypeGeocoreLayerEntryConfig => {
-  return verifyIfLayer?.entryType === 'geocore';
+  return verifyIfLayer?.entryType === 'geoCore';
 };
 
 /** ******************************************************************************************************************************
@@ -583,8 +620,10 @@ export type TypeBaseLayerEntryConfig = {
   /** This attribute is not part of the schema. It is used internally to distinguish layer groups derived from the
    * metadata. */
   isMetadataLayerGroup?: boolean;
+  /** Tag used to link the entry to a specific schema. */
+  schemaTag: TypeGeoviewLayerType;
   /** Layer entry data type. */
-  entryType?: 'vector' | 'vectorTile' | 'vectorHeatmap' | 'raster' | 'group';
+  entryType?: 'vector' | 'vector-tile' | 'vector-heatmap' | 'raster-image' | 'raster-tile' | 'group';
   /** The ending element of the layer configuration path. */
   layerPathEnding?: string;
   /** The id of the layer to display on the map. */
@@ -667,7 +706,11 @@ export interface TypeSourceImageWmsInitialConfig extends TypeBaseSourceImageInit
 /** ******************************************************************************************************************************
  * Initial settings for static image sources.
  */
-export interface TypeSourceImageStaticInitialConfig extends TypeBaseSourceImageInitialConfig {
+export interface TypeSourceImageStaticInitialConfig extends Omit<TypeBaseSourceImageInitialConfig, 'featureInfo'> {
+  /** Definition of the feature information structure that will be used by the getFeatureInfo method. We only use queryable and
+   * it must be set to false if specified.
+   */
+  featureInfo?: { queryable: false };
   /** Image extent */
   extent: Extent;
 }
@@ -711,25 +754,21 @@ export type TypeTileGrid = {
 /** ******************************************************************************************************************************
  * Initial settings for tile image sources.
  */
-export type TypeSourceTileInitialConfig = {
-  /** The path (English/French) to reach the data to display. If not specified, metadatAccessPath will be assigne to it. */
-  dataAccessPath: TypeLocalizedString;
-  /** The crossOrigin attribute for loaded images. Note that you must provide a crossOrigin value if you want to access pixel data
-   * with the Canvas renderer.
+export interface TypeSourceTileInitialConfig extends Omit<TypeBaseSourceImageInitialConfig, 'featureInfo'> {
+  /** Definition of the feature information structure that will be used by the getFeatureInfo method. We only use queryable and
+   * it must be set to false if specified.
    */
-  crossOrigin?: string;
-  /** Spatial Reference EPSG code supported (https://epsg.io/). We support Web Mercator and Lambert Conical Conform Canada. */
-  projection?: TypeValidMapProjectionCodes;
+  featureInfo?: { queryable: false };
   /** Tile grid parameters to use. */
   tileGrid?: TypeTileGrid;
-};
+}
 
 /** ******************************************************************************************************************************
  * Type used to identify a GeoView vector heamap layer to display on the map.
  */
 export interface TypeVectorHeatmapLayerEntryConfig extends TypeBaseLayerEntryConfig {
   /** Layer entry data type. */
-  entryType?: 'vectorHeatmap';
+  entryType?: 'vector-heatmap';
   /** Initial settings to apply to the GeoView vector layer source at creation time. */
   source?: TypeVectorSourceInitialConfig;
   /**
@@ -758,7 +797,7 @@ export interface TypeVectorTileSourceInitialConfig extends TypeBaseSourceVectorI
  */
 export interface TypeVectorTileLayerEntryConfig extends TypeBaseLayerEntryConfig {
   /** Layer entry data type. */
-  entryType?: 'vectorTile';
+  entryType?: 'vector-tile';
   /** Filter to apply on feature of this layer. */
   layerFilter?: string;
   /** Source settings to apply to the GeoView vector layer source at creation time. */
@@ -770,13 +809,15 @@ export interface TypeVectorTileLayerEntryConfig extends TypeBaseLayerEntryConfig
 /** ******************************************************************************************************************************
  * Type used to define a GeoView image layer to display on the map.
  */
-export interface TypeImageLayerEntryConfig extends TypeBaseLayerEntryConfig {
+export interface TypeOgcWmsLayerEntryConfig extends TypeBaseLayerEntryConfig {
+  /** Tag used to link the entry to a specific schema. */
+  schemaTag: 'ogcWms';
   /** Layer entry data type. */
-  entryType?: 'raster';
+  entryType?: 'raster-image';
   /** Filter to apply on feature of this layer. */
   layerFilter?: string;
   /** Source settings to apply to the GeoView image layer source at creation time. */
-  source?: TypeSourceImageInitialConfig;
+  source: TypeSourceImageWmsInitialConfig;
   /** Style to apply to the raster layer. */
   style?: TypeStyleConfig;
 }
@@ -784,9 +825,39 @@ export interface TypeImageLayerEntryConfig extends TypeBaseLayerEntryConfig {
 /** ******************************************************************************************************************************
  * Type used to define a GeoView image layer to display on the map.
  */
+export interface TypeEsriDynamicLayerEntryConfig extends TypeBaseLayerEntryConfig {
+  /** Tag used to link the entry to a specific schema. */
+  schemaTag: 'esriDynamic';
+  /** Layer entry data type. */
+  entryType?: 'raster-image';
+  /** Filter to apply on feature of this layer. */
+  layerFilter?: string;
+  /** Source settings to apply to the GeoView image layer source at creation time. */
+  source: TypeSourceImageEsriInitialConfig;
+  /** Style to apply to the raster layer. */
+  style?: TypeStyleConfig;
+}
+
+/** ******************************************************************************************************************************
+ * Type used to define a GeoView image layer to display on the map.
+ */
+export interface TypeImageStaticLayerEntryConfig extends TypeBaseLayerEntryConfig {
+  /** Tag used to link the entry to a specific schema. */
+  schemaTag: 'imageStatic';
+  /** Layer entry data type. */
+  entryType?: 'raster-image';
+  /** Filter to apply on feature of this layer. */
+  layerFilter?: string;
+  /** Source settings to apply to the GeoView image layer source at creation time. */
+  source: TypeSourceImageStaticInitialConfig;
+}
+
+/** ******************************************************************************************************************************
+ * Type used to define a GeoView image layer to display on the map.
+ */
 export interface TypeTileLayerEntryConfig extends TypeBaseLayerEntryConfig {
   /** Layer entry data type. */
-  entryType?: 'raster';
+  entryType?: 'raster-tile';
   /** Initial settings to apply to the GeoView image layer source at creation time. */
   source?: TypeSourceTileInitialConfig;
 }
@@ -802,8 +873,10 @@ export type TypeGeocoreLayerEntryConfig = {
   parentLayerConfig?: TypeGeoviewLayerConfig | TypeLayerGroupEntryConfig;
   /** This attribute is not part of the schema. It is used to link the displayed layer to its layer entry config. */
   gvLayer?: BaseLayer;
+  /** Tag used to link the entry to a specific schema. */
+  schemaTag: 'geoCore';
   /** Layer entry data type. */
-  entryType?: 'geocore';
+  entryType?: 'geoCore';
   /** The layerId is not used by geocore layers. */
   layerId: never;
   /** The layerPathEnding is not used by geocore layers. */
@@ -827,6 +900,10 @@ export type TypeGeocoreLayerEntryConfig = {
  * Initial settings to apply to the GeoView vector layer source at creation time.
  */
 export type TypeSourceGeocoreConfig = {
+  /** Definition of the feature information structure that will be used by the getFeatureInfo method. We only use queryable and
+   * it must be set to false if specified.
+   */
+  featureInfo?: { queryable: false };
   /** Path used to access the data. */
   dataAccessPath: TypeLocalizedString;
 };
@@ -855,7 +932,9 @@ export type TypeLayerEntryConfig =
   | TypeVectorHeatmapLayerEntryConfig
   | TypeVectorTileLayerEntryConfig
   | TypeVectorLayerEntryConfig
-  | TypeImageLayerEntryConfig
+  | TypeOgcWmsLayerEntryConfig
+  | TypeEsriDynamicLayerEntryConfig
+  | TypeImageStaticLayerEntryConfig
   | TypeTileLayerEntryConfig
   | TypeGeocoreLayerEntryConfig;
 
@@ -950,6 +1029,8 @@ export type TypeListOfGeoviewLayerConfig = TypeGeoviewLayerConfig[];
  *  Definition of a single Geoview layer configuration.
  */
 export type TypeGeoviewLayerConfig = {
+  /** This attribute is not part of the schema. It is used to link the displayed layer to its layer entry config. */
+  gvLayer?: BaseLayer;
   /**
    * The GeoView layer identifier.
    */

--- a/packages/geoview-core/src/ui/slider/slider-base.tsx
+++ b/packages/geoview-core/src/ui/slider/slider-base.tsx
@@ -27,6 +27,7 @@ export function SliderBase(props: TypeSliderProps): JSX.Element {
   const { ...properties } = props;
 
   const [sliderValue, setValue] = useState<number[] | number | undefined>(properties.value);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [activeThumb, setActiveThumb] = useState<number>(0);
 
   // handle constant change on the slider to set active thumb and instant values

--- a/packages/geoview-layers-panel/src/layer-stepper.tsx
+++ b/packages/geoview-layers-panel/src/layer-stepper.tsx
@@ -274,7 +274,7 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
       if (!supportedProj.includes(proj)) throw new Error('proj');
       const layers: TypeJsonArray[] = [];
       const hasChildLayers = (layer: TypeJsonObject) => {
-        if (layer.Layer && layer.Layer.length > 0) {
+        if (layer.Layer && (layer.Layer as TypeJsonArray).length > 0) {
           (layer.Layer as TypeJsonObject[]).forEach((childLayer: TypeJsonObject) => {
             hasChildLayers(childLayer);
           });
@@ -291,7 +291,7 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
           {
             layerId: (layersParam ?? layers[0][0]) as string,
           },
-        ]);
+        ] as TypeListOfLayerEntryConfig);
       } else {
         setLayerList(layers);
       }
@@ -326,7 +326,7 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
           {
             layerId: layers[0][0] as string,
           },
-        ]);
+        ] as TypeListOfLayerEntryConfig);
       } else {
         setLayerList(layers);
       }
@@ -357,7 +357,7 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
         {
           layerId: jsonSingle.id,
         },
-      ]);
+      ] as TypeListOfLayerEntryConfig);
       setLayerName(jsonSingle.title);
       return true;
     }
@@ -375,7 +375,7 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
           {
             layerId: layers[0][0] as string,
           },
-        ]);
+        ] as TypeListOfLayerEntryConfig);
       } else {
         setLayerList(layers);
       }
@@ -400,7 +400,7 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
         {
           layerId: layerURL,
         },
-      ]);
+      ] as TypeListOfLayerEntryConfig);
     } catch (err) {
       emitErrorServer('GeoCore UUID');
       return false;
@@ -427,7 +427,7 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
               {
                 layerId: layers[0][0] as string,
               },
-            ]);
+            ] as TypeListOfLayerEntryConfig);
           } else {
             setLayerList(layers);
           }
@@ -437,7 +437,7 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
             {
               layerId: esri.id as string,
             },
-          ]);
+          ] as TypeListOfLayerEntryConfig);
         }
       } else {
         throw new Error('err');
@@ -479,7 +479,7 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
           },
         },
       },
-    ]);
+    ] as TypeListOfLayerEntryConfig);
     return true;
   };
 
@@ -508,7 +508,7 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
             },
           },
         },
-      ]);
+      ] as TypeListOfLayerEntryConfig);
     } catch (err) {
       emitErrorServer('GeoJSON');
       return false;
@@ -536,7 +536,7 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
           },
         },
       },
-    ]);
+    ] as TypeListOfLayerEntryConfig);
     return true;
   };
 
@@ -763,11 +763,11 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
       setLayerEntries(
         newValue.map((x: string) => {
           return { layerId: `${x[0]}` };
-        })
+        }) as TypeListOfLayerEntryConfig
       );
       setLayerName(newValue.map((x) => x[1]).join(', '));
     } else {
-      setLayerEntries([{ layerId: `${newValue[0]}` }]);
+      setLayerEntries([{ layerId: `${newValue[0]}` }] as TypeListOfLayerEntryConfig);
       setLayerName(newValue[1]);
     }
   };


### PR DESCRIPTION
# Description

## Reduce schema validation verbosity

When the validation of the configuration is done with the help of the schema and an error is detected, the code in its current state prints an avalanche of messages making the detection of the error particularly difficult. In order to facilitate the interpretation of the error report by our users, we need to reduce the error log to its simplest form.

The validation is now done in two phases. The first phase validates the configuration of the map up to the level of the typeListOfLayerEntryConfig entries. The second phase is recursive and processes the entries of the configuration list according to the depth level.

## Visibility of single group of level one not working

The group creation algorithm has been rewritten to correct the problem.

Openlayers side effect: It should be noted that the visibility flag of a group that is alone in another group will not work unless a GeoView layer is placed with the group to prevent it from being alone.

Fixes:
- issue #1017
- issue #1023

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Using the DevTools by tracing the loading while forcing configuration errors.

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1018)
<!-- Reviewable:end -->
