### PR TITLE
fix(geolocator): geolocator zooms in closer to results

### DIFF
--- a/packages/geoview-core/src/api/events/constants/feature-highlight-constants.ts
+++ b/packages/geoview-core/src/api/events/constants/feature-highlight-constants.ts
@@ -6,7 +6,7 @@ import { EventStringId } from '../event-types';
  */
 
 /** Valid keys for the FEATURE_HIGHLIGHT category */
-export type FeatureHighlightEventKey = 'EVENT_HIGHLIGHT_FEATURE' | 'EVENT_HIGHLIGHT_CLEAR';
+export type FeatureHighlightEventKey = 'EVENT_HIGHLIGHT_FEATURE' | 'EVENT_HIGHLIGHT_CLEAR' | 'EVENT_HIGHLIGHT_BBOX';
 
 /** Record that associates FEATURE_HIGHLIGHT's event keys to their event string id */
 export const FEATURE_HIGHLIGHT: Record<FeatureHighlightEventKey, EventStringId> = {
@@ -19,4 +19,9 @@ export const FEATURE_HIGHLIGHT: Record<FeatureHighlightEventKey, EventStringId> 
    * Event is triggered when a call is made to clear highlighted features
    */
   EVENT_HIGHLIGHT_CLEAR: 'feature_highlight/clear',
+
+  /**
+   * Event is triggered when a call is made to highlight a bounding box on map
+   */
+  EVENT_HIGHLIGHT_BBOX: 'feature_highlight/highlightBBox',
 };

--- a/packages/geoview-core/src/api/events/event-types.ts
+++ b/packages/geoview-core/src/api/events/event-types.ts
@@ -63,6 +63,7 @@ export type EventStringId =
   | 'drawer/open_close'
   | 'feature_highlight/highlight'
   | 'feature_highlight/clear'
+  | 'feature_highlight/highlightBBox'
   | 'footerbar/expand_collapse'
   | 'footer_tabs/tab_create'
   | 'footer_tabs/tab_remove'

--- a/packages/geoview-core/src/api/events/payloads/bbox-highlight-payload.ts
+++ b/packages/geoview-core/src/api/events/payloads/bbox-highlight-payload.ts
@@ -1,0 +1,57 @@
+import { Extent } from 'ol/extent';
+import { PayloadBaseClass } from './payload-base-class';
+
+import { EventStringId, EVENT_NAMES } from '../event-types';
+
+/** Valid events that can create BBoxHighlightPayload */
+const validEvents: EventStringId[] = [EVENT_NAMES.FEATURE_HIGHLIGHT.EVENT_HIGHLIGHT_BBOX];
+
+/**
+ * type guard function that redefines a PayloadBaseClass as a BBoxHighlightPayload
+ * if the event attribute of the verifyIfPayload parameter is valid. The type ascention
+ * applies only to the true block of the if clause.
+ *
+ * @param {PayloadBaseClass} verifyIfPayload object to test in order to determine if the type ascention is valid
+ * @returns {boolean} returns true if the payload is valid
+ */
+export const payloadIsABBoxHighlight = (verifyIfPayload: PayloadBaseClass): verifyIfPayload is BBoxHighlightPayload => {
+  return validEvents.includes(verifyIfPayload?.event);
+};
+
+/**
+ * Class definition for BBoxHighlightPayload
+ *
+ * @exports
+ * @class BBoxHighlightPayload
+ */
+export class BBoxHighlightPayload extends PayloadBaseClass {
+  // the bounding box to highlight
+  bbox: Extent;
+
+  /**
+   * Constructor for the class
+   *
+   * @param {EventStringId} event the event identifier for which the payload is constructed
+   * @param {string | null} handlerName the handler name
+   * @param {Extent} bbox the bounding box to highlight
+   */
+  constructor(event: EventStringId, handlerName: string | null, bbox: Extent) {
+    if (!validEvents.includes(event)) throw new Error(`BBoxHighlightPayload can't be instanciated for event of type ${event}`);
+    super(event, handlerName);
+    this.bbox = bbox;
+  }
+}
+
+/**
+ * Helper function used to instanciate a BBoxHighlightPayload object. This function
+ * avoids the "new BBoxHighlightPayload" syntax.
+ *
+ * @param {EventStringId} event the event identifier for which the payload is constructed
+ * @param {string | null} handlerName the handler name
+ * @param {Extent} bbox the bounding box to highlight
+ *
+ * @returns {BBoxHighlightPayload} the BBoxHighlightPayload object created
+ */
+export const bboxHighlightPayload = (event: EventStringId, handlerName: string | null, bbox: Extent): BBoxHighlightPayload => {
+  return new BBoxHighlightPayload(event, handlerName, bbox);
+};

--- a/packages/geoview-core/src/ui/snackbar/snackbar.tsx
+++ b/packages/geoview-core/src/ui/snackbar/snackbar.tsx
@@ -110,7 +110,7 @@ export function Snackbar(props: SnackBarProps): JSX.Element {
     >
       <Alert onClose={handleClose} severity={snackbarType} sx={{ width: '100%' }}>
         {message}
-        {button}
+        {button !== undefined && button}
       </Alert>
     </MaterialSnackbar>
   );


### PR DESCRIPTION
Fixes #1300
Fixes #1308

# Description

Fixes issue with snackbar button appearing without content. Also fixes geolocator zoom levels to be zoomed closer to result, and displaying a bounding box of the feature (if it exists) for 5 seconds.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with many different search results throughout the country.

https://damonu2.github.io/geoview/basemaps.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1367)
<!-- Reviewable:end -->
