### PR TITLE
fix(webpack.common): Fix compile error about unable to locate doc folder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "editor.detectIndentation": false,
   "editor.renderWhitespace": "all",
   "editor.tabSize": 2,
-  "editor.hover.delay": 1000
+  "editor.hover.delay": 1000,
+  "window.title": "${activeEditorMedium}${separator}${rootName}${separator}${profileName}"
 }

--- a/packages/geoview-core/webpack.common.js
+++ b/packages/geoview-core/webpack.common.js
@@ -125,7 +125,7 @@ const config = {
     }),
     new CopyWebpackPlugin({
       patterns: [
-        { from: './public/docs', to: 'docs' },
+        { from: '../../docs', to: 'docs' },
         { from: './public/img', to: 'img' },
         { from: './public/configs', to: 'configs' },
         { from: './public/locales', to: 'locales', noErrorOnMissing: true },


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #1132 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

We get the compile error about unable to locate the doc folder after running "rush serve" related to unable to locate the "doc" folder. I updated "webpack.common.js" to target the "doc" folder in the root.
Also, updated ".vscode/settings.json", so we can see the path of the file in vscode tab.

https://amir-azma.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
