### PR TITLE
1071-Vector_layers_do_not_apply_initialSettings

### DIFF
--- a/packages/geoview-core/public/geojson/metadata.json
+++ b/packages/geoview-core/public/geojson/metadata.json
@@ -14,8 +14,7 @@
         }
       },
       "initialSettings": {
-        "visible": true,
-        "extent": [-177.29275972275843, 34.301384132573055, -9.977229778239453, 84.400481529465]
+        "visible": true
       },
       "style": {
         "Polygon": {
@@ -85,8 +84,7 @@
         }
       },
       "initialSettings": {
-        "visible": true,
-        "extent": [-177.29275972275843, 34.301384132573055, -9.977229778239453, 84.400481529465]
+        "visible": true
       },
       "style": {
         "LineString": {
@@ -114,8 +112,7 @@
         }
       },
       "initialSettings": {
-        "visible": true,
-        "extent": [-177.29275972275843, 34.301384132573055, -9.977229778239453, 84.400481529465]
+        "visible": true
       },
       "style": {
         "Point": {
@@ -143,8 +140,7 @@
         }
       },
       "initialSettings": {
-        "visible": true,
-        "extent": [-177.29275972275843, 34.301384132573055, -9.977229778239453, 84.400481529465]
+        "visible": true
       },
       "style": {
         "Point": {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -27,6 +27,7 @@ import {
   TypeOgcWmsLayerEntryConfig,
   TypeEsriDynamicLayerEntryConfig,
   TypeBaseSourceVectorInitialConfig,
+  TypeLayerInitialSettings,
 } from '../../map/map-schema-types';
 import {
   codedValueType,
@@ -261,7 +262,12 @@ export abstract class AbstractGeoViewLayer {
    */
   listOfLayerEntryConfig: TypeListOfLayerEntryConfig = [];
 
-  /** Name of listOfLayerEntryConfig that did not load. */
+  /**
+   * Initial settings to apply to the GeoView layer at creation time. This attribute is allowed only if listOfLayerEntryConfig.length > 1.
+   */
+  initialSettings?: TypeLayerInitialSettings;
+
+  /** layers of listOfLayerEntryConfig that did not load. */
   layerLoadError: { layer: string; consoleMessage: string }[] = [];
 
   /**
@@ -311,6 +317,7 @@ export abstract class AbstractGeoViewLayer {
     if (mapLayerConfig.metadataAccessPath?.en) this.metadataAccessPath.en = mapLayerConfig.metadataAccessPath.en.trim();
     if (mapLayerConfig.metadataAccessPath?.fr) this.metadataAccessPath.fr = mapLayerConfig.metadataAccessPath.fr.trim();
     if (mapLayerConfig.listOfLayerEntryConfig) this.listOfLayerEntryConfig = mapLayerConfig.listOfLayerEntryConfig;
+    this.initialSettings = mapLayerConfig.initialSettings;
     this.serverDateFragmentsOrder = mapLayerConfig.serviceDateFormat
       ? api.dateUtilities.getDateFragmentsOrder(mapLayerConfig.serviceDateFormat)
       : undefined;
@@ -898,21 +905,6 @@ export abstract class AbstractGeoViewLayer {
   }
 
   /** ***************************************************************************************************************************
-   * Return the extent of the layer or undefined if it will be visible regardless of extent. The layer extent is an array of
-   * numbers representing an extent: [minx, miny, maxx, maxy]. If layerPathOrConfig is undefined, the activeLayer of the class
-   * will be used. This routine return undefined when no layerPathOrConfig is specified and the active layer is null. The extent
-   * is used to clip the data displayed on the map.
-   *
-   * @param {string | TypeLayerEntryConfig | null} layerPathOrConfig Optional layer path or configuration.
-   *
-   * @returns {Extent} The layer extent.
-   */
-  getExtent(layerPathOrConfig: string | TypeLayerEntryConfig | null = this.activeLayer): Extent | undefined {
-    const gvLayer = typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig)?.gvLayer : layerPathOrConfig?.gvLayer;
-    return gvLayer ? gvLayer.getExtent() : undefined;
-  }
-
-  /** ***************************************************************************************************************************
    * Returns the domaine of the specified field or null if the field has no domain.
    *
    * @param {string} fieldName field name for which we want to get the domaine.
@@ -936,6 +928,21 @@ export abstract class AbstractGeoViewLayer {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected getFieldType(fieldName: string, layerConfig: TypeLayerEntryConfig): 'string' | 'date' | 'number' {
     return 'string';
+  }
+
+  /** ***************************************************************************************************************************
+   * Return the extent of the layer or undefined if it will be visible regardless of extent. The layer extent is an array of
+   * numbers representing an extent: [minx, miny, maxx, maxy]. If layerPathOrConfig is undefined, the activeLayer of the class
+   * will be used. This routine return undefined when no layerPathOrConfig is specified and the active layer is null. The extent
+   * is used to clip the data displayed on the map.
+   *
+   * @param {string | TypeLayerEntryConfig | null} layerPathOrConfig Optional layer path or configuration.
+   *
+   * @returns {Extent} The layer extent.
+   */
+  getExtent(layerPathOrConfig: string | TypeLayerEntryConfig | null = this.activeLayer): Extent | undefined {
+    const gvLayer = typeof layerPathOrConfig === 'string' ? this.getLayerConfig(layerPathOrConfig)?.gvLayer : layerPathOrConfig?.gvLayer;
+    return gvLayer ? gvLayer.getExtent() : undefined;
   }
 
   /** ***************************************************************************************************************************

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -5,6 +5,7 @@ import { Options as SourceOptions } from 'ol/source/Vector';
 import { VectorImage as VectorLayer } from 'ol/layer';
 import { Options as VectorLayerOptions } from 'ol/layer/VectorImage';
 import { Geometry, Point } from 'ol/geom';
+import { all, bbox } from 'ol/loadingstrategy';
 import { ReadOptions } from 'ol/format/Feature';
 import BaseLayer from 'ol/layer/Base';
 import LayerGroup from 'ol/layer/Group';
@@ -95,11 +96,14 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
     // The line below uses var because a var declaration has a wider scope than a let declaration.
     var vectorSource: VectorSource<Geometry>;
     if (this.attributions.length !== 0) sourceOptions.attributions = this.attributions;
-    const childLoaderInitialisation = sourceOptions.loader;
+
+    // set loading strategy option
+    sourceOptions.strategy = (layerEntryConfig.source! as TypeBaseSourceVectorInitialConfig).strategy === 'bbox' ? bbox : all;
 
     sourceOptions.loader = (extent, resolution, projection, success, failure) => {
-      if (childLoaderInitialisation) childLoaderInitialisation.call(vectorSource, extent, resolution, projection, success, failure);
-      const url = vectorSource.getUrl();
+      let url = vectorSource.getUrl();
+      if (typeof url === 'function') url = url(extent, resolution, projection);
+
       const xhr = new XMLHttpRequest();
       if ((layerEntryConfig?.source as TypeBaseSourceVectorInitialConfig)?.postSettings) {
         const { postSettings } = layerEntryConfig.source as TypeBaseSourceVectorInitialConfig;
@@ -220,6 +224,15 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
     };
 
     layerEntryConfig.gvLayer = new VectorLayer(layerOptions);
+    if (layerEntryConfig.initialSettings?.extent !== undefined) this.setExtent(layerEntryConfig.initialSettings?.extent, layerEntryConfig);
+    if (layerEntryConfig.initialSettings?.maxZoom !== undefined)
+      this.setMaxZoom(layerEntryConfig.initialSettings?.maxZoom, layerEntryConfig);
+    if (layerEntryConfig.initialSettings?.minZoom !== undefined)
+      this.setMinZoom(layerEntryConfig.initialSettings?.minZoom, layerEntryConfig);
+    if (layerEntryConfig.initialSettings?.opacity !== undefined)
+      this.setOpacity(layerEntryConfig.initialSettings?.opacity, layerEntryConfig);
+    if (layerEntryConfig.initialSettings?.visible !== undefined)
+      this.setVisible(layerEntryConfig.initialSettings?.visible, layerEntryConfig);
     this.applyViewFilter(layerEntryConfig, layerEntryConfig.layerFilter ? layerEntryConfig.layerFilter : '');
 
     return layerEntryConfig.gvLayer as VectorLayer<VectorSource>;

--- a/packages/geoview-core/src/geo/map/map.ts
+++ b/packages/geoview-core/src/geo/map/map.ts
@@ -196,7 +196,7 @@ export class MapViewer {
           this.layerLoadedTimeoutId[geoviewLayerConfig.geoviewLayerId] = setTimeout(() => {
             if (this.remainingLayersThatNeedToBeLoadedIsDecrementedToZero4TheFirstTime())
               api.event.emit(GeoViewLayerPayload.createTestGeoviewLayersPayload('run cgpv.init callback?'));
-            const isNotLoaded = !this.layer.geoviewLayers[geoviewLayerConfig.geoviewLayerId]?.isLoaded;
+            const isNotLoaded = !this?.layer?.geoviewLayers?.[geoviewLayerConfig.geoviewLayerId]?.isLoaded;
             if (isNotLoaded && i > 15) {
               if (geoviewLayerConfig.geoviewLayerId in this.layer.geoviewLayers)
                 this.layer.geoviewLayers[geoviewLayerConfig.geoviewLayerId].loadError = true;


### PR DESCRIPTION
# Description

All vector layers do not apply initialSettings.

Fixes #1071-Vector_layers_do_not_apply_initialSettings

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using the test.html template and the chrome devtools debugger to see that everythings work as expected.

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1072)
<!-- Reviewable:end -->
