### PR TITLE
Adding sx support to the Accordion and reverting the Select component to using the react 'children' props for the MenuItems

### DIFF
--- a/packages/geoview-core/src/ui/accordion/accordion.tsx
+++ b/packages/geoview-core/src/ui/accordion/accordion.tsx
@@ -1,6 +1,7 @@
-import { useState, useCallback, ReactNode } from 'react';
+import { useState, useCallback, ReactNode, CSSProperties } from 'react';
 
 import {
+  Box,
   Accordion as MaterialAccordion,
   AccordionSummary as MaterialAccordionSummary,
   AccordionDetails as MaterialAccordionDetails,
@@ -13,6 +14,7 @@ import { generateId } from '@/core/utils/utilities';
  */
 interface AccordionProps {
   id: string;
+  sx: CSSProperties;
   items: Array<AccordionItem>;
   className: string;
   defaultExpanded: boolean;
@@ -45,7 +47,7 @@ const sxClasses = {
  * @returns {JSX.Element} the created Fade element
  */
 export function Accordion(props: AccordionProps): ReactNode {
-  const { id, items, className, defaultExpanded = false, showLoadingIcon = false } = props;
+  const { id, sx, items, className, defaultExpanded = false, showLoadingIcon = false } = props;
 
   // internal state
   const [expandedStates, setExpandedStates] = useState<boolean[]>(Array(items.length).fill(defaultExpanded));
@@ -75,7 +77,7 @@ export function Accordion(props: AccordionProps): ReactNode {
   );
 
   return (
-    <div id={generateId(id)} className="accordion-group">
+    <Box id={generateId(id)} sx={sx} className="accordion-group">
       {items.map((item: AccordionItem, idx: number) => (
         <MaterialAccordion
           // eslint-disable-next-line react/no-array-index-key
@@ -94,14 +96,13 @@ export function Accordion(props: AccordionProps): ReactNode {
           <MaterialAccordionDetails>{item.content}</MaterialAccordionDetails>
         </MaterialAccordion>
       ))}
-    </div>
+    </Box>
   );
 }
 
 /**
  * Example of usage
  * <Accordion
-      className="accordion-theme"
       items={Object.values(items).map((item: AccordionItem) => (
           {
               title: writeTitle(item),

--- a/packages/geoview-core/src/ui/select/select.tsx
+++ b/packages/geoview-core/src/ui/select/select.tsx
@@ -29,7 +29,6 @@ interface TypeSelectProps extends SelectProps {
  */
 interface TypeMenuItemProps {
   type?: 'item' | 'header';
-  content?: JSX.Element;
   item: MenuItemProps | ListSubheaderProps | null;
 }
 
@@ -58,12 +57,8 @@ export function Select(props: TypeSelectProps): JSX.Element {
               return <ListSubheader key={index} {...(menuItem.item as ListSubheaderProps)} />;
             }
 
-            return (
-              // eslint-disable-next-line react/no-array-index-key
-              <MenuItem key={index} {...(menuItem.item as MenuItemProps)} sx={sxClasses.menuItem}>
-                {menuItem.content}
-              </MenuItem>
-            );
+            // eslint-disable-next-line react/no-array-index-key
+            return <MenuItem key={index} {...(menuItem.item as MenuItemProps)} sx={sxClasses.menuItem} />;
           }
 
           return null;


### PR DESCRIPTION
# Description

This adds 'sx' support to the Accordion component and reverts a recent modification on the way the Select works with the MenuItems.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The Accordion was tested in Clip Zip Ship plugin.
The Select was tested in GeoChart component and in Layers Panel plugin.

# Checklist:

- [ ] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1512)
<!-- Reviewable:end -->
