### PR TITLE
feat(version-appbar): Add version feature as popover in appbar

### DIFF
--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -40,7 +40,8 @@
     "help": "Help",
     "layers": "Layers",
     "share": "Share",
-    "version": "Access GitHub repo"
+    "version": "About GeoView",
+    "repoLink": "Repo link"
   },
   "legend": {
     "unknown": "Unknown Layer Title",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -40,7 +40,8 @@
     "help": "Aide",
     "layers": "Couches",
     "share": "Partager",
-    "version": "Accéder au repo sur GitHub"
+    "version": "À propos de GéoView",
+    "repoLink": "Lien repo"
   },
   "legend": {
     "unknown": "Titre de légende inconnu",

--- a/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
@@ -14,6 +14,7 @@ import { TypeButtonPanel } from '@/ui/panel/panel-types';
 
 import Export from './buttons/export';
 import Geolocator from './buttons/geolocator';
+import Version from './buttons/version';
 import ExportModal from '../export/export-modal';
 
 const useStyles = makeStyles((theme) => ({
@@ -76,9 +77,9 @@ const useStyles = makeStyles((theme) => ({
       width: 20,
     },
   },
-  appBarButtonIcon: {
-    backgroundColor: theme.palette.primary.dark,
-    color: theme.palette.primary.light,
+  versionButtonDiv: {
+    position: 'absolute',
+    bottom: 0,
   },
   appBarPanels: {},
 }));
@@ -242,6 +243,13 @@ export function Appbar({ setActivetrap }: AppbarProps): JSX.Element {
             </List>
           </div>
         )}
+        <div className={classes.versionButtonDiv}>
+          <List className={classes.appBarList}>
+            <ListItem>
+              <Version />
+            </ListItem>
+          </List>
+        </div>
       </div>
       {Object.keys(buttonPanelGroups).map((groupName: string) => {
         // get button panels from group

--- a/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
@@ -1,8 +1,9 @@
-import makeStyles from '@mui/styles/makeStyles';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Typography, Box, Link, Theme } from '@mui/material';
 
-import { GITUHUB_REPO } from '../../../utils/constant';
-
-import { Button, GitHubIcon } from '@/ui';
+import { GITUHUB_REPO, GEO_URL_TEXT } from '@/core/utils/constant';
+import { GitHubIcon, Popover, IconButton } from '@/ui';
 
 // eslint-disable-next-line no-underscore-dangle
 declare const __VERSION__: TypeAppVersion;
@@ -21,61 +22,72 @@ export type TypeAppVersion = {
   timestamp: string;
 };
 
-const useStyles = makeStyles((theme) => {
-  return {
-    github: {
-      textAlign: 'center',
-      lineHeight: theme.typography.subtitle1.lineHeight,
-      '& .cgp-version': {
-        fontWeight: 'bold',
-        display: 'block',
-        fontSize: theme.typography.subtitle1.fontSize,
-      },
-      '& .cgp-timestamp': {
-        fontWeight: 'normal',
-        fontSize: theme.typography.subtitle2.fontSize,
-      },
+export default function Version(): JSX.Element {
+  const { t } = useTranslation<string>();
+
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popover' : undefined;
+
+  const sxClasses = {
+    p: 7,
+    m: 7,
+    justifyContent: 'center',
+    textAlign: 'center',
+    '& a': {
+      color: (theme: Theme) => theme.palette.primary.light,
+      textDecoration: 'underLine',
     },
   };
-});
-
-interface VersionProps {
-  drawerStatus: boolean;
-}
-
-export default function Version(props: VersionProps): JSX.Element {
-  const { drawerStatus } = props;
-
-  const classes = useStyles();
-
-  function getRepo(): void {
-    window.open(GITUHUB_REPO, '_blank');
-  }
-
-  function getVersion(): string {
-    return `v.${__VERSION__.major}.${__VERSION__.minor}.${__VERSION__.patch}`;
-  }
-
-  function getTimestamp(): string {
-    return new Date(__VERSION__.timestamp).toLocaleDateString();
-  }
 
   return (
-    <Button
-      id="version-button"
-      variant="text"
-      tooltip="appbar.version"
-      tooltipPlacement="right"
-      type="textWithIcon"
-      onClick={() => getRepo()}
-      icon={<GitHubIcon />}
-      className=""
-      state={drawerStatus ? 'expanded' : 'collapsed'}
-    >
-      <div className={classes.github}>
-        <span className="cgp-version">{getVersion()}</span>
-        <span className="cgp-timestamp">{getTimestamp()}</span>
-      </div>
-    </Button>
+    <>
+      <IconButton
+        aria-describedby={id}
+        id="version-button"
+        tooltip="appbar.version"
+        tooltipPlacement="bottom-end"
+        onClick={handleClick}
+        className={open ? 'active' : ''}
+      >
+        <GitHubIcon />
+      </IconButton>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      >
+        <Box sx={sxClasses}>
+          <Typography component="div">
+            <Typography component="div">{t('appbar.version')}</Typography>
+            <hr />
+            <Typography component="div">
+              <Link rel="noopener" href={GEO_URL_TEXT.url} target="_black">
+                {GEO_URL_TEXT.text}
+              </Link>
+            </Typography>
+            <Typography component="div">
+              <Link rel="noopener" href={GITUHUB_REPO} target="_black">
+                {t('appbar.repoLink')}
+              </Link>
+            </Typography>
+            <Typography component="div">{`v.${__VERSION__.major}.${__VERSION__.minor}.${__VERSION__.patch}`}</Typography>
+            <Typography component="div">{new Date(__VERSION__.timestamp).toLocaleDateString()}</Typography>
+          </Typography>
+        </Box>
+      </Popover>
+    </>
   );
 }

--- a/packages/geoview-core/src/core/utils/constant.ts
+++ b/packages/geoview-core/src/core/utils/constant.ts
@@ -1,2 +1,8 @@
 // Repositry URL for GitHub
 export const GITUHUB_REPO = 'https://github.com/Canadian-Geospatial-Platform/geoview';
+
+// Geo URL
+export const GEO_URL_TEXT = {
+  url: 'https://geo.ca/',
+  text: 'Geo.ca',
+};

--- a/packages/geoview-core/src/ui/index.ts
+++ b/packages/geoview-core/src/ui/index.ts
@@ -17,6 +17,7 @@ export * from './icons';
 export * from './list';
 export * from './modal';
 export * from './panel';
+export * from './popover/popover';
 export * from './select/select';
 export * from './slider/slider';
 export * from './slider/slider-base';

--- a/packages/geoview-core/src/ui/popover/popover.tsx
+++ b/packages/geoview-core/src/ui/popover/popover.tsx
@@ -1,0 +1,11 @@
+import { Popover as PopoverElement, PopoverProps } from '@mui/material';
+
+/**
+ * Create a popover component
+ *
+ * @param {PopoverProps} props popover properties
+ * @returns {JSX.Element} returns popover component
+ */
+export function Popover(props: PopoverProps): JSX.Element {
+  return <PopoverElement {...props} />;
+}


### PR DESCRIPTION
# Description

We need to have a Popover component to be used in AppBar to show the version of the application and a link to GitHub to know more about project.

The version button will be always in AppBar section.

Fixes #1112 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Open any of the maps in demo site. The version button should be at the bottom of the AppBar and a popover feature should be displayed once we click on version icon. Make sure once the popover is opened, the state of the version icon is active.

https://amir-azma.github.io/geoview/index.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1197)
<!-- Reviewable:end -->
