### PR TITLE
feat(popover-component): Popover component to be used for version button in appbar

### DIFF
--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -40,7 +40,8 @@
     "help": "Help",
     "layers": "Layers",
     "share": "Share",
-    "version": "Access GitHub repo"
+    "version": "About GeoView",
+    "repoLink": "Repo link"
   },
   "legend": {
     "unknown": "Unknown Layer Title",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -40,7 +40,8 @@
     "help": "Aide",
     "layers": "Couches",
     "share": "Partager",
-    "version": "Accéder au repo sur GitHub"
+    "version": "À propos de GéoView",
+    "repoLink": "Lien repo"
   },
   "legend": {
     "unknown": "Titre de légende inconnu",

--- a/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
@@ -1,8 +1,12 @@
 import { useState, useRef, useEffect, useCallback, Fragment, useContext, SetStateAction, Dispatch } from 'react';
+import { useTranslation } from 'react-i18next';
+import Typography from '@mui/material/Typography';
 
 import makeStyles from '@mui/styles/makeStyles';
 
-import { List, ListItem, Panel, IconButton } from '../../../ui';
+import { List, ListItem, Panel, IconButton, Popover } from '../../../ui';
+
+import { GITUHUB_REPO, GEO_URL_TEXT } from '../../utils/constant';
 
 import { api } from '../../../app';
 import { EVENT_NAMES } from '../../../api/events/event-types';
@@ -15,6 +19,23 @@ import { TypeButtonPanel } from '../../../ui/panel/panel-types';
 import Export from './buttons/export';
 import Geolocator from './buttons/geolocator';
 import ExportModal from '../export/export-modal';
+
+// eslint-disable-next-line no-underscore-dangle
+declare const __VERSION__: TypeAppVersion;
+
+/**
+ * An object containing version information.
+ *
+ * @export
+ * @interface TypeAppVersion
+ */
+export type TypeAppVersion = {
+  hash: string;
+  major: number;
+  minor: number;
+  patch: number;
+  timestamp: string;
+};
 
 const useStyles = makeStyles((theme) => ({
   appBar: {
@@ -76,9 +97,14 @@ const useStyles = makeStyles((theme) => ({
       width: 20,
     },
   },
-  appBarButtonIcon: {
-    backgroundColor: theme.palette.primary.dark,
-    color: theme.palette.primary.light,
+  versionButtonDiv: {
+    position: 'absolute',
+    bottom: 0,
+  },
+  appBarPopoverContent: {
+    '& a': {
+      color: theme.palette.primary.light,
+    },
   },
   appBarPanels: {},
 }));
@@ -100,6 +126,8 @@ export function Appbar({ setActivetrap }: AppbarProps): JSX.Element {
   const appBar = useRef<HTMLDivElement>(null);
 
   const mapConfig = useContext(MapContext);
+
+  const { t } = useTranslation<string>();
 
   const { mapId } = mapConfig;
   const { mapFeaturesConfig } = api.map(mapId);
@@ -143,6 +171,27 @@ export function Appbar({ setActivetrap }: AppbarProps): JSX.Element {
     },
     [setButtonPanelGroups]
   );
+
+  const getPopoverContent = (): JSX.Element => {
+    return (
+      <Typography component="div" className={classes.appBarPopoverContent}>
+        <Typography component="div">{t('appbar.version')}</Typography>
+        <hr />
+        <Typography component="div">
+          <a href={GEO_URL_TEXT.url} target="_black">
+            {GEO_URL_TEXT.text}
+          </a>
+        </Typography>
+        <Typography component="div">
+          <a href={GITUHUB_REPO} target="_black">
+            {t('appbar.repoLink')}
+          </a>
+        </Typography>
+        <Typography component="div">{`v.${__VERSION__.major}.${__VERSION__.minor}.${__VERSION__.patch}`}</Typography>
+        <Typography component="div">{new Date(__VERSION__.timestamp).toLocaleDateString()}</Typography>
+      </Typography>
+    );
+  };
 
   useEffect(() => {
     // listen to new panel creation
@@ -242,6 +291,13 @@ export function Appbar({ setActivetrap }: AppbarProps): JSX.Element {
             </List>
           </div>
         )}
+        <div className={classes.versionButtonDiv}>
+          <List className={classes.appBarList}>
+            <ListItem>
+              <Popover content={getPopoverContent()} />
+            </ListItem>
+          </List>
+        </div>
       </div>
       {Object.keys(buttonPanelGroups).map((groupName: string) => {
         // get button panels from group

--- a/packages/geoview-core/src/core/types/cgpv-types.ts
+++ b/packages/geoview-core/src/core/types/cgpv-types.ts
@@ -5,7 +5,7 @@ export * from '../components/app-bar/app-bar';
 export * from '../components/app-bar/app-bar-buttons';
 export * from '../components/app-bar/buttons/export';
 export * from '../components/app-bar/buttons/help';
-export * from '../components/app-bar/buttons/version';
+// export * from '../components/app-bar/buttons/version';
 export * from '../components/attribution/attribution';
 export * from '../components/click-marker/click-marker';
 export * from '../components/crosshair/crosshair';

--- a/packages/geoview-core/src/core/utils/constant.ts
+++ b/packages/geoview-core/src/core/utils/constant.ts
@@ -1,2 +1,8 @@
 // Repositry URL for GitHub
 export const GITUHUB_REPO = 'https://github.com/Canadian-Geospatial-Platform/geoview';
+
+// Geo URL
+export const GEO_URL_TEXT = {
+  url: 'https://geo.ca/',
+  text: 'Geo.ca',
+};

--- a/packages/geoview-core/src/ui/index.ts
+++ b/packages/geoview-core/src/ui/index.ts
@@ -17,6 +17,7 @@ export * from './icons';
 export * from './list';
 export * from './modal';
 export * from './panel';
+export * from './popover/popover';
 export * from './select/select';
 export * from './slider/slider';
 export * from './slider/slider-base';

--- a/packages/geoview-core/src/ui/popover/popover.tsx
+++ b/packages/geoview-core/src/ui/popover/popover.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable react/require-default-props */
+import { useState } from 'react';
+import { Popover as MaterialPopover } from '@mui/material';
+import Box from '@mui/material/Box';
+import { IconButton, GitHubIcon } from '..';
+
+/**
+ * Type of Popover position properties
+ */
+type PopoverPositionType = {
+  vertical: 'top' | 'center' | 'bottom';
+  horizontal: 'left' | 'center' | 'right';
+};
+
+/**
+ * Properties for the Popover element
+ */
+interface PopoverProps {
+  content: JSX.Element;
+  className?: string | undefined;
+  anchorOrigin?: PopoverPositionType;
+  transformOrigin?: PopoverPositionType;
+}
+
+/**
+ * Create a customized Material UI Popover
+ *
+ * @param {PopoverProps} props the properties passed to the Popover element
+ * @returns {JSX.Element} the created Popover element
+ */
+export function Popover(props: PopoverProps): JSX.Element {
+  const {
+    content,
+    anchorOrigin = { vertical: 'top', horizontal: 'right' },
+    transformOrigin = { vertical: 'bottom', horizontal: 'left' },
+    className = '',
+  } = props;
+
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popover' : undefined;
+
+  const sxClasses = {
+    p: 7,
+    m: 7,
+    justifyContent: 'center',
+    textAlign: 'center',
+  };
+
+  return (
+    <>
+      <IconButton
+        aria-describedby={id}
+        id="version-button"
+        tooltip="appbar.version"
+        tooltipPlacement="bottom-end"
+        onClick={handleClick}
+        className={`${className} ${open ? 'active' : ''}`}
+      >
+        <GitHubIcon />
+      </IconButton>
+      <MaterialPopover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={anchorOrigin}
+        transformOrigin={transformOrigin}
+      >
+        <Box sx={sxClasses}>{content}</Box>
+      </MaterialPopover>
+    </>
+  );
+}


### PR DESCRIPTION
# Description

We need to have a Popover component to be used in AppBar to show the version of the application and a link to GitHub to know more about project.

The version button will be always in AppBar section.

Fixes #1112 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Open any of the maps in demo site. The version button should be at the bottom of the AppBar and a popover feature should be displayed once we click on version icon. Make sure once the popover is opened, the state of the version icon is active.

https://amir-azma.github.io/geoview/index.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1194)
<!-- Reviewable:end -->
