### PR TITLE
fix(layerStatus): 'loaded' handling refactored for groups

### DIFF
--- a/packages/geoview-core/public/templates/layers/esri-dynamic.html
+++ b/packages/geoview-core/public/templates/layers/esri-dynamic.html
@@ -762,37 +762,40 @@
 
       window.setInterval(() => {
         const displayField1 = document.getElementById('HLYR1-state');
-        const geoviewLayers = cgpv.api.maps?.LYR1?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR1').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR1?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR1?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = cgpv.api.maps.LYR1.layer.registeredLayers[layerId].layerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField1.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField1.textContent = '(undefined)';
       }, 250)
 
       window.setInterval(() => {
         const displayField2 = document.getElementById('HLYR2-state');
-        const geoviewLayers = cgpv.api.maps?.LYR2?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR2').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR2?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR2?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = cgpv.api.maps.LYR2.layer.registeredLayers[layerId].layerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField2.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField2.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField2.textContent = '(undefined)';
       }, 250)
 
       window.setInterval(() => {
         const displayField3 = document.getElementById('HLYR3-state');
-        const geoviewLayers = cgpv.api.maps?.LYR3?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR3').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR3?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR3?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = cgpv.api.maps.LYR3.layer.registeredLayers[layerId].layerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField3.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField3.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';;
         } else displayField3.textContent = '(undefined)';
       }, 250)
 

--- a/packages/geoview-core/public/templates/layers/esri-feature.html
+++ b/packages/geoview-core/public/templates/layers/esri-feature.html
@@ -406,37 +406,40 @@
 
       window.setInterval(() => {
         const displayField1 = document.getElementById('HLYR1-state');
-        const geoviewLayers = cgpv.api.maps?.LYR1?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR1').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR1?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR1?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = cgpv.api.maps.LYR1.layer.registeredLayers[layerId].layerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField1.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField1.textContent = '(undefined)';
       }, 250)
 
       window.setInterval(() => {
         const displayField2 = document.getElementById('HLYR2-state');
-        const geoviewLayers = cgpv.api.maps?.LYR2?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR2').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR2?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR2?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = cgpv.api.maps.LYR2.layer.registeredLayers[layerId].layerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField2.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField2.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField2.textContent = '(undefined)';
       }, 250)
 
       window.setInterval(() => {
         const displayField3 = document.getElementById('HLYR3-state');
-        const geoviewLayers = cgpv.api.maps?.LYR3?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR3').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR3?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR3?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = cgpv.api.maps.LYR3.layer.registeredLayers[layerId].layerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField3.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField3.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField3.textContent = '(undefined)';
       }, 250)
 

--- a/packages/geoview-core/public/templates/layers/geocore.html
+++ b/packages/geoview-core/public/templates/layers/geocore.html
@@ -200,14 +200,14 @@
       
       window.setInterval(() => {
         const displayField1 = document.getElementById('HLYR1-state');
-        const geoviewLayers = cgpv.api.maps?.LYR1?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR1').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR1?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const layerName = cgpv.api.maps?.LYR1?.layer?.geoviewLayers[layerId].geoviewLayerName.en;
-            const stateValue = cgpv.api.maps?.LYR1?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerName}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = cgpv.api.maps.LYR1.layer.geoviewLayers[layerId.split('/')[0]].geoviewLayerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField1.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField1.textContent = '(undefined)';
       }, 250)
 

--- a/packages/geoview-core/public/templates/layers/geojson.html
+++ b/packages/geoview-core/public/templates/layers/geojson.html
@@ -248,13 +248,14 @@
 
       window.setInterval(() => {
         const displayField1 = document.getElementById('HLYR1-state');
-        const geoviewLayers = cgpv.api.maps?.LYR1?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR1').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR1?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR1?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = cgpv.api.maps.LYR1.layer.registeredLayers[layerId].layerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField1.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField1.textContent = '(undefined)';
       }, 250)
 

--- a/packages/geoview-core/public/templates/layers/geopackage.html
+++ b/packages/geoview-core/public/templates/layers/geopackage.html
@@ -232,25 +232,27 @@
 
       window.setInterval(() => {
         const displayField1 = document.getElementById('HLYR1-state');
-        const geoviewLayers = cgpv.api.maps?.LYR1?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR1').resultSets;
         if (geoviewLayers) {
           const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+            const layerName = cgpv.api.maps.LYR1.layer.registeredLayers[layerId].layerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField1.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField1.textContent = '(undefined)';
       }, 250)
 
       window.setInterval(() => {
         const displayField1 = document.getElementById('HLYR2-state');
-        const geoviewLayers = cgpv.api.maps?.LYR2?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR2').resultSets;
         if (geoviewLayers) {
           const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+            const layerName = cgpv.api.maps.LYR2.layer.registeredLayers[layerId].layerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField1.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField1.textContent = '(undefined)';
       }, 250)
 

--- a/packages/geoview-core/public/templates/layers/image-static.html
+++ b/packages/geoview-core/public/templates/layers/image-static.html
@@ -159,13 +159,14 @@
 
       window.setInterval(() => {
         const displayField1 = document.getElementById('HLYR1-state');
-        const geoviewLayers = cgpv.api.maps?.LYR1?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR1').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR1?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR1?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = cgpv.api.maps.LYR1.layer.registeredLayers[layerId].layerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField1.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField1.textContent = '(undefined)';
       }, 250)
 

--- a/packages/geoview-core/public/templates/layers/ogc-feature.html
+++ b/packages/geoview-core/public/templates/layers/ogc-feature.html
@@ -164,13 +164,14 @@
 
       window.setInterval(() => {
         const displayField1 = document.getElementById('HLYR1-state');
-        const geoviewLayers = cgpv.api.maps?.LYR1?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR1').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR1?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR1?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = cgpv.api.maps.LYR1.layer.registeredLayers[layerId].layerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField1.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField1.textContent = '(undefined)';
       }, 250)
 

--- a/packages/geoview-core/public/templates/layers/vector-tiles.html
+++ b/packages/geoview-core/public/templates/layers/vector-tiles.html
@@ -196,37 +196,42 @@
 
       window.setInterval(() => {
         const displayField1 = document.getElementById('HLYR1-state');
-        const geoviewLayers = cgpv.api.maps?.LYR1?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.maps?.LYR1?.layer?.registeredLayers;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR1?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR1?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = geoviewLayers[layerId].layerName?.en ? geoviewLayers[layerId].layerName?.en : layerId;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField1.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField1.textContent = '(undefined)';
       }, 250)
 
       window.setInterval(() => {
         const displayField2 = document.getElementById('HLYR2-state');
-        const geoviewLayers = cgpv.api.maps?.LYR2?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.maps?.LYR2?.layer?.registeredLayers;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR2?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR2?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = geoviewLayers[layerId].layerName?.en ? geoviewLayers[layerId].layerName?.en : layerId;
+            const {layerPhase} = geoviewLayers[layerId];
+            const {layerStatus} = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField2.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField2.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField2.textContent = '(undefined)';
       }, 250)
 
       window.setInterval(() => {
         const displayField3 = document.getElementById('HLYR3-state');
-        const geoviewLayers = cgpv.api.maps?.LYR3?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.maps?.LYR3?.layer?.registeredLayers;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR3?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR3?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = geoviewLayers[layerId].layerName?.en ? geoviewLayers[layerId].layerName?.en : layerId;
+            const {layerPhase} = geoviewLayers[layerId];
+            const {layerStatus} = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField3.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField3.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField3.textContent = '(undefined)';
       }, 250)
 

--- a/packages/geoview-core/public/templates/layers/wfs.html
+++ b/packages/geoview-core/public/templates/layers/wfs.html
@@ -225,25 +225,27 @@
 
       window.setInterval(() => {
         const displayField1 = document.getElementById('HLYR1-state');
-        const geoviewLayers = cgpv.api.maps?.LYR1?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR1').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR1?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR1?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = cgpv.api.maps.LYR1.layer.registeredLayers[layerId].layerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField1.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField1.textContent = '(undefined)';
       }, 250)
 
       window.setInterval(() => {
         const displayField2 = document.getElementById('HLYR2-state');
-        const geoviewLayers = cgpv.api.maps?.LYR2?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR2').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR2?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR2?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = cgpv.api.maps.LYR2.layer.registeredLayers[layerId].layerName.en;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField2.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField2.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField2.textContent = '(undefined)';
       }, 250)
 

--- a/packages/geoview-core/public/templates/layers/wms.html
+++ b/packages/geoview-core/public/templates/layers/wms.html
@@ -14,14 +14,23 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" href="css/style.css" />
     <style>
-      table.info, th.info, td.info, th.infoCol1, td.infoCol1 {
+      table.info,
+      th.info,
+      td.info,
+      th.infoCol1,
+      td.infoCol1 {
         border: 1px solid black;
       }
-      th.info, td.info, th.infoCol1, td.infoCol1 {
+      th.info,
+      td.info,
+      th.infoCol1,
+      td.infoCol1 {
         padding: 15px;
         width: 15%;
       }
-      th.info, th.infoCol1, td.infoCol1 {
+      th.info,
+      th.infoCol1,
+      td.infoCol1 {
         text-align: left;
         font-weight: bold;
         font-size: 15px;
@@ -66,7 +75,8 @@
 
     <div class="map-title-holder">
       <h4 id="HLYR1">1. Many WMS Layers</h4>
-      &nbsp;<h5 id="HLYR1-state">(undefined)</h5>
+      &nbsp;
+      <h5 id="HLYR1-state">(undefined)</h5>
       <a class="ref-link" href="#top">Top</a>
     </div>
     <button class="test-refresh-WMS-btn">Test Refresh WMS</button>
@@ -179,7 +189,8 @@
 
     <div class="map-title-holder">
       <h4 id="HLYR2">2. All Styles of a WMS Layer</h4>
-      &nbsp;<h5 id="HLYR2-state">(undefined)</h5>
+      &nbsp;
+      <h5 id="HLYR2-state">(undefined)</h5>
       <a class="ref-link" href="#top">Top</a>
     </div>
     <div
@@ -364,7 +375,8 @@
 
     <div class="map-title-holder">
       <h4 id="HLYR3">3. All Styles of a WMS Layer</h4>
-      &nbsp;<h5 id="HLYR3-state">(undefined)</h5>
+      &nbsp;
+      <h5 id="HLYR3-state">(undefined)</h5>
       <a class="ref-link" href="#top">Top</a>
     </div>
     <div
@@ -422,7 +434,8 @@
 
     <div class="map-title-holder">
       <h4 id="HLYR4">4. Automatic group creation from metadata information</h4>
-      &nbsp;<h5 id="HLYR4-state">(undefined)</h5>
+      &nbsp;
+      <h5 id="HLYR4-state">(undefined)</h5>
       <a class="ref-link" href="#top">Top</a>
     </div>
     <div
@@ -471,7 +484,7 @@
     <p>This map has a wms layer added from configuration.</p>
     <button type="button" class="collapsible">Configuration Snippet</button>
     <pre id="LYR4CS" class="panel"></pre>
-   <hr />
+    <hr />
     <button type="button" class="collapsible">Code Snippet</button>
     <pre id="codeSnippet" class="panel"></pre>
 
@@ -503,12 +516,15 @@
                   dropDownContent.appendChild(element);
                 });
                 dropDownContent.addEventListener('click', (e) => {
-                  cgpv.api.maps.LYR3.layer.geoviewLayers['wmsLYR3-Root'].setStyle(dropDownContent.value, 'wmsLYR3-Root/landcover_2015_19classes');
+                  cgpv.api.maps.LYR3.layer.geoviewLayers['wmsLYR3-Root'].setStyle(
+                    dropDownContent.value,
+                    'wmsLYR3-Root/landcover_2015_19classes'
+                  );
                 });
               }
               clearInterval(intervalId);
             }
-          }, 1000)
+          }, 1000);
 
           //LYR1 ===================================================================================================================
           const featureInfoLayerSet1 = cgpv.api.getFeatureInfoLayerSet('LYR1');
@@ -537,7 +553,9 @@
           // Test a refresh WMS from projection change
           var testRefreshBtn = document.getElementsByClassName('test-refresh-WMS-btn')[0];
           testRefreshBtn.addEventListener('click', function (e) {
-            cgpv.api.event.emit(cgpv.types.mapViewProjectionPayload(cgpv.api.eventNames.MAP.EVENT_MAP_VIEW_PROJECTION_CHANGE, 'LYR1', 3978));
+            cgpv.api.event.emit(
+              cgpv.types.mapViewProjectionPayload(cgpv.api.eventNames.MAP.EVENT_MAP_VIEW_PROJECTION_CHANGE, 'LYR1', 3978)
+            );
           });
 
           // LYR2 ===================================================================================================================
@@ -603,7 +621,9 @@
           // Test a refresh WMS from projection change
           var testRefreshBtn = document.getElementsByClassName('test-refresh-WMS-btn')[0];
           testRefreshBtn.addEventListener('click', function (e) {
-            cgpv.api.event.emit(cgpv.types.mapViewProjectionPayload(cgpv.api.eventNames.MAP.EVENT_MAP_VIEW_PROJECTION_CHANGE, 'LYR1', 3978));
+            cgpv.api.event.emit(
+              cgpv.types.mapViewProjectionPayload(cgpv.api.eventNames.MAP.EVENT_MAP_VIEW_PROJECTION_CHANGE, 'LYR1', 3978)
+            );
           });
 
           // ========================================================================================================================
@@ -611,23 +631,31 @@
           let i = 0;
           window.setInterval(() => {
             const layerConfig = cgpv.api.maps.LYR1.layer.registeredLayers['wmsLYR1-spatiotemporel/RADAR_1KM_RSNO'];
-            const temporalData = cgpv.api.maps.LYR1.layer.geoviewLayers['wmsLYR1-spatiotemporel'].layerTemporalDimension['wmsLYR1-spatiotemporel/RADAR_1KM_RSNO'];
+            const temporalData =
+              cgpv.api.maps.LYR1.layer.geoviewLayers['wmsLYR1-spatiotemporel'].layerTemporalDimension[
+                'wmsLYR1-spatiotemporel/RADAR_1KM_RSNO'
+              ];
             if (temporalData) {
-              cgpv.api.maps.LYR1.layer.geoviewLayers['wmsLYR1-spatiotemporel'].applyViewFilter(layerConfig, `time=date '${temporalData.range.range[i]}'`);
+              cgpv.api.maps.LYR1.layer.geoviewLayers['wmsLYR1-spatiotemporel'].applyViewFilter(
+                layerConfig,
+                `time=date '${temporalData.range.range[i]}'`
+              );
               if (++i === temporalData.range.range.length) i = 0;
             }
-          }, 2500)
+          }, 2500);
 
           let j = 0;
           window.setInterval(() => {
             const layerConfig = cgpv.api.maps.LYR1.layer.registeredLayers['wmsLYR1-msi/msi-94-or-more'];
             const temporalData = cgpv.api.maps.LYR1.layer.geoviewLayers['wmsLYR1-msi'].layerTemporalDimension['wmsLYR1-msi/msi-94-or-more'];
             if (temporalData) {
-              cgpv.api.maps.LYR1.layer.geoviewLayers['wmsLYR1-msi'].applyViewFilter(layerConfig, `time=date '${temporalData.range.range[j]}'`);
+              cgpv.api.maps.LYR1.layer.geoviewLayers['wmsLYR1-msi'].applyViewFilter(
+                layerConfig,
+                `time=date '${temporalData.range.range[j]}'`
+              );
               if (++j === temporalData.range.range.length) j = 0;
             }
-          }, 2500)
-
+          }, 2500);
         }
       });
 
@@ -635,46 +663,52 @@
       // Display layer state
       window.setInterval(() => {
         const displayField1 = document.getElementById('HLYR1-state');
-        const geoviewLayers = cgpv.api.maps?.LYR1?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR1').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR1?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR1?.layer?.geoviewLayers[layerId].layerPhase;
-            const numberOfErrors = cgpv.api.maps?.LYR1?.layer?.geoviewLayers[layerId].countErrorStatus();
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            const numberOfErrors = cgpv.api.maps?.LYR1?.layer?.geoviewLayers[layerId.split('/')[0]].countErrorStatus();
             let errorIndicator = '';
             if (numberOfErrors) errorIndicator = numberOfErrors === 1 ? ' (1 error)' : ` (${numberOfErrors} errors)`;
-            return `${outputValue}${layerId}: ${stateValue}${errorIndicator}, `;
+            return `${outputValue}${
+              layerId.split('/')[layerId.split('/').length - 1]
+            } - status: ${layerStatus}, phase: ${layerPhase}${errorIndicator}, `;
           }, '(');
-          displayField1.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField1.textContent = '(undefined)';
-      }, 250)
+      }, 250);
 
       window.setInterval(() => {
         const displayField2 = document.getElementById('HLYR2-state');
-        const geoviewLayers = cgpv.api.maps?.LYR2?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR2').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR2?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR2?.layer?.geoviewLayers[layerId].layerPhase;
-            const numberOfErrors = cgpv.api.maps?.LYR2?.layer?.geoviewLayers[layerId].countErrorStatus();
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            const numberOfErrors = cgpv.api.maps?.LYR2?.layer?.geoviewLayers[layerId.split('/')[0]].countErrorStatus();
             let errorIndicator = '';
             if (numberOfErrors) errorIndicator = numberOfErrors === 1 ? ' (1 error)' : ` (${numberOfErrors} errors)`;
-            return `${outputValue}${layerId}: ${stateValue}${errorIndicator}, `;
+            return `${outputValue}${
+              layerId.split('/')[layerId.split('/').length - 1]
+            } - status: ${layerStatus}, phase: ${layerPhase}${errorIndicator}, `;
           }, '(');
-          displayField2.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField2.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField2.textContent = '(undefined)';
       }, 250);
 
       window.setInterval(() => {
         const displayField3 = document.getElementById('HLYR3-state');
-        const geoviewLayers = cgpv.api.maps?.LYR3?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('LYR3').resultSets;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR3?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR3?.layer?.geoviewLayers[layerId].layerPhase;
-            const numberOfErrors = cgpv.api.maps?.LYR3?.layer?.geoviewLayers[layerId].countErrorStatus();
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            const numberOfErrors = cgpv.api.maps?.LYR3?.layer?.geoviewLayers[layerId.split('/')[0]].countErrorStatus();
             let errorIndicator = '';
             if (numberOfErrors) errorIndicator = numberOfErrors === 1 ? ' (1 error)' : ` (${numberOfErrors} errors)`;
-            return `${outputValue}${layerId}: ${stateValue}${errorIndicator}, `;
+            return `${outputValue}${
+              layerId.split('/')[layerId.split('/').length - 1]
+            } - status: ${layerStatus}, phase: ${layerPhase}${errorIndicator}, `;
           }, '(');
-          displayField3.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField3.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField3.textContent = '(undefined)';
       }, 250);
 

--- a/packages/geoview-core/public/templates/layers/xyz.html
+++ b/packages/geoview-core/public/templates/layers/xyz.html
@@ -121,13 +121,14 @@
 
       window.setInterval(() => {
         const displayField1 = document.getElementById('HLYR1-state');
-        const geoviewLayers = cgpv.api.maps?.LYR1?.layer?.geoviewLayers;
+        const geoviewLayers = cgpv.api.maps?.LYR1?.layer?.registeredLayers;
         if (geoviewLayers) {
-          const output = Object.keys(cgpv.api.maps?.LYR1?.layer?.geoviewLayers).reduce((outputValue, layerId) => {
-            const stateValue = cgpv.api.maps?.LYR1?.layer?.geoviewLayers[layerId].layerPhase;
-            return `${outputValue}${layerId}: ${stateValue}, `;
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const layerName = geoviewLayers[layerId].layerName?.en ? geoviewLayers[layerId].layerName?.en : layerId;
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerName} - status: ${layerStatus}, phase: ${layerPhase}, `;
           }, '(');
-          displayField1.textContent = output ? `${output.slice(0, -2)})` : '(undefined)';
+          displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
         } else displayField1.textContent = '(undefined)';
       }, 250)
 

--- a/packages/geoview-core/public/templates/package-swiper.html
+++ b/packages/geoview-core/public/templates/package-swiper.html
@@ -61,6 +61,8 @@
 
     <div class="map-title-holder">
       <h4 id="HUC3">3. Layers type Configuration</h4>
+      &nbsp;
+      <h5 id="HUC3-state">(undefined)</h5>
       <a class="ref-link" href="#top">Top</a>
     </div>
     <div id="mapWM3" class="llwp-map" data-lang="en" data-config-url="./configs/package-swiper3-config.json"></div>
@@ -77,6 +79,17 @@
         createConfigSnippet();
         createCodeSnippet();
       });
+      window.setInterval(() => {
+        const displayField1 = document.getElementById('HUC3-state');
+        const geoviewLayers = cgpv.api.getFeatureInfoLayerSet('mapWM3').resultSets;
+        if (geoviewLayers) {
+          const output = Object.keys(geoviewLayers).reduce((outputValue, layerId) => {
+            const { layerPhase, layerStatus } = geoviewLayers[layerId];
+            return `${outputValue}${layerId.split('/')[layerId.split('/').length - 1]} - status: ${layerStatus}, phase: ${layerPhase}, `;
+          }, '(');
+          displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
+        } else displayField1.textContent = '(undefined)';
+      }, 250);
     </script>
   </body>
 </html>

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -298,8 +298,11 @@ export class EsriDynamic extends AbstractGeoViewRaster {
       layerEntryConfig.gvLayer = new ImageLayer(imageLayerOptions);
       this.applyViewFilter(layerEntryConfig, layerEntryConfig.layerFilter ? layerEntryConfig.layerFilter : '');
 
+      super.addLoadendListener(layerEntryConfig, 'image');
+
       resolve(layerEntryConfig.gvLayer);
     });
+
     return promisedVectorLayer;
   }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
@@ -280,8 +280,12 @@ export class ImageStatic extends AbstractGeoViewRaster {
           layerEntryConfig.initialSettings?.visible === 'yes' || layerEntryConfig.initialSettings?.visible === 'always';
 
       layerEntryConfig.gvLayer = new ImageLayer(staticImageOptions);
+
+      super.addLoadendListener(layerEntryConfig, 'image');
+
       resolve(layerEntryConfig.gvLayer);
     });
+
     return promisedVectorLayer;
   }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
@@ -215,6 +215,9 @@ export class VectorTiles extends AbstractGeoViewRaster {
           layerEntryConfig.initialSettings?.visible === 'yes' || layerEntryConfig.initialSettings?.visible === 'always';
 
       layerEntryConfig.gvLayer = new VectorTileLayer(tileLayerOptions);
+
+      super.addLoadendListener(layerEntryConfig, 'tile');
+
       resolve(layerEntryConfig.gvLayer);
     });
     return promisedVectorLayer;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -582,6 +582,9 @@ export class WMS extends AbstractGeoViewRaster {
 
           layerEntryConfig.gvLayer = new ImageLayer(imageLayerOptions);
           this.applyViewFilter(layerEntryConfig, layerEntryConfig.layerFilter ? layerEntryConfig.layerFilter : '');
+
+          super.addLoadendListener(layerEntryConfig, 'image');
+
           resolve(layerEntryConfig.gvLayer);
         } else {
           const trans = i18n.getFixedT(api.maps[this.mapId].displayLanguage);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -214,6 +214,9 @@ export class XYZTiles extends AbstractGeoViewRaster {
           layerEntryConfig.initialSettings?.visible === 'yes' || layerEntryConfig.initialSettings?.visible === 'always';
 
       layerEntryConfig.gvLayer = new TileLayer(tileLayerOptions);
+
+      super.addLoadendListener(layerEntryConfig, 'tile');
+
       resolve(layerEntryConfig.gvLayer);
     });
     return promisedVectorLayer;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -169,6 +169,20 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
     };
 
     vectorSource = new VectorSource(sourceOptions);
+
+    let featuresLoadErrorHandler: () => void;
+    const featuresLoadEndHandler = () => {
+      api.event.emit(LayerSetPayload.createLayerSetChangeLayerStatusPayload(this.mapId, layerEntryConfig, 'loaded'));
+      vectorSource.un('featuresloaderror', featuresLoadErrorHandler);
+    };
+    featuresLoadErrorHandler = () => {
+      api.event.emit(LayerSetPayload.createLayerSetChangeLayerStatusPayload(this.mapId, layerEntryConfig, 'error'));
+      vectorSource.un('featuresloadend', featuresLoadEndHandler);
+    };
+
+    vectorSource.once('featuresloadend', featuresLoadEndHandler);
+    vectorSource.once('featuresloaderror', featuresLoadErrorHandler);
+
     return vectorSource;
   }
 
@@ -227,6 +241,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
     };
 
     layerEntryConfig.gvLayer = new VectorLayer(layerOptions);
+
     if (layerEntryConfig.initialSettings?.extent !== undefined) this.setExtent(layerEntryConfig.initialSettings?.extent, layerEntryConfig);
     if (layerEntryConfig.initialSettings?.maxZoom !== undefined)
       this.setMaxZoom(layerEntryConfig.initialSettings?.maxZoom, layerEntryConfig);

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -15,7 +15,6 @@ import {
   payloadIsALayerConfig,
   GeoViewLayerPayload,
   payloadIsRemoveGeoViewLayer,
-  LayerSetPayload,
   PayloadBaseClass,
 } from '@/api/events/payloads';
 import { AbstractGeoViewLayer } from './geoview-layers/abstract-geoview-layers';
@@ -319,41 +318,6 @@ export class Layer {
           api.event.emit(GeoViewLayerPayload.createGeoviewLayerAddedPayload(`${this.mapId}/${geoviewLayer.geoviewLayerId}`, geoviewLayer));
         }
       });
-      if (geoviewLayer.gvLayers!.get('source')) {
-        geoviewLayer.gvLayers!.get('source').on('featuresloadend', () => {
-          if (geoviewLayer.getLayerConfig()) {
-            api.event.emit(
-              LayerSetPayload.createLayerSetChangeLayerStatusPayload(
-                this.mapId,
-                Layer.getLayerPath(geoviewLayer.getLayerConfig()!),
-                'loaded'
-              )
-            );
-          }
-        });
-        geoviewLayer.gvLayers!.get('source').on('imageloadend', () => {
-          if (geoviewLayer.getLayerConfig()) {
-            api.event.emit(
-              LayerSetPayload.createLayerSetChangeLayerStatusPayload(
-                this.mapId,
-                Layer.getLayerPath(geoviewLayer.getLayerConfig()!),
-                'loaded'
-              )
-            );
-          }
-        });
-        geoviewLayer.gvLayers!.get('source').on('tileloadend', () => {
-          if (geoviewLayer.getLayerConfig()) {
-            api.event.emit(
-              LayerSetPayload.createLayerSetChangeLayerStatusPayload(
-                this.mapId,
-                Layer.getLayerPath(geoviewLayer.getLayerConfig()!),
-                'loaded'
-              )
-            );
-          }
-        });
-      }
       api.maps[this.mapId].map.addLayer(geoviewLayer.gvLayers!);
     }
   }


### PR DESCRIPTION
fixes #1337

# Description

loadend events moved to raster layers and abstract-geoview-vector, so the 'loaded' status is applied to sublayers of groups.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Checked by fetching the registeredGeoviewLayers from the api and checking for 'loaded' layerStatus for each of the layer types.

https://damonu2.github.io/geoview/type-of-layers.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1355)
<!-- Reviewable:end -->
