### PR TITLE
fix(DataTable): add min and max filters for datatable Closes #1251

### DIFF
--- a/packages/geoview-core/src/core/components/data-table/map-data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/map-data-table.tsx
@@ -239,7 +239,7 @@ function MapDataTable({ data, layerId, mapId, layerKey, projectionConfig }: MapD
       columnList.push({
         accessorKey: key,
         header: value.alias,
-        ...(value.dataType === 'number' && { filterFn: 'between', size: 175 }),
+        ...(value.dataType === 'number' && { filterFn: 'betweenInclusive', size: 175 }),
         Header: ({ column }) => getTableHeader(column.columnDef.header),
         Cell: ({ cell }) => getCellValueWithTooltip(cell.getValue() as string),
         ...([t('dataTable.icon'), t('dataTable.zoom')].includes(value.alias) && { size: 100, enableColumnFilter: false }),
@@ -293,7 +293,6 @@ function MapDataTable({ data, layerId, mapId, layerKey, projectionConfig }: MapD
           columnPinning: { left: [t('dataTable.icon'), t('dataTable.zoom')] },
           density: 'compact',
           pagination: { pageSize: 10, pageIndex: 0 },
-          showColumnFilters: true,
         }}
         onSortingChange={setSorting}
         onColumnFiltersChange={setColumnFilters}

--- a/packages/geoview-core/src/core/components/data-table/map-data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/map-data-table.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import debounce from 'lodash/debounce';
 import {
   MaterialReactTable,
   type MRT_ColumnDef as MRTColumnDef,
@@ -67,6 +68,7 @@ interface MapDataTableProps {
 
 function MapDataTable({ data, layerId, mapId, layerKey, projectionConfig }: MapDataTableProps) {
   const mountedRef = useRef(false);
+  const FILTER_MAP_DELAY = 1000;
   const { t } = useTranslation<string>();
   const iconColumn = { alias: t('dataTable.icon'), dataType: 'string', id: t('dataTable.icon') };
   const zoomColumn = { alias: t('dataTable.zoom'), dataType: 'string', id: t('dataTable.zoom') };
@@ -74,7 +76,6 @@ function MapDataTable({ data, layerId, mapId, layerKey, projectionConfig }: MapD
   const [mapFiltered, setMapFiltered] = useState<boolean>(false);
   const [filteredData] = useState(data.features);
   const [columnFilters, setColumnFilters] = useState<MRTColumnFiltersState>([]);
-  const [filterStrings, setFilterStrings] = useState<string[]>();
 
   const [rowSelection, setRowSelection] = useState<Record<number, boolean>>({});
   const rowSelectionRef = useRef<Array<number>>([]);
@@ -104,12 +105,47 @@ function MapDataTable({ data, layerId, mapId, layerKey, projectionConfig }: MapD
   const buildFilterList = useCallback((columnFilter: MRTColumnFiltersState) => {
     if (!columnFilter.length) return [''];
     return columnFilter.map((filter) => {
-      if ((filter.value as string).match(/^-?\d+$/)) {
-        return `${filter.id} = ${filter.value}`;
+      const filterValue = filter.value;
+      const filterId = filter.id;
+      // Check if filterValue is of type array because columnfilters return array with min and max.
+      if (Array.isArray(filterValue)) {
+        let arrQuery = '';
+        const minValue = Number(filterValue[0]);
+        const maxValue = Number(filterValue[1]);
+
+        if (minValue && maxValue) {
+          arrQuery = `${filterId} >= ${filterValue[0]} and ${filterId} <= ${filterValue[1]}`;
+        } else if (minValue) {
+          arrQuery = `${filterId} > ${filterValue[0]}`;
+        } else if (maxValue) {
+          arrQuery = `${filterId} < ${filterValue[1]}`;
+        }
+        return arrQuery;
       }
-      return `${filter.id} like '%${filter.value}%'`;
+      return `upper(${filterId}) like upper('%${filter.value}%')`;
     });
   }, []);
+
+  /**
+   * Filter map based on the filter strings of data table.
+   *
+   * @param {Array} filterStrings list of filter strings.
+   */
+  const filterMap = debounce((filters: MRTColumnFiltersState) => {
+    const filterStrings = buildFilterList(filters).join(' and ');
+    const geoviewLayerInstance = api.maps[mapId].layer.geoviewLayers[layerId];
+    const filterLayerConfig = api.maps[mapId].layer.registeredLayers[layerKey] as TypeLayerEntryConfig;
+    console.log('new str', filterStrings);
+
+    if (mapFiltered && geoviewLayerInstance !== undefined && filterLayerConfig !== undefined && filterStrings.length) {
+      (geoviewLayerInstance as AbstractGeoViewVector | EsriDynamic)?.applyViewFilter(filterLayerConfig, filterStrings);
+    } else {
+      (geoviewLayerInstance as AbstractGeoViewVector | EsriDynamic)?.applyViewFilter(filterLayerConfig, '');
+    }
+  }, FILTER_MAP_DELAY);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debouncedColumnFilters = useCallback((filters: MRTColumnFiltersState) => filterMap(filters), [mapFiltered]);
 
   useEffect(() => {
     // scroll to the top of the table when the sorting changes
@@ -121,33 +157,19 @@ function MapDataTable({ data, layerId, mapId, layerKey, projectionConfig }: MapD
     }
   }, [sorting]);
 
+  // update map when column filters change
   useEffect(() => {
-    if (columnFilters && mountedRef.current) {
-      const filterList = buildFilterList(columnFilters);
-      setFilterStrings(filterList);
+    if (columnFilters && mountedRef.current && mapFiltered) {
+      debouncedColumnFilters(columnFilters);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [columnFilters]);
 
+  // Update map when filter map switch is toggled.
   useEffect(() => {
-    const geoviewLayerInstance = api.maps[mapId].layer.geoviewLayers[layerId];
-    const filterLayerConfig = api.maps[mapId].layer.registeredLayers[layerKey] as TypeLayerEntryConfig;
-    // filter map when filterMap is toggled true.
-    if (mapFiltered && filterStrings) {
-      filterStrings.forEach((filterString) => {
-        if (mapFiltered && geoviewLayerInstance !== undefined && filterLayerConfig !== undefined) {
-          (geoviewLayerInstance as AbstractGeoViewVector | EsriDynamic)?.applyViewFilter(filterLayerConfig, filterString);
-        } else {
-          (geoviewLayerInstance as AbstractGeoViewVector | EsriDynamic)?.applyViewFilter(filterLayerConfig, '');
-        }
-      });
-    }
-    // clear filters filtering is off
-    if (!mapFiltered) {
-      (geoviewLayerInstance as AbstractGeoViewVector | EsriDynamic)?.applyViewFilter(filterLayerConfig, '');
-    }
+    filterMap(columnFilters);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapFiltered, filterStrings]);
+  }, [mapFiltered]);
 
   useEffect(() => {
     // This is created to counter column filter that is fired when component is mounted.
@@ -217,6 +239,7 @@ function MapDataTable({ data, layerId, mapId, layerKey, projectionConfig }: MapD
       columnList.push({
         accessorKey: key,
         header: value.alias,
+        ...(value.dataType === 'number' && { filterFn: 'between', size: 175 }),
         Header: ({ column }) => getTableHeader(column.columnDef.header),
         Cell: ({ cell }) => getCellValueWithTooltip(cell.getValue() as string),
         ...([t('dataTable.icon'), t('dataTable.zoom')].includes(value.alias) && { size: 100, enableColumnFilter: false }),
@@ -270,6 +293,7 @@ function MapDataTable({ data, layerId, mapId, layerKey, projectionConfig }: MapD
           columnPinning: { left: [t('dataTable.icon'), t('dataTable.zoom')] },
           density: 'compact',
           pagination: { pageSize: 10, pageIndex: 0 },
+          showColumnFilters: true,
         }}
         onSortingChange={setSorting}
         onColumnFiltersChange={setColumnFilters}
@@ -286,10 +310,10 @@ function MapDataTable({ data, layerId, mapId, layerKey, projectionConfig }: MapD
             </ExportButton>
           </Box>
         )}
+        enableFilterMatchHighlighting
         enableBottomToolbar={false}
         enableColumnResizing
         enableColumnVirtualization
-        enableGlobalFilterModes
         enablePagination={false}
         enablePinning
         enableRowVirtualization
@@ -297,6 +321,11 @@ function MapDataTable({ data, layerId, mapId, layerKey, projectionConfig }: MapD
         rowVirtualizerInstanceRef={rowVirtualizerInstanceRef}
         rowVirtualizerProps={{ overscan: 5 }}
         columnVirtualizerProps={{ overscan: 2 }}
+        muiTableHeadCellFilterTextFieldProps={{
+          sx: () => ({
+            minWidth: '50px',
+          }),
+        }}
         muiTableBodyProps={{
           sx: (theme) => ({
             // stripe style of table

--- a/packages/geoview-core/src/core/components/data-table/map-data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/map-data-table.tsx
@@ -132,10 +132,11 @@ function MapDataTable({ data, layerId, mapId, layerKey, projectionConfig }: MapD
    * @param {Array} filterStrings list of filter strings.
    */
   const filterMap = debounce((filters: MRTColumnFiltersState) => {
-    const filterStrings = buildFilterList(filters).join(' and ');
+    const filterStrings = buildFilterList(filters)
+      .filter((filterValue) => filterValue.length)
+      .join(' and ');
     const geoviewLayerInstance = api.maps[mapId].layer.geoviewLayers[layerId];
     const filterLayerConfig = api.maps[mapId].layer.registeredLayers[layerKey] as TypeLayerEntryConfig;
-    console.log('new str', filterStrings);
 
     if (mapFiltered && geoviewLayerInstance !== undefined && filterLayerConfig !== undefined && filterStrings.length) {
       (geoviewLayerInstance as AbstractGeoViewVector | EsriDynamic)?.applyViewFilter(filterLayerConfig, filterStrings);


### PR DESCRIPTION
# Description
Add `min` and `max` filters for data table.

Fixes # ([1251](https://app.zenhub.com/workspaces/geoview-web-team-6332f4560a41153d1fefbcbc/issues/gh/canadian-geospatial-platform/geoview/1251))

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

__Add the URL for your deploy!__
https://kaminderpal.github.io/geoview/raw-data-table.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1283)
<!-- Reviewable:end -->
