### PR TITLE
New getGeoviewLayerByIdAsync function mimicking the getGeoviewLayerById

### DIFF
--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -9,7 +9,7 @@ import { api } from '@/app';
 import { EVENT_NAMES } from '@/api/events/event-types';
 
 import { Config } from '@/core/utils/config/config';
-import { generateId, showError, replaceParams } from '@/core/utils/utilities';
+import { generateId, showError, replaceParams, whenThisThenAsync } from '@/core/utils/utilities';
 import {
   layerConfigPayload,
   payloadIsALayerConfig,
@@ -423,6 +423,41 @@ export class Layer {
    */
   getGeoviewLayerById = (geoviewLayerId: string): AbstractGeoViewLayer | null => {
     return this.geoviewLayers?.[geoviewLayerId] || null;
+  };
+
+  /**
+   * Search asynchronously for a layer using it's id and return the layer data.
+   * If the layer we're searching for has to be loaded, set mustBeLoaded to true when awaiting on this method.
+   * This function waits the timeout period before abandonning (or uses the default timeout when not provided).
+   *
+   * @param {string} id the layer id to look for
+   * @param {string} mustBeLoaded indicate if the layer we're searching for must be found only once loaded
+   * @returns the found layer data object
+   */
+  getGeoviewLayerByIdAsync = async (
+    layerID: string,
+    mustBeLoaded: boolean,
+    checkFrequency?: number,
+    timeout?: number
+  ): Promise<AbstractGeoViewLayer | null> => {
+    // Get the layer
+    return whenThisThenAsync<AbstractGeoViewLayer | null>(
+      () => {
+        // Redirects
+        const lyr = this.getGeoviewLayerById(layerID);
+        if (lyr) {
+          // Layer was found, check if we wanted it straight away or in loaded state
+          if (!mustBeLoaded || (mustBeLoaded && lyr.layerPhase === 'processed')) {
+            return lyr;
+          }
+        }
+
+        // Not found yet
+        return null;
+      },
+      checkFrequency,
+      timeout
+    );
   };
 
   /**


### PR DESCRIPTION
# Description

New getGeoviewLayerByIdAsync function mimicking the getGeoviewLayerById, but awaitable. That way, you can run asynchronous code that awaits for the layer to be loaded, before returning the layer.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested during Clip Zip Ship GeoView development.

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1371)
<!-- Reviewable:end -->
