### PR TITLE
Utility functions to add a notification quickly and improved showMessage() functions too

### DIFF
--- a/packages/geoview-core/src/core/utils/utilities.ts
+++ b/packages/geoview-core/src/core/utils/utilities.ts
@@ -15,6 +15,7 @@ import { EVENT_NAMES } from '@/api/events/event-types';
 
 import { Cast, TypeJsonArray, TypeJsonObject, TypeJsonValue } from '../types/global-types';
 import { snackbarMessagePayload } from '@/api/events/payloads';
+import { NotificationType, notificationPayload } from '@/api/events/payloads/notification-payload';
 
 /**
  * Get the string associated to the current display language.
@@ -27,6 +28,66 @@ import { snackbarMessagePayload } from '@/api/events/payloads';
 export function getLocalizedValue(localizedString: TypeLocalizedString | undefined, mapId: string): string | undefined {
   if (localizedString) return localizedString[api.maps[mapId].displayLanguage];
   return undefined;
+}
+
+/**
+ * Reusable utility function to send event to add a notification in the notifications manager
+ *
+ * @param {string} mapId the map to show the message for
+ * @param {string} type optional, the type of message (info, success, warning, error), info by default
+ * @param {string} message optional, the message string
+ * @param {string} description optional, the description string
+ */
+function _addNotification(mapId: string, type: NotificationType = 'info', message = '', description = '') {
+  api.event.emit(notificationPayload(EVENT_NAMES.NOTIFICATIONS.NOTIFICATION_ADD, mapId, type, message, description));
+}
+
+/**
+ * Add a notification message
+ *
+ * @param {string} mapId the map to show the message for
+ * @param {string} message optional, the message string
+ * @param {string} description optional, the description string
+ */
+export function addNotificationMessage(mapId: string, message: string, description: string) {
+  // Redirect
+  _addNotification(mapId, 'info', message, description);
+}
+
+/**
+ * Add a notification success
+ *
+ * @param {string} mapId the map to show the message for
+ * @param {string} message optional, the message string
+ * @param {string} description optional, the description string
+ */
+export function addNotificationSuccess(mapId: string, message: string, description: string) {
+  // Redirect
+  _addNotification(mapId, 'success', message, description);
+}
+
+/**
+ * Add a notification warning
+ *
+ * @param {string} mapId the map to show the message for
+ * @param {string} message optional, the message string
+ * @param {string} description optional, the description string
+ */
+export function addNotificationWarning(mapId: string, message: string, description: string) {
+  // Redirect
+  _addNotification(mapId, 'warning', message, description);
+}
+
+/**
+ * Add a notification error
+ *
+ * @param {string} mapId the map to show the message for
+ * @param {string} message optional, the message string
+ * @param {string} description optional, the description string
+ */
+export function addNotificationError(mapId: string, message: string, description: string) {
+  // Redirect
+  _addNotification(mapId, 'error', message, description);
 }
 
 /**
@@ -54,10 +115,12 @@ function _showSnackbarMessage(mapId: string, type: string, message: string, opti
  *
  * @param {string} mapId the map to show the message for
  * @param {string} message the message string
+ * @param {string} withNotification optional, indicates if the message should also be added as a notification, default true
  */
-export function showMessage(mapId: string, message: string) {
+export function showMessage(mapId: string, message: string, withNotification = true) {
   // Redirect
   _showSnackbarMessage(mapId, 'string', message);
+  if (withNotification) addNotificationMessage(mapId, message, '');
 }
 
 /**
@@ -65,12 +128,14 @@ export function showMessage(mapId: string, message: string) {
  *
  * @param {string} mapId the map to show the message for
  * @param {string} message the message string
+ * @param {string} withNotification optional, indicates if the message should also be added as a notification, default true
  */
-export function showSuccess(mapId: string, message: string) {
+export function showSuccess(mapId: string, message: string, withNotification = true) {
   // Redirect
   _showSnackbarMessage(mapId, 'string', message, {
     variant: 'success',
   } as unknown as TypeJsonObject);
+  if (withNotification) addNotificationSuccess(mapId, message, '');
 }
 
 /**
@@ -78,12 +143,14 @@ export function showSuccess(mapId: string, message: string) {
  *
  * @param {string} mapId the map to show the message for
  * @param {string} message the message string
+ * @param {string} withNotification optional, indicates if the message should also be added as a notification, default true
  */
-export function showWarning(mapId: string, message: string) {
+export function showWarning(mapId: string, message: string, withNotification = true) {
   // Redirect
   _showSnackbarMessage(mapId, 'string', message, {
     variant: 'warning',
   } as unknown as TypeJsonObject);
+  if (withNotification) addNotificationWarning(mapId, message, '');
 }
 
 /**
@@ -91,12 +158,14 @@ export function showWarning(mapId: string, message: string) {
  *
  * @param {string} mapId the map to show the message for
  * @param {string} message the message string
+ * @param {string} withNotification optional, indicates if the message should also be added as a notification, default true
  */
-export function showError(mapId: string, message: string) {
+export function showError(mapId: string, message: string, withNotification = true) {
   // Redirect
   _showSnackbarMessage(mapId, 'string', message, {
     variant: 'error',
   } as unknown as TypeJsonObject);
+  if (withNotification) addNotificationError(mapId, message, '');
 }
 
 /**


### PR DESCRIPTION
Utility functions to add a notification, quickly, and show a message WITH (or without) a notification alongside it - so that a dev only has 1 method to call from its development level.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1273)
<!-- Reviewable:end -->
