### PR TITLE
feat(accordion): Add loading icon to accordion

### DIFF
--- a/packages/geoview-core/public/templates/raw-feature-info.html
+++ b/packages/geoview-core/public/templates/raw-feature-info.html
@@ -334,7 +334,7 @@
           }
           cgpv.api.addUiComponent(
             'accordionList',
-            cgpv.react.createElement(cgpv.ui.elements.Accordion, { items: [itemAcc] })
+            cgpv.react.createElement(cgpv.ui.elements.Accordion, { items: [itemAcc], showLoadingIcon: true })
           );
           console.log(`Rendered Accordion ${Date.now() - startAcc}`);
         }

--- a/packages/geoview-core/src/core/components/feature-info/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/feature-info/feature-info.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/require-default-props */
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useTheme, Theme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 
@@ -90,7 +90,7 @@ export function FeatureInfo(props: TypeFeatureInfoProps): JSX.Element {
   const { feature, startOpen, mapId } = props;
   const featureIconSrc = feature.featureIcon.toDataURL();
   const nameFieldValue = feature.fieldInfo[feature.nameField!]!.value as string;
-  const [isOpen, setOpen] = useState<boolean>(false);
+  const [isOpen, setOpen] = useState<boolean | undefined>(startOpen);
   const featureInfoList: TypeFieldEntry[] = Object.keys(feature.fieldInfo).map((fieldName) => {
     return {
       fieldKey: feature.fieldInfo[fieldName]!.fieldKey,
@@ -128,14 +128,6 @@ export function FeatureInfo(props: TypeFeatureInfoProps): JSX.Element {
     api.map(mapId).zoomToExtent(feature.extent);
     setOpen(true);
   }
-
-  useEffect(() => {
-    // a list of FeatureInfo with only one element will pass down the startOpen prop
-    if (startOpen) {
-      setOpen(true);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   /**
    * Parse the content of the field to see if we need to create an image, a string element or a link

--- a/packages/geoview-core/src/ui/accordion/accordion.tsx
+++ b/packages/geoview-core/src/ui/accordion/accordion.tsx
@@ -1,9 +1,10 @@
+import { useState, useCallback } from 'react';
 import {
   Accordion as MaterialAccordion,
   AccordionSummary as MaterialAccordionSummary,
   AccordionDetails as MaterialAccordionDetails,
 } from '@mui/material';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { ExpandMore as ExpandMoreIcon, Loop as LoopIcon } from '@mui/icons-material';
 import { generateId } from '../../core/utils/utilities';
 
 /**
@@ -14,11 +15,26 @@ interface AccordionProps {
   items: Array<AccordionItem>;
   className: string;
   defaultExpanded: boolean;
+  showLoadingIcon: boolean;
 }
 
 export type AccordionItem = {
   title: string;
   content: React.ReactNode | Element;
+};
+
+const sxClasses = {
+  loadingIcon: {
+    animation: 'rotate 1s infinite linear',
+    '@keyframes rotate': {
+      from: {
+        transform: 'rotate(360deg)',
+      },
+      to: {
+        transform: 'rotate(0deg)',
+      },
+    },
+  },
 };
 
 /**
@@ -28,14 +44,39 @@ export type AccordionItem = {
  * @returns {JSX.Element} the created Fade element
  */
 export function Accordion(props: AccordionProps): JSX.Element {
-  const { id, items, className, defaultExpanded = false } = props;
+  const { id, items, className, defaultExpanded = false, showLoadingIcon = false } = props;
+
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+  const [isTransitionStarted, setIsTransitionStarted] = useState<boolean>(false);
+
+  const handleTransitionEnd = useCallback(
+    (e: React.TransitionEvent) => {
+      if (!isExpanded && showLoadingIcon) {
+        setIsTransitionStarted(true);
+        if (e.propertyName === 'height') {
+          setIsTransitionStarted(false);
+        }
+      }
+    },
+    [isExpanded, showLoadingIcon]
+  );
 
   return (
     <div id={generateId(id)} className="accordion-group">
       {Object.values(items).map((item: AccordionItem, idx: number) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <MaterialAccordion key={idx} className={className} defaultExpanded={defaultExpanded}>
-          <MaterialAccordionSummary expandIcon={<ExpandMoreIcon />} aria-controls={`accordion-panel-${idx}-a-content`}>
+        /* eslint-disable react/no-array-index-key */
+        <MaterialAccordion
+          key={idx}
+          className={className}
+          defaultExpanded={defaultExpanded}
+          onChange={(_, expanded) => setIsExpanded(expanded)}
+          onTransitionEnd={handleTransitionEnd}
+          expanded={isExpanded}
+        >
+          <MaterialAccordionSummary
+            expandIcon={showLoadingIcon && isTransitionStarted ? <LoopIcon sx={sxClasses.loadingIcon} /> : <ExpandMoreIcon />}
+            aria-controls={`accordion-panel-${idx}-a-content`}
+          >
             <div>{item.title}</div>
           </MaterialAccordionSummary>
           <MaterialAccordionDetails>{item.content}</MaterialAccordionDetails>


### PR DESCRIPTION
# Description

Add loading icon to Accordion component. This feature can be enabled by setting `showLoadingIcon` prop to true. By default, this prop is set to `false`.
Also, we can have a condition to check if the number of elements in accordion is more than X.
For example:
`showLoadingIcon: arrayOfItemsInAccordion.length > X`

Fixes #1161 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Open accordion and some of its items and sub-item. Then try to close the accordion. We should be able to see the loading indicating accordion is closing.

https://amir-azma.github.io/geoview/raw-feature-info.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1163)
<!-- Reviewable:end -->
