### PR TITLE
Added a rule about having an await if a function has the 'async' keyword

### DIFF
--- a/packages/.eslintrc
+++ b/packages/.eslintrc
@@ -74,6 +74,7 @@
       {
         "endOfLine": "auto"
       }
-    ]
+    ],
+    "require-await": 1 // warning
   }
 }

--- a/packages/geoview-core/src/api/plugin/plugin.ts
+++ b/packages/geoview-core/src/api/plugin/plugin.ts
@@ -36,7 +36,7 @@ export class Plugin {
    * @param {string} pluginId the package id to load
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  loadScript = async (pluginId: string): Promise<any> => {
+  loadScript = (pluginId: string): Promise<any> => {
     return new Promise((resolve) => {
       const existingScript = document.getElementById(pluginId);
 

--- a/packages/geoview-core/src/app.tsx
+++ b/packages/geoview-core/src/app.tsx
@@ -94,7 +94,7 @@ export function addReloadListener(mapId: string) {
  * @param {Element} mapDiv The ma div to initialise
  * @param {string} mapConfig a new config passed in from the function call
  */
-export async function initMapDivFromFunctionCall(mapDiv: HTMLElement, mapConfig: string) {
+export function initMapDivFromFunctionCall(mapDiv: HTMLElement, mapConfig: string): void {
   mapDiv.classList.add('llwp-map');
   // render the map with the config
   reactRoot[mapDiv.id] = createRoot(mapDiv!);

--- a/packages/geoview-core/src/core/components/map/map.tsx
+++ b/packages/geoview-core/src/core/components/map/map.tsx
@@ -107,7 +107,7 @@ export function Map(mapFeaturesConfig: TypeMapFeaturesConfig): JSX.Element {
     viewer.toggleMapInteraction(mapConfig.interaction);
   };
 
-  const initMap = async () => {
+  const initMap = (): void => {
     // create map
     const projection = api.projection.projections[mapConfig.viewSettings.projection];
 

--- a/packages/geoview-core/src/core/utils/utilities.ts
+++ b/packages/geoview-core/src/core/utils/utilities.ts
@@ -544,7 +544,7 @@ function _whenThisThenThat<T>(
   startDate: Date,
   checkFrequency: number,
   timeout: number
-) {
+): void {
   // Check if we're good
   const v = checkCallback();
   if (v) {
@@ -578,7 +578,7 @@ export function whenThisThenThat<T>(
   failCallback: (reason?: any) => void,
   checkFrequency?: number,
   timeout?: number
-) {
+): void {
   const startDate = new Date();
   if (!checkFrequency) checkFrequency = 100; // Check every 100 milliseconds by default
   if (!timeout) timeout = 10000; // Timeout after 10 seconds by default
@@ -592,7 +592,7 @@ export function whenThisThenThat<T>(
  * @param checkFrequency the frequency in milliseconds to check for an update (defaults to 100 milliseconds)
  * @param timeout the duration in milliseconds until the task is aborted (defaults to 10 seconds)
  */
-export async function whenThisThenAsync<T>(checkCallback: () => T, checkFrequency?: number, timeout?: number) {
+export function whenThisThen<T>(checkCallback: () => T, checkFrequency?: number, timeout?: number): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     // Redirect
     whenThisThenThat(checkCallback, resolve, reject, checkFrequency, timeout);

--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -385,7 +385,7 @@ export class Basemap {
    *
    * @param {TypeBasemapOptions} basemapOptions basemap options
    */
-  async createCoreBasemap(basemapOptions: TypeBasemapOptions, projection?: number): Promise<TypeBasemapProps | undefined> {
+  createCoreBasemap(basemapOptions: TypeBasemapOptions, projection?: number): Promise<TypeBasemapProps | undefined> {
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve) => {
       const basemapLayers: TypeBasemapLayer[] = [];

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -841,7 +841,7 @@ export class WMS extends AbstractGeoViewRaster {
    *
    * @returns {Promise<TypeWmsLegendStylel>} The legend of the style.
    */
-  private async getStyleLegend(layerConfig: TypeOgcWmsLayerEntryConfig, position: number): Promise<TypeWmsLegendStyle> {
+  private getStyleLegend(layerConfig: TypeOgcWmsLayerEntryConfig, position: number): Promise<TypeWmsLegendStyle> {
     const promisedStyleLegend = new Promise<TypeWmsLegendStyle>((resolve) => {
       const chosenStyle: string | undefined = this.WMSStyles[position];
       let styleLegend: TypeWmsLegendStyle;
@@ -915,7 +915,7 @@ export class WMS extends AbstractGeoViewRaster {
           };
           resolve(legend);
         } else {
-          api.maps[this.mapId].geoviewRenderer.loadImage(legendImage as string).then(async (image) => {
+          api.maps[this.mapId].geoviewRenderer.loadImage(legendImage as string).then((image) => {
             if (image) {
               const drawingCanvas = document.createElement('canvas');
               drawingCanvas.width = image.width;

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -9,7 +9,7 @@ import { api } from '@/app';
 import { EVENT_NAMES } from '@/api/events/event-types';
 
 import { Config } from '@/core/utils/config/config';
-import { generateId, showError, replaceParams, whenThisThenAsync } from '@/core/utils/utilities';
+import { generateId, showError, replaceParams, whenThisThen } from '@/core/utils/utilities';
 import {
   layerConfigPayload,
   payloadIsALayerConfig,
@@ -429,19 +429,22 @@ export class Layer {
    * Search asynchronously for a layer using it's id and return the layer data.
    * If the layer we're searching for has to be loaded, set mustBeLoaded to true when awaiting on this method.
    * This function waits the timeout period before abandonning (or uses the default timeout when not provided).
+   * Note this function uses 'Async' suffix only to differentiate it from 'getGeoviewLayerById'.
    *
-   * @param {string} id the layer id to look for
+   * @param {string} layerID the layer id to look for
    * @param {string} mustBeLoaded indicate if the layer we're searching for must be found only once loaded
+   * @param {string} checkFrequency optionally indicate the frequency at which to check for the condition on the layer
+   * @param {string} timeout optionally indicate the timeout after which time to abandon the promise
    * @returns the found layer data object
    */
-  getGeoviewLayerByIdAsync = async (
+  getGeoviewLayerByIdAsync = (
     layerID: string,
     mustBeLoaded: boolean,
     checkFrequency?: number,
     timeout?: number
   ): Promise<AbstractGeoViewLayer | null> => {
     // Get the layer
-    return whenThisThenAsync<AbstractGeoViewLayer | null>(
+    return whenThisThen<AbstractGeoViewLayer | null>(
       () => {
         // Redirects
         const lyr = this.getGeoviewLayerById(layerID);

--- a/packages/geoview-layers-panel/src/layer-stepper.tsx
+++ b/packages/geoview-layers-panel/src/layer-stepper.tsx
@@ -375,7 +375,7 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
    *
    * @returns {Promise<boolean>} True if layer passes validation
    */
-  const geocoreValidation = async (): Promise<boolean> => {
+  const geocoreValidation = (): boolean => {
     try {
       const isValid = layerURL.indexOf('/') === -1 && layerURL.replaceAll('-', '').length === 32;
       if (!isValid) throw new Error('err');
@@ -580,7 +580,7 @@ function LayerStepper({ mapId, setAddLayerVisible }: Props): JSX.Element {
     else if (layerType === ESRI_FEATURE) valid = await esriValidation(ESRI_FEATURE);
     else if (layerType === GEOJSON) valid = await geoJSONValidation();
     else if (layerType === GEOPACKAGE) valid = geoPackageValidation();
-    else if (layerType === GEOCORE) valid = await geocoreValidation();
+    else if (layerType === GEOCORE) valid = geocoreValidation();
     if (valid) {
       setIsLoading(false);
       setActiveStep(2);


### PR DESCRIPTION
Added a rule about using 'async' strictly if a function is using 'await' keyword and enforcing the return to be a Promise.

Maybe needs particular attention around the initMap() function.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [ ] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1435)
<!-- Reviewable:end -->
