### PR TITLE
Further improved createCodeSnippetUsingIDs for multiple scripts stacking

### DIFF
--- a/packages/geoview-core/public/templates/codedoc.js
+++ b/packages/geoview-core/public/templates/codedoc.js
@@ -28,13 +28,10 @@ function createCodeSnippetUsingIDs() {
   for (let i = 0; i < scripts.length; i++) {
     // Try to find a codeSnippet flag interested in that script
     const script = scripts[i];
-    const el = document.getElementById(`${script.id}CS`);
-    if (el !== null) {
-      el.innerHTML = `<pre>${script.textContent
-        .replace('//create snippets\n', '')
-        .replace('createConfigSnippet();\n', '')
-        .replace('createCodeSnippet();\n', '')}</pre>`;
-    }
+    document.querySelectorAll(`[id-script="${script.id}"]`).forEach((el) => {
+      // eslint-disable-next-line no-param-reassign
+      el.innerHTML = `<pre>${script.textContent}</pre>`;
+    });
   }
 }
 


### PR DESCRIPTION
Further improved the new `createCodeSnippetUsingIDs` function to be able to not only point to different scripts in the html template, but **stack** different scripts on top of each other in the UI (to be able to show standardized code which might be re-using common functions throughout the template).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

During development of the template for Geoview-geochart.

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1390)
<!-- Reviewable:end -->
