### PR TITLE
fix(layer-selection) Pre select the previously selected layer in left panel

### DIFF
--- a/packages/geoview-core/src/core/components/details/details.tsx
+++ b/packages/geoview-core/src/core/components/details/details.tsx
@@ -1,6 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
+import { useStore } from 'zustand';
 import { TypeArrayOfFeatureInfoEntries } from '@/api/events/payloads';
 import { LayersListFooter } from './layers-list-footer';
+import { getGeoViewStore } from '@/core/stores/stores-managers';
 
 export interface TypeDetailsProps {
   arrayOfLayerData: TypeArrayOfLayerData;
@@ -20,11 +22,15 @@ export type TypeArrayOfLayerData = TypeLayerData[];
  * @returns {JSX.Element} returns the Details component
  */
 export function DetailsFooter({ arrayOfLayerData, mapId }: TypeDetailsProps): JSX.Element | null {
-  const [details, setDetails] = useState<TypeArrayOfLayerData>([]);
+  const store = getGeoViewStore(mapId);
+  const { storeArrayOfLayerData } = useStore(store, (state) => state.detailsState);
 
   useEffect(() => {
-    setDetails(arrayOfLayerData);
+    store.setState({
+      detailsState: { ...store.getState().detailsState, storeArrayOfLayerData: arrayOfLayerData },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [arrayOfLayerData]);
 
-  return <LayersListFooter arrayOfLayerData={details} mapId={mapId} />;
+  return <LayersListFooter arrayOfLayerData={storeArrayOfLayerData} mapId={mapId} />;
 }

--- a/packages/geoview-core/src/core/components/details/details.tsx
+++ b/packages/geoview-core/src/core/components/details/details.tsx
@@ -23,7 +23,7 @@ export type TypeArrayOfLayerData = TypeLayerData[];
  */
 export function DetailsFooter({ arrayOfLayerData, mapId }: TypeDetailsProps): JSX.Element | null {
   const store = getGeoViewStore(mapId);
-  const { storeArrayOfLayerData } = useStore(store, (state) => state.detailsState);
+  const storeArrayOfLayerData = useStore(store, (state) => state.detailsState.storeArrayOfLayerData);
 
   useEffect(() => {
     store.setState({

--- a/packages/geoview-core/src/core/components/details/details.tsx
+++ b/packages/geoview-core/src/core/components/details/details.tsx
@@ -23,14 +23,14 @@ export type TypeArrayOfLayerData = TypeLayerData[];
  */
 export function DetailsFooter({ arrayOfLayerData, mapId }: TypeDetailsProps): JSX.Element | null {
   const store = getGeoViewStore(mapId);
-  const storeArrayOfLayerData = useStore(store, (state) => state.detailsState.storeArrayOfLayerData);
+  const layerDataArray = useStore(store, (state) => state.detailsState.layerDataArray);
 
   useEffect(() => {
     store.setState({
-      detailsState: { ...store.getState().detailsState, storeArrayOfLayerData: arrayOfLayerData },
+      detailsState: { ...store.getState().detailsState, layerDataArray: arrayOfLayerData },
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [arrayOfLayerData]);
 
-  return <LayersListFooter arrayOfLayerData={storeArrayOfLayerData} mapId={mapId} />;
+  return <LayersListFooter arrayOfLayerData={layerDataArray} mapId={mapId} />;
 }

--- a/packages/geoview-core/src/core/components/details/layers-list-footer.tsx
+++ b/packages/geoview-core/src/core/components/details/layers-list-footer.tsx
@@ -56,7 +56,7 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
   const selectedFeatures = useRef<string[]>([]);
 
   const store = getGeoViewStore(mapId);
-  const storeSelectedLayerPath = useStore(store, (state) => state.detailsState.storeSelectedLayerPath);
+  const selectedLayerPath = useStore(store, (state) => state.detailsState.selectedLayerPath);
 
   const [layerDataInfo, setLayerDataInfo] = useState<TypeLayerData | null>(null);
   const [currentFeatureIndex, setCurrentFeatureIndex] = useState<number>(0);
@@ -146,12 +146,12 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
     if (arrayOfLayerData.length > 0) {
       // Check if have the previouse selected layer path in incoming arrayOfLayerData
       // if so, get the index of the found layer, we need to pass to setLayerDataInfo to load layer in left panel
-      const commonLayerPathIndex = findLayerPathIndex(arrayOfLayerData, storeSelectedLayerPath);
+      const commonLayerPathIndex = findLayerPathIndex(arrayOfLayerData, selectedLayerPath);
       setLayerDataInfo(arrayOfLayerData[commonLayerPathIndex > -1 ? commonLayerPathIndex : 0]);
       store.setState({
         detailsState: {
           ...store.getState().detailsState,
-          storeSelectedLayerPath: arrayOfLayerData[commonLayerPathIndex > -1 ? commonLayerPathIndex : 0].layerPath,
+          selectedLayerPath: arrayOfLayerData[commonLayerPathIndex > -1 ? commonLayerPathIndex : 0].layerPath,
         },
       });
 
@@ -185,7 +185,7 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
                     setLayerDataInfo(layerData);
                     setCurrentFeatureIndex(0);
                     store.setState({
-                      detailsState: { ...store.getState().detailsState, storeSelectedLayerPath: layerData.layerPath },
+                      detailsState: { ...store.getState().detailsState, selectedLayerPath: layerData.layerPath },
                     });
                   }}
                   sx={{ height: '67px' }}

--- a/packages/geoview-core/src/core/components/details/layers-list-footer.tsx
+++ b/packages/geoview-core/src/core/components/details/layers-list-footer.tsx
@@ -56,9 +56,10 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
   const selectedFeatures = useRef<string[]>([]);
 
   const store = getGeoViewStore(mapId);
-  const { storeCurrentFeatureIndex, storeSelectedLayerPath, setStoreCurrentFeatureIndex } = useStore(store, (state) => state.detailsState);
+  const storeSelectedLayerPath = useStore(store, (state) => state.detailsState.storeSelectedLayerPath);
 
   const [layerDataInfo, setLayerDataInfo] = useState<TypeLayerData | null>(null);
+  const [currentFeatureIndex, setCurrentFeatureIndex] = useState<number>(0);
   const [isClearAllCheckboxes, setIsClearAllCheckboxes] = useState<boolean>(false);
   const [disableClearAllBtn, setDisableClearAllBtn] = useState<boolean>(false);
 
@@ -93,7 +94,7 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
       featureHighlightPayload(
         EVENT_NAMES.FEATURE_HIGHLIGHT.EVENT_HIGHLIGHT_FEATURE,
         mapId,
-        layerDataInfo?.features[storeCurrentFeatureIndex] as TypeFeatureInfoEntry
+        layerDataInfo?.features[currentFeatureIndex] as TypeFeatureInfoEntry
       )
     );
 
@@ -146,11 +147,15 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
       // Check if have the previouse selected layer path in incoming arrayOfLayerData
       // if so, get the index of the found layer, we need to pass to setLayerDataInfo to load layer in left panel
       const commonLayerPathIndex = findLayerPathIndex(arrayOfLayerData, storeSelectedLayerPath);
-      setLayerDataInfo(commonLayerPathIndex > -1 ? arrayOfLayerData[commonLayerPathIndex] : arrayOfLayerData[0]);
-      setStoreCurrentFeatureIndex(0);
+      setLayerDataInfo(arrayOfLayerData[commonLayerPathIndex > -1 ? commonLayerPathIndex : 0]);
       store.setState({
-        detailsState: { ...store.getState().detailsState, storeSelectedLayerPath: arrayOfLayerData[0].layerPath },
+        detailsState: {
+          ...store.getState().detailsState,
+          storeSelectedLayerPath: arrayOfLayerData[commonLayerPathIndex > -1 ? commonLayerPathIndex : 0].layerPath,
+        },
       });
+
+      setCurrentFeatureIndex(0);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [arrayOfLayerData]);
@@ -178,7 +183,7 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
                 <ListItemButton
                   onClick={() => {
                     setLayerDataInfo(layerData);
-                    setStoreCurrentFeatureIndex(0);
+                    setCurrentFeatureIndex(0);
                     store.setState({
                       detailsState: { ...store.getState().detailsState, storeSelectedLayerPath: layerData.layerPath },
                     });
@@ -231,7 +236,7 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
                 <Grid container sx={sxClasses.rightPanelBtnHolder}>
                   <Grid item xs={6}>
                     <div style={{ marginLeft: '22px' }}>
-                      Feature {storeCurrentFeatureIndex + 1} of {layerDataInfo?.features.length}
+                      Feature {currentFeatureIndex + 1} of {layerDataInfo?.features.length}
                       <IconButton
                         sx={{ marginLeft: '20px' }}
                         aria-label="clear-all-features"
@@ -250,8 +255,8 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
                         aria-label="backward"
                         tooltip="details.previousFeatureBtn"
                         tooltipPlacement="top"
-                        onClick={() => setStoreCurrentFeatureIndex(storeCurrentFeatureIndex - 1)}
-                        disabled={storeCurrentFeatureIndex === 0}
+                        onClick={() => setCurrentFeatureIndex(currentFeatureIndex - 1)}
+                        disabled={currentFeatureIndex === 0}
                       >
                         <ArrowBackIosOutlinedIcon />
                       </IconButton>
@@ -260,9 +265,9 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
                         aria-label="forward"
                         tooltip="details.nextFeatureBtn"
                         tooltipPlacement="top"
-                        onClick={() => setStoreCurrentFeatureIndex(storeCurrentFeatureIndex + 1)}
+                        onClick={() => setCurrentFeatureIndex(currentFeatureIndex + 1)}
                         // eslint-disable-next-line no-unsafe-optional-chaining
-                        disabled={storeCurrentFeatureIndex === layerDataInfo?.features.length - 1}
+                        disabled={currentFeatureIndex === layerDataInfo?.features.length - 1}
                       >
                         <ArrowForwardIosOutlinedIcon />
                       </IconButton>
@@ -271,7 +276,7 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
                 </Grid>
                 <FeatureInfo
                   features={layerDataInfo?.features}
-                  currentFeatureIndex={storeCurrentFeatureIndex}
+                  currentFeatureIndex={currentFeatureIndex}
                   selectedFeatures={selectedFeatures}
                   mapId={mapId}
                   onClearCheckboxes={() => setIsClearAllCheckboxes(false)}

--- a/packages/geoview-core/src/core/components/details/layers-list-footer.tsx
+++ b/packages/geoview-core/src/core/components/details/layers-list-footer.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/require-default-props */
 import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { useStore } from 'zustand';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { getUid } from 'ol/util';
@@ -35,6 +36,7 @@ import {
   TypeGeometry,
 } from '@/api/events/payloads';
 import { getSxClasses } from './details-style';
+import { getGeoViewStore } from '@/core/stores/stores-managers';
 
 interface TypeLayersListProps {
   arrayOfLayerData: TypeArrayOfLayerData;
@@ -52,12 +54,20 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
   const { t } = useTranslation<string>();
   const theme = useTheme();
   const selectedFeatures = useRef<string[]>([]);
+
+  const store = getGeoViewStore(mapId);
+  const { storeCurrentFeatureIndex, storeSelectedLayerPath, setStoreCurrentFeatureIndex } = useStore(store, (state) => state.detailsState);
+
   const [layerDataInfo, setLayerDataInfo] = useState<TypeLayerData | null>(null);
-  const [currentFeatureIndex, setCurrentFeatureIndex] = useState<number>(0);
   const [isClearAllCheckboxes, setIsClearAllCheckboxes] = useState<boolean>(false);
   const [disableClearAllBtn, setDisableClearAllBtn] = useState<boolean>(false);
 
   const sxClasses = getSxClasses(theme);
+
+  // Returns the index of matching layer based on the found layer path
+  const findLayerPathIndex = (layerDataArray: TypeArrayOfLayerData, layerPathSearch: string): number => {
+    return layerDataArray.findIndex((item) => item.layerPath === layerPathSearch);
+  };
 
   const highlightCallbackFunction = (payload: PayloadBaseClass) => {
     if (payloadIsAFeatureHighlight(payload)) {
@@ -83,7 +93,7 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
       featureHighlightPayload(
         EVENT_NAMES.FEATURE_HIGHLIGHT.EVENT_HIGHLIGHT_FEATURE,
         mapId,
-        layerDataInfo?.features[currentFeatureIndex] as TypeFeatureInfoEntry
+        layerDataInfo?.features[storeCurrentFeatureIndex] as TypeFeatureInfoEntry
       )
     );
 
@@ -133,11 +143,16 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
 
   useEffect(() => {
     if (arrayOfLayerData.length > 0) {
-      // load the first layer we clicked with its feature info in right panel
-      // if there are multiple layers, we load the first one on the list with its feature info
-      setLayerDataInfo(arrayOfLayerData[0]);
-      setCurrentFeatureIndex(0);
+      // Check if have the previouse selected layer path in incoming arrayOfLayerData
+      // if so, get the index of the found layer, we need to pass to setLayerDataInfo to load layer in left panel
+      const commonLayerPathIndex = findLayerPathIndex(arrayOfLayerData, storeSelectedLayerPath);
+      setLayerDataInfo(commonLayerPathIndex > -1 ? arrayOfLayerData[commonLayerPathIndex] : arrayOfLayerData[0]);
+      setStoreCurrentFeatureIndex(0);
+      store.setState({
+        detailsState: { ...store.getState().detailsState, storeSelectedLayerPath: arrayOfLayerData[0].layerPath },
+      });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [arrayOfLayerData]);
 
   const renderLayerList = useCallback(() => {
@@ -163,7 +178,10 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
                 <ListItemButton
                   onClick={() => {
                     setLayerDataInfo(layerData);
-                    setCurrentFeatureIndex(0);
+                    setStoreCurrentFeatureIndex(0);
+                    store.setState({
+                      detailsState: { ...store.getState().detailsState, storeSelectedLayerPath: layerData.layerPath },
+                    });
                   }}
                   sx={{ height: '67px' }}
                 >
@@ -213,7 +231,7 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
                 <Grid container sx={sxClasses.rightPanelBtnHolder}>
                   <Grid item xs={6}>
                     <div style={{ marginLeft: '22px' }}>
-                      Feature {currentFeatureIndex + 1} of {layerDataInfo?.features.length}
+                      Feature {storeCurrentFeatureIndex + 1} of {layerDataInfo?.features.length}
                       <IconButton
                         sx={{ marginLeft: '20px' }}
                         aria-label="clear-all-features"
@@ -232,8 +250,8 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
                         aria-label="backward"
                         tooltip="details.previousFeatureBtn"
                         tooltipPlacement="top"
-                        onClick={() => setCurrentFeatureIndex((prevValue) => prevValue - 1)}
-                        disabled={currentFeatureIndex === 0}
+                        onClick={() => setStoreCurrentFeatureIndex(storeCurrentFeatureIndex - 1)}
+                        disabled={storeCurrentFeatureIndex === 0}
                       >
                         <ArrowBackIosOutlinedIcon />
                       </IconButton>
@@ -242,9 +260,9 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
                         aria-label="forward"
                         tooltip="details.nextFeatureBtn"
                         tooltipPlacement="top"
-                        onClick={() => setCurrentFeatureIndex((prevValue) => prevValue + 1)}
+                        onClick={() => setStoreCurrentFeatureIndex(storeCurrentFeatureIndex + 1)}
                         // eslint-disable-next-line no-unsafe-optional-chaining
-                        disabled={currentFeatureIndex === layerDataInfo?.features.length - 1}
+                        disabled={storeCurrentFeatureIndex === layerDataInfo?.features.length - 1}
                       >
                         <ArrowForwardIosOutlinedIcon />
                       </IconButton>
@@ -253,7 +271,7 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
                 </Grid>
                 <FeatureInfo
                   features={layerDataInfo?.features}
-                  currentFeatureIndex={currentFeatureIndex}
+                  currentFeatureIndex={storeCurrentFeatureIndex}
                   selectedFeatures={selectedFeatures}
                   mapId={mapId}
                   onClearCheckboxes={() => setIsClearAllCheckboxes(false)}

--- a/packages/geoview-core/src/core/components/details/layers-list-footer.tsx
+++ b/packages/geoview-core/src/core/components/details/layers-list-footer.tsx
@@ -144,7 +144,7 @@ export function LayersListFooter(props: TypeLayersListProps): JSX.Element {
 
   useEffect(() => {
     if (arrayOfLayerData.length > 0) {
-      // Check if have the previouse selected layer path in incoming arrayOfLayerData
+      // Check if have the previous selected layer path in incoming arrayOfLayerData
       // if so, get the index of the found layer, we need to pass to setLayerDataInfo to load layer in left panel
       const commonLayerPathIndex = findLayerPathIndex(arrayOfLayerData, selectedLayerPath);
       setLayerDataInfo(arrayOfLayerData[commonLayerPathIndex > -1 ? commonLayerPathIndex : 0]);

--- a/packages/geoview-core/src/core/stores/geoview-store.ts
+++ b/packages/geoview-core/src/core/stores/geoview-store.ts
@@ -90,8 +90,8 @@ export interface IMapDataTableState {
 }
 
 export interface IDetailsState {
-  storeArrayOfLayerData: TypeArrayOfLayerData;
-  storeSelectedLayerPath: string;
+  layerDataArray: TypeArrayOfLayerData;
+  selectedLayerPath: string;
 }
 
 export interface IGeoViewState {
@@ -197,8 +197,8 @@ export const geoViewStoreDefinition = (
       selectedLayers: {},
     },
     detailsState: {
-      storeArrayOfLayerData: [],
-      storeSelectedLayerPath: '',
+      layerDataArray: [],
+      selectedLayerPath: '',
     },
     notificationState: {
       notifications: [],

--- a/packages/geoview-core/src/core/stores/geoview-store.ts
+++ b/packages/geoview-core/src/core/stores/geoview-store.ts
@@ -14,6 +14,7 @@ import { toLonLat } from 'ol/proj';
 
 import { TypeMapFeaturesConfig, TypeValidMapProjectionCodes } from '@/core/types/global-types';
 import { TypeLegendItemProps } from '../components/legend-2/types';
+import { TypeArrayOfLayerData } from '../components/details/details';
 
 import { TypeMapMouseInfo } from '@/api/events/payloads';
 import { TypeDisplayLanguage, TypeInteraction } from '@/geo/map/map-schema-types';
@@ -88,6 +89,13 @@ export interface IMapDataTableState {
   setToolbarRowSelectedMessage: (message: string) => void;
 }
 
+export interface IDetailsState {
+  storeCurrentFeatureIndex: number;
+  storeArrayOfLayerData: TypeArrayOfLayerData;
+  storeSelectedLayerPath: string;
+  setStoreCurrentFeatureIndex: (newFeatureIndex: number) => void;
+}
+
 export interface IGeoViewState {
   displayLanguage: TypeDisplayLanguage;
   isCrosshairsActive: boolean;
@@ -100,6 +108,7 @@ export interface IGeoViewState {
   legendState: ILegendState;
   mapState: IMapState;
   notificationState: INotificationsState;
+  detailsState: IDetailsState;
   dataTableState: IMapDataTableState;
   setMapConfig: (config: TypeMapFeaturesConfig) => void;
   onMapLoaded: (mapElem: OLMap) => void;
@@ -188,6 +197,19 @@ export const geoViewStoreDefinition = (
       selectedItem: undefined,
       selectedIsVisible: true,
       selectedLayers: {},
+    },
+    detailsState: {
+      storeCurrentFeatureIndex: 0,
+      storeArrayOfLayerData: [],
+      storeSelectedLayerPath: '',
+      setStoreCurrentFeatureIndex: (newFeatureIndex: number) => {
+        set({
+          detailsState: {
+            ...get().detailsState,
+            storeCurrentFeatureIndex: newFeatureIndex,
+          },
+        });
+      },
     },
     notificationState: {
       notifications: [],

--- a/packages/geoview-core/src/core/stores/geoview-store.ts
+++ b/packages/geoview-core/src/core/stores/geoview-store.ts
@@ -90,10 +90,8 @@ export interface IMapDataTableState {
 }
 
 export interface IDetailsState {
-  storeCurrentFeatureIndex: number;
   storeArrayOfLayerData: TypeArrayOfLayerData;
   storeSelectedLayerPath: string;
-  setStoreCurrentFeatureIndex: (newFeatureIndex: number) => void;
 }
 
 export interface IGeoViewState {
@@ -199,17 +197,8 @@ export const geoViewStoreDefinition = (
       selectedLayers: {},
     },
     detailsState: {
-      storeCurrentFeatureIndex: 0,
       storeArrayOfLayerData: [],
       storeSelectedLayerPath: '',
-      setStoreCurrentFeatureIndex: (newFeatureIndex: number) => {
-        set({
-          detailsState: {
-            ...get().detailsState,
-            storeCurrentFeatureIndex: newFeatureIndex,
-          },
-        });
-      },
     },
     notificationState: {
       notifications: [],


### PR DESCRIPTION
# Description

We need to use store management in our Details tab. Also, the left panel selected layer should be the same as our previous layer selected.

Fixes #1376 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

https://amir-azma.github.io/geoview/raw-feature-info-1.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1432)
<!-- Reviewable:end -->
