### PR TITLE
fix(datatable): show default layer list on mobile and tablet  #1510

### DIFF
--- a/packages/geoview-core/src/core/components/common/close-button.tsx
+++ b/packages/geoview-core/src/core/components/common/close-button.tsx
@@ -29,10 +29,10 @@ export function CloseButton({ isLayersPanelVisible, setIsLayersPanelVisible }: C
         ...sxClasses.enlargeBtn,
         marginLeft: '1rem',
         [theme.breakpoints.up('md')]: { display: 'none' },
-        [theme.breakpoints.between('sm', 'md')]: { display: !isLayersPanelVisible ? 'block' : 'none' },
-        [theme.breakpoints.down('md')]: { display: !isLayersPanelVisible ? 'block' : 'none' },
+        [theme.breakpoints.between('sm', 'md')]: { display: !isLayersPanelVisible ? 'none' : 'block' },
+        [theme.breakpoints.down('md')]: { display: !isLayersPanelVisible ? 'none' : 'block' },
       }}
-      onClick={() => setIsLayersPanelVisible(true)}
+      onClick={() => setIsLayersPanelVisible(false)}
       tooltip={t('dataTable.close') ?? ''}
       tooltipPlacement="top"
     >

--- a/packages/geoview-core/src/core/components/common/responsive-grid.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid.tsx
@@ -39,11 +39,11 @@ function ResponsiveGridLeftPanel({ children, isLayersPanelVisible = false, isEnl
   return (
     <Grid
       item
-      xs={isLayersPanelVisible ? 12 : 0}
+      xs={isLayersPanelVisible ? 0 : 12}
       md={!isEnlargeDataTable ? 4 : 2}
       lg={!isEnlargeDataTable ? 4 : 1.25}
       sx={{
-        [theme.breakpoints.down('md')]: { display: isLayersPanelVisible ? 'block' : 'none' },
+        [theme.breakpoints.down('md')]: { display: isLayersPanelVisible ? 'none' : 'block' },
       }}
       {...rest}
     >
@@ -71,13 +71,13 @@ function ResponsiveGridRightPanel({
   return (
     <Grid
       item
-      xs={!isLayersPanelVisible ? 12 : 0}
+      xs={!isLayersPanelVisible ? 0 : 12}
       md={!isEnlargeDataTable ? 8 : 10}
       lg={!isEnlargeDataTable ? 8 : 10.75}
       sx={{
         position: 'relative',
         [theme.breakpoints.up('md')]: { paddingLeft: '1rem' },
-        [theme.breakpoints.down('md')]: { display: !isLayersPanelVisible ? 'block' : 'none' },
+        [theme.breakpoints.down('md')]: { display: !isLayersPanelVisible ? 'none' : 'block' },
         ...sxProps,
       }}
       {...rest}

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -51,7 +51,7 @@ export function Datapanel({ layerData, mapId, projectionConfig, language }: Data
   const handleListItemClick = useCallback((layer: LayerListEntry, index: number) => {
     setSelectedLayerIndex(index);
     setIsLoading(true);
-    setIsLayersPanelVisible(false);
+    setIsLayersPanelVisible(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -174,7 +174,7 @@ export function Detailspanel({ mapId }: DetailsPanelProps): JSX.Element {
           setLayerDataInfo(arrayOfLayerData[index]);
           setCurrentFeatureIndex(0);
           setSelectedLayerPath(arrayOfLayerData[index].layerPath);
-          setIsLayersPanelVisible(false);
+          setIsLayersPanelVisible(true);
         }}
       />
     );

--- a/packages/geoview-core/src/core/components/time-slider/time-slider-panel.tsx
+++ b/packages/geoview-core/src/core/components/time-slider/time-slider-panel.tsx
@@ -42,7 +42,7 @@ export function TimeSliderPanel(props: TypeTimeSliderProps): JSX.Element {
         selectedLayerIndex={layersList.indexOf(selectedLayer)}
         handleListItemClick={(layer) => {
           setSelectedLayer(layer.layerPath);
-          setIsLayersPanelVisible(false);
+          setIsLayersPanelVisible(true);
         }}
         layerList={layersList.map((layer) => ({ layerName: layer, layerPath: layer, tooltip: layer as string }))}
       />


### PR DESCRIPTION
# Description
Show left panel as default view when browser is resized in responsive grid.

Fixes # (1510)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

__Add the URL for your deploy!__

1. https://kaminderpal.github.io/geoview/raw-data-table.html
2. https://kaminderpal.github.io/geoview/raw-feature-info-1.html
3. https://kaminderpal.github.io/geoview/package-time-slider.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1515)
<!-- Reviewable:end -->
