### PR TITLE
fix(filter): fixed error with 'upper' in filter query

### DIFF
--- a/packages/geoview-core/src/core/components/data-table/map-data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/map-data-table.tsx
@@ -78,11 +78,11 @@ const DATE_FILTER: Record<string, string> = {
 };
 
 const STRING_FILTER: Record<string, string> = {
-  contains: `upper(filterId) like upper('%value%')`,
-  startsWith: `upper(filterId) like upper('value%')`,
-  endsWith: `upper(filterId) like upper('%value')`,
-  empty: 'upper(filterId) is null',
-  notEmpty: 'upper(filterId) is not null',
+  contains: `(filterId) like ('%value%')`,
+  startsWith: `(filterId) like ('value%')`,
+  endsWith: `(filterId) like ('%value')`,
+  empty: '(filterId) is null',
+  notEmpty: '(filterId) is not null',
   equals: `filterId = 'value'`,
   notEquals: `filterId <> 'value'`,
 };
@@ -152,7 +152,7 @@ function MapDataTable({ data, layerId, mapId, layerKey, projectionConfig }: MapD
 
     if (!columnFilter.length) return [''];
     return columnFilter.map((filter) => {
-      const filterValue = filter.value as string;
+      const filterValue = filter.value;
       const filterId = filter.id;
       // Check if filterValue is of type array because columnfilters return array with min and max.
       if (Array.isArray(filterValue)) {
@@ -187,7 +187,7 @@ function MapDataTable({ data, layerId, mapId, layerKey, projectionConfig }: MapD
 
       const strFilter = STRING_FILTER[operator] as string;
 
-      return `${strFilter.replace('filterId', filterId).replace('value', filterValue)}`;
+      return `${strFilter.replace('filterId', filterId).replace('value', filterValue as string)}`;
     });
   }, []);
 

--- a/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
@@ -1525,7 +1525,7 @@ export class GeoviewRenderer {
             }
           }
         else {
-          // Validate the UPPER and LOWER syntaxe (i.e.: must be followed by an opening parenthesis)
+          // Validate the UPPER and LOWER syntax (i.e.: must be followed by an opening parenthesis)
           if (
             ['upper', 'lower'].includes(filterEquation[i].nodeValue as string) &&
             (filterEquation.length === i + 1 ||
@@ -1672,11 +1672,11 @@ export class GeoviewRenderer {
               throw new Error(`like operator error`);
             else {
               const regularExpression = new RegExp(
-                operand2.nodeValue.replaceAll('.', '\\.').replaceAll('%', '.*').replaceAll('_', '.'),
+                operand2.nodeValue.toLowerCase().replaceAll('.', '\\.').replaceAll('%', '.*').replaceAll('_', '.'),
                 ''
               );
-              const match = operand1.nodeValue ? operand1.nodeValue.match(regularExpression) : null;
-              dataStack.push({ nodeType: NodeType.variable, nodeValue: match !== null && match[0] === operand1.nodeValue });
+              const match = operand1.nodeValue ? operand1.nodeValue.toLowerCase().match(regularExpression) : null;
+              dataStack.push({ nodeType: NodeType.variable, nodeValue: match !== null && match[0] === operand1.nodeValue?.toLowerCase() });
             }
             break;
           case ',':
@@ -1748,7 +1748,7 @@ export class GeoviewRenderer {
             else dataStack.push({ nodeType: NodeType.variable, nodeValue: operand.nodeValue.toLowerCase() });
             break;
           default:
-            throw new Error(`unknoown operator error`);
+            throw new Error(`unknown operator error`);
         }
       }
     }


### PR DESCRIPTION
fixes #1311
Also removes case-sensitivity from 'like' map filters to match what is shown in table

# Description

Fixed issue with queries getting 'upper' added to them, causing errors for non-string values, also removes case-sensitivity in map filter queries to match table results.

Fixes # 1311

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with historical flood on raw-data-table.html

https://damonu2.github.io/geoview/raw-data-table.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1325)
<!-- Reviewable:end -->
