### PR TITLE
1423-[BUG] Map loaded is not fired

### DIFF
--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -483,6 +483,8 @@ export class Layer {
    * @param {AbstractGeoViewLayer} geoviewLayer layer to set Z index for
    */
   setLayerZIndices = (geoviewLayer: AbstractGeoViewLayer) => {
+    // if olLayers is null, the layer is in error and we return.
+    if (!geoviewLayer.olLayers) return;
     const zIndex =
       this.layerOrder.indexOf(geoviewLayer.geoviewLayerId) !== -1 ? this.layerOrder.indexOf(geoviewLayer.geoviewLayerId) * 100 : 0;
     geoviewLayer.olLayers!.setZIndex(zIndex);

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -15,8 +15,6 @@ import { Cast, TypeJsonObject } from '@/core/types/global-types';
 import { TypeFeatureStyle } from '@/geo/layer/geometry/geometry-types';
 import { xmlToJson } from '@/core/utils/utilities';
 
-import { api } from '@/app';
-import { LayerSetPayload } from '@/api/events/payloads';
 import { TypeLayerEntryConfig, TypeListOfLayerEntryConfig, layerEntryIsGroupLayer } from '@/geo/map/map-schema-types';
 import { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { Layer } from '@/geo/layer/layer';
@@ -46,7 +44,7 @@ export class GeoUtilities {
         this.setAllLayerStatusToError(geoviewLayerInstance, layerEntryConfig.listOfLayerEntryConfig, errorMessage);
       else {
         const layerPath = Layer.getLayerPath(layerEntryConfig);
-        api.event.emit(LayerSetPayload.createLayerSetChangeLayerStatusPayload(geoviewLayerInstance.mapId, layerPath, 'error'));
+        geoviewLayerInstance.changeLayerStatus('error', layerEntryConfig);
         geoviewLayerInstance.layerLoadError.push({
           layer: layerPath,
           consoleMessage: `${errorMessage} for layer ${layerPath} of map ${geoviewLayerInstance.mapId}`,


### PR DESCRIPTION
# Description

Correction to the map loaded bug when a server is down..

Fixes #1423

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using the Chrome Devtool, force a get metadata error to simulate a server not responding error (downtime simulation). This test can only be done on a localhost. 

__Deploy URL:__ https://ychoquet.github.io/GeoView/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1430)
<!-- Reviewable:end -->
