### PR TITLE
fix(calculateBounds): moved function to abstract

### DIFF
--- a/packages/geoview-core/src/core/components/legend/legend-icon-list.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-icon-list.tsx
@@ -125,10 +125,11 @@ export function LegendIconList(props: TypeLegendIconListProps): JSX.Element {
       setCheckCount(isParentVisible === true ? allChecked.length : 0);
       setInitParentVisible(isParentVisible);
     }
+
     if (layerConfig && layerConfig.style !== undefined && geometryKey && mapId) {
       const layerPath = layerConfig.geoviewRootLayer
-        ? `${layerConfig.geoviewRootLayer.geoviewLayerId}/${layerConfig.layerId.replace('-unclustered', '')}`
-        : layerConfig.layerId.replace('-unclustered', '');
+        ? `${layerConfig.geoviewRootLayer.geoviewLayerId}/${String(layerConfig.layerId).replace('-unclustered', '')}`
+        : String(layerConfig.layerId).replace('-unclustered', '');
       const unclusteredLayerPath = `${layerPath}-unclustered`;
       const cluster = !!api.maps[mapId].layer.registeredLayers[unclusteredLayerPath];
       if (cluster) {

--- a/packages/geoview-core/src/core/utils/utilities.ts
+++ b/packages/geoview-core/src/core/utils/utilities.ts
@@ -5,6 +5,8 @@ import { MutableRefObject } from 'react';
 /* eslint-disable no-underscore-dangle */
 import ReactDOM from 'react-dom';
 
+import { Extent } from 'ol/extent';
+
 import sanitizeHtml from 'sanitize-html';
 
 import { AbstractGeoViewLayer, api } from '../../app';
@@ -385,3 +387,31 @@ export const findPropertyNameByRegex = (objectItem: TypeJsonObject, regex: RegEx
   }
   return undefined;
 };
+
+/**
+ * Compare sets of extents of the same projection and return the smallest or largest set.
+ * Extents must be in OpenLayers extent format - [minx, miny, maxx, maxy]
+ *
+ * @param {Extent} extentsA First set of extents
+ * @param {Extent} extentsB Second set of extents
+ * @param {string} minmax Decides whether to get smallest or largest extent
+ * @returns {Extent} the smallest or largest set from the extents
+ */
+export function getMinOrMaxExtents(extentsA: Extent, extentsB: Extent, minmax = 'max'): Extent {
+  let bounds: Extent = [];
+  if (minmax === 'max')
+    bounds = [
+      Math.min(extentsA[0], extentsB[0]),
+      Math.min(extentsA[1], extentsB[1]),
+      Math.max(extentsA[2], extentsB[2]),
+      Math.max(extentsA[3], extentsB[3]),
+    ];
+  else if (minmax === 'min')
+    bounds = [
+      Math.max(extentsA[0], extentsB[0]),
+      Math.max(extentsA[1], extentsB[1]),
+      Math.min(extentsA[2], extentsB[2]),
+      Math.min(extentsA[3], extentsB[3]),
+    ];
+  return bounds;
+}

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
@@ -18,7 +18,7 @@ import {
   layerEntryIsGroupLayer,
   TypeImageStaticLayerEntryConfig,
 } from '../../../map/map-schema-types';
-import { getLocalizedValue } from '../../../../core/utils/utilities';
+import { getLocalizedValue, getMinOrMaxExtents } from '../../../../core/utils/utilities';
 import { api } from '../../../../app';
 import { Layer } from '../../layer';
 
@@ -281,65 +281,25 @@ export class ImageStatic extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Compute the layer bounds or undefined if the result can not be obtained from the feature extents that compose the layer. If
-   * layerPathOrConfig is undefined, the active layer is used. If projectionCode is defined, returns the bounds in the specified
-   * projection otherwise use the map projection. The bounds are different from the extent. They are mainly used for display
-   * purposes to show the bounding box in which the data resides and to zoom in on the entire layer data. It is not used by
-   * openlayer to limit the display of data on the map. If the bounds lie outside the extents, they are reduced to the extents.
+   * Get the bounds of the layer represented in the layerConfig, returns updated bounds
    *
-   * @param {string | TypeLayerEntryConfig | TypeListOfLayerEntryConfig | null} layerPathOrConfig Optional layer path or
-   * configuration.
-   * @param {string | number | undefined} projectionCode Optional projection code to use for the returned bounds.
+   * @param {TypeLayerEntryConfig} layerConfig Layer config to get bounds from.
+   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
    * @returns {Extent} The layer bounding box.
    */
-  calculateBounds(
-    layerPathOrConfig: string | TypeLayerEntryConfig | TypeListOfLayerEntryConfig | null = this.activeLayer,
-    projectionCode: string | number = api.map(this.mapId).currentProjection
-  ): Extent | undefined {
-    let bounds: Extent | undefined;
-    const processGroupLayerBounds = (listOfLayerEntryConfig: TypeListOfLayerEntryConfig) => {
-      listOfLayerEntryConfig.forEach((layerConfig) => {
-        if (layerEntryIsGroupLayer(layerConfig)) processGroupLayerBounds(layerConfig.listOfLayerEntryConfig);
-        else {
-          const layerBounds = (layerConfig.gvLayer as ImageLayer<Static>).getSource()?.getImageExtent();
-          const projection =
-            (layerConfig.gvLayer as ImageLayer<Static>).getSource()?.getProjection()?.getCode().replace('EPSG:', '') ||
-            api.map(this.mapId).currentProjection;
-          if (layerBounds) {
-            const transformedBounds = transformExtent(layerBounds, `EPSG:${projection}`, `EPSG:4326`);
-            if (!bounds) bounds = [transformedBounds[0], transformedBounds[1], transformedBounds[2], transformedBounds[3]];
-            else {
-              bounds = [
-                Math.min(transformedBounds[0], bounds[0]),
-                Math.min(transformedBounds[1], bounds[1]),
-                Math.max(transformedBounds[2], bounds[2]),
-                Math.max(transformedBounds[3], bounds[3]),
-              ];
-            }
-          }
-        }
-      });
-    };
-    const rootLayerConfig = typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig) : layerPathOrConfig;
-    if (rootLayerConfig) {
-      if (Array.isArray(rootLayerConfig)) processGroupLayerBounds(rootLayerConfig);
-      else processGroupLayerBounds([rootLayerConfig]);
-      const extent = transformExtent(
-        this.getExtent() || api.map(this.mapId).getView().get('extent'),
-        `EPSG:${api.map(this.mapId).currentProjection}`,
-        `EPSG:4326`
-      );
-      if (bounds) {
-        bounds = [
-          Math.max(extent[0], bounds[0]),
-          Math.max(extent[1], bounds[1]),
-          Math.min(extent[2], bounds[2]),
-          Math.min(extent[3], bounds[3]),
-        ];
-        bounds = transformExtent(bounds, `EPSG:4326`, `EPSG:${projectionCode}`);
-      }
+  getBounds(layerConfig: TypeLayerEntryConfig, bounds: Extent | undefined): Extent | undefined {
+    const layerBounds = (layerConfig.gvLayer as ImageLayer<Static>).getSource()?.getImageExtent();
+    const projection =
+      (layerConfig.gvLayer as ImageLayer<Static>).getSource()?.getProjection()?.getCode().replace('EPSG:', '') ||
+      api.map(this.mapId).currentProjection;
+
+    if (layerBounds) {
+      const transformedBounds = transformExtent(layerBounds, `EPSG:${projection}`, `EPSG:4326`);
+      if (!bounds) bounds = [transformedBounds[0], transformedBounds[1], transformedBounds[2], transformedBounds[3]];
+      else bounds = getMinOrMaxExtents(bounds, transformedBounds);
     }
+
     return bounds;
   }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -19,7 +19,7 @@ import {
   layerEntryIsGroupLayer,
   TypeLocalizedString,
 } from '../../../map/map-schema-types';
-import { getLocalizedValue, getXMLHttpRequest } from '../../../../core/utils/utilities';
+import { getLocalizedValue, getMinOrMaxExtents, getXMLHttpRequest } from '../../../../core/utils/utilities';
 import { Cast, toJsonObject } from '../../../../core/types/global-types';
 import { api } from '../../../../app';
 import { Layer } from '../../layer';
@@ -284,65 +284,25 @@ export class XYZTiles extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Compute the layer bounds or undefined if the result can not be obtained from the feature extents that compose the layer. If
-   * layerPathOrConfig is undefined, the active layer is used. If projectionCode is defined, returns the bounds in the specified
-   * projection otherwise use the map projection. The bounds are different from the extent. They are mainly used for display
-   * purposes to show the bounding box in which the data resides and to zoom in on the entire layer data. It is not used by
-   * openlayer to limit the display of data on the map. If the bounds lie outside the extents, they are reduced to the extents.
+   * Get the bounds of the layer represented in the layerConfig, returns updated bounds
    *
-   * @param {string | TypeLayerEntryConfig | TypeListOfLayerEntryConfig | null} layerPathOrConfig Optional layer path or
-   * configuration.
-   * @param {string | number | undefined} projectionCode Optional projection code to use for the returned bounds.
+   * @param {TypeLayerEntryConfig} layerConfig Layer config to get bounds from.
+   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
    * @returns {Extent} The layer bounding box.
    */
-  calculateBounds(
-    layerPathOrConfig: string | TypeLayerEntryConfig | TypeListOfLayerEntryConfig | null = this.activeLayer,
-    projectionCode: string | number = api.map(this.mapId).currentProjection
-  ): Extent | undefined {
-    let bounds: Extent | undefined;
-    const processGroupLayerBounds = (listOfLayerEntryConfig: TypeListOfLayerEntryConfig) => {
-      listOfLayerEntryConfig.forEach((layerConfig) => {
-        if (layerEntryIsGroupLayer(layerConfig)) processGroupLayerBounds(layerConfig.listOfLayerEntryConfig);
-        else {
-          const layerBounds = (layerConfig.gvLayer as TileLayer<XYZ>).getSource()?.getTileGrid()?.getExtent();
-          const projection =
-            (layerConfig.gvLayer as TileLayer<XYZ>).getSource()?.getProjection()?.getCode().replace('EPSG:', '') ||
-            api.map(this.mapId).currentProjection;
-          if (layerBounds) {
-            const transformedBounds = transformExtent(layerBounds, `EPSG:${projection}`, `EPSG:4326`);
-            if (!bounds) bounds = [transformedBounds[0], transformedBounds[1], transformedBounds[2], transformedBounds[3]];
-            else {
-              bounds = [
-                Math.min(transformedBounds[0], bounds[0]),
-                Math.min(transformedBounds[1], bounds[1]),
-                Math.max(transformedBounds[2], bounds[2]),
-                Math.max(transformedBounds[3], bounds[3]),
-              ];
-            }
-          }
-        }
-      });
-    };
-    const rootLayerConfig = typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig) : layerPathOrConfig;
-    if (rootLayerConfig) {
-      if (Array.isArray(rootLayerConfig)) processGroupLayerBounds(rootLayerConfig);
-      else processGroupLayerBounds([rootLayerConfig]);
-      const extent = transformExtent(
-        this.getExtent() || api.map(this.mapId).getView().get('extent'),
-        `EPSG:${api.map(this.mapId).currentProjection}`,
-        `EPSG:4326`
-      );
-      if (bounds) {
-        bounds = [
-          Math.max(extent[0], bounds[0]),
-          Math.max(extent[1], bounds[1]),
-          Math.min(extent[2], bounds[2]),
-          Math.min(extent[3], bounds[3]),
-        ];
-        bounds = transformExtent(bounds, `EPSG:4326`, `EPSG:${projectionCode}`);
-      }
+  getBounds(layerConfig: TypeLayerEntryConfig, bounds: Extent | undefined): Extent | undefined {
+    const layerBounds = (layerConfig.gvLayer as TileLayer<XYZ>).getSource()?.getTileGrid()?.getExtent();
+    const projection =
+      (layerConfig.gvLayer as TileLayer<XYZ>).getSource()?.getProjection()?.getCode().replace('EPSG:', '') ||
+      api.map(this.mapId).currentProjection;
+
+    if (layerBounds) {
+      const transformedBounds = transformExtent(layerBounds, `EPSG:${projection}`, `EPSG:4326`);
+      if (!bounds) bounds = [transformedBounds[0], transformedBounds[1], transformedBounds[2], transformedBounds[3]];
+      else bounds = getMinOrMaxExtents(bounds, transformedBounds);
     }
+
     return bounds;
   }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -257,7 +257,7 @@ export class EsriFeature extends AbstractGeoViewVector {
     // eslint-disable-next-line no-var
     var vectorSource: VectorSource<Geometry>;
     sourceOptions.url = getLocalizedValue(layerEntryConfig.source!.dataAccessPath!, this.mapId);
-    sourceOptions.url = `${sourceOptions.url}/${layerEntryConfig.layerId.replace(
+    sourceOptions.url = `${sourceOptions.url}/${String(layerEntryConfig.layerId).replace(
       '-unclustered',
       ''
     )}/query?f=pjson&outfields=*&where=1%3D1`;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
@@ -238,8 +238,8 @@ export class OgcFeature extends AbstractGeoViewVector {
       const metadataUrl = getLocalizedValue(this.metadataAccessPath, this.mapId);
       if (metadataUrl) {
         const queryUrl = metadataUrl.endsWith('/')
-          ? `${metadataUrl}collections/${layerEntryConfig.layerId.replace('-unclustered', '')}/queryables?f=json`
-          : `${metadataUrl}/collections/${layerEntryConfig.layerId.replace('-unclustered', '')}/queryables?f=json`;
+          ? `${metadataUrl}collections/${String(layerEntryConfig.layerId).replace('-unclustered', '')}/queryables?f=json`
+          : `${metadataUrl}/collections/${String(layerEntryConfig.layerId).replace('-unclustered', '')}/queryables?f=json`;
         const queryResult = axios.get<TypeJsonObject>(queryUrl);
         queryResult.then((response) => {
           if (response.data.properties) {


### PR DESCRIPTION
Closes #1058

# Description

Moved calculteBounds to abstract-geoview-layer, each layer type (or abstract-vector-layer) has its own getBounds function, and getMinOrMaxExtents added to utilities.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with all layer types, using as many different layers as were readily available.

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1069)
<!-- Reviewable:end -->
