### PR TITLE
PayloadBaseClass now generic

### DIFF
--- a/packages/geoview-core/src/api/events/payloads/payload-base-class.ts
+++ b/packages/geoview-core/src/api/events/payloads/payload-base-class.ts
@@ -6,9 +6,9 @@ import { EventStringId } from '../event-types';
  * @exports
  * @class PayloadBaseClass
  */
-export class PayloadBaseClass {
+export class PayloadBaseClass<T = EventStringId> {
   // Type of payload
-  event: EventStringId;
+  event: T;
 
   // the event handler name of the payload
   handlerName: string | null;
@@ -16,10 +16,10 @@ export class PayloadBaseClass {
   /**
    * Constructor for the class
    *
-   * @param {EventStringId} event the event identifier for which the payload is constructed
+   * @param {T} event the event identifier for which the payload is constructed
    * @param {string | null} handlerName the handler Name
    */
-  constructor(event: EventStringId, handlerName: string | null) {
+  constructor(event: T, handlerName: string | null) {
     this.event = event;
     this.handlerName = handlerName;
   }
@@ -29,11 +29,12 @@ export class PayloadBaseClass {
  * Helper function used to instanciate a PayloadBaseClass object. This function
  * avoids the "new PayloadBaseClass" syntax.
  *
- * @param {EventStringId} event the event identifier for which the payload is constructed
+ * @param {T} event the event identifier for which the payload is constructed
  * @param {string | null} handlerName the handler Name
  *
  * @returns {PayloadBaseClass} the PayloadBaseClass object created
  */
-export const payloadBaseClass = (event: EventStringId, handlerName: string | null): PayloadBaseClass => {
-  return new PayloadBaseClass(event, handlerName);
+type FunctionType<T = EventStringId> = (event: T, handlerName: string | null) => PayloadBaseClass;
+export const payloadBaseClass: FunctionType = <T = EventStringId>(event: T, handlerName: string | null) => {
+  return new PayloadBaseClass<T>(event, handlerName);
 };


### PR DESCRIPTION
# Description

At the time of development of GeoChart, the events were still going to be handled by api and PayloadBaseClass principles. I'm not sure if this is super relevant at this time, but for GeoChart it is.

The `api.event.emit` works in pair with a `PayloadBaseClass` which is tightly coupled with a fixed `EventStringId` type - only valid for core events.

To be able to leverage that concept and still be able to use `api.event.emit`, I wanted to have plugin-specific events inheriting the `PayloadBaseClass` and providing an extended list of event-names (which is the sum of the { events in the core} + {events in the plugin}).

Turning the class generic and accepting any type 'inheriting' from EventStringId allows this functionality.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested as part of the GeoChart plugin development.

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1369)
<!-- Reviewable:end -->
