### PR TITLE
refactor(store): Use configuration from the store

### DIFF
--- a/packages/geoview-basemap-panel/src/basemap-panel.tsx
+++ b/packages/geoview-basemap-panel/src/basemap-panel.tsx
@@ -10,6 +10,7 @@ import {
   TypeBasemapOptions,
   TypeValidMapProjectionCodes,
 } from 'geoview-core';
+import { useMapProjection } from 'geoview-core/src/core/stores/store-interface-and-intial-values/map-state';
 import { getSxClasses } from './basemap-panel-style';
 
 const w = window as TypeWindow;
@@ -30,18 +31,17 @@ export function BasemapPanel(props: BaseMapPanelProps): JSX.Element {
 
   const { useState, useEffect } = react;
 
+  const theme = ui.useTheme();
+  const sxClasses = getSxClasses(theme);
+
+  // internal state and store values
   const [basemapList, setBasemapList] = useState<TypeBasemapProps[]>([]);
   const [activeBasemapId, setActiveBasemapId] = useState<string>('');
   const [canSwichProjection] = useState(config.canSwichProjection);
-
-  const theme = ui.useTheme();
-
-  const sxClasses = getSxClasses(theme);
-
-  // TODO: change the path for getting projection on schema refactor
   const projections: number[] =
     (config.supportedProjections as TypeJsonArray).map((obj: TypeJsonObject) => obj?.projectionCode as number) || [];
-  const [mapProjection, setMapProjection] = useState(myMap.mapFeaturesConfig.map.viewSettings.projection);
+  const storeProjection = useMapProjection();
+  const [mapProjection, setMapProjection] = useState(storeProjection);
 
   /**
    * Update the basemap with the layers on the map

--- a/packages/geoview-core/public/templates/default-config.html
+++ b/packages/geoview-core/public/templates/default-config.html
@@ -207,7 +207,7 @@
       <a class="ref-link" href="#top">Top</a>
     </div>
     <div id="CONF7" class="llwp-map" data-lang="fr"></div>
-    <p>This map loads it's configurations from a function call</p>
+    <p>This map loads it's configurations from a function call (after 10 seconds). Configuration error with double layer id.</p>
     <hr />
 
     <button type="button" class="collapsible">Code Snippet</button>
@@ -219,62 +219,64 @@
       cgpv.init(function (mapId) {
         console.log('api is ready');
 
-        if (cgpv.api.maps['CONF7']) {
-          setTimeout(() => {
-            cgpv.api.maps['CONF7'].loadMapFromJsonStringConfig (`{
-              'map': {
-                'interaction': 'dynamic',
-                'viewSettings': {
-                  'zoom': 7,
-                  'center': [-110, 70],
-                  'projection': 3978
+        // TODO: init is not call for individual maps, onlly for all aps but in facts all maps are not created yet
+        //! bug
+        setTimeout(() => {
+          if (cgpv.api.maps['CONF7']) {
+              cgpv.api.maps['CONF7'].loadMapFromJsonStringConfig (`{
+                'map': {
+                  'interaction': 'dynamic',
+                  'viewSettings': {
+                    'zoom': 10,
+                    'center': [-110, 70],
+                    'projection': 3978
+                  },
+                  'basemapOptions': {
+                    'basemapId': 'transport',
+                    'shaded': false,
+                    'labeled': true
+                  },
+                  'listOfGeoviewLayerConfig': [{
+                    'geoviewLayerId': 'wmsLYR1',
+                    'geoviewLayerName': {
+                      'en': 'earthquakes',
+                      'fr': 'earthquakes'
+                    },
+                    'metadataAccessPath': {
+                      'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/earthquakes_en/MapServer/',
+                      'fr': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/earthquakes_en/MapServer/'
+                    },
+                    'geoviewLayerType': 'esriDynamic',
+                    'listOfLayerEntryConfig': [
+                      {
+                        'layerId': '0'
+                      }
+                    ]
+                  }, {
+                    'geoviewLayerId': 'wmsLYR1',
+                    'geoviewLayerName': {
+                      'en': 'earthquakes',
+                      'fr': 'earthquakes'
+                    },
+                    'metadataAccessPath': {
+                      'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/earthquakes_en/MapServer/',
+                      'fr': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/earthquakes_en/MapServer/'
+                    },
+                    'geoviewLayerType': 'esriDynamic',
+                    'listOfLayerEntryConfig': [
+                      {
+                        'layerId': '0'
+                      }
+                    ]
+                  }]
                 },
-                'basemapOptions': {
-                  'basemapId': 'transport',
-                  'shaded': false,
-                  'labeled': true
-                },
-                'listOfGeoviewLayerConfig': [{
-                  'geoviewLayerId': 'wmsLYR1',
-                  'geoviewLayerName': {
-                    'en': 'earthquakes',
-                    'fr': 'earthquakes'
-                  },
-                  'metadataAccessPath': {
-                    'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/earthquakes_en/MapServer/',
-                    'fr': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/earthquakes_en/MapServer/'
-                  },
-                  'geoviewLayerType': 'esriDynamic',
-                  'listOfLayerEntryConfig': [
-                    {
-                      'layerId': '0'
-                    }
-                  ]
-                }, {
-                  'geoviewLayerId': 'wmsLYR1',
-                  'geoviewLayerName': {
-                    'en': 'earthquakes',
-                    'fr': 'earthquakes'
-                  },
-                  'metadataAccessPath': {
-                    'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/earthquakes_en/MapServer/',
-                    'fr': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/earthquakes_en/MapServer/'
-                  },
-                  'geoviewLayerType': 'esriDynamic',
-                  'listOfLayerEntryConfig': [
-                    {
-                      'layerId': '0'
-                    }
-                  ]
-                }]
-              },
-              'components': ['overview-map', 'nav-bar'],
-              'corePackages': [],
-              'theme': 'dark',
-              'suportedLanguages': ['en']
-            }`);
-          }, 2000);
-        }
+                'components': ['overview-map'],
+                'corePackages': [],
+                'theme': 'dark',
+                'suportedLanguages': ['en']
+              }`);
+          }
+        }, 10000);
 
         //create snippets
         createCodeSnippet();

--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -1647,6 +1647,7 @@
       "additionalProperties": false,
       "type": "object",
       "properties": {
+        "mapId": { "type": "string" },
         "map": {
           "$ref": "#/definitions/TypeMapConfig"
         },

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/app-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/app-event-processor.ts
@@ -1,7 +1,7 @@
 import { GeoViewStoreType } from '@/core/stores/geoview-store';
 import { AbstractEventProcessor } from '../abstract-event-processor';
 import { getGeoViewStore } from '@/core/stores/stores-managers';
-import { NotificationDetailsType } from '@/core/types/cgpv-types';
+import { NotificationDetailsType, TypeDisplayLanguage, TypeHTMLElement } from '@/core/types/cgpv-types';
 
 export class AppEventProcessor extends AbstractEventProcessor {
   onInitialize(store: GeoViewStoreType) {
@@ -12,15 +12,42 @@ export class AppEventProcessor extends AbstractEventProcessor {
   }
 
   // **********************************************************
-  // Static functions for Typescript files to set store values
+  // Static functions for Typescript files to access store actions
   // **********************************************************
-  static setAppIsCrosshairActive(mapId: string, isActive: boolean) {
-    const store = getGeoViewStore(mapId);
-    store.getState().appState.actions.setCrosshairActive(isActive);
-  }
-
+  //! Typescript MUST always use store action to modify store - NEVER use setState!
+  //! Some action does state modifications AND map actions.
+  //! ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
+  // #region
   static addAppNotification(mapId: string, notification: NotificationDetailsType) {
     const store = getGeoViewStore(mapId);
     store.getState().appState.actions.addNotification(notification);
   }
+
+  static getDisplayLanguage(mapId: string): TypeDisplayLanguage {
+    return getGeoViewStore(mapId).getState().appState.displayLanguage;
+  }
+
+  static getSupportedLanguages(mapId: string): TypeDisplayLanguage[] {
+    return getGeoViewStore(mapId).getState().appState.suportedLanguages;
+  }
+
+  static setAppIsCrosshairActive(mapId: string, isActive: boolean): void {
+    const store = getGeoViewStore(mapId);
+    store.getState().appState.actions.setCrosshairActive(isActive);
+  }
+
+  static setDisplayLanguage(mapId: string, lang: TypeDisplayLanguage): void {
+    getGeoViewStore(mapId).getState().appState.actions.setDisplayLanguage(lang);
+  }
+
+  static toggleFullscreen(mapId: string, active: boolean, element: TypeHTMLElement): void {
+    getGeoViewStore(mapId).getState().appState.actions.setFullScreenActive(active, element);
+  }
+  // #endregion
+
+  // **********************************************************
+  // Static functions for Store Map State to action on API
+  // **********************************************************
+  //! NEVER add a store action who does set state AND map action at a same time.
+  //! Review the action in store state to make sure
 }

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -7,8 +7,8 @@ import { KeyboardPan } from 'ol/interaction';
 
 import { GeoViewStoreType } from '@/core/stores/geoview-store';
 import { AbstractEventProcessor } from '../abstract-event-processor';
-import { api, Coordinate, NORTH_POLE_POSITION, TypeClickMarker } from '@/app';
-import { TypeMapState } from '@/geo/map/map-schema-types';
+import { api, Coordinate, NORTH_POLE_POSITION, TypeBasemapOptions, TypeClickMarker } from '@/app';
+import { TypeMapState, TypeValidMapProjectionCodes } from '@/geo/map/map-schema-types';
 import {
   mapPayload,
   lngLatPayload,
@@ -114,7 +114,8 @@ export class MapEventProcessor extends AbstractEventProcessor {
     const unsubMapSelectedFeatures = store.subscribe(
       (state) => state.mapState.selectedFeatures,
       (curFeatures, prevFeatures) => {
-        if (curFeatures.length === 0) api.maps[mapId].layer.featureHighlight.resetAnimation('all');
+        // TODO: on reload, layer object is undefined, need to test for now and solve in #1580
+        if (curFeatures.length === 0 && api.maps[mapId].layer !== undefined) api.maps[mapId].layer.featureHighlight.resetAnimation('all');
         else {
           const curFeatureUids = curFeatures.map((feature) => (feature.geometry as TypeGeometry).ol_uid);
           const prevFeatureUids = prevFeatures.map((feature) => (feature.geometry as TypeGeometry).ol_uid);
@@ -230,10 +231,14 @@ export class MapEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Typescript files to access store actions
   // **********************************************************
-  //! Typescript MUST always use storte action to modify store - NEVER use setState!
-  //! Some action does state modfication AND map actions.
+  //! Typescript MUST always use store action to modify store - NEVER use setState!
+  //! Some action does state modifications AND map actions.
   //! ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
   // #region
+  static getBasemapOptions(mapId: string): TypeBasemapOptions {
+    return getGeoViewStore(mapId).getState().mapState.basemapOptions;
+  }
+
   static clickMarkerIconHide(mapId: string): void {
     getGeoViewStore(mapId).getState().mapState.actions.hideClickMarker();
   }
@@ -244,7 +249,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
 
   static getMapState(mapId: string): TypeMapState {
     return {
-      currentProjection: getGeoViewStore(mapId).getState().mapState.currentProjection,
+      currentProjection: getGeoViewStore(mapId).getState().mapState.currentProjection as TypeValidMapProjectionCodes,
       currentZoom: getGeoViewStore(mapId).getState().mapState.zoom,
       mapCenterCoordinates: getGeoViewStore(mapId).getState().mapState.centerCoordinates,
       pointerPosition: getGeoViewStore(mapId).getState().mapState.pointerPosition || {
@@ -293,10 +298,16 @@ export class MapEventProcessor extends AbstractEventProcessor {
     mapElement!.addInteraction(new KeyboardPan({ pixelDelta: panDelta }));
   }
 
-  // TODO: use store because it is one line in map viewer, move and use same as rotate because state is handle in event
-  // OPEN for discussion
-  static zoomToExtent(mapId: string, extent: Extent, options?: FitOptions): void {
-    api.maps[mapId].zoomToExtent(extent, options);
+  /**
+   * Zoom to the specified extent.
+   *
+   * @param {string} mapId The map id.
+   * @param {Extent} extent The extent to zoom to.
+   * @param {FitOptions} options The options to configure the zoomToExtent (default: { padding: [100, 100, 100, 100], maxZoom: 11 }).
+   */
+  static zoomToExtent(mapId: string, extent: Extent, options: FitOptions = { padding: [100, 100, 100, 100], maxZoom: 11, duration: 1000 }) {
+    // store state will be updated by map event
+    api.maps[mapId].getView().fit(extent, options);
   }
 
   static zoomToGeoLocatorLocation(mapId: string, coords: Coordinate, bbox?: Extent): void {

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/ui-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/ui-event-processor.ts
@@ -1,0 +1,35 @@
+import { GeoViewStoreType } from '@/core/stores/geoview-store';
+import { AbstractEventProcessor } from '../abstract-event-processor';
+import { getGeoViewStore } from '@/core/stores/stores-managers';
+import { TypeAppBarProps, TypeMapCorePackages } from '@/geo';
+
+export class UIEventProcessor extends AbstractEventProcessor {
+  onInitialize(store: GeoViewStoreType) {
+    store.getState();
+
+    // add to arr of subscriptions so it can be destroyed later
+    this.subscriptionArr.push();
+  }
+
+  // **********************************************************
+  // Static functions for Typescript files to access store actions
+  // **********************************************************
+  //! Typescript MUST always use store action to modify store - NEVER use setState!
+  //! Some action does state modifications AND map actions.
+  //! ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
+  // #region
+  static getAppBarComponents(mapId: string): TypeAppBarProps {
+    return getGeoViewStore(mapId).getState().uiState.appBarComponents;
+  }
+
+  static getCorePackageComponents(mapId: string): TypeMapCorePackages {
+    return getGeoViewStore(mapId).getState().uiState.corePackagesComponents;
+  }
+  // #endregion
+
+  // **********************************************************
+  // Static functions for Store Map State to action on API
+  // **********************************************************
+  //! NEVER add a store action who does set state AND map action at a same time.
+  //! Review the action in store state to make sure
+}

--- a/packages/geoview-core/src/api/plugin/plugin.ts
+++ b/packages/geoview-core/src/api/plugin/plugin.ts
@@ -8,12 +8,12 @@ import * as translate from 'react-i18next';
 import Ajv from 'ajv';
 
 import { showError } from '@/core/utils/utilities';
-import { MapViewer } from '@/geo/map/map-viewer';
 
 import { api } from '@/app';
 import { AbstractPlugin } from './abstract-plugin';
 import { TypePluginStructure, TypeRecordOfPlugin } from './plugin-types';
 import { toJsonObject, TypeJsonObject, TypeJsonValue } from '@/core/types/global-types';
+import { UIEventProcessor } from '../event-processors/event-processor-children/ui-event-processor';
 
 /**
  * Class to manage plugins
@@ -281,11 +281,11 @@ export class Plugin {
    */
   loadPlugin = (mapIndex: number, pluginIndex: number) => {
     const mapId = Object.keys(api.maps)[mapIndex];
-    const map = api.maps[mapId] as MapViewer;
 
     // check if the map at this index have core packages and if there is a package at the plugin index
-    if (map.mapFeaturesConfig.corePackages && map.mapFeaturesConfig.corePackages[pluginIndex]) {
-      const pluginId = map.mapFeaturesConfig.corePackages[pluginIndex];
+    const corePackages = UIEventProcessor.getCorePackageComponents(mapId);
+    if (corePackages[pluginIndex]) {
+      const pluginId = corePackages[pluginIndex];
 
       // load the plugin from the script tag or create it
       this.loadScript(pluginId).then((constructor) => {
@@ -300,7 +300,7 @@ export class Plugin {
         );
 
         // check if there is a next plugin at the current map index
-        if (map.mapFeaturesConfig.corePackages && map.mapFeaturesConfig.corePackages[pluginIndex + 1]) {
+        if (corePackages[pluginIndex + 1]) {
           // load next plugin at the same map index
           this.loadPlugin(mapIndex, pluginIndex + 1);
           // if no more plugins at current map index then check if there is another map

--- a/packages/geoview-core/src/core/app-start.tsx
+++ b/packages/geoview-core/src/core/app-start.tsx
@@ -46,6 +46,7 @@ interface AppStartProps {
  * Initialize the app with maps from inline html configs, url params
  */
 function AppStart(props: AppStartProps): JSX.Element {
+  //! store is not finilize yet so we setup the map with the configuration object instead
   const { mapFeaturesConfig } = props;
 
   const mapContextValue = useMemo(() => {

--- a/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
@@ -16,14 +16,15 @@ import Geolocator from './buttons/geolocator';
 import Notifications from '@/core/components/notifications/notifications';
 import Version from './buttons/version';
 import { getSxClasses } from './app-bar-style';
-import { useUIActiveFocusItem } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useUIActiveFocusItem, useUIAppbarComponents } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
 
 /**
  * Create an app-bar with buttons that can open a panel
  */
 export function Appbar(): JSX.Element {
   const mapContext = useContext(MapContext);
-  const { mapFeaturesConfig, mapId } = mapContext as Required<TypeMapContext>;
+  const { mapId } = mapContext as Required<TypeMapContext>;
 
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
@@ -35,6 +36,8 @@ export function Appbar(): JSX.Element {
 
   // get store values and action
   const activeModalId = useUIActiveFocusItem().activeElementId;
+  const interaction = useMapInteraction();
+  const appBarComponents = useUIAppbarComponents();
 
   const appBarPanelCloseListenerFunction = () => setSelectedAppbarButtonId('');
 
@@ -95,7 +98,7 @@ export function Appbar(): JSX.Element {
   return (
     <Box sx={sxClasses.appBar} ref={appBar}>
       <Box sx={sxClasses.appBarButtons}>
-        {mapFeaturesConfig.appBar?.includes('geolocator') && mapFeaturesConfig?.map.interaction === 'dynamic' && (
+        {appBarComponents.includes('geolocator') && interaction === 'dynamic' && (
           <Box>
             <List sx={sxClasses.appBarList}>
               <ListItem>
@@ -143,7 +146,7 @@ export function Appbar(): JSX.Element {
             </List>
           );
         })}
-        {mapFeaturesConfig.appBar?.includes('export') && (
+        {appBarComponents.includes('export') && (
           <Box>
             <List sx={sxClasses.appBarList}>
               <ListItem>

--- a/packages/geoview-core/src/core/components/data-table/data-table-api.ts
+++ b/packages/geoview-core/src/core/components/data-table/data-table-api.ts
@@ -4,6 +4,7 @@ import DataTable, { DataTableData } from './data-table';
 import { api, TypeListOfLayerEntryConfig, TypeArrayOfFeatureInfoEntries, TypeFieldEntry, TypeLocalizedString } from '@/app';
 import { MapDataTableData as MapDataTableDataProps } from './map-data-table';
 import { Datapanel } from './data-panel';
+import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 
 export interface GroupLayers {
   layerId: string;
@@ -107,7 +108,7 @@ export class DataTableApi {
   createDataPanel = async (): Promise<ReactElement | null> => {
     let groupLayers: GroupLayers[] = [];
     // TODO: use Store event processor
-    const language = api.maps[this.mapId].displayLanguage;
+    const language = AppEventProcessor.getDisplayLanguage(this.mapId);
     const geoLayers = Object.keys(api.maps[this.mapId].layer.geoviewLayers);
 
     geoLayers.forEach((layerId: string) => {

--- a/packages/geoview-core/src/core/components/data-table/map-data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/map-data-table.tsx
@@ -46,7 +46,7 @@ import {
   useDataTableStoreToolbarRowSelectedMessageRecord,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { useLightBox, useSelectedRowMessage, useFilteredRowMessage } from './hooks';
-import { useGeoviewDisplayLanguage } from '@/core/stores/geoview-store';
+import { useAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
 
 export interface MapDataTableDataEntrys extends TypeFeatureInfoEntry {
   rows: Record<string, string>;
@@ -124,7 +124,7 @@ function MapDataTable({ data, layerId, mapId, layerKey }: MapDataTableProps) {
   // get store actions and values
   const { addHighlightedFeature, removeHighlightedFeature, zoomToExtent } = useMapStoreActions();
 
-  const language = useGeoviewDisplayLanguage();
+  const language = useAppDisplayLanguage();
 
   const dataTableLocalization = language === 'fr' ? MRTLocalizationFR : MRTLocalizationEN;
 

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar-style.ts
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar-style.ts
@@ -23,11 +23,12 @@ export const sxClassesFooterBar = {
       cursor: 'pointer',
       margin: 'auto 0 auto auto',
     },
+    justifyContent: 'end',
   },
   rotationControlsContainer: {
     display: 'flex',
     flexDirection: 'column',
-    marginLeft: 20,
+    marginLeft: '20px',
     alignItems: 'flex-end',
   },
 };

--- a/packages/geoview-core/src/core/components/geolocator/geolocator.tsx
+++ b/packages/geoview-core/src/core/components/geolocator/geolocator.tsx
@@ -10,8 +10,7 @@ import { StyledInputField, sxClasses } from './geolocator-style';
 import { OL_ZOOM_DURATION } from '@/core/utils/constant';
 import { useUIAppbarGeolocatorActive } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { useMapSize, useMapStoreActions } from '@/core/stores/store-interface-and-intial-values/map-state';
-import { useGeolocatorServiceURL } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { useGeoviewDisplayLanguage } from '@/core/stores/geoview-store';
+import { useAppGeolocatorServiceURL, useAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
 
 export interface GeoListItem {
   key: string;
@@ -34,8 +33,8 @@ export function Geolocator() {
   const [isSearchInputVisible, setIsSearchInputVisible] = useState<boolean>(false);
 
   // get store values
-  const displayLanguage = useGeoviewDisplayLanguage();
-  const geolocatorServiceURL = useGeolocatorServiceURL();
+  const displayLanguage = useAppDisplayLanguage();
+  const geolocatorServiceURL = useAppGeolocatorServiceURL();
   const mapSize = useMapSize();
 
   // set the active (visible) or not active (hidden) from geolocator button click

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -18,7 +18,11 @@ import {
   BrowserNotSupportedIcon,
   Divider,
 } from '@/ui';
-import { useLayerHighlightedLayer, useLayerStoreActions } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import {
+  useLayerHighlightedLayer,
+  useLayerSelectedLayer,
+  useLayerStoreActions,
+} from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { useUIStoreActions } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { generateId } from '@/core/utils/utilities';
 
@@ -38,6 +42,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   const highlightedLayer = useLayerHighlightedLayer();
   const { setAllItemsVisibility, toggleItemVisibility, setLayerOpacity, setHighlightLayer, zoomToLayerExtent } = useLayerStoreActions();
   const { openModal } = useUIStoreActions();
+  const selectedLayer = useLayerSelectedLayer();
 
   const handleZoomTo = () => {
     zoomToLayerExtent(layerDetails.layerPath);
@@ -48,6 +53,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   };
 
   const handleRefreshLayer = () => {
+    // eslint-disable-next-line no-console
     console.log('refresh layer');
   };
 
@@ -132,7 +138,12 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
         >
           <HighlightOutlinedIcon />
         </IconButton>
-        <IconButton tooltip="legend.zoomTo" onClick={handleZoomTo} sx={{ backgroundColor: '#F6F6F6' }}>
+        <IconButton
+          tooltip="legend.zoomTo"
+          onClick={handleZoomTo}
+          sx={{ backgroundColor: '#F6F6F6' }}
+          disabled={selectedLayer.bounds === undefined}
+        >
           <ZoomInSearchIcon />
         </IconButton>
       </Box>

--- a/packages/geoview-core/src/core/components/legend-2/legend.tsx
+++ b/packages/geoview-core/src/core/components/legend-2/legend.tsx
@@ -7,9 +7,12 @@ import { getSxClasses } from './legend-styles';
 import { LegendLayer } from './legend-layer';
 
 export function Legend(): JSX.Element {
+  const { t } = useTranslation<string>();
+
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
-  const { t } = useTranslation<string>();
+
+  // TODO: use store use atomic selector
   const store = useGeoViewStore();
   const legendLayers = useStore(store, (state) =>
     state.layerState.legendLayers.filter((f) => f.isVisible && !['error', 'loading'].includes(f.layerStatus ?? ''))

--- a/packages/geoview-core/src/core/components/legend/legend-item.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-item.tsx
@@ -469,7 +469,7 @@ export function LegendItem(props: TypeLegendItemProps): JSX.Element {
     )
       bounds = api.maps[mapId].getView().get('extent');
 
-    if (bounds) api.maps[mapId].zoomToExtent(bounds);
+    if (bounds) MapEventProcessor.zoomToExtent(mapId, bounds);
     handleCloseMenu();
   };
 

--- a/packages/geoview-core/src/core/components/map/map.tsx
+++ b/packages/geoview-core/src/core/components/map/map.tsx
@@ -21,25 +21,18 @@ import { OverviewMap } from '@/core/components/overview-map/overview-map';
 import { ClickMarker } from '@/core/components/click-marker/click-marker';
 import { HoverTooltip } from '@/core/components/hover-tooltip/hover-tooltip';
 
-import { generateId } from '@/core/utils/utilities';
-
 import { TypeBasemapLayer, api } from '@/app';
 import { EVENT_NAMES } from '@/api/events/event-types';
 
 import { MapViewer } from '@/geo/map/map-viewer';
 
 import { payloadIsABasemapLayerArray, payloadIsAMapViewProjection, PayloadBaseClass } from '@/api/events/payloads';
-import { TypeBasemapProps, TypeMapFeaturesConfig } from '../../types/global-types';
+import { TypeBasemapProps, TypeValidMapProjectionCodes } from '@/core/types/global-types';
 import { sxClasses } from './map-style';
 import { useMapLoaded, useMapNorthArrow, useMapOverviewMap } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useGeoViewConfig, useGeoViewMapId } from '@/core/stores/geoview-store';
 
-export function Map(mapFeaturesConfig: TypeMapFeaturesConfig): JSX.Element {
-  const { map: mapConfig } = mapFeaturesConfig;
-
-  // make sure the id is not undefined
-  // eslint-disable-next-line react/destructuring-assignment
-  const mapId = mapFeaturesConfig.mapId ? mapFeaturesConfig.mapId : generateId('');
-
+export function Map(): JSX.Element {
   const defaultTheme = useTheme();
 
   // internal state - get ref to div element
@@ -48,9 +41,11 @@ export function Map(mapFeaturesConfig: TypeMapFeaturesConfig): JSX.Element {
   const deviceSizeMedUp = useMediaQuery(defaultTheme.breakpoints.up('md')); // if screen size is medium and up
 
   // get values from the store
+  const mapId = useGeoViewMapId();
   const overviewMap = useMapOverviewMap();
   const northArrow = useMapNorthArrow();
   const mapLoaded = useMapLoaded();
+  const mapStoreConfig = useGeoViewConfig();
 
   // create a new map viewer instance
   // TODO: use store
@@ -71,12 +66,12 @@ export function Map(mapFeaturesConfig: TypeMapFeaturesConfig): JSX.Element {
       api.plugin.loadPlugins();
     });
 
-    viewer.toggleMapInteraction(mapConfig.interaction);
+    viewer.toggleMapInteraction(mapStoreConfig?.map.interaction as string);
   };
 
   const initMap = (): void => {
     // create map
-    const projection = api.projection.projections[mapConfig.viewSettings.projection];
+    const projection = api.projection.projections[mapStoreConfig?.map.viewSettings.projection as TypeValidMapProjectionCodes];
 
     // create empty tilelayer to use as initial basemap while we load basemap
     const emptyBasemap: TypeBasemapLayer = {
@@ -93,19 +88,23 @@ export function Map(mapFeaturesConfig: TypeMapFeaturesConfig): JSX.Element {
     const emptyLayer = new TileLayer(emptyBasemap);
     emptyLayer.set('mapId', 'basemap');
 
-    let extent: Extent | undefined;
-    if (mapConfig.viewSettings?.extent) extent = transformExtent(mapConfig.viewSettings.extent, 'EPSG:4326', projection.getCode());
+    let extentProjected: Extent | undefined;
+    if (mapStoreConfig?.map.viewSettings.extent)
+      extentProjected = transformExtent(mapStoreConfig?.map.viewSettings.extent, 'EPSG:4326', projection.getCode());
 
     const initialMap = new OLMap({
       target: mapElement.current as string | HTMLElement | undefined,
       layers: [emptyLayer],
       view: new View({
         projection,
-        center: fromLonLat([mapConfig.viewSettings.center[0], mapConfig.viewSettings.center[1]], projection),
-        zoom: mapConfig.viewSettings.zoom,
-        extent: extent || undefined,
-        minZoom: mapConfig.viewSettings.minZoom || 0,
-        maxZoom: mapConfig.viewSettings.maxZoom || 17,
+        center: fromLonLat(
+          [mapStoreConfig?.map.viewSettings.center[0] || -105, mapStoreConfig?.map.viewSettings.center[1] || 60],
+          projection
+        ),
+        zoom: mapStoreConfig?.map.viewSettings.zoom,
+        extent: extentProjected || undefined,
+        minZoom: mapStoreConfig?.map.viewSettings.minZoom || 0,
+        maxZoom: mapStoreConfig?.map.viewSettings.maxZoom || 17,
       }),
       controls: [],
       keyboardEventTarget: document.getElementById(`map-${mapId}`) as HTMLElement,

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/fullscreen.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/fullscreen.tsx
@@ -6,7 +6,7 @@ import { MapContext } from '@/core/app-start';
 import { IconButton, FullscreenIcon, FullscreenExitIcon } from '@/ui';
 import { TypeHTMLElement } from '@/core/types/global-types';
 import { getSxClasses } from '../nav-bar-style';
-import { useAppStoreActions, useFullscreenActive } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useAppStoreActions, useAppFullscreenActive } from '@/core/stores/store-interface-and-intial-values/app-state';
 
 /**
  * Create a toggle button to toggle between fullscreen
@@ -21,7 +21,7 @@ export default function Fullscreen(): JSX.Element {
   const sxClasses = getSxClasses(theme);
 
   // get the values from store
-  const isFullScreen = useFullscreenActive();
+  const isFullScreen = useAppFullscreenActive();
   const { setFullScreenActive } = useAppStoreActions();
 
   /**

--- a/packages/geoview-core/src/core/components/nav-bar/nav-bar.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/nav-bar.tsx
@@ -19,14 +19,18 @@ import { EVENT_NAMES } from '@/api/events/event-types';
 import { payloadIsAButtonPanel, ButtonPanelPayload, PayloadBaseClass } from '@/api/events/payloads';
 import { TypeButtonPanel } from '@/ui/panel/panel-types';
 import { getSxClasses } from './nav-bar-style';
-import { useUIActiveFocusItem, useUIFooterBarExpanded } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import {
+  useUIActiveFocusItem,
+  useUIFooterBarExpanded,
+  useUINavbarComponents,
+} from '@/core/stores/store-interface-and-intial-values/ui-state';
 
 /**
  * Create a nav-bar with buttons that can call functions or open custom panels
  */
 export function Navbar(): JSX.Element {
   const mapConfig = useContext(MapContext);
-  const { mapId, mapFeaturesConfig } = mapConfig;
+  const { mapId } = mapConfig;
 
   const { t } = useTranslation<string>();
 
@@ -36,11 +40,11 @@ export function Navbar(): JSX.Element {
   // internal state
   const navBarRef = useRef<HTMLDivElement>(null);
   const [buttonPanelGroups, setButtonPanelGroups] = useState<Record<string, Record<string, TypeButtonPanel>>>({});
-  const navBar = mapFeaturesConfig!.navBar || [];
 
   // get the expand or collapse from store
   const footerBarExpanded = useUIFooterBarExpanded();
   const activeModalId = useUIActiveFocusItem().activeElementId;
+  const navBarComponents = useUINavbarComponents();
 
   // #region REACT HOOKS
   const addButtonPanel = useCallback(
@@ -167,12 +171,12 @@ export function Navbar(): JSX.Element {
           <ZoomOut />
         </ButtonGroup>
         <ButtonGroup orientation="vertical" aria-label={t('mapnav.arianavbar')!} variant="contained" sx={sxClasses.navBtnGroup}>
-          {navBar?.includes('fullscreen') && <Fullscreen />}
-          {navBar?.includes('location') && <Location />}
-          {navBar?.includes('home') && <Home />}
-          {navBar?.includes('export') && <ExportButton className={`${sxClasses.navButton} ${activeModalId ? 'export' : ''}`} />}
+          {navBarComponents.includes('fullscreen') && <Fullscreen />}
+          {navBarComponents.includes('location') && <Location />}
+          {navBarComponents.includes('home') && <Home />}
+          {navBarComponents.includes('export') && <ExportButton className={`${sxClasses.navButton} ${activeModalId ? 'export' : ''}`} />}
           {/* // TODO We might need to refactor code below based on the best solution, issue #1448 */}
-          {navBar?.includes('focus') && <Focus />}
+          {navBarComponents.includes('focus') && <Focus />}
         </ButtonGroup>
       </Box>
     </Box>

--- a/packages/geoview-core/src/core/components/overview-map/overview-map.tsx
+++ b/packages/geoview-core/src/core/components/overview-map/overview-map.tsx
@@ -10,13 +10,14 @@ import makeStyles from '@mui/styles/makeStyles';
 import TileLayer from 'ol/layer/Tile';
 import { OverviewMap as OLOverviewMap } from 'ol/control';
 
-import { useStore } from 'zustand';
 import { getGeoViewStore } from '@/core/stores/stores-managers';
 
 import { MapContext } from '@/core/app-start';
 import { cgpvTheme } from '@/ui/style/theme';
 import { OverviewMapToggle } from './overview-map-toggle';
 import { api } from '@/app';
+import { useAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useMapElement, useMapOverviewMapHideZoom } from '@/core/stores/store-interface-and-intial-values/map-state';
 
 // TODO: We need to find solution to remove makeStyles with either plain css or material ui.
 const useStyles = makeStyles((theme) => ({
@@ -96,9 +97,9 @@ export function OverviewMap(): JSX.Element {
   const { mapId } = mapConfig;
 
   // get the values from store
-  const mapElement = useStore(getGeoViewStore(mapId), (state) => state.mapState.mapElement);
-  const hideOnZoom = useStore(getGeoViewStore(mapId), (state) => state.mapState.overviewMapHideZoom);
-  const displayLanguage = useStore(getGeoViewStore(mapId), (state) => state.displayLanguage);
+  const mapElement = useMapElement();
+  const hideOnZoom = useMapOverviewMapHideZoom();
+  const displayLanguage = useAppDisplayLanguage();
 
   // TODO: remove useStyle
   const classes = useStyles();

--- a/packages/geoview-core/src/core/containers/shell.tsx
+++ b/packages/geoview-core/src/core/containers/shell.tsx
@@ -29,10 +29,15 @@ import {
 } from '@/api/events/payloads';
 import { MapContext } from '@/core/app-start';
 import { getShellSxClasses } from './containers-style';
-import { useMapLoaded } from '@/core/stores/store-interface-and-intial-values/map-state';
-import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useMapInteraction, useMapLoaded } from '@/core/stores/store-interface-and-intial-values/map-state';
+import {
+  useUIActiveTrapGeoView,
+  useUIAppbarComponents,
+  useUICorePackagesComponents,
+} from '@/core/stores/store-interface-and-intial-values/ui-state';
 import ExportModal from '@/core/components/export/export-modal';
 import DataTableModal from '@/core/components/data-table/data-table-modal';
+import { useGeoViewMapId } from '@/core/stores/geoview-store';
 
 /**
  * Interface for the shell properties
@@ -64,6 +69,10 @@ export function Shell(props: ShellProps): JSX.Element {
   // get values from the store
   const mapLoaded = useMapLoaded();
   const activeTrapGeoView = useUIActiveTrapGeoView();
+  const mapId = useGeoViewMapId();
+  const interaction = useMapInteraction();
+  const appBarComponents = useUIAppbarComponents();
+  const corePackagesComponents = useUICorePackagesComponents();
 
   /**
    * Causes the shell to re-render
@@ -138,19 +147,19 @@ export function Shell(props: ShellProps): JSX.Element {
           <Box sx={sxClasses.mapShellContainer} className="mapContainer">
             <Appbar />
             {/* load geolocator component if config includes in list of components in appBar */}
-            {mapFeaturesConfig?.appBar?.includes('geolocator') && mapFeaturesConfig?.map.interaction === 'dynamic' && <Geolocator />}
+            {appBarComponents.includes('geolocator') && interaction === 'dynamic' && <Geolocator />}
             <Box sx={sxClasses.mapContainer}>
-              <Map {...mapFeaturesConfig} />
+              <Map />
               <Footerbar />
             </Box>
-            {mapFeaturesConfig?.map.interaction === 'dynamic' && <Navbar />}
+            {interaction === 'dynamic' && <Navbar />}
           </Box>
-          {mapFeaturesConfig?.corePackages && mapFeaturesConfig?.corePackages.includes('footer-panel') && <FooterTabs />}
+          {corePackagesComponents.includes('footer-panel') && <FooterTabs />}
           {Object.keys(api.maps[shellId].modal.modals).map((modalId) => (
             <Modal key={modalId} id={modalId} open={false} mapId={shellId} />
           ))}
           {/* modal section start */}
-          <FocusTrapDialog mapId={mapFeaturesConfig.mapId} focusTrapId={shellId} />
+          <FocusTrapDialog mapId={mapId} focusTrapId={shellId} />
           <ExportModal />
           <DataTableModal />
           {/* modal section end */}

--- a/packages/geoview-core/src/core/stores/geoview-store.ts
+++ b/packages/geoview-core/src/core/stores/geoview-store.ts
@@ -10,10 +10,10 @@ import { IMapDataTableState, initialDataTableState } from './store-interface-and
 import { ITimeSliderState, initializeTimeSliderState } from './store-interface-and-intial-values/time-slider-state';
 import { IUIState, initializeUIState } from './store-interface-and-intial-values/ui-state';
 
-import { TypeDisplayLanguage } from '@/geo/map/map-schema-types';
 import { TypeLegendResultSets } from '@/api/events/payloads/get-legends-payload';
 import { TypeFeatureInfoResultSets } from '@/api/events/payloads/get-feature-info-payload';
 import { TypeMapFeaturesConfig } from '@/core/types/global-types';
+import { generateId } from '@/core/utils/utilities';
 
 export type TypeSetStore = (
   partial: IGeoViewState | Partial<IGeoViewState> | ((state: IGeoViewState) => IGeoViewState | Partial<IGeoViewState>),
@@ -22,9 +22,8 @@ export type TypeSetStore = (
 export type TypeGetStore = () => IGeoViewState;
 
 export interface IGeoViewState {
-  displayLanguage: TypeDisplayLanguage;
-  mapId: string;
   mapConfig: TypeMapFeaturesConfig | undefined;
+  mapId: string;
   setMapConfig: (config: TypeMapFeaturesConfig) => void;
 
   // state interfaces
@@ -43,15 +42,14 @@ export interface IGeoViewState {
 
 export const geoViewStoreDefinition = (set: TypeSetStore, get: TypeGetStore) =>
   ({
-    displayLanguage: 'en' as TypeDisplayLanguage,
-    mapId: '',
     mapConfig: undefined,
     setMapConfig: (config: TypeMapFeaturesConfig) => {
-      set({ mapConfig: config, mapId: config.mapId, displayLanguage: config.displayLanguage });
+      set({ mapConfig: config, mapId: config.mapId || generateId('') });
 
       // initialize default stores section from config information
       get().appState.setDefaultConfigValues(config);
       get().mapState.setDefaultConfigValues(config);
+      get().uiState.setDefaultConfigValues(config);
     },
 
     appState: initializeAppState(set, get),
@@ -74,5 +72,5 @@ export type GeoViewStoreType = typeof fakeStore;
 // **********************************************************
 // GeoView state selectors
 // **********************************************************
-export const useGeoviewMapId = () => useStore(useGeoViewStore(), (state) => state.mapId);
-export const useGeoviewDisplayLanguage = () => useStore(useGeoViewStore(), (state) => state.displayLanguage);
+export const useGeoViewMapId = () => useStore(useGeoViewStore(), (state) => state.mapId);
+export const useGeoViewConfig = () => useStore(useGeoViewStore(), (state) => state.mapConfig);

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/app-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/app-state.ts
@@ -2,20 +2,23 @@ import { useStore } from 'zustand';
 import { useGeoViewStore } from '@/core/stores/stores-managers';
 import { TypeSetStore, TypeGetStore } from '@/core/stores/geoview-store';
 
-import { NotificationDetailsType, TypeHTMLElement, TypeMapFeaturesConfig } from '@/core/types/cgpv-types';
+import { NotificationDetailsType, TypeDisplayLanguage, TypeHTMLElement, TypeMapFeaturesConfig } from '@/core/types/cgpv-types';
 import { api } from '@/app';
 
 export interface IAppState {
+  displayLanguage: TypeDisplayLanguage;
   isCrosshairsActive: boolean;
   isFullscreenActive: boolean;
   notifications: Array<NotificationDetailsType>;
   geolocatorServiceURL: string | undefined;
+  suportedLanguages: TypeDisplayLanguage[];
 
   setDefaultConfigValues: (geoviewConfig: TypeMapFeaturesConfig) => void;
 
   actions: {
     addNotification: (notif: NotificationDetailsType) => void;
     setCrosshairActive: (active: boolean) => void;
+    setDisplayLanguage: (lang: TypeDisplayLanguage) => void;
     setFullScreenActive: (active: boolean, element?: TypeHTMLElement) => void;
     removeNotification: (key: string) => void;
   };
@@ -23,17 +26,21 @@ export interface IAppState {
 
 export function initializeAppState(set: TypeSetStore, get: TypeGetStore): IAppState {
   return {
+    displayLanguage: 'en' as TypeDisplayLanguage,
     isCrosshairsActive: false,
     isFullscreenActive: false,
     notifications: [],
     geolocatorServiceURL: '',
+    suportedLanguages: [],
 
     // initialize default stores section from config information when store receive configuration file
     setDefaultConfigValues: (geoviewConfig: TypeMapFeaturesConfig) => {
       set({
         appState: {
           ...get().appState,
+          displayLanguage: geoviewConfig.displayLanguage as TypeDisplayLanguage,
           geolocatorServiceURL: geoviewConfig.serviceUrls?.geolocator,
+          suportedLanguages: geoviewConfig.suportedLanguages,
         },
       });
     },
@@ -58,6 +65,14 @@ export function initializeAppState(set: TypeSetStore, get: TypeGetStore): IAppSt
           },
         });
       },
+      setDisplayLanguage: (lang: TypeDisplayLanguage) => {
+        set({
+          appState: {
+            ...get().appState,
+            displayLanguage: lang,
+          },
+        });
+      },
       setFullScreenActive: (active: boolean, element?: TypeHTMLElement) => {
         set({
           appState: {
@@ -66,7 +81,7 @@ export function initializeAppState(set: TypeSetStore, get: TypeGetStore): IAppSt
           },
         });
 
-        // TODO: keep reference to geoview map instance in the store or keep accessing with api - discussion
+        //! we need to keep the call to the api map object because there is a state involve
         if (element !== undefined) api.maps[get().mapId].toggleFullscreen(active, element);
       },
       removeNotification: (key: string) => {
@@ -85,8 +100,10 @@ export function initializeAppState(set: TypeSetStore, get: TypeGetStore): IAppSt
 // App state selectors
 // **********************************************************
 export const useAppCrosshairsActive = () => useStore(useGeoViewStore(), (state) => state.appState.isCrosshairsActive);
+export const useAppDisplayLanguage = () => useStore(useGeoViewStore(), (state) => state.appState.displayLanguage);
+export const useAppFullscreenActive = () => useStore(useGeoViewStore(), (state) => state.appState.isFullscreenActive);
+export const useAppGeolocatorServiceURL = () => useStore(useGeoViewStore(), (state) => state.appState.geolocatorServiceURL);
 export const useAppNotifications = () => useStore(useGeoViewStore(), (state) => state.appState.notifications);
-export const useFullscreenActive = () => useStore(useGeoViewStore(), (state) => state.appState.isFullscreenActive);
-export const useGeolocatorServiceURL = () => useStore(useGeoViewStore(), (state) => state.appState.geolocatorServiceURL);
+export const useAppSuportedLanguages = () => useStore(useGeoViewStore(), (state) => state.appState.suportedLanguages);
 
 export const useAppStoreActions = () => useStore(useGeoViewStore(), (state) => state.appState.actions);

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
@@ -11,7 +11,7 @@ import { useStore } from 'zustand';
 import { useGeoViewStore } from '@/core/stores/stores-managers';
 import { TypeSetStore, TypeGetStore } from '@/core/stores/geoview-store';
 
-import { TypeMapFeaturesConfig, TypeValidMapProjectionCodes } from '@/core/types/global-types';
+import { TypeBasemapOptions, TypeMapFeaturesConfig, TypeValidMapProjectionCodes } from '@/core/types/global-types';
 import { TypeFeatureInfoEntry, TypeGeometry, TypeMapMouseInfo } from '@/api/events/payloads';
 import { TypeInteraction } from '@/geo/map/map-schema-types';
 import { TypeClickMarker, api } from '@/app';
@@ -31,6 +31,7 @@ export interface TypeNorthArrow {
 
 export interface IMapState {
   attribution: string[];
+  basemapOptions: TypeBasemapOptions;
   centerCoordinates: Coordinate;
   clickCoordinates?: TypeMapMouseInfo;
   clickMarker: TypeClickMarker | undefined;
@@ -40,6 +41,7 @@ export interface IMapState {
   interaction: TypeInteraction;
   pointerPosition?: TypeMapMouseInfo;
   mapElement?: OLMap;
+  mapExtent: Extent | undefined;
   mapLoaded: boolean;
   northArrow: boolean;
   northArrowElement: TypeNorthArrow;
@@ -105,12 +107,14 @@ function setScale(mapId: string): TypeScaleInfo {
 export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapState {
   const init = {
     attribution: [],
+    basemapOptions: { basemapId: 'transport', shaded: true, labeled: true },
     centerCoordinates: [0, 0] as Coordinate,
     clickMarker: undefined,
     currentProjection: 3857 as TypeValidMapProjectionCodes,
     fixNorth: false,
     highlightedFeatures: [],
     interaction: 'static',
+    mapExtent: undefined,
     mapLoaded: false,
     northArrow: false,
     northArrowElement: { degreeRotation: '180.0', isNorthVisible: true } as TypeNorthArrow,
@@ -128,9 +132,11 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
       set({
         mapState: {
           ...get().mapState,
+          basemapOptions: geoviewConfig.map.basemapOptions,
           centerCoordinates: geoviewConfig.map.viewSettings.center as Coordinate,
           currentProjection: geoviewConfig.map.viewSettings.projection as TypeValidMapProjectionCodes,
           interaction: geoviewConfig.map.interaction || 'dynamic',
+          mapExtent: geoviewConfig.map.viewSettings.extent,
           northArrow: geoviewConfig.components!.indexOf('north-arrow') > -1 || false,
           overviewMap: geoviewConfig.components!.indexOf('overview-map') > -1 || false,
           overviewMapHideZoom: geoviewConfig.overviewMap !== undefined ? geoviewConfig.overviewMap.hideOnZoom : 0,
@@ -420,17 +426,20 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 // Map state selectors
 // **********************************************************
 export const useMapAttribution = () => useStore(useGeoViewStore(), (state) => state.mapState.attribution);
+export const useMapBasemapOptions = () => useStore(useGeoViewStore(), (state) => state.mapState.basemapOptions);
 export const useMapCenterCoordinates = () => useStore(useGeoViewStore(), (state) => state.mapState.centerCoordinates);
 export const useMapClickMarker = () => useStore(useGeoViewStore(), (state) => state.mapState.clickMarker);
-export const useMapProjection = () => useStore(useGeoViewStore(), (state) => state.mapState.currentProjection);
 export const useMapElement = () => useStore(useGeoViewStore(), (state) => state.mapState.mapElement);
+export const useMapExtent = () => useStore(useGeoViewStore(), (state) => state.mapState.mapExtent);
 export const useMapFixNorth = () => useStore(useGeoViewStore(), (state) => state.mapState.fixNorth);
 export const useMapInteraction = () => useStore(useGeoViewStore(), (state) => state.mapState.interaction);
 export const useMapLoaded = () => useStore(useGeoViewStore(), (state) => state.mapState.mapLoaded);
 export const useMapNorthArrow = () => useStore(useGeoViewStore(), (state) => state.mapState.northArrow);
 export const useMapNorthArrowElement = () => useStore(useGeoViewStore(), (state) => state.mapState.northArrowElement);
 export const useMapOverviewMap = () => useStore(useGeoViewStore(), (state) => state.mapState.overviewMap);
+export const useMapOverviewMapHideZoom = () => useStore(useGeoViewStore(), (state) => state.mapState.overviewMapHideZoom);
 export const useMapPointerPosition = () => useStore(useGeoViewStore(), (state) => state.mapState.pointerPosition);
+export const useMapProjection = () => useStore(useGeoViewStore(), (state) => state.mapState.currentProjection);
 export const useMapRotation = () => useStore(useGeoViewStore(), (state) => state.mapState.rotation);
 export const useMapSelectedFeatures = () => useStore(useGeoViewStore(), (state) => state.mapState.selectedFeatures);
 export const useMapScale = () => useStore(useGeoViewStore(), (state) => state.mapState.scale);

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
@@ -1,6 +1,8 @@
 import { useStore } from 'zustand';
 import { useGeoViewStore } from '@/core/stores/stores-managers';
 import { TypeSetStore, TypeGetStore } from '@/core/stores/geoview-store';
+import { TypeAppBarProps, TypeMapCorePackages, TypeNavBarProps } from '@/geo';
+import { TypeMapFeaturesConfig } from '@/core/types/cgpv-types';
 
 type focusItemProps = {
   activeElementId: string | false;
@@ -9,9 +11,14 @@ type focusItemProps = {
 
 export interface IUIState {
   activeTrapGeoView: boolean;
+  appBarComponents: TypeAppBarProps;
+  corePackagesComponents: TypeMapCorePackages;
   focusITem: focusItemProps;
   footerBarExpanded: boolean;
   geoLocatorActive: boolean;
+  navBarComponents: TypeNavBarProps;
+
+  setDefaultConfigValues: (geoviewConfig: TypeMapFeaturesConfig) => void;
 
   actions: {
     closeModal: () => void;
@@ -24,10 +31,25 @@ export interface IUIState {
 
 export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIState {
   const init = {
+    appBarComponents: ['geolocator', 'export'],
     activeTrapGeoView: false,
+    corePackagesComponents: [],
     focusITem: { activeElementId: false, callbackElementId: false },
     footerBarExpanded: false,
     geoLocatorActive: false,
+    navBarComponents: [],
+
+    // initialize default stores section from config information when store receive configuration file
+    setDefaultConfigValues: (geoviewConfig: TypeMapFeaturesConfig) => {
+      set({
+        uiState: {
+          ...get().uiState,
+          appBarComponents: geoviewConfig.appBar || [],
+          corePackagesComponents: geoviewConfig.corePackages || [],
+          navBarComponents: geoviewConfig.navBar || [],
+        },
+      });
+    },
 
     // #region ACTIONS
     actions: {
@@ -84,7 +106,10 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
 // **********************************************************
 export const useUIActiveFocusItem = () => useStore(useGeoViewStore(), (state) => state.uiState.focusITem);
 export const useUIActiveTrapGeoView = () => useStore(useGeoViewStore(), (state) => state.uiState.activeTrapGeoView);
+export const useUIAppbarComponents = () => useStore(useGeoViewStore(), (state) => state.uiState.appBarComponents);
 export const useUIAppbarGeolocatorActive = () => useStore(useGeoViewStore(), (state) => state.uiState.geoLocatorActive);
+export const useUICorePackagesComponents = () => useStore(useGeoViewStore(), (state) => state.uiState.corePackagesComponents);
 export const useUIFooterBarExpanded = () => useStore(useGeoViewStore(), (state) => state.uiState.footerBarExpanded);
+export const useUINavbarComponents = () => useStore(useGeoViewStore(), (state) => state.uiState.navBarComponents);
 
 export const useUIStoreActions = () => useStore(useGeoViewStore(), (state) => state.uiState.actions);

--- a/packages/geoview-core/src/core/stores/stores-managers.ts
+++ b/packages/geoview-core/src/core/stores/stores-managers.ts
@@ -4,7 +4,7 @@ import { create, createStore } from 'zustand';
 import { mountStoreDevtool } from 'simple-zustand-devtools';
 
 import { initializeEventProcessors } from '@/api/event-processors';
-import { TypeMapFeaturesConfig } from '../types/global-types';
+import { TypeMapFeaturesConfig } from '@/core/types/global-types';
 import { IGeoViewState, GeoViewStoreType, geoViewStoreDefinitionWithSubscribeSelector } from './geoview-store';
 import { MapContext } from '@/core/app-start';
 

--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -598,7 +598,7 @@ export class Basemap {
    * @returns {TypeBasemapProps | undefined} the default basemap
    */
   async loadDefaultBasemaps(): Promise<TypeBasemapProps | undefined> {
-    const basemap = await this.createCoreBasemap(api.maps[this.mapId].mapFeaturesConfig.map.basemapOptions);
+    const basemap = await this.createCoreBasemap(MapEventProcessor.getBasemapOptions(this.mapId));
     const overviewBasemap = await this.createCoreBasemap({ basemapId: 'transport', shaded: false, labeled: false });
     if (overviewBasemap) this.overviewMap = overviewBasemap;
     else {

--- a/packages/geoview-core/src/geo/layer/other/geocore.ts
+++ b/packages/geoview-core/src/geo/layer/other/geocore.ts
@@ -14,6 +14,7 @@ import {
 import { CONST_LAYER_TYPES } from '../geoview-layers/abstract-geoview-layers';
 import { UUIDmapConfigReader } from '@/core/utils/config/reader/uuid-config-reader';
 import { ConfigValidation } from '@/core/utils/config/config-validation';
+import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 
 export interface TypeGeoCoreLayerConfig extends Omit<TypeGeoviewLayerConfig, 'listOfLayerEntryConfig'> {
   geoviewLayerType: 'geoCore';
@@ -87,7 +88,7 @@ export class GeoCore {
             this.copyConfigSettingsOverGeocoreSettings(geocoreLayerConfig.listOfLayerEntryConfig[index], geoviewLayerConfig);
           });
           this.configValidation.validateListOfGeoviewLayerConfig(
-            api.maps[this.mapId].mapFeaturesConfig.suportedLanguages,
+            AppEventProcessor.getSupportedLanguages(this.mapId),
             listOfGeoviewLayerConfig
           );
         });

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -362,6 +362,8 @@ export class GeoUtilities {
    * @returns {boolean} true if visible, false otherwise
    */
   checkNorth(map: OLMap): boolean {
+    if (map === undefined) return false;
+
     // Check the container value for top middle of the screen
     // Convert this value to a lat long coordinate
     const pointXY = [map.getSize()![0] / 2, 1];

--- a/packages/geoview-time-slider/src/time-slider-panel.tsx
+++ b/packages/geoview-time-slider/src/time-slider-panel.tsx
@@ -1,6 +1,6 @@
 import { TypeWindow } from 'geoview-core';
 import { CloseButton, EnlargeButton, LayerList, LayerListEntry, LayerTitle, ResponsiveGrid } from 'geoview-core/src/core/components/common';
-import { useVisibleTimeSliderLayers, useTimeSliderLayers, useGeoviewDisplayLanguage } from 'geoview-core/src/core/stores';
+import { useVisibleTimeSliderLayers, useTimeSliderLayers, useAppDisplayLanguage } from 'geoview-core/src/core/stores';
 import { getSxClasses } from './time-slider-style';
 import { TimeSlider } from './time-slider';
 
@@ -42,7 +42,7 @@ export function TimeSliderPanel(props: TypeTimeSliderProps): JSX.Element {
   const [isLayersPanelVisible, setIsLayersPanelVisible] = useState(false);
   const [isEnlargeDataTable, setIsEnlargeDataTable] = useState(false);
 
-  const displayLanguage = useGeoviewDisplayLanguage();
+  const displayLanguage = useAppDisplayLanguage();
   const visibleTimeSliderLayers = useVisibleTimeSliderLayers();
   const timeSliderLayers = useTimeSliderLayers();
 

--- a/packages/geoview-time-slider/src/time-slider.tsx
+++ b/packages/geoview-time-slider/src/time-slider.tsx
@@ -1,8 +1,7 @@
 import { useTheme } from '@mui/material/styles';
 import { FormControl, InputLabel, NativeSelect } from '@mui/material';
-import { TypeWindow, useStore } from 'geoview-core';
-import { useTimeSliderStoreActions } from 'geoview-core/src/core/stores';
-import { useGeoViewStore } from 'geoview-core/src/core/stores/stores-managers';
+import { TypeWindow } from 'geoview-core';
+import { useTimeSliderLayers, useTimeSliderStoreActions } from 'geoview-core/src/core/stores';
 import { getSxClasses } from './time-slider-style';
 
 /**
@@ -85,17 +84,18 @@ export function TimeSlider(TimeSliderPanelProps: TimeSliderPanelProps) {
   const sliderDeltaRef = useRef<number>();
 
   // Get actions and states from store
+  // TODO: evaluate best option to set value by layer path.... trough a getter?
   const { setValues, setLocked, setReversed, setDelay, setFiltering } = useTimeSliderStoreActions();
-  const range = useStore(useGeoViewStore(), (state) => state.timeSliderState.timeSliderLayers[layerPath].range);
-  const defaultValue = useStore(useGeoViewStore(), (state) => state.timeSliderState.timeSliderLayers[layerPath].defaultValue);
-  const minAndMax = useStore(useGeoViewStore(), (state) => state.timeSliderState.timeSliderLayers[layerPath].minAndMax);
-  const fieldAlias = useStore(useGeoViewStore(), (state) => state.timeSliderState.timeSliderLayers[layerPath].fieldAlias);
-  const singleHandle = useStore(useGeoViewStore(), (state) => state.timeSliderState.timeSliderLayers[layerPath].singleHandle);
-  const values = useStore(useGeoViewStore(), (state) => state.timeSliderState.timeSliderLayers[layerPath].values);
-  const filtering = useStore(useGeoViewStore(), (state) => state.timeSliderState.timeSliderLayers[layerPath].filtering);
-  const delay = useStore(useGeoViewStore(), (state) => state.timeSliderState.timeSliderLayers[layerPath].delay);
-  const locked = useStore(useGeoViewStore(), (state) => state.timeSliderState.timeSliderLayers[layerPath].locked);
-  const reversed = useStore(useGeoViewStore(), (state) => state.timeSliderState.timeSliderLayers[layerPath].reversed);
+  const { range } = useTimeSliderLayers()[layerPath];
+  const { defaultValue } = useTimeSliderLayers()[layerPath];
+  const { minAndMax } = useTimeSliderLayers()[layerPath];
+  const { fieldAlias } = useTimeSliderLayers()[layerPath];
+  const { singleHandle } = useTimeSliderLayers()[layerPath];
+  const { values } = useTimeSliderLayers()[layerPath];
+  const { filtering } = useTimeSliderLayers()[layerPath];
+  const { delay } = useTimeSliderLayers()[layerPath];
+  const { locked } = useTimeSliderLayers()[layerPath];
+  const { reversed } = useTimeSliderLayers()[layerPath];
 
   const timeStampRange = range.map((entry) => new Date(entry).getTime());
   // Check if range occurs in a single day or year


### PR DESCRIPTION
Closes #1560

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Remove as I can the use of map class configuration and replace by the store. Next step is to make sure config store the good version then every files access the store. When we reload the config the store one is use. Issue #1580
Fixes #1560 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

Because it touches many components, I have tested many demo like basemap, basemap paackage, default config, feature info, ...
https://jolevesq.github.io/geoview/index.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1584)
<!-- Reviewable:end -->
