### PR TITLE
Fix the panel relative position so that content within it is better l…

### DIFF
--- a/packages/geoview-core/src/ui/panel/panel.tsx
+++ b/packages/geoview-core/src/ui/panel/panel.tsx
@@ -77,6 +77,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   panelContentContainer: {
+    position: 'relative',
     flexBasis: 'auto',
     overflow: 'hidden',
     overflowY: 'auto',


### PR DESCRIPTION
Fix the panel relative position so that content within it is better lay out, especially when the overlap vertically with a scrollbar.

# Description

When the side panel explodes vertically, this makes sure the content within it will be scrollable correctly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

During GeoView Clip Zip Ship plugin development.

# Checklist:

- [ ] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
