### PR TITLE
fix(scale): Set scale on load, not waiting for the first map move

### DIFF
--- a/packages/geoview-core/src/core/components/scale/scale.tsx
+++ b/packages/geoview-core/src/core/components/scale/scale.tsx
@@ -137,6 +137,9 @@ export function Scale(): JSX.Element {
 
     map.on('moveend', onMoveEnd);
 
+    // trigger the move end manually to load the map with the scale
+    setTimeout(() => onMoveEnd({ map: api.maps[mapId].map } as MapEvent), 0);
+
     api.event.on(EVENT_NAMES.FOOTERBAR.EVENT_FOOTERBAR_EXPAND_COLLAPSE, footerbarExpandCollapseListenerFunction, mapId);
 
     return () => {

--- a/packages/geoview-core/src/ui/modal/modal.tsx
+++ b/packages/geoview-core/src/ui/modal/modal.tsx
@@ -281,6 +281,7 @@ export function Modal(props: TypeDialogProps): JSX.Element {
       api.event.off(EVENT_NAMES.MODAL.EVENT_MODAL_CLOSE, mapId, modalCloseListenerFunction);
       api.event.off(EVENT_NAMES.MODAL.EVENT_MODAL_UPDATE, mapId, modalUpdateListenerFunction);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [updateModal, createdModal]);
 
   return (


### PR DESCRIPTION
CLoses #1268

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Open any page and scalebar is there on load

__Add the URL for your deploy!__ https://jolevesq.github.io/geoview/vector.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1275)
<!-- Reviewable:end -->
