### PR TITLE
BUG-reloadMap-trigger-twice-event-add-layer

### DIFF
--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -10,7 +10,13 @@ import { EVENT_NAMES } from '@/api/events/event-types';
 
 import { Config } from '@/core/utils/config/config';
 import { generateId, showError, replaceParams } from '@/core/utils/utilities';
-import { layerConfigPayload, payloadIsALayerConfig, GeoViewLayerPayload, payloadIsRemoveGeoViewLayer } from '@/api/events/payloads';
+import {
+  layerConfigPayload,
+  payloadIsALayerConfig,
+  GeoViewLayerPayload,
+  payloadIsRemoveGeoViewLayer,
+  PayloadBaseClass,
+} from '@/api/events/payloads';
 import { AbstractGeoViewLayer } from './geoview-layers/abstract-geoview-layers';
 import {
   TypeBaseLayerEntryConfig,
@@ -30,6 +36,11 @@ import { layerConfigIsWFS, WFS } from './geoview-layers/vector/wfs';
 import { layerConfigIsOgcFeature, OgcFeature } from './geoview-layers/vector/ogc-feature';
 import { layerConfigIsXYZTiles, XYZTiles } from './geoview-layers/raster/xyz-tiles';
 import { layerConfigIsVectorTiles, VectorTiles } from './geoview-layers/raster/vector-tiles';
+
+type TypeEventHandlerFunctions = {
+  addLayer: (payload: PayloadBaseClass) => void;
+  removeLayer: (payload: PayloadBaseClass) => void;
+};
 
 /**
  * A class to get the layer from layer type. Layer type can be esriFeature, esriDynamic and ogcWMS
@@ -53,6 +64,9 @@ export class Layer {
   /** used to reference the map id */
   private mapId: string;
 
+  /** used to keep a reference the Layer's event handler functions */
+  private eventHandlerFunctions: TypeEventHandlerFunctions;
+
   /**
    * Initialize layer types and listen to add/remove layer events from outside
    *
@@ -63,10 +77,8 @@ export class Layer {
 
     this.vector = new Vector(this.mapId);
 
-    // listen to outside events to add layers
-    api.event.on(
-      EVENT_NAMES.LAYER.EVENT_ADD_LAYER,
-      (payload) => {
+    this.eventHandlerFunctions = {
+      addLayer: (payload: PayloadBaseClass) => {
         if (payloadIsALayerConfig(payload)) {
           const { layerConfig } = payload;
 
@@ -132,49 +144,51 @@ export class Layer {
           }
         }
       },
-      this.mapId
-    );
-
-    // listen to outside events to remove layers
-    api.event.on(
-      EVENT_NAMES.LAYER.EVENT_REMOVE_LAYER,
-      (payload) => {
+      removeLayer: (payload: PayloadBaseClass) => {
         if (payloadIsRemoveGeoViewLayer(payload)) {
           // remove layer from outside
           this.removeLayersUsingPath(payload.geoviewLayer!.geoviewLayerId);
         }
       },
-      this.mapId
-    );
+    };
+
+    // listen to outside events to add layers
+    api.event.on(EVENT_NAMES.LAYER.EVENT_ADD_LAYER, this.eventHandlerFunctions.addLayer, this.mapId);
+
+    // listen to outside events to remove layers
+    api.event.on(EVENT_NAMES.LAYER.EVENT_REMOVE_LAYER, this.eventHandlerFunctions.removeLayer, this.mapId);
+  }
+
+  /**
+   * Delete the event handler functions associated to the Layer instance.
+   */
+  deleteEventHandlerFunctionsOfThisLayerInstance() {
+    api.event.off(EVENT_NAMES.LAYER.EVENT_ADD_LAYER, this.mapId, this.eventHandlerFunctions!.addLayer);
+    api.event.off(EVENT_NAMES.LAYER.EVENT_REMOVE_LAYER, this.mapId, this.eventHandlerFunctions.removeLayer);
   }
 
   /**
    * Load layers that was passed in with the map config
    *
-   * @param {TypeGeoviewLayerConfig[]} layersConfig an optional array containing layers passed within the map config
+   * @param {TypeGeoviewLayerConfig[]} geoviewLayerConfigs an optional array containing layers passed within the map config
    */
   loadListOfGeoviewLayer(geoviewLayerConfigs?: TypeGeoviewLayerConfig[]) {
     const validGeoviewLayerConfigs = this.deleteDuplicatGeoviewLayerConfig(geoviewLayerConfigs);
 
     // set order for layers to appear on the map according to config
     this.layerOrder = [];
-    validGeoviewLayerConfigs.forEach((layer) => {
-      if (layer.geoviewLayerId) {
+    validGeoviewLayerConfigs.forEach((geoviewLayerConfig) => {
+      if (geoviewLayerConfig.geoviewLayerId) {
         // layer order reversed so highest index is top layer
-        this.layerOrder.unshift(layer.geoviewLayerId);
+        this.layerOrder.unshift(geoviewLayerConfig.geoviewLayerId);
         // layers without id uses sublayer ids
-      } else if (layer.listOfLayerEntryConfig !== undefined) {
-        layer.listOfLayerEntryConfig.forEach((subLayer) => {
+      } else if (geoviewLayerConfig.listOfLayerEntryConfig !== undefined) {
+        geoviewLayerConfig.listOfLayerEntryConfig.forEach((subLayer) => {
           if (subLayer.layerId) this.layerOrder.unshift(subLayer.layerId);
         });
       }
+      api.event.emit(layerConfigPayload(EVENT_NAMES.LAYER.EVENT_ADD_LAYER, this.mapId, geoviewLayerConfig));
     });
-
-    if (validGeoviewLayerConfigs.length > 0) {
-      validGeoviewLayerConfigs.forEach((geoviewLayerConfig) =>
-        api.event.emit(layerConfigPayload(EVENT_NAMES.LAYER.EVENT_ADD_LAYER, this.mapId, geoviewLayerConfig))
-      );
-    }
   }
 
   /**
@@ -381,6 +395,17 @@ export class Layer {
     api.event.emit(GeoViewLayerPayload.createRemoveGeoviewLayerPayload(this.mapId, geoviewLayer));
 
     return geoviewLayer.geoviewLayerId;
+  };
+
+  /**
+   * Remove all geoview layers from the map
+   */
+  removeAllGeoviewLayers = () => {
+    Object.keys(this.geoviewLayers).forEach((geoviewLayerId: string) => {
+      this.removeGeoviewLayer(this.geoviewLayers[geoviewLayerId]);
+    });
+
+    return this.mapId;
   };
 
   /**

--- a/packages/geoview-core/src/geo/map/map.ts
+++ b/packages/geoview-core/src/geo/map/map.ts
@@ -413,8 +413,30 @@ export class MapViewer {
       updatedMapConfig.map.listOfGeoviewLayerConfig = listOfGeoviewLayerConfig;
     }
 
-    // emit an event to reload the map to change the language
-    api.event.emit(mapConfigPayload(EVENT_NAMES.MAP.EVENT_MAP_RELOAD, 'all', updatedMapConfig));
+    // reload the map to change the language
+    this.reloadMap(updatedMapConfig);
+  };
+
+  /**
+   * Reload map from config
+   *
+   * @param {TypeMapFeaturesConfig} mapFeaturesConfig a new config passed in from the function call
+   */
+  reloadMap = async (mapFeaturesConfig: TypeMapFeaturesConfig) => {
+    const map = api.maps[this.mapId];
+    // remove geoview layers from map
+    map.layer.removeAllGeoviewLayers();
+
+    // unload all loaded plugins on the map
+    api.plugin.removePlugins(this.mapId);
+    api.plugin.pluginsLoaded = false;
+
+    map.layer.deleteEventHandlerFunctionsOfThisLayerInstance();
+
+    map.mapFeaturesConfig = mapFeaturesConfig;
+
+    // emit an event to reload the map with the new config
+    api.event.emit(mapConfigPayload(EVENT_NAMES.MAP.EVENT_MAP_RELOAD, 'all', mapFeaturesConfig));
   };
 
   /**
@@ -423,7 +445,7 @@ export class MapViewer {
    * @param {string} mapConfig a new config passed in from the function call
    */
   loadMapConfig = (mapConfig: string) => {
-    const targetDiv = this.map.getTargetElement().parentElement!.parentElement!.parentElement;
+    const targetDiv = document.getElementById(this.mapId);
 
     const configObjString = removeCommentsFromJSON(mapConfig);
     const parsedMapConfig = parseJSONConfig(configObjString);
@@ -436,8 +458,8 @@ export class MapViewer {
       configObj!.displayLanguage = this.displayLanguage;
     }
 
-    // emit an event to reload the map with the new config
-    api.event.emit(mapConfigPayload(EVENT_NAMES.MAP.EVENT_MAP_RELOAD, 'all', configObj!));
+    // reload the map with the new config
+    this.reloadMap(configObj!);
   };
 
   /**


### PR DESCRIPTION
# Description

When we call the reloadMap function of the MapViewer class defined in map.ts, we have a duplicate layer error caused by a double call to the EVENT_ADD_LAYER handler function. We need to unregister the previous handler functions defined in the Layer class before triggering the EVENT_MAP_RELOAD.

Fixes #1266

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

As usual, using the chrome devtools and the draft PR 1150 created by Damon.

__Deploy URL:__ https://ychoquet.github.io/GeoView/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1269)
<!-- Reviewable:end -->
