### PR TITLE
refactor(unregister-event): Refactor useEffect for unregister event

### DIFF
--- a/packages/geoview-details-panel/src/details-item.tsx
+++ b/packages/geoview-details-panel/src/details-item.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/require-default-props */
 import type React from 'react';
+import { PayloadBaseClass } from 'geoview-core/src/api/events/payloads';
 import {
   TypeWindow,
   payloadIsAMapMouseEvent,
@@ -35,52 +36,48 @@ export function DetailsItem({ mapId, buttonId }: Props): JSX.Element {
 
   const panel = api.map(mapId).appBarButtons.getAppBarButtonPanelById(buttonId === undefined ? '' : buttonId)?.panel;
 
+  const allQueriesDoneListenerFunction = (payload: PayloadBaseClass) => {
+    if (payloadIsAllQueriesDone(payload)) {
+      const { resultSets } = payload;
+      const newDetails: TypeArrayOfLayerData = [];
+      Object.keys(resultSets).forEach((layerPath) => {
+        const layerName = getLocalizedValue(api.map(mapId).layer.registeredLayers[layerPath].layerName, mapId)!;
+        const features = resultSets[layerPath]!.data;
+        if (features.length > 0) {
+          newDetails.push({ layerPath, layerName, features });
+        }
+      });
+      if (newDetails.length > 0) {
+        setDetails(newDetails);
+        // open the details panel
+        panel?.open();
+      } else {
+        setDetails([]);
+      }
+    } else {
+      setDetails([]);
+    }
+  };
+
+  const eventMapSingleClickListenerFunction = (payload: PayloadBaseClass) => {
+    if (payloadIsAMapMouseEvent(payload)) {
+      const { coordinates } = payload;
+      setHandlerName(payload.handlerName);
+      setLngLat(coordinates.lnglat);
+    } else {
+      setLngLat([]);
+    }
+  };
+
   useEffect(() => {
     // create the listener to return the details
-    api.event.on(
-      api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      (payload) => {
-        if (payloadIsAllQueriesDone(payload)) {
-          const { resultSets } = payload;
-          const newDetails: TypeArrayOfLayerData = [];
-          Object.keys(resultSets).forEach((layerPath) => {
-            const layerName = getLocalizedValue(api.map(mapId).layer.registeredLayers[layerPath].layerName, mapId)!;
-            const features = resultSets[layerPath]!.data;
-            if (features.length > 0) {
-              newDetails.push({ layerPath, layerName, features });
-            }
-          });
-          if (newDetails.length > 0) {
-            setDetails(newDetails);
-            // open the details panel
-            panel?.open();
-          } else {
-            setDetails([]);
-          }
-        } else {
-          setDetails([]);
-        }
-      },
-      `${mapId}/$FeatureInfoLayerSet$`
-    );
+    api.event.on(api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE, allQueriesDoneListenerFunction, `${mapId}/$FeatureInfoLayerSet$`);
     // get click info.
-    api.event.on(
-      api.eventNames.MAP.EVENT_MAP_SINGLE_CLICK,
-      (payload) => {
-        if (payloadIsAMapMouseEvent(payload)) {
-          const { coordinates } = payload;
-          setHandlerName(payload.handlerName);
-          setLngLat(coordinates.lnglat);
-        } else {
-          setLngLat([]);
-        }
-      },
-      mapId
-    );
+    api.event.on(api.eventNames.MAP.EVENT_MAP_SINGLE_CLICK, eventMapSingleClickListenerFunction, mapId);
 
     return () => {
-      api.event.off(api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE, mapId);
-      api.event.off(api.eventNames.MAP.EVENT_MAP_SINGLE_CLICK, mapId);
+      api.event.off(api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE, mapId, allQueriesDoneListenerFunction);
+      api.event.off(api.eventNames.MAP.EVENT_MAP_SINGLE_CLICK, mapId, eventMapSingleClickListenerFunction);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/geoview-footer-panel/src/details-item.tsx
+++ b/packages/geoview-footer-panel/src/details-item.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/require-default-props */
 import type React from 'react';
+import { PayloadBaseClass } from 'geoview-core/src/api/events/payloads';
 import {
   TypeWindow,
   payloadIsAMapMouseEvent,
@@ -32,48 +33,44 @@ export function DetailsItem({ mapId }: Props): JSX.Element {
   const [lngLat, setLngLat] = useState<Coordinate>([]);
   const [handlerName, setHandlerName] = useState<string | null>(null);
 
+  const allQueriesDoneListenerFunction = (payload: PayloadBaseClass) => {
+    if (payloadIsAllQueriesDone(payload)) {
+      const { resultSets } = payload;
+      const newDetails: TypeArrayOfLayerData = [];
+      Object.keys(resultSets).forEach((layerPath) => {
+        const layerName = getLocalizedValue(api.map(mapId).layer.registeredLayers[layerPath].layerName, mapId)!;
+        const features = resultSets[layerPath]!.data;
+        if (features.length > 0) {
+          newDetails.push({ layerPath, layerName, features });
+        }
+      });
+      if (newDetails.length > 0) {
+        setDetails(newDetails);
+      } else {
+        setDetails([]);
+      }
+    } else {
+      setDetails([]);
+    }
+  };
+
+  const eventMapSingleClickListenerFunction = (payload: PayloadBaseClass) => {
+    if (payloadIsAMapMouseEvent(payload)) {
+      const { coordinates } = payload;
+      setHandlerName(payload.handlerName);
+      setLngLat(coordinates.lnglat);
+    } else {
+      setLngLat([]);
+    }
+  };
+
   useEffect(() => {
     // create the listener to return the details
-    api.event.on(
-      api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      (payload) => {
-        if (payloadIsAllQueriesDone(payload)) {
-          const { resultSets } = payload;
-          const newDetails: TypeArrayOfLayerData = [];
-          Object.keys(resultSets).forEach((layerPath) => {
-            const layerName = getLocalizedValue(api.map(mapId).layer.registeredLayers[layerPath].layerName, mapId)!;
-            const features = resultSets[layerPath]!.data;
-            if (features.length > 0) {
-              newDetails.push({ layerPath, layerName, features });
-            }
-          });
-          if (newDetails.length > 0) {
-            setDetails(newDetails);
-          } else {
-            setDetails([]);
-          }
-        } else {
-          setDetails([]);
-        }
-      },
-      `${mapId}/$FeatureInfoLayerSet$`
-    );
-    api.event.on(
-      api.eventNames.MAP.EVENT_MAP_SINGLE_CLICK,
-      (payload) => {
-        if (payloadIsAMapMouseEvent(payload)) {
-          const { coordinates } = payload;
-          setHandlerName(payload.handlerName);
-          setLngLat(coordinates.lnglat);
-        } else {
-          setLngLat([]);
-        }
-      },
-      mapId
-    );
+    api.event.on(api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE, allQueriesDoneListenerFunction, `${mapId}/$FeatureInfoLayerSet$`);
+    api.event.on(api.eventNames.MAP.EVENT_MAP_SINGLE_CLICK, eventMapSingleClickListenerFunction, mapId);
     return () => {
-      api.event.off(api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE, mapId);
-      api.event.off(api.eventNames.MAP.EVENT_MAP_SINGLE_CLICK, mapId);
+      api.event.off(api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE, mapId, allQueriesDoneListenerFunction);
+      api.event.off(api.eventNames.MAP.EVENT_MAP_SINGLE_CLICK, mapId, eventMapSingleClickListenerFunction);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/geoview-layers-panel/src/layer-stepper.tsx
+++ b/packages/geoview-layers-panel/src/layer-stepper.tsx
@@ -10,6 +10,8 @@ import {
   ButtonPropsLayerPanel,
   TypeListOfLayerEntryConfig,
   TypeJsonObject,
+  PayloadBaseClass,
+  payloadIsASnackbarMessage,
 } from 'geoview-core';
 
 type Event = { target: { value: string } };
@@ -142,20 +144,18 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
     },
   };
 
+  const snackbarEventOpenListenerFunction = (payload: PayloadBaseClass) => {
+    if (payloadIsASnackbarMessage(payload)) {
+      if (payload.message && payload.message.value === 'validation.layer.loadfailed') {
+        setIsLoading(false);
+      }
+    }
+  };
+
   useEffect(() => {
-    api.event.on(
-      api.eventNames.SNACKBAR.EVENT_SNACKBAR_OPEN,
-      (payload) => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        if (payload.message && payload.message.value === 'validation.layer.loadfailed') {
-          setIsLoading(false);
-        }
-      },
-      mapId
-    );
+    api.event.on(api.eventNames.SNACKBAR.EVENT_SNACKBAR_OPEN, snackbarEventOpenListenerFunction, mapId);
     return () => {
-      api.event.off(api.eventNames.SNACKBAR.EVENT_SNACKBAR_OPEN, mapId);
+      api.event.off(api.eventNames.SNACKBAR.EVENT_SNACKBAR_OPEN, mapId, snackbarEventOpenListenerFunction);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/geoview-layers-panel/src/panel-content.tsx
+++ b/packages/geoview-layers-panel/src/panel-content.tsx
@@ -112,6 +112,8 @@ function PanelContent(props: TypePanelContentProps): JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const updateLayersListenerFunction = () => updateLayers();
+
   useEffect(() => {
     api.event.on(
       api.eventNames.MAP.EVENT_MAP_LOADED,
@@ -148,7 +150,7 @@ function PanelContent(props: TypePanelContentProps): JSX.Element {
     //   mapId
     // );
     return () => {
-      api.event.off(api.eventNames.MAP.EVENT_MAP_LOADED, mapId);
+      api.event.off(api.eventNames.MAP.EVENT_MAP_LOADED, mapId, updateLayersListenerFunction);
       api.event.off(api.eventNames.LAYER.EVENT_ADD_LAYER, mapId);
       api.event.off(api.eventNames.LAYER.EVENT_REMOVE_LAYER, mapId);
     };
@@ -161,16 +163,11 @@ function PanelContent(props: TypePanelContentProps): JSX.Element {
   }, [mapLayers]);
 
   useEffect(() => {
-    api.event.on(
-      api.eventNames.PANEL.EVENT_PANEL_CLOSE,
-      () => {
-        setAddLayerVisible(false);
-      },
-      `${mapId}/${buttonPanel.buttonPanelId}`
-    );
+    const setAddLayerVisibleListenerFunction = () => setAddLayerVisible(false);
 
+    api.event.on(api.eventNames.PANEL.EVENT_PANEL_CLOSE, setAddLayerVisibleListenerFunction, `${mapId}/${buttonPanel.buttonPanelId}`);
     return () => {
-      api.event.off(api.eventNames.PANEL.EVENT_PANEL_CLOSE, `${mapId}/${buttonPanel.buttonPanelId}`);
+      api.event.off(api.eventNames.PANEL.EVENT_PANEL_CLOSE, `${mapId}/${buttonPanel.buttonPanelId}`, setAddLayerVisibleListenerFunction);
     };
   }, [api, buttonPanel.buttonPanelId, mapId]);
 


### PR DESCRIPTION
# Description

Some GeoView events are listening to the same event name and use a different handler function to react to the event. When we create events, we must keep a reference to the handler function so that when we want to unregister the listener, we can provide the handler to make sure we deactivate only the targeted listener because if we don't do that, all handlers will be deactivated.

Fixes #1076 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

https://amir-azma.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1221)
<!-- Reviewable:end -->
