### PR TITLE
feat(basemap): load a blank basemap initially

### DIFF
--- a/packages/geoview-core/public/templates/basemaps.html
+++ b/packages/geoview-core/public/templates/basemaps.html
@@ -119,7 +119,7 @@
             'zoom': 4,
             'center': [-100, 60],
             'projection': 3978,
-            'extent': [-160, 40, -40, 75]
+            'extent': [-130, 30, -50, 70]
           },
           'basemapOptions': {
             'basemapId': 'nogeom',

--- a/packages/geoview-core/src/ui/snackbar/snackbar.tsx
+++ b/packages/geoview-core/src/ui/snackbar/snackbar.tsx
@@ -60,7 +60,7 @@ export function Snackbar(props: SnackBarProps): JSX.Element {
   const snackBarOpenListenerFunction = (payload: PayloadBaseClass) => {
     if (payloadIsASnackbarMessage(payload)) {
       // apply function if provided
-      const myButton = payload.button
+      const myButton = payload.button?.label
         ? SnackButton({
             label: payload.button.label as string,
             action: Cast<() => void>(payload.button.action),


### PR DESCRIPTION
Fixes #1387
Fixes #703

# Description

Loads a blank basemap at map creation before loading actual basemap. Also updates extent handling to use transformExtent which makes extent useable (if a bit clunky) for LCC projections.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with most demo pages, testing somewhat incomplete with basemap servers currently down. Will require further testing, especially on package-basemap-panel.html once basemaps are back.

https://damonu2.github.io/geoview/basemaps.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1388)
<!-- Reviewable:end -->
