### PR TITLE
feat(footer-bar): Refactor footer-bar, attribution and more

### DIFF
--- a/packages/geoview-core/src/core/components/attribution/attribution-style.ts
+++ b/packages/geoview-core/src/core/components/attribution/attribution-style.ts
@@ -2,13 +2,17 @@ import { Theme } from '@mui/material/styles';
 
 export const getSxClasses = (theme: Theme) => ({
   attributionContainer: {
-    display: 'flex',
+    [theme.breakpoints.down('md')]: {
+      display: 'none',
+    },
+    p: '15px',
+    marginTop: '10px',
+    width: '300px',
     padding: theme.spacing(0, 4),
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
     alignItems: 'center',
-    width: '100%',
     transition: 'opacity 1ms ease-in 300ms',
     '& .ol-attribution': {
       display: 'flex !important',

--- a/packages/geoview-core/src/core/components/attribution/attribution.tsx
+++ b/packages/geoview-core/src/core/components/attribution/attribution.tsx
@@ -1,11 +1,9 @@
 /* eslint-disable no-underscore-dangle */
-import { useContext, useEffect, useState } from 'react';
-
+import { useState } from 'react';
 import { useTheme } from '@mui/material/styles';
-
-import { MapContext } from '@/core/app-start';
 import { Box, MoreHorizIcon, Popover, IconButton } from '@/ui';
-import { getSxClasses } from './attribution-style';
+// TODO remove import below if we are sure we don't need any of its styles for attribution
+// import { getSxClasses } from './attribution-style';
 import { useUIFooterBarExpanded } from '@/core/stores/store-interface-and-intial-values/ui-state';
 
 /**
@@ -15,13 +13,10 @@ import { useUIFooterBarExpanded } from '@/core/stores/store-interface-and-intial
  * @returns {JSX.Element} created attribution element
  */
 export function Attribution(): JSX.Element {
-  const mapConfig = useContext(MapContext);
-  const { mapId } = mapConfig;
-
   const theme = useTheme();
   // TODO for now keep the sxClasses, need to make sure we don't need any of those styles when we add back the attribution
   // TODO if we don't need any of styles, please remove the style file and remove line below
-  const sxClasses = getSxClasses(theme);
+  // const sxClasses = getSxClasses(theme);
 
   // internal state
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
@@ -35,29 +30,8 @@ export function Attribution(): JSX.Element {
     setAnchorEl(null);
   };
 
-  // internal component state
-  const [attribution, setAttribution] = useState('');
-
   // get store value
   const expanded = useUIFooterBarExpanded();
-
-  useEffect(() => {
-    const attributionTextElement = document.getElementById(`${mapId}-attribution-text`) as HTMLElement;
-
-    // TODO: put attribution in store from add layer events
-    const tooltipAttribution = [];
-    if (attributionTextElement) {
-      const liElements = attributionTextElement.getElementsByTagName('LI');
-      if (liElements && liElements.length > 0) {
-        for (let liElementIndex = 0; liElementIndex < liElements.length; liElementIndex++) {
-          const liElement = liElements[liElementIndex] as HTMLElement;
-          tooltipAttribution.push(liElement.innerText);
-        }
-      }
-    }
-
-    setAttribution(tooltipAttribution.join('\n'));
-  }, [mapId, open]);
 
   return (
     <>

--- a/packages/geoview-core/src/core/components/attribution/attribution.tsx
+++ b/packages/geoview-core/src/core/components/attribution/attribution.tsx
@@ -2,10 +2,9 @@
 import { useContext, useEffect, useState } from 'react';
 
 import { useTheme } from '@mui/material/styles';
-import { useMediaQuery } from '@mui/material';
 
 import { MapContext } from '@/core/app-start';
-import { Tooltip, Box, MoreHorizIcon, Popover, IconButton } from '@/ui';
+import { Box, MoreHorizIcon, Popover, IconButton } from '@/ui';
 import { getSxClasses } from './attribution-style';
 import { useUIFooterBarExpanded } from '@/core/stores/store-interface-and-intial-values/ui-state';
 
@@ -20,13 +19,12 @@ export function Attribution(): JSX.Element {
   const { mapId } = mapConfig;
 
   const theme = useTheme();
+  // TODO for now keep the sxClasses, need to make sure we don't need any of those styles when we add back the attribution
+  // TODO if we don't need any of styles, please remove the style file and remove line below
   const sxClasses = getSxClasses(theme);
-
-  const deviceSizeMedUp = useMediaQuery(theme.breakpoints.up('md'));
 
   // internal state
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-
   const open = Boolean(anchorEl);
 
   const handleOpenPopover = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -42,13 +40,6 @@ export function Attribution(): JSX.Element {
 
   // get store value
   const expanded = useUIFooterBarExpanded();
-
-  // close the popover attribution when page size is medium or larger if popover is open
-  useEffect(() => {
-    if (deviceSizeMedUp && open) {
-      handleClosePopover();
-    }
-  }, [deviceSizeMedUp, open]);
 
   useEffect(() => {
     const attributionTextElement = document.getElementById(`${mapId}-attribution-text`) as HTMLElement;
@@ -75,11 +66,11 @@ export function Attribution(): JSX.Element {
         onClick={handleOpenPopover}
         className={open ? 'active' : ''}
         sx={{
-          [theme.breakpoints.up('md')]: {
-            display: 'none',
-          },
           color: 'primary.light',
           marginTop: expanded ? '12px' : '4px',
+          [theme.breakpoints.up('md')]: {
+            marginTop: expanded ? '23px' : 'none',
+          },
           width: '30px',
           height: '30px',
         }}
@@ -101,36 +92,13 @@ export function Attribution(): JSX.Element {
       >
         <Box
           sx={{
-            [theme.breakpoints.up('md')]: {
-              display: 'none',
-            },
             p: '15px',
             width: '300px',
           }}
         >
-          {attribution}
+          Attribution content
         </Box>
       </Popover>
-      <Tooltip
-        title={attribution}
-        sx={{
-          [theme.breakpoints.up('md')]: {
-            display: 'none',
-          },
-        }}
-      >
-        <Box
-          onKeyDown={(evt) => {
-            if (evt.code === 'Space') {
-              evt.preventDefault(); // prevent space keydown to scroll the page
-              evt.stopPropagation();
-            }
-          }}
-          id={`${mapId}-attribution-text`}
-          sx={[sxClasses.attributionContainer, { visibility: expanded ? 'visible' : 'hidden' }]}
-          tabIndex={0}
-        />
-      </Tooltip>
     </>
   );
 }

--- a/packages/geoview-core/src/core/components/attribution/attribution.tsx
+++ b/packages/geoview-core/src/core/components/attribution/attribution.tsx
@@ -2,9 +2,10 @@
 import { useContext, useEffect, useState } from 'react';
 
 import { useTheme } from '@mui/material/styles';
+import { useMediaQuery } from '@mui/material';
 
 import { MapContext } from '@/core/app-start';
-import { Tooltip, Box } from '@/ui';
+import { Tooltip, Box, MoreHorizIcon, Popover, IconButton } from '@/ui';
 import { getSxClasses } from './attribution-style';
 import { useUIFooterBarExpanded } from '@/core/stores/store-interface-and-intial-values/ui-state';
 
@@ -21,18 +22,40 @@ export function Attribution(): JSX.Element {
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
 
+  const deviceSizeMedUp = useMediaQuery(theme.breakpoints.up('md'));
+
+  // internal state
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  const open = Boolean(anchorEl);
+
+  const handleOpenPopover = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClosePopover = () => {
+    setAnchorEl(null);
+  };
+
   // internal component state
   const [attribution, setAttribution] = useState('');
 
   // get store value
   const expanded = useUIFooterBarExpanded();
 
+  // close the popover attribution when page size is medium or larger if popover is open
+  useEffect(() => {
+    if (deviceSizeMedUp && open) {
+      handleClosePopover();
+    }
+  }, [deviceSizeMedUp, open]);
+
   useEffect(() => {
     const attributionTextElement = document.getElementById(`${mapId}-attribution-text`) as HTMLElement;
 
     // TODO: put attribution in store from add layer events
     const tooltipAttribution = [];
-    if (attributionTextElement && expanded) {
+    if (attributionTextElement) {
       const liElements = attributionTextElement.getElementsByTagName('LI');
       if (liElements && liElements.length > 0) {
         for (let liElementIndex = 0; liElementIndex < liElements.length; liElementIndex++) {
@@ -43,21 +66,71 @@ export function Attribution(): JSX.Element {
     }
 
     setAttribution(tooltipAttribution.join('\n'));
-  }, [expanded, mapId]);
+  }, [mapId, open]);
 
   return (
-    <Tooltip title={attribution}>
-      <Box
-        onKeyDown={(evt) => {
-          if (evt.code === 'Space') {
-            evt.preventDefault(); // prevent space keydown to scroll the page
-            evt.stopPropagation();
-          }
+    <>
+      <IconButton
+        id="attribution"
+        onClick={handleOpenPopover}
+        className={open ? 'active' : ''}
+        sx={{
+          [theme.breakpoints.up('md')]: {
+            display: 'none',
+          },
+          color: 'primary.light',
+          marginTop: expanded ? '12px' : '4px',
+          width: '30px',
+          height: '30px',
         }}
-        id={`${mapId}-attribution-text`}
-        sx={[sxClasses.attributionContainer, { visibility: expanded ? 'visible' : 'hidden' }]}
-        tabIndex={0}
-      />
-    </Tooltip>
+      >
+        <MoreHorizIcon />
+      </IconButton>
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        onClose={handleClosePopover}
+      >
+        <Box
+          sx={{
+            [theme.breakpoints.up('md')]: {
+              display: 'none',
+            },
+            p: '15px',
+            width: '300px',
+          }}
+        >
+          {attribution}
+        </Box>
+      </Popover>
+      <Tooltip
+        title={attribution}
+        sx={{
+          [theme.breakpoints.up('md')]: {
+            display: 'none',
+          },
+        }}
+      >
+        <Box
+          onKeyDown={(evt) => {
+            if (evt.code === 'Space') {
+              evt.preventDefault(); // prevent space keydown to scroll the page
+              evt.stopPropagation();
+            }
+          }}
+          id={`${mapId}-attribution-text`}
+          sx={[sxClasses.attributionContainer, { visibility: expanded ? 'visible' : 'hidden' }]}
+          tabIndex={0}
+        />
+      </Tooltip>
+    </>
   );
 }

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar-expand-button.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar-expand-button.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 
 import { ExpandMoreIcon, ExpandLessIcon, IconButton, Box } from '@/ui';
 import { MapContext } from '@/core/app-start';
@@ -18,6 +18,10 @@ export function FooterbarExpandButton(): JSX.Element {
   const expanded = useUIFooterBarExpanded();
   const { setFooterBarExpanded } = useUIStoreActions();
 
+  const handleTransitionEnd = () => {
+    setFooterBarExpanded(true);
+  };
+
   /**
    * Expand the footer bar
    */
@@ -33,10 +37,10 @@ export function FooterbarExpandButton(): JSX.Element {
       if (ulElement) {
         ulElement.style.width = '100%';
       }
-    }
 
-    // footerbar expanded
-    setFooterBarExpanded(true);
+      // event listener for transitionend
+      footerBar.addEventListener('transitionend', handleTransitionEnd, { once: true });
+    }
   };
 
   /**
@@ -59,6 +63,16 @@ export function FooterbarExpandButton(): JSX.Element {
     // set footerbar collapsed
     setFooterBarExpanded(false);
   };
+
+  useEffect(() => {
+    return () => {
+      const footerBar = document.getElementById(`${mapId}-footerBar`);
+      if (footerBar) {
+        footerBar.removeEventListener('transitionend', handleTransitionEnd);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Box>

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar-fixnorth-switch.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar-fixnorth-switch.tsx
@@ -20,6 +20,7 @@ import {
  */
 export function FooterbarFixNorthSwitch(): JSX.Element {
   const { t } = useTranslation<string>();
+
   const theme = useTheme();
   const deviceSizeMedUp = useMediaQuery(theme.breakpoints.down('md'));
 

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar-fixnorth-switch.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar-fixnorth-switch.tsx
@@ -1,6 +1,9 @@
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useTheme } from '@mui/material/styles';
+import { useMediaQuery } from '@mui/material';
 
-import { Switch } from '@/ui';
+import { Switch, Box } from '@/ui';
 import { PROJECTION_NAMES } from '@/geo/projection/projection';
 import { useUIFooterBarExpanded } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import {
@@ -17,6 +20,8 @@ import {
  */
 export function FooterbarFixNorthSwitch(): JSX.Element {
   const { t } = useTranslation<string>();
+  const theme = useTheme();
+  const deviceSizeMedUp = useMediaQuery(theme.breakpoints.down('md'));
 
   // get store values
   const expanded = useUIFooterBarExpanded();
@@ -38,11 +43,23 @@ export function FooterbarFixNorthSwitch(): JSX.Element {
     }
   };
 
+  useEffect(() => {
+    if (deviceSizeMedUp) {
+      setFixNorth(false);
+    }
+  }, [deviceSizeMedUp]);
+
   return (
-    <div>
+    <Box
+      sx={{
+        [theme.breakpoints.down('md')]: {
+          display: 'none',
+        },
+      }}
+    >
       {expanded && `EPSG:${mapProjection}` === PROJECTION_NAMES.LCC && isNorthEnable ? (
         <Switch size="small" onChange={fixNorth} title={t('mapctrl.rotation.fixedNorth')!} checked={isFixNorth} />
       ) : null}
-    </div>
+    </Box>
   );
 }

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar-style.ts
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar-style.ts
@@ -1,6 +1,7 @@
 // footer-bar.tsx
 export const sxClassesFooterBar = {
   footerBarContainer: {
+    flexGrow: 1,
     zIndex: 50,
     display: 'flex',
     flexDirection: 'row',
@@ -20,7 +21,7 @@ export const sxClassesFooterBar = {
     flexDirection: 'row',
     '& button': {
       cursor: 'pointer',
-      margin: 'auto',
+      margin: 'auto 0 auto auto',
     },
   },
   rotationControlsContainer: {

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -39,21 +39,20 @@ export function Footerbar(): JSX.Element {
     <Box id={`${mapId}-footerBar`} sx={sxClassesFooterBar.footerBarContainer} ref={footerBarRef as MutableRefObject<HTMLDivElement>}>
       <FooterbarExpandButton />
       <Grid container justifyContent="space-between">
-        <Grid item md={4}>
+        <Grid item md={1}>
           <Attribution />
         </Grid>
 
-        <Grid item md={8}>
+        <Grid item md={11} spacing={2}>
           <Grid container justifyContent="flex-end">
-            <Grid item md={9}>
+            <Grid item md={10}>
               <Box id="mouseAndScaleControls" sx={sxClassesFooterBar.mouseScaleControlsContainer}>
                 {interaction === 'dynamic' && <MousePosition />}
                 <Scale />
               </Box>
             </Grid>
-
             {interaction === 'dynamic' && (
-              <Grid item md={3}>
+              <Grid item md={2}>
                 <Box
                   sx={{
                     ...sxClassesFooterBar.rotationControlsContainer,

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -56,8 +56,9 @@ export function Footerbar(): JSX.Element {
                 <Box
                   sx={{
                     ...sxClassesFooterBar.rotationControlsContainer,
-                    [theme.breakpoints.up('md')]: {
-                      marginTop: !expanded ? '10px' : 'none',
+                    marginTop: !expanded ? '5px' : 'none',
+                    [theme.breakpoints.down('md')]: {
+                      marginTop: expanded ? '10px' : 'none',
                     },
                   }}
                 >

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -22,13 +22,14 @@ import { useUIFooterBarExpanded } from '@/core/stores/store-interface-and-intial
 export function Footerbar(): JSX.Element {
   const mapConfig = useContext(MapContext);
   const { mapId } = mapConfig;
-  const theme = useTheme();
 
-  // get store values
-  const expanded = useUIFooterBarExpanded();
+  const theme = useTheme();
 
   // internal state
   const footerBarRef = useRef<HTMLDivElement>();
+
+  // get store values
+  const expanded = useUIFooterBarExpanded();
 
   // get value from the store
   // if map is static do not display mouse position or rotation controls
@@ -56,7 +57,7 @@ export function Footerbar(): JSX.Element {
                 <Box
                   sx={{
                     ...sxClassesFooterBar.rotationControlsContainer,
-                    marginTop: !expanded ? '5px' : 'none',
+                    marginTop: !expanded ? '5px' : '10px',
                     [theme.breakpoints.down('md')]: {
                       marginTop: expanded ? '10px' : 'none',
                     },

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -1,9 +1,7 @@
 import { MutableRefObject, useContext, useRef } from 'react';
-
-import { useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
-import { Box } from '@/ui';
+import { Box, Grid } from '@/ui';
 import { Attribution } from '@/core/components/attribution/attribution';
 import { MousePosition } from '@/core/components/mouse-position/mouse-position';
 import { Scale } from '@/core/components/scale/scale';
@@ -14,6 +12,7 @@ import { FooterbarRotationButton } from './footer-bar-rotation-button';
 import { FooterbarFixNorthSwitch } from './footer-bar-fixnorth-switch';
 import { sxClassesFooterBar } from './footer-bar-style';
 import { useMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useUIFooterBarExpanded } from '@/core/stores/store-interface-and-intial-values/ui-state';
 
 /**
  * Create a footer bar element that contains attribtuion, mouse position and scale
@@ -23,13 +22,13 @@ import { useMapInteraction } from '@/core/stores/store-interface-and-intial-valu
 export function Footerbar(): JSX.Element {
   const mapConfig = useContext(MapContext);
   const { mapId } = mapConfig;
-
   const theme = useTheme();
+
+  // get store values
+  const expanded = useUIFooterBarExpanded();
 
   // internal state
   const footerBarRef = useRef<HTMLDivElement>();
-  // if screen size is medium and up
-  const deviceSizeMedUp = useMediaQuery(theme.breakpoints.up('sm'));
 
   // get value from the store
   // if map is static do not display mouse position or rotation controls
@@ -38,17 +37,38 @@ export function Footerbar(): JSX.Element {
   return (
     <Box id={`${mapId}-footerBar`} sx={sxClassesFooterBar.footerBarContainer} ref={footerBarRef as MutableRefObject<HTMLDivElement>}>
       <FooterbarExpandButton />
-      {deviceSizeMedUp && <Attribution />}
-      <Box id="mouseAndScaleControls" sx={sxClassesFooterBar.mouseScaleControlsContainer}>
-        {deviceSizeMedUp && interaction === 'dynamic' && <MousePosition />}
-        <Scale />
-      </Box>
-      {interaction === 'dynamic' && (
-        <Box sx={sxClassesFooterBar.rotationControlsContainer}>
-          <FooterbarRotationButton />
-          <FooterbarFixNorthSwitch />
-        </Box>
-      )}
+      <Grid container justifyContent="space-between">
+        <Grid item md={4}>
+          <Attribution />
+        </Grid>
+
+        <Grid item md={8}>
+          <Grid container justifyContent="flex-end">
+            <Grid item md={9}>
+              <Box id="mouseAndScaleControls" sx={sxClassesFooterBar.mouseScaleControlsContainer}>
+                {interaction === 'dynamic' && <MousePosition />}
+                <Scale />
+              </Box>
+            </Grid>
+
+            {interaction === 'dynamic' && (
+              <Grid item md={3}>
+                <Box
+                  sx={{
+                    ...sxClassesFooterBar.rotationControlsContainer,
+                    [theme.breakpoints.up('md')]: {
+                      marginTop: !expanded ? '10px' : 'none',
+                    },
+                  }}
+                >
+                  <FooterbarRotationButton />
+                  <FooterbarFixNorthSwitch />
+                </Box>
+              </Grid>
+            )}
+          </Grid>
+        </Grid>
+      </Grid>
     </Box>
   );
 }

--- a/packages/geoview-core/src/core/components/mouse-position/mouse-position-style.ts
+++ b/packages/geoview-core/src/core/components/mouse-position/mouse-position-style.ts
@@ -8,7 +8,6 @@ export const getSxClasses = (theme: Theme) => ({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     alignItems: 'center',
-    border: 'none',
     width: 'auto',
     backgroundColor: 'transparent !important',
     height: 'inherit !important',
@@ -22,6 +21,9 @@ export const getSxClasses = (theme: Theme) => ({
   mousePositionTextContainer: {
     display: 'flex',
     flexDirection: 'column',
+    [theme.breakpoints.down('md')]: {
+      display: 'none',
+    },
   },
   mousePositionTextCheckmarkContainer: {
     display: 'flex',

--- a/packages/geoview-core/src/core/components/mouse-position/mouse-position-style.ts
+++ b/packages/geoview-core/src/core/components/mouse-position/mouse-position-style.ts
@@ -3,6 +3,7 @@ import { Theme } from '@mui/material/styles';
 export const getSxClasses = (theme: Theme) => ({
   mousePosition: {
     display: 'flex',
+    minWidth: 'fit-content',
     padding: theme.spacing(0, 4),
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',


### PR DESCRIPTION
# Description

Fixes issues in footer-bar that the map and footer-bar extend outside of the div containing them, which cuts off the overview-map and footer-bar. This also causes some shaking when mousing over the map.

Added 3 dots icon in small size pages that will open in popover component to display the attributions.

Fixes #1406 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please open footer-bar and try to resize the page in different sizes, the Fix North and Overview map should not get cut from the container div, we should not have shaking map in some areas if we hover the map, also we should be able to use popover content of attribution.

https://amir-azma.github.io/geoview/index.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1533)
<!-- Reviewable:end -->
