### PR TITLE
simplify how we import icons

### DIFF
--- a/packages/geoview-core/src/ui/icons/index.ts
+++ b/packages/geoview-core/src/ui/icons/index.ts
@@ -1,56 +1,9 @@
-import Layers from '@mui/icons-material/Layers';
-import GitHub from '@mui/icons-material/GitHub';
-import ChevronLeft from '@mui/icons-material/ChevronLeft';
-import ChevronRight from '@mui/icons-material/ChevronRight';
-import Fullscreen from '@mui/icons-material/Fullscreen';
-import FullscreenExit from '@mui/icons-material/FullscreenExit';
-import Home from '@mui/icons-material/Home';
-import Add from '@mui/icons-material/Add';
-import Remove from '@mui/icons-material/Remove';
-import Close from '@mui/icons-material/Close';
-import Details from '@mui/icons-material/Details';
-import LayersOutlined from '@mui/icons-material/LayersOutlined';
-import Map from '@mui/icons-material/Map';
-import OpenInBrowser from '@mui/icons-material/OpenInBrowser';
-import Apps from '@mui/icons-material/Apps';
-import Group from '@mui/icons-material/Group';
-import ArrowBack from '@mui/icons-material/ArrowBack';
-import Expand from '@mui/icons-material/KeyboardDoubleArrowDown';
-import Collapse from '@mui/icons-material/KeyboardDoubleArrowUp';
-import Check from '@mui/icons-material/CheckCircle';
-import ArrowUp from '@mui/icons-material/ArrowUpward';
-import ExpandMore from '@mui/icons-material/ExpandMore';
-import ExpandLess from '@mui/icons-material/ExpandLess';
-import WhereToVoteIcon from '@mui/icons-material/WhereToVote';
-import LiveHelp from '@mui/icons-material/LiveHelp';
-import ListAlt from '@mui/icons-material/ListAlt';
-import Visibility from '@mui/icons-material/Visibility';
-import VisibilityOff from '@mui/icons-material/VisibilityOff';
-import MoreVert from '@mui/icons-material/MoreVert';
-import { ArrowDropDown, ArrowRight, ArrowLeft } from '@mui/icons-material';
-import DragHandle from '@mui/icons-material/DragHandle';
-import Opacity from '@mui/icons-material/Opacity';
-import Menu from '@mui/icons-material/Menu';
-import ImportExport from '@mui/icons-material/ImportExport';
-import DownloadIcon from '@mui/icons-material/Download';
-import CheckBoxIcon from '@mui/icons-material/CheckBox';
-import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
-import ZoomInSearchIcon from '@mui/icons-material/ZoomIn';
-import ZoomOutSearchIcon from '@mui/icons-material/ZoomOut';
-import SearchIcon from '@mui/icons-material/Search';
-import FileUploadIcon from '@mui/icons-material/FileUpload';
-import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
-import BrowserNotSupportedIcon from '@mui/icons-material/BrowserNotSupported';
-import EmojiPeopleIcon from '@mui/icons-material/EmojiPeople';
-import RadioButtonCheckedIcon from '@mui/icons-material/RadioButtonChecked';
-import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
-import NotificationsIcon from '@mui/icons-material/Notifications';
-import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
-import ErrorIcon from '@mui/icons-material/Error';
-import WarningIcon from '@mui/icons-material/Warning';
-import InfoIcon from '@mui/icons-material/Info';
-
 export {
+  GroupWork as GroupWorkIcon,
+  KeyboardArrowDown as KeyboardArrowDownIcon,
+  KeyboardArrowUp as KeyboardArrowUpIcon,
+  KeyboardArrowRight as KeyboardArrowRightIcon,
+  KeyboardArrowLeft as KeyboardArrowLeftIcon,
   Layers as LayersIcon,
   GitHub as GitHubIcon,
   ChevronLeft as ChevronLeftIcon,
@@ -70,12 +23,12 @@ export {
   Group as GroupIcon,
   ArrowBack as ArrowBackIcon,
   Expand as ExpandIcon,
-  Collapse as CollapseIcon,
+  KeyboardDoubleArrowUp as CollapseIcon,
   Check as CheckIcon,
-  ArrowUp as ArrowUpIcon,
+  ArrowUpward as ArrowUpIcon,
   ExpandMore as ExpandMoreIcon,
   ExpandLess as ExpandLessIcon,
-  WhereToVoteIcon as ClickMapMarker,
+  WhereToVote as ClickMapMarker,
   LiveHelp as TodoIcon,
   ListAlt as ListAltIcon,
   Visibility as VisibilityIcon,
@@ -88,22 +41,22 @@ export {
   Opacity as OpacityIcon,
   Menu as MenuIcon,
   ImportExport as ReorderIcon,
-  DownloadIcon,
-  CheckBoxIcon,
-  CheckBoxOutlineBlankIcon as CheckBoxOutIcon,
-  ZoomInSearchIcon,
-  ZoomOutSearchIcon,
-  SearchIcon,
-  FileUploadIcon,
-  MoreHorizIcon,
-  BrowserNotSupportedIcon,
-  EmojiPeopleIcon,
-  RadioButtonCheckedIcon,
-  RadioButtonUncheckedIcon,
-  NotificationsIcon,
-  NotificationsActiveIcon,
-  ErrorIcon,
+  Download as DownloadIcon,
+  CheckBox as CheckBoxIcon,
+  CheckBoxOutlineBlank as CheckBoxOutIcon,
+  ZoomIn as ZoomInSearchIcon,
+  ZoomOut as ZoomOutSearchIcon,
+  Search as SearchIcon,
+  FileUpload as FileUploadIcon,
+  MoreHoriz as MoreHorizIcon,
+  BrowserNotSupported as BrowserNotSupportedIcon,
+  EmojiPeople as EmojiPeopleIcon,
+  RadioButtonChecked as RadioButtonCheckedIcon,
+  RadioButtonUnchecked as RadioButtonUncheckedIcon,
+  Notifications as NotificationsIcon,
+  NotificationsActive as NotificationsActiveIcon,
+  Error as ErrorIcon,
   Check as CheckCircleIcon,
-  WarningIcon,
-  InfoIcon,
-};
+  Warning as WarningIcon,
+  Info as InfoIcon,
+} from '@mui/icons-material';


### PR DESCRIPTION
# Description

Closes #1245 

This code change simplifies how we import icons.
It uses `export {...} from '@mui/icons-material';`

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

https://cphelefu.github.io/geoview/

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1246)
<!-- Reviewable:end -->
