### PR TITLE
Capability to specify the projection of the coordinates when using the vector class to draw on map

### DIFF
--- a/packages/geoview-core/src/geo/layer/vector/vector.ts
+++ b/packages/geoview-core/src/geo/layer/vector/vector.ts
@@ -123,6 +123,7 @@ export class Vector {
   addPolyline = (
     points: Coordinate,
     options?: {
+      projection?: number;
       geometryLayout?: 'XY' | 'XYZ' | 'XYM' | 'XYZM';
       style?: TypeFeatureStyle;
     },
@@ -135,7 +136,7 @@ export class Vector {
     // create a line geometry
     const polyline = new Feature({
       geometry: new LineString(points, polylineOptions.geometryLayout).transform(
-        'EPSG:4326',
+        `EPSG:${options?.projection || 4326}`,
         api.projection.projections[api.map(this.#mapId).currentProjection]
       ),
     });
@@ -194,6 +195,7 @@ export class Vector {
   addPolygon = (
     points: number[] | Coordinate[][],
     options?: {
+      projection?: number;
       geometryLayout?: 'XY' | 'XYZ' | 'XYM' | 'XYZM';
       style?: TypeFeatureStyle;
     },
@@ -206,7 +208,7 @@ export class Vector {
     // create a line geometry
     const polygon = new Feature({
       geometry: new Polygon(points, polygonOptions.geometryLayout).transform(
-        'EPSG:4326',
+        `EPSG:${options?.projection || 4326}`,
         api.projection.projections[api.map(this.#mapId).currentProjection]
       ),
     });
@@ -265,6 +267,7 @@ export class Vector {
   addCircle = (
     coordinate: Coordinate,
     options?: {
+      projection?: number;
       geometryLayout?: 'XY' | 'XYZ' | 'XYM' | 'XYZM';
       style?: TypeFeatureCircleStyle;
     },
@@ -280,7 +283,7 @@ export class Vector {
     // create a line geometry
     const circle = new Feature({
       geometry: new Circle(coordinate, radius, circleOptions.geometryLayout).transform(
-        'EPSG:4326',
+        `EPSG:${options?.projection || 4326}`,
         api.projection.projections[api.map(this.#mapId).currentProjection]
       ),
     });
@@ -339,6 +342,7 @@ export class Vector {
   addMarkerIcon = (
     coordinate: Coordinate,
     options?: {
+      projection?: number;
       geometryLayout?: 'XY' | 'XYZ' | 'XYM' | 'XYZM';
       style?: TypeIconStyle;
     },
@@ -361,7 +365,7 @@ export class Vector {
     // create a point feature
     const marker = new Feature({
       geometry: new Point(coordinate, markerOptions.geometryLayout).transform(
-        'EPSG:4326',
+        `EPSG:${options?.projection || 4326}`,
         api.projection.projections[api.map(this.#mapId).currentProjection]
       ),
     });


### PR DESCRIPTION
# Description

Capability to specify the projection of the coordinates when using the vector class to draw on map

Fixes #1019

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1020)
<!-- Reviewable:end -->
