### PR TITLE
fix(geo): calculateBounds function added to all layers

### DIFF
--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -2,13 +2,10 @@
 /* eslint-disable no-param-reassign */
 import axios from 'axios';
 import { Extent } from 'ol/extent';
-import BaseLayer from 'ol/layer/Base';
-import { Pixel } from 'ol/pixel';
-import { transform, transformExtent } from 'ol/proj';
+import { transformExtent } from 'ol/proj';
 
 import cloneDeep from 'lodash/cloneDeep';
-import { Cast, Coordinate, TypeJsonArray, TypeJsonObject } from '../../../core/types/global-types';
-import { AbstractGeoViewLayer, TypeGeoviewLayerType } from './abstract-geoview-layers';
+import { Cast, TypeJsonArray, TypeJsonObject } from '../../../core/types/global-types';
 import {
   layerEntryIsGroupLayer,
   TypeEsriDynamicLayerEntryConfig,
@@ -19,12 +16,11 @@ import {
 import { getLocalizedValue, getXMLHttpRequest } from '../../../core/utils/utilities';
 import { api } from '../../../app';
 import { Layer } from '../layer';
-import { EsriDynamic, geoviewEntryIsEsriDynamic, TypeEsriDynamicLayerConfig } from './raster/esri-dynamic';
-import { EsriFeature, geoviewEntryIsEsriFeature, TypeEsriFeatureLayerConfig, TypeEsriFeatureLayerEntryConfig } from './vector/esri-feature';
+import { EsriDynamic, geoviewEntryIsEsriDynamic } from './raster/esri-dynamic';
+import { EsriFeature, geoviewEntryIsEsriFeature, TypeEsriFeatureLayerEntryConfig } from './vector/esri-feature';
 import { EsriBaseRenderer, getStyleFromEsriRenderer } from '../../renderer/esri-renderer';
 import { TimeDimensionESRI } from '../../../core/utils/date-mgt';
-import { codedValueType, rangeDomainType, TypeArrayOfFeatureInfoEntries } from '../../../api/events/payloads/get-feature-info-payload';
-import { AbstractGeoViewVector } from './vector/abstract-geoview-vector';
+import { codedValueType, rangeDomainType } from '../../../api/events/payloads/get-feature-info-payload';
 
 /** ***************************************************************************************************************************
  * This method reads the service metadata from the metadataAccessPath.

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
@@ -7,6 +7,8 @@ import Static, { Options as SourceOptions } from 'ol/source/ImageStatic';
 import { Options as ImageOptions } from 'ol/layer/BaseImage';
 import { Coordinate } from 'ol/coordinate';
 import { Pixel } from 'ol/pixel';
+import { Extent } from 'ol/extent';
+import { transformExtent } from 'ol/proj';
 
 import { Cast, TypeJsonObject } from '../../../../core/types/global-types';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES, TypeLegend } from '../abstract-geoview-layers';
@@ -400,5 +402,68 @@ export class ImageStatic extends AbstractGeoViewRaster {
       resolve([]);
     });
     return promisedQueryResult;
+  }
+
+  /** ***************************************************************************************************************************
+   * Compute the layer bounds or undefined if the result can not be obtained from the feature extents that compose the layer. If
+   * layerPathOrConfig is undefined, the active layer is used. If projectionCode is defined, returns the bounds in the specified
+   * projection otherwise use the map projection. The bounds are different from the extent. They are mainly used for display
+   * purposes to show the bounding box in which the data resides and to zoom in on the entire layer data. It is not used by
+   * openlayer to limit the display of data on the map. If the bounds lie outside the extents, they are reduced to the extents.
+   *
+   * @param {string | TypeLayerEntryConfig | TypeListOfLayerEntryConfig | null} layerPathOrConfig Optional layer path or
+   * configuration.
+   * @param {string | number | undefined} projectionCode Optional projection code to use for the returned bounds.
+   *
+   * @returns {Extent} The layer bounding box.
+   */
+  calculateBounds(
+    layerPathOrConfig: string | TypeLayerEntryConfig | TypeListOfLayerEntryConfig | null = this.activeLayer,
+    projectionCode: string | number = api.map(this.mapId).currentProjection
+  ): Extent | undefined {
+    let bounds: Extent | undefined;
+    const processGroupLayerBounds = (listOfLayerEntryConfig: TypeListOfLayerEntryConfig) => {
+      listOfLayerEntryConfig.forEach((layerConfig) => {
+        if (layerEntryIsGroupLayer(layerConfig)) processGroupLayerBounds(layerConfig.listOfLayerEntryConfig);
+        else {
+          const layerBounds = (layerConfig.gvLayer as ImageLayer<Static>).getSource()?.getImageExtent();
+          const projection =
+            (layerConfig.gvLayer as ImageLayer<Static>).getSource()?.getProjection()?.getCode().replace('EPSG:', '') ||
+            api.map(this.mapId).currentProjection;
+          if (layerBounds) {
+            const transformedBounds = transformExtent(layerBounds, `EPSG:${projection}`, `EPSG:4326`);
+            if (!bounds) bounds = [transformedBounds[0], transformedBounds[1], transformedBounds[2], transformedBounds[3]];
+            else {
+              bounds = [
+                Math.min(transformedBounds[0], bounds[0]),
+                Math.min(transformedBounds[1], bounds[1]),
+                Math.max(transformedBounds[2], bounds[2]),
+                Math.max(transformedBounds[3], bounds[3]),
+              ];
+            }
+          }
+        }
+      });
+    };
+    const rootLayerConfig = typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig) : layerPathOrConfig;
+    if (rootLayerConfig) {
+      if (Array.isArray(rootLayerConfig)) processGroupLayerBounds(rootLayerConfig);
+      else processGroupLayerBounds([rootLayerConfig]);
+      const extent = transformExtent(
+        this.getExtent() || api.map(this.mapId).getView().get('extent'),
+        `EPSG:${api.map(this.mapId).currentProjection}`,
+        `EPSG:4326`
+      );
+      if (bounds) {
+        bounds = [
+          Math.max(extent[0], bounds[0]),
+          Math.max(extent[1], bounds[1]),
+          Math.min(extent[2], bounds[2]),
+          Math.min(extent[3], bounds[3]),
+        ];
+        bounds = transformExtent(bounds, `EPSG:4326`, `EPSG:${projectionCode}`);
+      }
+    }
+    return bounds;
   }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -377,4 +377,67 @@ export class XYZTiles extends AbstractGeoViewRaster {
     });
     return promisedQueryResult;
   }
+
+  /** ***************************************************************************************************************************
+   * Compute the layer bounds or undefined if the result can not be obtained from the feature extents that compose the layer. If
+   * layerPathOrConfig is undefined, the active layer is used. If projectionCode is defined, returns the bounds in the specified
+   * projection otherwise use the map projection. The bounds are different from the extent. They are mainly used for display
+   * purposes to show the bounding box in which the data resides and to zoom in on the entire layer data. It is not used by
+   * openlayer to limit the display of data on the map. If the bounds lie outside the extents, they are reduced to the extents.
+   *
+   * @param {string | TypeLayerEntryConfig | TypeListOfLayerEntryConfig | null} layerPathOrConfig Optional layer path or
+   * configuration.
+   * @param {string | number | undefined} projectionCode Optional projection code to use for the returned bounds.
+   *
+   * @returns {Extent} The layer bounding box.
+   */
+  calculateBounds(
+    layerPathOrConfig: string | TypeLayerEntryConfig | TypeListOfLayerEntryConfig | null = this.activeLayer,
+    projectionCode: string | number = api.map(this.mapId).currentProjection
+  ): Extent | undefined {
+    let bounds: Extent | undefined;
+    const processGroupLayerBounds = (listOfLayerEntryConfig: TypeListOfLayerEntryConfig) => {
+      listOfLayerEntryConfig.forEach((layerConfig) => {
+        if (layerEntryIsGroupLayer(layerConfig)) processGroupLayerBounds(layerConfig.listOfLayerEntryConfig);
+        else {
+          const layerBounds = (layerConfig.gvLayer as TileLayer<XYZ>).getSource()?.getTileGrid()?.getExtent();
+          const projection =
+            (layerConfig.gvLayer as TileLayer<XYZ>).getSource()?.getProjection()?.getCode().replace('EPSG:', '') ||
+            api.map(this.mapId).currentProjection;
+          if (layerBounds) {
+            const transformedBounds = transformExtent(layerBounds, `EPSG:${projection}`, `EPSG:4326`);
+            if (!bounds) bounds = [transformedBounds[0], transformedBounds[1], transformedBounds[2], transformedBounds[3]];
+            else {
+              bounds = [
+                Math.min(transformedBounds[0], bounds[0]),
+                Math.min(transformedBounds[1], bounds[1]),
+                Math.max(transformedBounds[2], bounds[2]),
+                Math.max(transformedBounds[3], bounds[3]),
+              ];
+            }
+          }
+        }
+      });
+    };
+    const rootLayerConfig = typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig) : layerPathOrConfig;
+    if (rootLayerConfig) {
+      if (Array.isArray(rootLayerConfig)) processGroupLayerBounds(rootLayerConfig);
+      else processGroupLayerBounds([rootLayerConfig]);
+      const extent = transformExtent(
+        this.getExtent() || api.map(this.mapId).getView().get('extent'),
+        `EPSG:${api.map(this.mapId).currentProjection}`,
+        `EPSG:4326`
+      );
+      if (bounds) {
+        bounds = [
+          Math.max(extent[0], bounds[0]),
+          Math.max(extent[1], bounds[1]),
+          Math.min(extent[2], bounds[2]),
+          Math.min(extent[3], bounds[3]),
+        ];
+        bounds = transformExtent(bounds, `EPSG:4326`, `EPSG:${projectionCode}`);
+      }
+    }
+    return bounds;
+  }
 }


### PR DESCRIPTION
Closes #998

# Description

calculateBounds function has been added for all layers, it will provide bounds. trimmed to fit in the layer or map extents, in the maps given projection.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ x New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Checked with each of the raster layers on their html pages. Will require further testing once functionality is being used in zoom to layer.

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1057)
<!-- Reviewable:end -->
