### PR TITLE
fix(config): changing config extent has no effect

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -169,7 +169,7 @@ importers:
       i18next-http-backend: ^1.0.21
       immutable: ^4.0.0
       jest: ^27.4.7
-      linkify-html: ^4.1.0
+      linkify-html: ^4.1.1
       linkifyjs: ^4.1.0
       lodash: ^4.17.21
       lodash-webpack-plugin: ^0.11.6

--- a/packages/geoview-core/package.json
+++ b/packages/geoview-core/package.json
@@ -65,7 +65,7 @@
     "i18next": "^22.4.13",
     "i18next-http-backend": "^1.0.21",
     "immutable": "^4.0.0",
-    "linkify-html": "^4.1.0",
+    "linkify-html": "^4.1.1",
     "linkifyjs": "^4.1.0",
     "lodash": "^4.17.21",
     "material-react-table": "^1.14.0",

--- a/packages/geoview-core/public/templates/basemaps.html
+++ b/packages/geoview-core/public/templates/basemaps.html
@@ -61,8 +61,7 @@
             'viewSettings': {
               'zoom': 4,
               'center': [-100, 60],
-              'projection': 3978,
-              'extent': [-170, 0, -10, 90]
+              'projection': 3978
             },
             'basemapOptions': {
               'basemapId': 'transport',
@@ -120,7 +119,7 @@
             'zoom': 4,
             'center': [-100, 60],
             'projection': 3978,
-            'extent': [-170, 0, -10, 90]
+            'extent': [-160, 40, -40, 75]
           },
           'basemapOptions': {
             'basemapId': 'nogeom',
@@ -148,7 +147,8 @@
           'viewSettings': {
             'zoom': 4,
             'center': [-100, 60],
-            'projection': 3857
+            'projection': 3857,
+            'extent': [-160, 40, -40, 75]
           },
           'basemapOptions': {
             'basemapId': 'osm',

--- a/packages/geoview-core/src/core/components/map/map.tsx
+++ b/packages/geoview-core/src/core/components/map/map.tsx
@@ -15,6 +15,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
+import { Extent } from 'ol/extent';
 import { NorthArrow, NorthPoleFlag } from '../north-arrow/north-arrow';
 import { Crosshair } from '../crosshair/crosshair';
 import { Footerbar } from '../footer-bar/footer-bar';
@@ -24,7 +25,7 @@ import { HoverTooltip } from '../hover-tooltip/hover-tooltip';
 
 import { disableScrolling, generateId } from '../../utils/utilities';
 
-import { TypeVectorSourceInitialConfig, api, inKeyfocusPayload } from '@/app';
+import { TypeVectorSourceInitialConfig, api, inKeyfocusPayload, notificationPayload } from '@/app';
 import { EVENT_NAMES } from '@/api/events/event-types';
 
 import { MapViewer } from '@/geo/map/map';
@@ -207,6 +208,26 @@ export function Map(mapFeaturesConfig: TypeMapFeaturesConfig): JSX.Element {
 
     const defaultBasemap = await api.map(mapId).basemap.loadDefaultBasemaps();
 
+    let extent: Extent | undefined;
+    if (mapConfig.viewSettings?.extent) {
+      if (projection.getCode() === 'EPSG:3978') {
+        // eslint-disable-next-line no-console
+        console.error('Extents not available for LLC projections (EPSG: 3978)');
+        api.event.emit(
+          notificationPayload(
+            EVENT_NAMES.NOTIFICATIONS.NOTIFICATION_ADD,
+            mapId,
+            'warning',
+            'Extents not available for LLC projections (EPSG: 3978)'
+          )
+        );
+      } else {
+        const mins = fromLonLat([mapConfig.viewSettings.extent[0], mapConfig.viewSettings.extent[1]], projection.getCode());
+        const maxs = fromLonLat([mapConfig.viewSettings.extent[2], mapConfig.viewSettings.extent[3]], projection.getCode());
+        extent = [mins[0], mins[1], maxs[0], maxs[1]];
+      }
+    }
+
     const initialMap = new OLMap({
       target: mapElement.current as string | HTMLElement | undefined,
       layers: defaultBasemap?.layers.map((layer) => {
@@ -225,8 +246,7 @@ export function Map(mapFeaturesConfig: TypeMapFeaturesConfig): JSX.Element {
         projection,
         center: fromLonLat([mapConfig.viewSettings.center[0], mapConfig.viewSettings.center[1]], projection),
         zoom: mapConfig.viewSettings.zoom,
-        // TODO: is still valid? extent: projectionConfig.extent,
-        extent: defaultBasemap?.defaultExtent ? defaultBasemap?.defaultExtent : undefined,
+        extent: extent || defaultBasemap?.defaultExtent || undefined,
         minZoom: mapConfig.viewSettings.minZoom || defaultBasemap?.zoomLevels.min || 0,
         maxZoom: mapConfig.viewSettings.maxZoom || defaultBasemap?.zoomLevels.max || 17,
       }),

--- a/packages/geoview-core/src/core/utils/config/config-validation.ts
+++ b/packages/geoview-core/src/core/utils/config/config-validation.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-console, no-underscore-dangle, no-param-reassign */
+import { Extent } from 'ol/extent';
+
 import Ajv from 'ajv';
 import { AnyValidateFunction } from 'ajv/dist/types';
 
@@ -283,7 +285,7 @@ export class ConfigValidation {
   /** ***************************************************************************************************************************
    * Validate the center.
    * @param {TypeValidMapProjectionCodes} projection The projection used by the map.
-   * @param {[number, number]} center The map center to valdate.
+   * @param {[number, number]} center The map center to validate.
    *
    * @returns {[number, number]} A valid map center.
    */
@@ -304,6 +306,31 @@ export class ConfigValidation {
       return [x, y];
     }
     return this._defaultMapFeaturesConfig.map.viewSettings.center;
+  }
+
+  /** ***************************************************************************************************************************
+   * Validate the extent.
+   * @param {TypeValidMapProjectionCodes} projection The projection used by the map.
+   * @param {[number, number, number, number]} extent The map extent to valdate.
+   * @param {[number, number]} center The map extent to validate.
+   *
+   * @returns {[number, number, number, number]} A valid map extent.
+   */
+  private validateExtent(
+    projection: TypeValidMapProjectionCodes,
+    extent: [number, number, number, number],
+    center: [number, number]
+  ): Extent | undefined {
+    if (projection && extent) {
+      const [extentMinX, extentMinY, extentMaxX, extentMaxY] = extent;
+      const minX = !Number.isNaN(extentMinX) && extentMinX < center[0] ? extentMinX : this._center[projection].long[0];
+      const minY = !Number.isNaN(extentMinY) && extentMinY < center[1] ? extentMinY : this._center[projection].lat[0];
+      const maxX = !Number.isNaN(extentMaxX) && extentMaxX > center[0] ? extentMaxX : this._center[projection].long[1];
+      const maxY = !Number.isNaN(extentMaxY) && extentMaxY > center[1] ? extentMaxY : this._center[projection].lat[1];
+
+      return [minX, minY, maxX, maxY] as Extent;
+    }
+    return undefined;
   }
 
   /** ***************************************************************************************************************************
@@ -846,6 +873,9 @@ export class ConfigValidation {
     const schemaVersionUsed = this.validateVersion(tempMapFeaturesConfig.schemaVersionUsed);
     const minZoom = this.validateMinZoom(tempMapFeaturesConfig?.map?.viewSettings?.minZoom);
     const maxZoom = this.validateMaxZoom(tempMapFeaturesConfig?.map?.viewSettings?.maxZoom);
+    const extent = tempMapFeaturesConfig?.map?.viewSettings?.extent
+      ? this.validateExtent(projection, tempMapFeaturesConfig?.map?.viewSettings?.extent as [number, number, number, number], center)
+      : undefined;
 
     // recreate the prop object to remove unwanted items and check if same as original. Log the modifications
     const validMapFeaturesConfig: TypeMapFeaturesConfig = {
@@ -857,6 +887,7 @@ export class ConfigValidation {
           projection,
           minZoom,
           maxZoom,
+          extent,
         },
         interaction: tempMapFeaturesConfig.map.interaction,
         listOfGeoviewLayerConfig: tempMapFeaturesConfig.map.listOfGeoviewLayerConfig,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -771,7 +771,9 @@ export class WMS extends AbstractGeoViewRaster {
     if (Array.isArray(layerCapabilities?.Style)) {
       let legendStyle;
       if (chosenStyle) {
-        legendStyle = layerCapabilities?.Style[chosenStyle];
+        [legendStyle] = layerCapabilities!.Style.filter((style) => {
+          return style.Name === chosenStyle;
+        });
       } else {
         legendStyle = layerCapabilities?.Style.find((style) => {
           if (layerConfig?.source?.style && !Array.isArray(layerConfig?.source?.style)) return layerConfig.source.style === style.Name;
@@ -844,9 +846,7 @@ export class WMS extends AbstractGeoViewRaster {
    */
   private async getStyleLegend(layerConfig: TypeOgcWmsLayerEntryConfig, position: number): Promise<TypeWmsLegendStyle> {
     const promisedStyleLegend = new Promise<TypeWmsLegendStyle>((resolve) => {
-      let chosenStyle: string | undefined;
-      if (this.WMSStyles[position] === 'default') chosenStyle = undefined;
-      else chosenStyle = this.WMSStyles[position];
+      const chosenStyle: string | undefined = this.WMSStyles[position];
       let styleLegend: TypeWmsLegendStyle;
       this.getLegendImage(layerConfig!, chosenStyle).then((styleLegendImage) => {
         if (!styleLegendImage) {


### PR DESCRIPTION
# Description

Changes to extents are reflected on maps - use of config extents in LLC projections generates warning. Also fixed issue with WMS styles showing incorrect legend image.

Fixes # 643
Fixes # 1218

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added extents to last two maps on basemaps.html (remaining in code), hardcoded changes to basemap default extents.

[__https://damonu2.github.io/geoview/basemaps.html__](https://damonu2.github.io/geoview/basemaps.html)

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1190)
<!-- Reviewable:end -->
