### PR TITLE
1073-Use_singleton_patern_for_layerSets

### DIFF
--- a/packages/geoview-core/public/templates/layers/esri-dynamic.html
+++ b/packages/geoview-core/public/templates/layers/esri-dynamic.html
@@ -634,9 +634,9 @@
           createTableOfFilter('LYR1');
           createTableOfFilter('LYR2');
           createTableOfFilter('LYR3');
-          cgpv.api.event.emit({ handlerName: 'LYR1/LegendsId1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
-          cgpv.api.event.emit({ handlerName: 'LYR2/LegendsId2', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
-          cgpv.api.event.emit({ handlerName: 'LYR3/LegendsId3', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR1/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR2/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR3/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
 
           const LYR2_FILTERS = ["year >= date '01/01/2018 05:00:00' and year <= date '12/31/2019 19:00:00-05:00'",
                                 "year > date '01/01/2018 05:00:00' and year <= date '01/01/2020 05:00:00Z'",
@@ -693,66 +693,66 @@
       });
 
       // LYR1 ===================================================================================================================
-      const featureInfoWmsLayerSet1 = cgpv.api.createFeatureInfoLayerSet('LYR1', 'ResultSetId1');
+      const featureInfoLayerSet1 = cgpv.api.getFeatureInfoLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR1', 'ResultSetId1', resultSets);
         },
-        'LYR1/ResultSetId1'
+        'LYR1/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet1 = cgpv.api.createLegendsLayerSet('LYR1', 'LegendsId1');
+      const LegendsLayerSet1 = cgpv.api.getLegendsLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId1', resultSets);
         },
-        'LYR1/LegendsId1'
+        'LYR1/$LegendsLayerSet$'
       );
 
       // LYR2 ===================================================================================================================
-      const featureInfoWmsLayerSet2 = cgpv.api.createFeatureInfoLayerSet('LYR2', 'ResultSetId2');
+      const featureInfoLayerSet2 = cgpv.api.getFeatureInfoLayerSet('LYR2');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR2', 'ResultSetId2', resultSets);
         },
-        'LYR2/ResultSetId2'
+        'LYR2/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet2 = cgpv.api.createLegendsLayerSet('LYR2', 'LegendsId2');
+      const LegendsLayerSet2 = cgpv.api.getLegendsLayerSet('LYR2');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId2', resultSets);
         },
-        'LYR2/LegendsId2'
+        'LYR2/$LegendsLayerSet$'
       );
 
       // LYR3 ===================================================================================================================
-      const featureInfoWmsLayerSet3 = cgpv.api.createFeatureInfoLayerSet('LYR3', 'ResultSetId3');
+      const featureInfoLayerSet3 = cgpv.api.getFeatureInfoLayerSet('LYR3');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR3', 'ResultSetId3', resultSets);
         },
-        'LYR3/ResultSetId3'
+        'LYR3/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet3 = cgpv.api.createLegendsLayerSet('LYR3', 'LegendsId3');
+      const LegendsLayerSet3 = cgpv.api.getLegendsLayerSet('LYR3');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId3', resultSets);
         },
-        'LYR3/LegendsId3'
+        'LYR3/$LegendsLayerSet$'
       );
     </script>
   </body>

--- a/packages/geoview-core/public/templates/layers/esri-feature.html
+++ b/packages/geoview-core/public/templates/layers/esri-feature.html
@@ -278,9 +278,9 @@
           createTableOfFilter('LYR1');
           createTableOfFilter('LYR2');
           createTableOfFilter('LYR3');
-          cgpv.api.event.emit({ handlerName: 'LYR1/LegendsId1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
-          cgpv.api.event.emit({ handlerName: 'LYR2/LegendsId2', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
-          cgpv.api.event.emit({ handlerName: 'LYR3/LegendsId3', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR1/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR2/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR3/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
 
           const LYR2_FILTERS = ["year >= date '01/01/2018 05:00:00' and year <= date '12/31/2019 19:00:00-05:00'",
                                 "year > date '01/01/2018 05:00:00' and year <= date '01/01/2020 05:00:00Z'",
@@ -337,66 +337,66 @@
       });
 
       // LYR1 ===================================================================================================================
-      const featureInfoWmsLayerSet1 = cgpv.api.createFeatureInfoLayerSet('LYR1', 'ResultSetId1');
+      const featureInfoLayerSet1 = cgpv.api.getFeatureInfoLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR1', 'ResultSetId1', resultSets);
         },
-        'LYR1/ResultSetId1'
+        'LYR1/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet1 = cgpv.api.createLegendsLayerSet('LYR1', 'LegendsId1');
+      const LegendsLayerSet1 = cgpv.api.getLegendsLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId1', resultSets);
         },
-        'LYR1/LegendsId1'
+        'LYR1/$LegendsLayerSet$'
       );
 
       // LYR2 ===================================================================================================================
-      const featureInfoWmsLayerSet2 = cgpv.api.createFeatureInfoLayerSet('LYR2', 'ResultSetId2');
+      const featureInfoLayerSet2 = cgpv.api.getFeatureInfoLayerSet('LYR2');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR2', 'ResultSetId2', resultSets);
         },
-        'LYR2/ResultSetId2'
+        'LYR2/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet2 = cgpv.api.createLegendsLayerSet('LYR2', 'LegendsId2');
+      const LegendsLayerSet2 = cgpv.api.getLegendsLayerSet('LYR2');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId2', resultSets);
         },
-        'LYR2/LegendsId2'
+        'LYR2/$LegendsLayerSet$'
       );
 
       // LYR3 ===================================================================================================================
-      const featureInfoWmsLayerSet3 = cgpv.api.createFeatureInfoLayerSet('LYR3', 'ResultSetId3');
+      const featureInfoLayerSet3 = cgpv.api.getFeatureInfoLayerSet('LYR3');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR3', 'ResultSetId3', resultSets);
         },
-        'LYR3/ResultSetId3'
+        'LYR3/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet3 = cgpv.api.createLegendsLayerSet('LYR3', 'LegendsId3');
+      const LegendsLayerSet3 = cgpv.api.getLegendsLayerSet('LYR3');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId3', resultSets);
         },
-        'LYR3/LegendsId3'
+        'LYR3/$LegendsLayerSet$'
       );
     </script>
   </body>

--- a/packages/geoview-core/public/templates/layers/geocore.html
+++ b/packages/geoview-core/public/templates/layers/geocore.html
@@ -172,29 +172,29 @@
           createConfigSnippet();
 
           createTableOfFilter('LYR1');
-          cgpv.api.event.emit({ handlerName: 'LYR1/LegendsId1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR1/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
         }
       });
 
       // LYR1 ===================================================================================================================
-      const featureInfoWmsLayerSet1 = cgpv.api.createFeatureInfoLayerSet('LYR1', 'ResultSetId1');
+      const featureInfoLayerSet1 = cgpv.api.getFeatureInfoLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR1', 'ResultSetId1', resultSets);
         },
-        'LYR1/ResultSetId1'
+        'LYR1/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet1 = cgpv.api.createLegendsLayerSet('LYR1', 'LegendsId1');
+      const LegendsLayerSet1 = cgpv.api.getLegendsLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId1', resultSets);
         },
-        'LYR1/LegendsId1'
+        'LYR1/$LegendsLayerSet$'
       );
     </script>
   </body>

--- a/packages/geoview-core/public/templates/layers/geojson.html
+++ b/packages/geoview-core/public/templates/layers/geojson.html
@@ -160,7 +160,7 @@
           createConfigSnippet();
 
           createTableOfFilter('LYR1');
-          cgpv.api.event.emit({ handlerName: 'LYR1/LegendsId1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR1/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
         }
       });
 
@@ -224,24 +224,24 @@
       });
 
       // LYR1 ===================================================================================================================
-      const featureInfoWmsLayerSet1 = cgpv.api.createFeatureInfoLayerSet('LYR1', 'ResultSetId1');
+      const featureInfoLayerSet = cgpv.api.getFeatureInfoLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR1', 'ResultSetId1', resultSets);
         },
-        'LYR1/ResultSetId1'
+        'LYR1/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet1 = cgpv.api.createLegendsLayerSet('LYR1', 'LegendsId1');
+      const LegendLayerSet = cgpv.api.getLegendsLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId1', resultSets);
         },
-        'LYR1/LegendsId1'
+        'LYR1/$LegendsLayerSet$'
       );
     </script>
   </body>

--- a/packages/geoview-core/public/templates/layers/geopackage.html
+++ b/packages/geoview-core/public/templates/layers/geopackage.html
@@ -139,27 +139,27 @@
           createConfigSnippet();
 
           createTableOfFilter('LYR1');
-          cgpv.api.event.emit({ handlerName: 'LYR1/LegendsId1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR1/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
         }
       });
 
       // LYR1 ===================================================================================================================
-      const featureInfoWmsLayerSet1 = cgpv.api.createFeatureInfoLayerSet('LYR1', 'ResultSetId1');
+      const featureInfoLayerSet1 = cgpv.api.getFeatureInfoLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR1', 'ResultSetId1', resultSets);
         },
-        'LYR1/ResultSetId1'
+        'LYR1/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet1 = cgpv.api.createLegendsLayerSet('LYR1', 'LegendsId1');
+      const LegendsLayerSet1 = cgpv.api.getLegendsLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
-          displayLegend('LegendsId1', resultSets);
+          displayLegend('$LegendsLayerSet$', resultSets);
         },
         'LYR1/LegendsId1'
       );

--- a/packages/geoview-core/public/templates/layers/image-static.html
+++ b/packages/geoview-core/public/templates/layers/image-static.html
@@ -141,19 +141,19 @@
           createCodeSnippet();
           createConfigSnippet();
 
-          cgpv.api.event.emit({ handlerName: 'LYR1/LegendsId1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR1/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
         }
       });
 
       // LYR1 ===================================================================================================================
-      const LegendsWmsLayerSet1 = cgpv.api.createLegendsLayerSet('LYR1', 'LegendsId1');
+      const LegendsLayerSet1 = cgpv.api.getLegendsLayerSet('LYR1', 'LegendsId1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId1', resultSets);
         },
-        'LYR1/LegendsId1'
+        'LYR1/$LegendsLayerSet$'
       );
     </script>
   </body>

--- a/packages/geoview-core/public/templates/layers/layerlib.js
+++ b/packages/geoview-core/public/templates/layers/layerlib.js
@@ -189,18 +189,24 @@ const createTableOfFilter = (mapId) => {
           mapButtonsDiv.appendChild(geoviewLayerH1);
 
           const layerConfigH2 = document.createElement('h2');
-          layerConfigH2.innerText = `${layerConfig.layerName.en}  `;
+          layerConfigH2.innerText = `${layerConfig.layerName.en}`;
           layerConfigH2.style.height = '15px';
           mapButtonsDiv.appendChild(layerConfigH2);
 
           const toggleLayerVisibility = document.createElement('button');
           let visibilityFlag = geoviewLayer.getVisible(layerConfig);
-          if (visibilityFlag) toggleLayerVisibility.innerText = 'Hide';
-          else toggleLayerVisibility.innerText = 'Show';
+          if (visibilityFlag)
+            toggleLayerVisibility.innerText = layerConfig?.source?.style === undefined ? 'Hide' : `Hide style ${layerConfig.source.style}`;
+          else
+            toggleLayerVisibility.innerText = layerConfig?.source?.style === undefined ? 'Show' : `Show style ${layerConfig.source.style}`;
           toggleLayerVisibility.addEventListener('click', (e) => {
             visibilityFlag = !geoviewLayer.getVisible(layerConfig);
-            if (visibilityFlag) toggleLayerVisibility.innerText = 'Hide';
-            else toggleLayerVisibility.innerText = 'Show';
+            if (visibilityFlag)
+              toggleLayerVisibility.innerText =
+                layerConfig?.source?.style === undefined ? 'Hide' : `Hide style ${layerConfig.source.style}`;
+            else
+              toggleLayerVisibility.innerText =
+                layerConfig?.source?.style === undefined ? 'Show' : `Show style ${layerConfig.source.style}`;
             geoviewLayer.setVisible(visibilityFlag, layerConfig);
           });
           layerConfigH2.appendChild(toggleLayerVisibility);

--- a/packages/geoview-core/public/templates/layers/ogc-feature.html
+++ b/packages/geoview-core/public/templates/layers/ogc-feature.html
@@ -136,29 +136,29 @@
           createConfigSnippet();
 
           createTableOfFilter('LYR1');
-          cgpv.api.event.emit({ handlerName: 'LYR1/LegendsId1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR1/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
         }
       });
 
       // LYR1 ===================================================================================================================
-      const featureInfoWmsLayerSet1 = cgpv.api.createFeatureInfoLayerSet('LYR1', 'ResultSetId1');
+      const featureInfoLayerSet1 = cgpv.api.getFeatureInfoLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR1', 'ResultSetId1', resultSets);
         },
-        'LYR1/ResultSetId1'
+        'LYR1/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet1 = cgpv.api.createLegendsLayerSet('LYR1', 'LegendsId1');
+      const LegendsLayerSet1 = cgpv.api.getLegendsLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId1', resultSets);
         },
-        'LYR1/LegendsId1'
+        'LYR1/$LegendsLayerSet$'
       );
     </script>
   </body>

--- a/packages/geoview-core/public/templates/layers/wfs.html
+++ b/packages/geoview-core/public/templates/layers/wfs.html
@@ -170,29 +170,29 @@
           createConfigSnippet();
 
           createTableOfFilter('LYR1');
-          cgpv.api.event.emit({ handlerName: 'LYR1/LegendsId1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR1/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
         }
       });
 
       // LYR1 ===================================================================================================================
-      const featureInfoWmsLayerSet1 = cgpv.api.createFeatureInfoLayerSet('LYR1', 'ResultSetId1');
+      const featureInfoLayerSet1 = cgpv.api.getFeatureInfoLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR1', 'ResultSetId1', resultSets);
         },
-        'LYR1/ResultSetId1'
+        'LYR1/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet1 = cgpv.api.createLegendsLayerSet('LYR1', 'LegendsId1');
+      const LegendsLayerSet1 = cgpv.api.getLegendsLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId1', resultSets);
         },
-        'LYR1/LegendsId1'
+        'LYR1/$LegendsLayerSet$'
       );
     </script>
   </body>

--- a/packages/geoview-core/public/templates/layers/wms.html
+++ b/packages/geoview-core/public/templates/layers/wms.html
@@ -199,7 +199,7 @@
           'labeled': true
         },
         'listOfGeoviewLayerConfig': [
-          /*{
+          {
             'geoviewLayerId': 'wmsLYR2-Root',
             'geoviewLayerName': { 'en': 'QGis Test' },
             'metadataAccessPath': { 'en': 'https://qgis-stage.services.geo.ca/dev/nrcan/landcover_2010_15_20_en' },
@@ -340,7 +340,7 @@
                 }
               }
             ]
-          }*/
+          }
         ]
       },
       'components': ['overview-map', 'nav-bar', 'footer-bar'],
@@ -383,7 +383,7 @@
           'labeled': true
         },
         'listOfGeoviewLayerConfig': [
-          /*{
+          {
             'geoviewLayerId': 'wmsLYR3-Root',
             'geoviewLayerName': { 'en': 'QGis Test' },
             'metadataAccessPath': { 'en': 'https://qgis-stage.services.geo.ca/dev/nrcan/landcover_2010_15_20_en' },
@@ -397,7 +397,7 @@
                 }
               }
             ]
-          }*/
+          }
         ]
       },
       'components': ['overview-map', 'nav-bar', 'footer-bar'],
@@ -487,24 +487,29 @@
           createTableOfFilter('LYR1');
           createTableOfFilter('LYR2');
           createTableOfFilter('LYR4');
-          cgpv.api.event.emit({ handlerName: 'LYR1/LegendsId1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
-          cgpv.api.event.emit({ handlerName: 'LYR2/LegendsId2', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
-          cgpv.api.event.emit({ handlerName: 'LYR3/LegendsId3', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
-          cgpv.api.event.emit({ handlerName: 'LYR4/LegendsId4', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR1/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR2/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR3/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
+          cgpv.api.event.emit({ handlerName: 'LYR4/$LegendsLayerSet$', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
 
-          const lyr3LayerConfig = cgpv.api.maps.LYR3.layer.registeredLayers['wmsLYR3-Root/landcover_2015_19classes'];
-          if (Array.isArray(lyr3LayerConfig?.source?.style)) {
-            const dropDownContent = document.getElementById('style');
-            lyr3LayerConfig.source.style.forEach((style) => {
-              element = document.createElement('option');
-              element.value = style;
-              element.innerText = style;
-              dropDownContent.appendChild(element);
-            });
-            dropDownContent.addEventListener('click', (e) => {
-              cgpv.api.maps.LYR3.layer.geoviewLayers['wmsLYR3-Root'].setStyle(dropDownContent.value, 'wmsLYR3-Root/landcover_2015_19classes');
-            });
-          }
+          const intervalId = window.setInterval(() => {
+            if (cgpv.api.maps.LYR3.layer?.geoviewLayers?.['wmsLYR3-Root']?.isLoaded) {
+              const lyr3LayerConfig = cgpv.api.maps.LYR3.layer.registeredLayers['wmsLYR3-Root/landcover_2015_19classes'];
+              if (Array.isArray(lyr3LayerConfig?.source?.style)) {
+                const dropDownContent = document.getElementById('style');
+                lyr3LayerConfig.source.style.forEach((style) => {
+                  element = document.createElement('option');
+                  element.value = style;
+                  element.innerText = style;
+                  dropDownContent.appendChild(element);
+                });
+                dropDownContent.addEventListener('click', (e) => {
+                  cgpv.api.maps.LYR3.layer.geoviewLayers['wmsLYR3-Root'].setStyle(dropDownContent.value, 'wmsLYR3-Root/landcover_2015_19classes');
+                });
+              }
+              clearInterval(intervalId);
+            }
+          }, 1000)
 
           let i = 0;
           window.setInterval(() => {
@@ -525,24 +530,24 @@
       });
 
       //LYR1 ===================================================================================================================
-      const featureInfoWmsLayerSet1 = cgpv.api.createFeatureInfoLayerSet('LYR1', 'ResultSetId1');
+      const featureInfoLayerSet1 = cgpv.api.getFeatureInfoLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR1', 'ResultSetId1', resultSets);
         },
-        'LYR1/ResultSetId1'
+        'LYR1/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet1 = cgpv.api.createLegendsLayerSet('LYR1', 'LegendsId1');
+      const LegendsLayerSet1 = cgpv.api.getLegendsLayerSet('LYR1');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId1', resultSets);
         },
-        'LYR1/LegendsId1'
+        'LYR1/$LegendsLayerSet$'
       );
 
       // ========================================================================================================================
@@ -553,56 +558,56 @@
       });
 
       // LYR2 ===================================================================================================================
-      const featureInfoWmsLayerSet2 = cgpv.api.createFeatureInfoLayerSet('LYR2', 'ResultSetId2');
+      const featureInfoLayerSet2 = cgpv.api.getFeatureInfoLayerSet('LYR2');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR2', 'ResultSetId2', resultSets);
         },
-        'LYR2/ResultSetId2'
+        'LYR2/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet2 = cgpv.api.createLegendsLayerSet('LYR2', 'LegendsId2');
+      const LegendsLayerSet2 = cgpv.api.getLegendsLayerSet('LYR2');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId2', resultSets);
         },
-        'LYR2/LegendsId2'
+        'LYR2/$LegendsLayerSet$'
       );
 
       // LYR3 ===================================================================================================================
-      const featureInfoWmsLayerSet3 = cgpv.api.createFeatureInfoLayerSet('LYR3', 'ResultSetId3');
+      const featureInfoLayerSet3 = cgpv.api.getFeatureInfoLayerSet('LYR3');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
         (payload) => {
           const { layerSetId, resultSets } = payload;
           createInfoTable('LYR3', 'ResultSetId3', resultSets);
         },
-        'LYR3/ResultSetId3'
+        'LYR3/$FeatureInfoLayerSet$'
       );
 
-      const LegendsWmsLayerSet3 = cgpv.api.createLegendsLayerSet('LYR3', 'LegendsId3');
+      const LegendsLayerSet3 = cgpv.api.getLegendsLayerSet('LYR3');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId3', resultSets);
         },
-        'LYR3/LegendsId3'
+        'LYR3/$LegendsLayerSet$'
       );
 
       //LYR4 ===================================================================================================================
-      const LegendsWmsLayerSet4 = cgpv.api.createLegendsLayerSet('LYR4', 'LegendsId4');
+      const LegendsLayerSet4 = cgpv.api.getLegendsLayerSet('LYR4', 'LegendsId4');
       cgpv.api.event.on(
         cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
         (payload) => {
           const { resultSets } = payload;
           displayLegend('LegendsId4', resultSets);
         },
-        'LYR4/LegendsId4'
+        'LYR4/$LegendsLayerSet$'
       );
 
       // ========================================================================================================================

--- a/packages/geoview-core/public/templates/pygeoapi-processes.html
+++ b/packages/geoview-core/public/templates/pygeoapi-processes.html
@@ -508,7 +508,7 @@
     </script>
     <script>
     // GeoJson ==================================================================================================================
-    const featureInfoGeoJsonLayerSet = cgpv.api.createFeatureInfoLayerSet('LYR5', 'geoJsonResultSetId');
+    const featureInfoGeoJsonLayerSet = cgpv.api.getFeatureInfoLayerSet('LYR5', 'geoJsonResultSetId');
     cgpv.api.event.on(
       cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
       (payload) => {
@@ -518,7 +518,7 @@
       'LYR5/geoJsonResultSetId'
     );
 
-    const LegendsGeoJsonLayerSet = cgpv.api.createLegendsLayerSet('LYR5', 'geojsonLegendsId');
+    const LegendsGeoJsonLayerSet = cgpv.api.getLegendsLayerSet('LYR5', 'geojsonLegendsId');
     cgpv.api.event.on(
       cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
       (payload) => {

--- a/packages/geoview-core/public/templates/test.html
+++ b/packages/geoview-core/public/templates/test.html
@@ -187,7 +187,7 @@
         cgpv.api.event.emit({ handlerName: 'LYR1/LegendsId1', event: cgpv.api.eventNames.GET_LEGENDS.TRIGGER });
 
         //LYR1 ===================================================================================================================
-        const featureInfoWmsLayerSet1 = cgpv.api.createFeatureInfoLayerSet('LYR1', 'ResultSetId1');
+        const featureInfoWmsLayerSet1 = cgpv.api.getFeatureInfoLayerSet('LYR1', 'ResultSetId1');
         cgpv.api.event.on(
           cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
           (payload) => {
@@ -197,7 +197,7 @@
           'LYR1/ResultSetId1'
         );
 
-        const LegendsWmsLayerSet1 = cgpv.api.createLegendsLayerSet('LYR1', 'LegendsId1');
+        const LegendsWmsLayerSet1 = cgpv.api.getLegendsLayerSet('LYR1', 'LegendsId1');
         cgpv.api.event.on(
           cgpv.api.eventNames.GET_LEGENDS.ALL_LEGENDS_DONE,
           (payload) => {

--- a/packages/geoview-core/src/api/api.ts
+++ b/packages/geoview-core/src/api/api.ts
@@ -78,10 +78,10 @@ export class API {
   showMessage = showMessage;
 
   // FeatureInfo layer set instanciator
-  createFeatureInfoLayerSet = FeatureInfoLayerSet.create;
+  getFeatureInfoLayerSet = FeatureInfoLayerSet.get;
 
   // Legends layer set instanciator
-  createLegendsLayerSet = LegendsLayerSet.create;
+  getLegendsLayerSet = LegendsLayerSet.get;
 
   /**
    * Initiate the event and projection objects

--- a/packages/geoview-core/src/core/components/details/details-api.ts
+++ b/packages/geoview-core/src/core/components/details/details-api.ts
@@ -22,7 +22,7 @@ export class DetailsAPI {
    */
   constructor(mapId: string) {
     this.mapId = mapId;
-    this.featureInfoLayerSet = api.createFeatureInfoLayerSet(mapId, `${mapId}-DetailsAPI`);
+    this.featureInfoLayerSet = api.getFeatureInfoLayerSet(mapId);
   }
 
   /**

--- a/packages/geoview-core/src/core/components/legend/legend-api.ts
+++ b/packages/geoview-core/src/core/components/legend/legend-api.ts
@@ -30,7 +30,7 @@ export class LegendApi {
    */
   constructor(mapId: string) {
     this.mapId = mapId;
-    this.legendLayerSet = api.createLegendsLayerSet(mapId, `${mapId}Legends`);
+    this.legendLayerSet = api.getLegendsLayerSet(mapId);
   }
 
   /**
@@ -39,7 +39,7 @@ export class LegendApi {
    */
   createLegend = (props: TypeLegendProps) => {
     const { layerIds, isRemoveable, canSetOpacity, expandAll, hideAll } = props;
-    api.event.emit({ handlerName: `${this.mapId}/${this.mapId}Legends`, event: api.eventNames.GET_LEGENDS.TRIGGER });
+    api.event.emit({ handlerName: `${this.mapId}/$LegendsLayerSet$`, event: api.eventNames.GET_LEGENDS.TRIGGER });
     const legendItems = layerIds.map((layerId) => {
       const geoviewLayerInstance = api.map(this.mapId).layer.geoviewLayers[layerId];
       if (geoviewLayerInstance) {

--- a/packages/geoview-core/src/core/utils/config/config-validation.ts
+++ b/packages/geoview-core/src/core/utils/config/config-validation.ts
@@ -500,6 +500,8 @@ export class ConfigValidation {
   private doExtraValidation(listOfGeoviewLayerConfig?: TypeListOfGeoviewLayerConfig) {
     if (listOfGeoviewLayerConfig) {
       listOfGeoviewLayerConfig.forEach((geoviewLayerConfig) => {
+        // The default value for geoviewLayerConfig.initialSettings.visible is true.
+        if (!geoviewLayerConfig.initialSettings) geoviewLayerConfig.initialSettings = { visible: true };
         switch (geoviewLayerConfig.geoviewLayerType) {
           case 'GeoJSON':
           case 'xyzTiles':

--- a/packages/geoview-core/src/core/utils/date-mgt.ts
+++ b/packages/geoview-core/src/core/utils/date-mgt.ts
@@ -538,6 +538,7 @@ export class DateMgt {
    * @returns {string} The reformatted date string.
    */
   applyInputDateFormat(date: string, dateFragmentsOrder = ISO_UTC_DATE_FRAGMENTS_ORDER, reverseTimeZone = false): string {
+    if (!date) return date;
     const index = dateFragmentsOrder[0];
     const separators = dateFragmentsOrder[2];
     // eslint-disable-next-line prefer-const
@@ -589,6 +590,7 @@ export class DateMgt {
    * @returns {string} The reformatted date string.
    */
   applyOutputDateFormat(date: string, dateFragmentsOrder?: TypeDateFragments, reverseTimeZone = false): string {
+    if (!date) return date;
     if (dateFragmentsOrder) {
       const index = dateFragmentsOrder[1];
       const separators = dateFragmentsOrder[2];

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -287,7 +287,6 @@ export class EsriDynamic extends AbstractGeoViewRaster {
       // postpone the setVisible action until all layers have been loaded on the map.
       api.event.once(
         EVENT_NAMES.LAYER.EVENT_IF_CONDITION,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         (payload) => {
           this.setVisible(layerEntryConfig.initialSettings!.visible!, layerEntryConfig);
         },

--- a/packages/geoview-details-panel/src/details-item.tsx
+++ b/packages/geoview-details-panel/src/details-item.tsx
@@ -63,7 +63,7 @@ export function DetailsItem({ mapId, buttonId }: Props): JSX.Element {
           setDetails([]);
         }
       },
-      `${mapId}/${mapId}-DetailsAPI`
+      `${mapId}/$FeatureInfoLayerSet$`
     );
     // get click info.
     api.event.on(

--- a/packages/geoview-footer-panel/src/details-item.tsx
+++ b/packages/geoview-footer-panel/src/details-item.tsx
@@ -58,7 +58,7 @@ export function DetailsItem({ mapId }: Props): JSX.Element {
           setDetails([]);
         }
       },
-      `${mapId}/${mapId}-DetailsAPI`
+      `${mapId}/$FeatureInfoLayerSet$`
     );
     api.event.on(
       api.eventNames.MAP.EVENT_MAP_SINGLE_CLICK,

--- a/packages/geoview-footer-panel/src/index.tsx
+++ b/packages/geoview-footer-panel/src/index.tsx
@@ -130,7 +130,7 @@ class FooterPanelPlugin extends AbstractPlugin {
               }
             }
           },
-          `${mapId}/${mapId}-DetailsAPI`
+          `${mapId}/$FeatureInfoLayerSet$`
         );
       }
 


### PR DESCRIPTION
# Description

Modify the legendLayerSet and the featureInfoLayerSet so that there is only one instance per map.
The singleton design patern will be used for the implementation.

Fixes #1073-Use_singleton_patern_for_layerSets

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using the chrome devtools by tracing all type of layer templates.

# Checklist:

- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR if needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1074)
<!-- Reviewable:end -->
