### PR TITLE
fix/refactor(legend): legend fixes

### DIFF
--- a/packages/geoview-core/src/core/components/legend/legend-icon-list.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-icon-list.tsx
@@ -50,8 +50,36 @@ export function LegendIconList(props: TypeLegendIconListProps): JSX.Element {
 
   const allChecked = iconImages.map(() => true);
   const allUnChecked = iconImages.map(() => false);
-  const [isChecked, setChecked] = useState<boolean[]>(isParentVisible === true ? allChecked : allUnChecked);
-  const [checkedCount, setCheckCount] = useState<number>(isParentVisible === true ? iconImages.length : 0);
+  const initialChecked = isParentVisible ? allChecked : allUnChecked;
+
+  // set initial visibility of layers according to metadata
+  if (layerConfig && layerConfig.style !== undefined && geometryKey) {
+    const itemStyle = layerConfig.style[geometryKey];
+    if (itemStyle && itemStyle.styleType === 'uniqueValue' && (itemStyle as TypeUniqueValueStyleConfig).uniqueValueStyleInfo) {
+      const uniqueItemStyles = (itemStyle as TypeUniqueValueStyleConfig).uniqueValueStyleInfo;
+      for (let i = 0; i < uniqueItemStyles.length; i++) {
+        if (
+          uniqueItemStyles[i].visible === 'no' ||
+          ((itemStyle as TypeUniqueValueStyleConfig).defaultVisible === 'no' && uniqueItemStyles[i].visible !== 'always')
+        ) {
+          initialChecked[iconLabels.indexOf(uniqueItemStyles[i].label)] = false;
+        }
+      }
+    } else if (itemStyle && itemStyle.styleType === 'classBreaks' && (itemStyle as TypeClassBreakStyleConfig).classBreakStyleInfo) {
+      const classbreakItemStyles = (itemStyle as TypeClassBreakStyleConfig).classBreakStyleInfo;
+      for (let i = 0; i < classbreakItemStyles.length; i++) {
+        if (
+          classbreakItemStyles[i].visible === 'no' ||
+          ((itemStyle as TypeClassBreakStyleConfig).defaultVisible === 'no' && classbreakItemStyles[i].visible !== 'always')
+        ) {
+          initialChecked[iconLabels.indexOf(classbreakItemStyles[i].label)] = false;
+        }
+      }
+    }
+  }
+
+  const [isChecked, setChecked] = useState<boolean[]>(initialChecked);
+  const [checkedCount, setCheckCount] = useState<number>(isParentVisible ? iconImages.length : 0);
   const [initParentVisible, setInitParentVisible] = useState(isParentVisible);
 
   /**

--- a/packages/geoview-core/src/core/components/legend/legend-item.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-item.tsx
@@ -180,7 +180,9 @@ export function LegendItem(props: TypeLegendItemProps): JSX.Element {
   const canCluster = !!api.maps[mapId].layer.registeredLayers[unclusterLayerPath];
 
   const [isClusterToggleEnabled, setIsClusterToggleEnabled] = useState(false);
-  const [isChecked, setChecked] = useState(true);
+  const [isChecked, setChecked] = useState<boolean>(
+    api.map(mapId).layer.registeredLayers[clusterLayerPath]?.initialSettings?.visible !== false
+  );
   const [isOpacityOpen, setOpacityOpen] = useState(false);
   const [isGroupOpen, setGroupOpen] = useState(true);
   const [isLegendOpen, setLegendOpen] = useState(true);
@@ -351,7 +353,6 @@ export function LegendItem(props: TypeLegendItemProps): JSX.Element {
     if (hideAll !== undefined) setChecked(!hideAll);
   }, [hideAll]);
 
-  // TODO ! Revise this useEffect because it prevent the visibility flag of the config to work properly.
   useEffect(() => {
     if (layerConfigEntry) {
       if (isParentVisible && isChecked) {

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -380,11 +380,11 @@ export class Layer {
   /**
    * Remove a geoview layer from the map
    *
-   * @param {TypeGeoviewLayerConfig} layer the layer configuration to remove
+   * @param {TypeGeoviewLayerConfig} geoviewLayer the layer configuration to remove
    */
   removeGeoviewLayer = (geoviewLayer: AbstractGeoViewLayer): string => {
-    api.event.emit(GeoViewLayerPayload.createRemoveGeoviewLayerPayload(this.mapId, geoviewLayer));
     this.layerOrder.splice(indexOf(api.map(this.mapId).layer.layerOrder, geoviewLayer.geoviewLayerId), 1);
+    api.event.emit(GeoViewLayerPayload.createRemoveGeoviewLayerPayload(this.mapId, geoviewLayer));
 
     return geoviewLayer.geoviewLayerId;
   };
@@ -392,7 +392,7 @@ export class Layer {
   /**
    * Search for a layer using it's id and return the layer data
    *
-   * @param {string} id the layer id to look for
+   * @param {string} geoviewLayerId the layer id to look for
    * @returns the found layer data object
    */
   getGeoviewLayerById = (geoviewLayerId: string): AbstractGeoViewLayer | null => {

--- a/packages/geoview-core/src/geo/utils/layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/layer-set.ts
@@ -74,10 +74,10 @@ export class LayerSet {
                 layerStatus: 'newInstance',
                 layerName: api.map(this.mapId).layer.registeredLayers[layerPath].layerName,
               };
-              api.event.emit(LayerSetPayload.createLayerSetUpdatedPayload(`${this.layerSetId}/${layerPath}`, this.resultSets, layerPath));
+              api.event.emit(LayerSetPayload.createLayerSetUpdatedPayload(`${this.mapId}/$LegendsLayerSet$`, this.resultSets, layerPath));
             } else if (action === 'remove' && layerPath in this.resultSets) {
               delete this.resultSets[layerPath];
-              api.event.emit(LayerSetPayload.createLayerSetUpdatedPayload(`${this.layerSetId}/${layerPath}`, this.resultSets, layerPath));
+              api.event.emit(LayerSetPayload.createLayerSetUpdatedPayload(`${this.mapId}/$LegendsLayerSet$`, this.resultSets, layerPath));
             }
           }
         }

--- a/packages/geoview-footer-panel/src/data-item.tsx
+++ b/packages/geoview-footer-panel/src/data-item.tsx
@@ -20,10 +20,19 @@ export function DataItem({ mapId }: Props): JSX.Element {
   // eslint-disable-next-line @typescript-eslint/ban-types
   const [dataLayers, setDataLayers] = useState<string[]>([]);
 
+  const updateLayers = () => {
+    if (api.map(mapId).layer?.layerOrder !== undefined) setDataLayers([...api.map(mapId).layer.layerOrder].reverse());
+  };
+
   useEffect(() => {
-    setDataLayers(Object.keys(api.map(mapId!).layer.geoviewLayers));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [api, mapId]);
+    api.event.on(api.eventNames.MAP.EVENT_MAP_LOADED, updateLayers, mapId);
+    api.event.on(api.eventNames.LAYER_SET.UPDATED, updateLayers, `${mapId}/$LegendsLayerSet$`);
+
+    return () => {
+      api.event.off(api.eventNames.MAP.EVENT_MAP_LOADED, mapId, updateLayers);
+      api.event.off(api.eventNames.LAYER_SET.UPDATED, mapId, updateLayers);
+    };
+  });
 
   setTimeout(() => {
     dataLayers.forEach((layerId) => {


### PR DESCRIPTION
Closes #1104
Closes #1242
Closes #1067
Fixes multiple legend issues:
legend layer set now updates properly
legend add/remove functions utilize layer sets
visibility of layers and sublayers is not overridden by legend

# Description

Fixed the legend layer set to update when changes are made to layers, and updated the add/remove layer functions to utilize layer sets. Visibility of layers and sublayers now initially set by config and/or style settings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested primarily with the footer-panel page, where various settings are used to control initial visibility. Also tested in layers-panel with add/remove layers.

https://damonu2.github.io/geoview/package-footer-panel.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1243)
<!-- Reviewable:end -->
