### PR TITLE
feat(right-panel-style): Refactor details right panel, support long text and images

### DIFF
--- a/packages/geoview-core/public/geojson/points.json
+++ b/packages/geoview-core/public/geojson/points.json
@@ -5,9 +5,9 @@
       "type": "Feature",
       "properties": {
         "Red": 92,
-        "Green": 43.54,
-        "Blue": 12.3,
-        "Yellow": 66,
+        "Green": "1 Start, this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text. END",
+        "Blue": "2 Start, this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text. END",
+        "Yellow": "3 Start, this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text.this is very long text. END",
         "Orange": 75,
         "creationDate": "15/02/2022T05:00:00-05:00"
       },

--- a/packages/geoview-core/public/templates/raw-feature-info-1.html
+++ b/packages/geoview-core/public/templates/raw-feature-info-1.html
@@ -57,9 +57,9 @@
           'projection': 3978
         },
         'basemapOptions': {
-          'basemapId': 'transport',
+          'basemapId': 'osm',
           'shaded': false,
-          'labeled': true
+          'labeled': false
         },
         'listOfGeoviewLayerConfig': [
           {
@@ -145,7 +145,7 @@
       },
       'theme': 'royal',
       'navBar': ['zoom', 'fullscreen', 'home', 'location', 'export'],
-      'components': ['north-arrow', 'overview-map'],
+      'components': ['north-arrow'],
       'corePackages': ['footer-panel'],
       'externalPackages': [],
       'suportedLanguages': ['en']

--- a/packages/geoview-core/src/core/components/details-1/details-1-style.ts
+++ b/packages/geoview-core/src/core/components/details-1/details-1-style.ts
@@ -25,7 +25,9 @@ export const getSxClasses = (theme: Theme) => ({
     background: theme.footerPanel.contentBg,
   },
   layerNamePrimary: {
-    font: theme.footerPanel.titleFont,
+    '& .MuiListItemText-primary': {
+      font: theme.footerPanel.layerTitleFont,
+    },
     marginLeft: '10px',
   },
   list: {
@@ -46,21 +48,16 @@ export const getSxClasses = (theme: Theme) => ({
     boxShadow: '0px 12px 9px -13px #E0E0E0',
   },
   itemText: {
-    fontSize: 14,
-    noWrap: true,
     '& .MuiListItemText-primary': {
-      font: theme.footerPanel.titleFont,
-    },
-    '& .MuiListItemText-secondary': {
-      font: theme.footerPanel.layerSecondaryTitleFont,
-      color: theme.palette.common.black,
+      font: theme.footerPanel.layerTitleFont,
     },
   },
   featureInfoListContainer: {
     paddingLeft: '25px',
     paddingRight: '25px',
     paddingBottom: '25px',
-    height: '410px',
+    height: 'auto',
+    maxHeight: '80%',
     overflowY: 'scroll',
     overflowX: 'hidden',
   },
@@ -76,10 +73,14 @@ export const getSxClasses = (theme: Theme) => ({
     },
   },
   featureInfoItemValue: {
-    fontSize: '16px',
     marginRight: 0,
     wordBreak: 'break-word',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+  },
+  boxContainerFeatureInfo: {
+    wordWrap: 'break-word',
+    fontSize: '16px',
+    lineHeight: '19px',
   },
 });

--- a/packages/geoview-core/src/core/components/details-1/details-1-style.ts
+++ b/packages/geoview-core/src/core/components/details-1/details-1-style.ts
@@ -58,7 +58,7 @@ export const getSxClasses = (theme: Theme) => ({
     paddingBottom: '25px',
     height: 'auto',
     maxHeight: '80%',
-    overflowY: 'scroll',
+    overflowY: 'auto',
     overflowX: 'hidden',
   },
   featureInfoSingleImage: {

--- a/packages/geoview-core/src/core/components/details-1/details-1-style.ts
+++ b/packages/geoview-core/src/core/components/details-1/details-1-style.ts
@@ -61,7 +61,8 @@ export const getSxClasses = (theme: Theme) => ({
     paddingRight: '25px',
     paddingBottom: '25px',
     height: '410px',
-    overflow: 'scroll',
+    overflowY: 'scroll',
+    overflowX: 'hidden',
   },
   featureInfoSingleImage: {
     width: '35px',
@@ -77,7 +78,6 @@ export const getSxClasses = (theme: Theme) => ({
   featureInfoItemValue: {
     fontSize: '16px',
     marginRight: 0,
-    marginTop: '5px',
     wordBreak: 'break-word',
     overflow: 'hidden',
     textOverflow: 'ellipsis',

--- a/packages/geoview-core/src/core/components/details-1/feature-info-table.tsx
+++ b/packages/geoview-core/src/core/components/details-1/feature-info-table.tsx
@@ -94,7 +94,7 @@ export function FeatureInfoTable({ featureInfoList }: FeatureInfoTableProps): JS
   }
 
   return (
-    <Box sx={{ wordWrap: 'break-word', fontSize: '14px' }}>
+    <Box sx={sxClasses.boxContainerFeatureInfo}>
       {isLightBoxOpen && (
         <LightboxImg
           open={isLightBoxOpen}
@@ -115,7 +115,7 @@ export function FeatureInfoTable({ featureInfoList }: FeatureInfoTableProps): JS
           <Grid item xs="auto" sx={{ fontWeight: 'bold' }}>
             {featureInfoItem.alias}
           </Grid>
-          <Grid item sx={{ ml: 'auto', wordWrap: 'break-word', fontSize: '16px' }}>
+          <Grid item sx={{ ml: 'auto', wordWrap: 'break-word' }}>
             {setFeatureItem(featureInfoItem)}
           </Grid>
         </Grid>

--- a/packages/geoview-core/src/core/components/details-1/feature-info-table.tsx
+++ b/packages/geoview-core/src/core/components/details-1/feature-info-table.tsx
@@ -2,10 +2,9 @@ import React, { useState } from 'react';
 import { useTheme } from '@mui/material/styles';
 import linkifyHtml from 'linkify-html';
 import { useTranslation } from 'react-i18next';
-import { Table, TableBody, TableCell, TableContainer, TableRow } from '@mui/material';
 import { TypeFieldEntry } from '@/api/events/payloads';
 import { LightboxImg, LightBoxSlides } from '../lightbox/lightbox';
-import { CardMedia, Box } from '@/ui';
+import { CardMedia, Box, Grid } from '@/ui';
 import { isImage, stringify, generateId, sanitizeHtmlContent } from '../../utils/utilities';
 import { HtmlToReact } from '../../containers/html-to-react';
 import { getSxClasses } from './details-1-style';
@@ -95,7 +94,7 @@ export function FeatureInfoTable({ featureInfoList }: FeatureInfoTableProps): JS
   }
 
   return (
-    <TableContainer>
+    <Box sx={{ wordWrap: 'break-word', fontSize: '14px' }}>
       {isLightBoxOpen && (
         <LightboxImg
           open={isLightBoxOpen}
@@ -110,39 +109,17 @@ export function FeatureInfoTable({ featureInfoList }: FeatureInfoTableProps): JS
           }}
         />
       )}
-      <Table
-        sx={{
-          border: 'none',
-          minWidth: 300,
-        }}
-      >
-        <TableBody sx={{ fontSize: '14px' }}>
-          {featureInfoList.map((featureInfoItem, index) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <TableRow key={index} sx={{ backgroundColor: index % 2 > 0 ? '#F1F2F5' : '' }}>
-              <TableCell
-                sx={{
-                  borderRight: 'none',
-                  p: '5px',
-                  width: '70%',
-                  fontWeight: 'bold',
-                }}
-              >
-                {featureInfoItem.alias}
-              </TableCell>
-              <TableCell
-                sx={{
-                  p: '5px',
-                  textAlign: 'start',
-                  fontSize: '16px',
-                }}
-              >
-                {setFeatureItem(featureInfoItem)}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+      {featureInfoList.map((featureInfoItem, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <Grid container spacing={5} sx={{ backgroundColor: index % 2 > 0 ? '#F1F2F5' : '', marginBottom: '20px' }} key={index}>
+          <Grid item xs="auto" sx={{ fontWeight: 'bold' }}>
+            {featureInfoItem.alias}
+          </Grid>
+          <Grid item sx={{ ml: 'auto', wordWrap: 'break-word', fontSize: '16px' }}>
+            {setFeatureItem(featureInfoItem)}
+          </Grid>
+        </Grid>
+      ))}
+    </Box>
   );
 }

--- a/packages/geoview-core/src/core/components/details-1/layers-list-footer.tsx
+++ b/packages/geoview-core/src/core/components/details-1/layers-list-footer.tsx
@@ -8,6 +8,8 @@ import {
   ListItem,
   ListItemButton,
   List,
+  ListItemIcon,
+  SendIcon,
   Tooltip,
   IconButton,
   Grid,
@@ -134,6 +136,7 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
       // load the first layer we clicked with its feature info in right panel
       // if there are multiple layers, we load the first one on the list with its feature info
       setLayerDataInfo(arrayOfLayerData[0]);
+      setCurrentFeatureIndex(0);
     }
   }, [arrayOfLayerData]);
 
@@ -164,6 +167,9 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
                   }}
                   sx={{ height: '67px' }}
                 >
+                  <ListItemIcon>
+                    <SendIcon />
+                  </ListItemIcon>
                   <Tooltip title={layerData.layerName} placement="top" enterDelay={1000}>
                     <ListItemText
                       sx={sxClasses.layerNamePrimary}

--- a/packages/geoview-footer-panel/src/details-item.tsx
+++ b/packages/geoview-footer-panel/src/details-item.tsx
@@ -34,12 +34,12 @@ export function DetailsItem({ mapId }: Props): JSX.Element {
   const [handlerName, setHandlerName] = useState<string | null>(null);
 
   const allQueriesDoneListenerFunction = (payload: PayloadBaseClass) => {
-    if (payloadIsAllQueriesDone(payload)) {
+    if (payloadIsAllQueriesDone(payload) && (payload as TypeAllQueriesDonePayload).queryType === 'at_long_lat') {
       const { resultSets } = payload as TypeAllQueriesDonePayload;
       const newDetails: TypeArrayOfLayerData = [];
       Object.keys(resultSets).forEach((layerPath) => {
         const layerName = getLocalizedValue(api.maps[mapId].layer.registeredLayers[layerPath].layerName, mapId)!;
-        const features = resultSets[layerPath]?.data;
+        const features = resultSets[layerPath]?.data.at_long_lat;
         if (features?.length && features?.length > 0) {
           newDetails.push({ layerPath, layerName, features });
         }


### PR DESCRIPTION
# Description

We need to display long texts and images in Details tab (right panel) in order to show the full text similar to screenshot below:

![image](https://github.com/Canadian-Geospatial-Platform/geoview/assets/138072320/1430fe24-c90b-47db-b6a9-cf1fdba6f7cf)


Fixes #1361 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please select a point on map in order to load the layers in left panel, and its features on right panel. In case we have images, the need to take the full length of the right panel container, and long texts should display properly.

https://amir-azma.github.io/geoview/raw-feature-info-1.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1385)
<!-- Reviewable:end -->
