### PR TITLE
fix(filter): null values don't break 'like' filters

### DIFF
--- a/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
@@ -1575,11 +1575,11 @@ export class GeoviewRenderer {
         let valueToPush;
         switch (operator.nodeValue) {
           case 'is not':
-            if (operand2.nodeValue !== null) throw new Error(`Invalid is not null operator syntaxe`);
+            if (operand2.nodeValue !== null) throw new Error(`Invalid is not null operator syntax`);
             dataStack.push({ nodeType: NodeType.variable, nodeValue: operand1.nodeValue !== null });
             break;
           case 'is':
-            if (operand2.nodeValue !== null) throw new Error(`Invalid is null operator syntaxe`);
+            if (operand2.nodeValue !== null) throw new Error(`Invalid is null operator syntax`);
             dataStack.push({ nodeType: NodeType.variable, nodeValue: operand1.nodeValue === null });
             break;
           case '=':
@@ -1659,17 +1659,23 @@ export class GeoviewRenderer {
             else dataStack.push({ nodeType: NodeType.variable, nodeValue: operand1.nodeValue / operand2.nodeValue });
             break;
           case '||':
-            if (typeof operand1.nodeValue !== 'string' || typeof operand2.nodeValue !== 'string') throw new Error(`|| operator error`);
-            else dataStack.push({ nodeType: NodeType.variable, nodeValue: `${operand1.nodeValue}${operand2.nodeValue}` });
+            if ((typeof operand1.nodeValue !== 'string' && operand1.nodeValue !== null) || typeof operand2.nodeValue !== 'string')
+              throw new Error(`|| operator error`);
+            else
+              dataStack.push({
+                nodeType: NodeType.variable,
+                nodeValue: operand1.nodeValue === null ? null : `${operand1.nodeValue}${operand2.nodeValue}`,
+              });
             break;
           case 'like':
-            if (typeof operand1.nodeValue !== 'string' || typeof operand2.nodeValue !== 'string') throw new Error(`like operator error`);
+            if ((typeof operand1.nodeValue !== 'string' && operand1.nodeValue !== null) || typeof operand2.nodeValue !== 'string')
+              throw new Error(`like operator error`);
             else {
               const regularExpression = new RegExp(
                 operand2.nodeValue.replaceAll('.', '\\.').replaceAll('%', '.*').replaceAll('_', '.'),
                 ''
               );
-              const match = operand1.nodeValue.match(regularExpression);
+              const match = operand1.nodeValue ? operand1.nodeValue.match(regularExpression) : null;
               dataStack.push({ nodeType: NodeType.variable, nodeValue: match !== null && match[0] === operand1.nodeValue });
             }
             break;
@@ -1698,7 +1704,6 @@ export class GeoviewRenderer {
             break;
           default:
             throw new Error(`unknown operator error`);
-            break;
         }
       }
       return;
@@ -1744,7 +1749,6 @@ export class GeoviewRenderer {
             break;
           default:
             throw new Error(`unknoown operator error`);
-            break;
         }
       }
     }


### PR DESCRIPTION
# Description

Fixes error when filtering text entries with null values

Fixes # 1250

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with both new and old data tables.

https://damonu2.github.io/geoview/raw-data-table.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1324)
<!-- Reviewable:end -->
