### PR TITLE
Added a new optional callback when the panel has completed transitioning and is fully opened

### DIFF
--- a/packages/geoview-core/src/core/components/app-bar/app-bar-buttons.ts
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar-buttons.ts
@@ -101,6 +101,7 @@ export class AppbarButtons {
         panel: new PanelApi(panel, buttonId, this.mapId),
         button,
         groupName: group,
+        handlePanelOpened: panelProps.handlePanelOpened,
       };
 
       // add the new button panel to the correct group

--- a/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
@@ -259,7 +259,12 @@ export function Appbar({ activeTrap, activeTrapSet }: AppbarProps): JSX.Element 
             {Object.keys(buttonPanels).map((buttonPanelsKey) => {
               const buttonPanel = buttonPanels[buttonPanelsKey];
               return buttonPanel?.panel ? (
-                <Panel key={buttonPanel.panel.panelId} panel={buttonPanel.panel} button={buttonPanel.button} />
+                <Panel
+                  key={buttonPanel.panel.panelId}
+                  panel={buttonPanel.panel}
+                  button={buttonPanel.button}
+                  handlePanelOpened={buttonPanel.handlePanelOpened}
+                />
               ) : null;
             })}
           </Fragment>

--- a/packages/geoview-core/src/ui/panel/panel-types.ts
+++ b/packages/geoview-core/src/ui/panel/panel-types.ts
@@ -35,6 +35,8 @@ export type TypePanelProps = {
   content?: ReactNode;
   /** Custom panel styles */
   panelStyles?: PanelStyles;
+  /** Handler callback triggered when a panel is fully opened */
+  handlePanelOpened?: () => void;
 };
 
 export interface PanelStyles {
@@ -103,6 +105,8 @@ export type TypeButtonPanel = {
   button: TypeIconButtonProps;
   /** Group name. */
   groupName?: string;
+  /** Handler callback triggered when a panel is fully opened */
+  handlePanelOpened?: () => void;
 };
 
 /** ******************************************************************************************************************************

--- a/packages/geoview-core/src/ui/panel/panel.tsx
+++ b/packages/geoview-core/src/ui/panel/panel.tsx
@@ -11,6 +11,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import Card from '@mui/material/Card';
 import CardHeader from '@mui/material/CardHeader';
 import CardContent from '@mui/material/CardContent';
+import { useTheme } from '@mui/styles';
 
 import { Cast } from '@/core/types/global-types';
 import { HtmlToReact } from '@/core/containers/html-to-react';
@@ -37,6 +38,9 @@ type TypePanelAppProps = {
   panel: PanelApi;
   //   panelOpen: boolean;
   button: TypeIconButtonProps;
+
+  // Callback when the panel has completed opened (and transitioned in)
+  handlePanelOpened?: () => void;
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -102,16 +106,19 @@ const useStyles = makeStyles((theme) => ({
  * @returns {JSX.Element} the created Panel element
  */
 export function Panel(props: TypePanelAppProps): JSX.Element {
-  const { panel, button } = props;
+  const { panel, button, handlePanelOpened } = props;
   const { panelStyles } = panel;
   // set the active trap value for FocusTrap
   const [panelStatus, setPanelStatus] = useState(false);
+
+  // Get the theme
+  const theme = useTheme();
 
   const panelWidth = panel?.width ?? 350;
   const panelContainerStyles = {
     ...(panelStyles?.panelContainer && { ...panelStyles.panelContainer }),
     width: panelStatus ? panelWidth : 0,
-    transition: 'width 300ms ease',
+    transition: `width ${theme.transitions.duration.standard}ms ease`,
   };
 
   const [actionButtons, setActionButtons] = useState<JSX.Element[] & ReactNode[]>([]);
@@ -180,6 +187,13 @@ export function Panel(props: TypePanelAppProps): JSX.Element {
     if (payloadHasAButtonIdAndType(payload)) {
       // set focus on close button on panel open
       setPanelStatus(true);
+
+      if (handlePanelOpened) {
+        // Wait the transition period (+50 ms just to be sure of shenanigans)
+        setTimeout(() => {
+          handlePanelOpened!();
+        }, theme.transitions.duration.standard + 50);
+      }
 
       if (closeBtnRef && closeBtnRef.current) {
         (closeBtnRef.current as HTMLElement).focus();
@@ -339,3 +353,10 @@ export function Panel(props: TypePanelAppProps): JSX.Element {
     </Box>
   );
 }
+
+/**
+ * React's default properties for the Panel
+ */
+Panel.defaultProps = {
+  handlePanelOpened: null,
+};


### PR DESCRIPTION
# Description

For the purpose of using HTML canvas drawing (notably for the GeoChart), I needed to know when the panel has completed expanding, to force a redraw of the canvas. Of course, this PR focuses on implementing the callback logic without knowledge of the specific reason for the callback. It can serve other purposes too.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested as part of the GeoChart plugin.

# Checklist:

- [ ] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1368)
<!-- Reviewable:end -->
