### PR TITLE
fix(overview): Remove display of overview duplication on resize

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -174,7 +174,6 @@ importers:
       lodash: ^4.17.21
       lodash-webpack-plugin: ^0.11.6
       material-react-table: ^1.14.0
-      notistack: ^2.0.3
       ol: ^7.4.0
       ol-mapbox-style: ^10.6.0
       prettier: ^2.6.0
@@ -224,7 +223,6 @@ importers:
       linkifyjs: 4.1.1
       lodash: 4.17.21
       material-react-table: 1.14.0_k2uxuhlnjzq4sw57nvhf6qe33m
-      notistack: 2.0.8_zsjv5mog45rt46urvcagmaty34
       ol: 7.5.1
       ol-mapbox-style: 10.7.0
       proj4: 2.9.0
@@ -7551,29 +7549,6 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /notistack/2.0.8_zsjv5mog45rt46urvcagmaty34:
-    resolution: {integrity: sha512-/IY14wkFp5qjPgKNvAdfL5Jp6q90+MjgKTPh4c81r/lW70KeuX6b9pE/4f8L4FG31cNudbN9siiFS5ql1aSLRw==}
-    peerDependencies:
-      '@emotion/react': ^11.4.1
-      '@emotion/styled': ^11.3.0
-      '@mui/material': ^5.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-    dependencies:
-      '@emotion/react': 11.11.1_gq4reeurwxuj4hvyerswzzqthy
-      '@emotion/styled': 11.11.0_rra5sb3jh6znd7zvpi7zwpaeky
-      '@mui/material': 5.14.7_mcyaowhjtk6juxjmabqaayfcxi
-      clsx: 1.2.1
-      hoist-non-react-statics: 3.3.2
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-    dev: false
 
   /npm-run-path/4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}

--- a/packages/geoview-core/src/core/components/geolocator/geo-list.tsx
+++ b/packages/geoview-core/src/core/components/geolocator/geo-list.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ListItem, ListItemButton, Grid, Typography, Tooltip } from '@mui/material';
+import { ListItem, ListItemButton, Grid, Typography, Tooltip } from '@/ui';
 import { GeoListItem } from './geolocator';
 
 type GeoListProps = {

--- a/packages/geoview-core/src/ui/style/style.css
+++ b/packages/geoview-core/src/ui/style/style.css
@@ -13,3 +13,16 @@ Hold viewer specific css not inside theme
 .llwp-map {
   position: relative !important;
 }
+
+/* FIX: fix issue when overview map is added on resize.
+        This is a patch and would better resolve managing the screen resize event and trap the control creation.
+        Because it would not happen very often in production it may be a suitable patch. 
+*/
+.ol-overlaycontainer-stopevent .ol-overviewmap:not(:last-child) {
+  display: none;
+}
+@media (max-width: 960px) {
+  .ol-overviewmap {
+    display: none;
+  }
+}


### PR DESCRIPTION
Closes #1260

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

With css, remove display of default overview map control. The better improvement would be to trap the screen size and prevent the creation of the duplicate control. But because it will not happen often, this can be a patch for now.

Fixes #1260

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Got the page in link on a map were there is an overview map and resize the screen. No more other control

__Add the URL for your deploy!__
https://jolevesq.github.io/geoview/default-config.html?p=3857&z=4&c=-100,40&l=en&t=dark&b={basemapId:transport,shaded:false,labeled:true}&i=dynamic&cc=overview-map&keys=12acd145-626a-49eb-b850-0a59c9bc7506,ccc75c12-5acc-4a6a-959f-ef6f621147b9

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1290)
<!-- Reviewable:end -->
