### PR TITLE
fix(details): Loading all layers and pre select layers

### DIFF
--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -1,6 +1,18 @@
 import { ReactNode } from 'react';
 import { useTheme } from '@mui/material/styles';
-import { Box, ChevronRightIcon, IconButton, List, ListItem, ListItemButton, ListItemIcon, Paper, Tooltip, Typography } from '@/ui';
+import {
+  Box,
+  ChevronRightIcon,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  Paper,
+  Tooltip,
+  Typography,
+  CircularProgressBase,
+} from '@/ui';
 import { getSxClasses } from './layer-list-style';
 import { IconStack } from '@/app';
 
@@ -10,6 +22,8 @@ export interface LayerListEntry {
   layerFeatures?: ReactNode | undefined;
   mapFilteredIcon?: ReactNode | undefined;
   tooltip?: ReactNode | undefined;
+  layerFlags?: { layerStatus: string };
+  numOffeatures?: number;
 }
 
 interface LayerListProps {
@@ -35,15 +49,27 @@ export function LayerList({ layerList, isEnlargeDataTable, selectedLayerIndex, h
     <List sx={sxClasses.list}>
       {layerList.map((layer, index) => (
         <Paper
-          sx={{ ...sxClasses.paper, border: selectedLayerIndex === index ? sxClasses.borderWithIndex : sxClasses.borderNone }}
+          sx={{
+            ...sxClasses.paper,
+            border: selectedLayerIndex === index && layer.numOffeatures !== 0 ? sxClasses.borderWithIndex : sxClasses.borderNone,
+          }}
           key={layer.layerPath}
         >
           <Tooltip title={layer.tooltip} placement="top" arrow>
             <Box>
               <ListItem disablePadding>
-                <ListItemButton selected={selectedLayerIndex === index} onClick={() => handleListItemClick(layer, index)}>
+                <ListItemButton
+                  disabled={layer.numOffeatures === 0}
+                  selected={selectedLayerIndex === index && layer.numOffeatures !== 0}
+                  onClick={() => handleListItemClick(layer, index)}
+                >
                   <ListItemIcon>
-                    <IconStack layerPath={layer.layerPath} />
+                    {/* // TODO line below might need to be reviewd related to getting layer status correctly  */}
+                    {layer.layerFlags?.layerStatus === 'loading' ? (
+                      <CircularProgressBase size={20} />
+                    ) : (
+                      <IconStack layerPath={layer.layerPath} />
+                    )}
                   </ListItemIcon>
                   <Box sx={sxClasses.listPrimaryText}>
                     <Typography className="layerTitle">{layer.layerName}</Typography>

--- a/packages/geoview-core/src/core/components/details/feature-info-new.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info-new.tsx
@@ -34,21 +34,21 @@ export function FeatureInfo({ features, currentFeatureIndex }: TypeFeatureInfoPr
   // internal state
   const [checked, setChecked] = useState<boolean>(false);
   const feature = features![currentFeatureIndex];
-  const featureUid = feature.geometry ? (feature.geometry as TypeGeometry).ol_uid : null;
-  const featureIconSrc = feature.featureIcon.toDataURL();
-  const nameFieldValue = feature.nameField ? (feature.fieldInfo[feature.nameField!]!.value as string) : 'No name';
+  const featureUid = feature?.geometry ? (feature.geometry as TypeGeometry).ol_uid : null;
+  const featureIconSrc = feature?.featureIcon.toDataURL();
+  const nameFieldValue = feature?.nameField ? (feature.fieldInfo[feature.nameField!]!.value as string) : 'No name';
 
   // states from store
   const checkedFeatures = useDetailsStoreCheckedFeatures();
   const { addCheckedFeature, removeCheckedFeature } = useDetailsStoreActions();
   const { zoomToExtent } = useMapStoreActions();
 
-  const featureInfoList: TypeFieldEntry[] = Object.keys(feature.fieldInfo).map((fieldName) => {
+  const featureInfoList: TypeFieldEntry[] = Object.keys(feature?.fieldInfo).map((fieldName) => {
     return {
-      fieldKey: feature.fieldInfo[fieldName]!.fieldKey,
-      value: feature.fieldInfo[fieldName]!.value,
-      dataType: feature.fieldInfo[fieldName]!.dataType,
-      alias: feature.fieldInfo[fieldName]!.alias ? feature.fieldInfo[fieldName]!.alias : fieldName,
+      fieldKey: feature?.fieldInfo[fieldName]!.fieldKey,
+      value: feature?.fieldInfo[fieldName]!.value,
+      dataType: feature?.fieldInfo[fieldName]!.dataType,
+      alias: feature?.fieldInfo[fieldName]!.alias ? feature?.fieldInfo[fieldName]!.alias : fieldName,
       domain: null,
     };
   });

--- a/packages/geoview-core/src/core/components/map/map.tsx
+++ b/packages/geoview-core/src/core/components/map/map.tsx
@@ -18,7 +18,8 @@ import { XYZ } from 'ol/source';
 import { NorthArrow, NorthPoleFlag } from '@/core/components/north-arrow/north-arrow';
 import { Crosshair } from '@/core/components/crosshair/crosshair';
 import { OverviewMap } from '@/core/components/overview-map/overview-map';
-import { ClickMarker } from '@/core/components/click-marker/click-marker';
+// TODO: Repair commented line below, needs to fix click marker
+// import { ClickMarker } from '@/core/components/click-marker/click-marker';
 import { HoverTooltip } from '@/core/components/hover-tooltip/hover-tooltip';
 
 import { TypeBasemapLayer, api } from '@/app';
@@ -208,7 +209,8 @@ export function Map(): JSX.Element {
           {northArrow && <NorthArrow />}
           <NorthPoleFlag />
           <Crosshair />
-          <ClickMarker />
+          {/* // TODO: Repair commented out line below, needs to fix click marker */}
+          {/* <ClickMarker /> */}
           <HoverTooltip />
           {deviceSizeMedUp && overviewMap && overviewBaseMap && <OverviewMap />}
         </>

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/details-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/details-state.ts
@@ -7,12 +7,14 @@ export interface IDetailsState {
   checkedFeatures: Array<TypeFeatureInfoEntry>;
   layerDataArray: TypeArrayOfLayerData;
   selectedLayerPath: string;
+  selectedLayerIndex: number;
 
   actions: {
     addCheckedFeature: (feature: TypeFeatureInfoEntry) => void;
     removeCheckedFeature: (feature: TypeFeatureInfoEntry | 'all') => void;
     setLayerDataArray: (layerDataArray: TypeArrayOfLayerData) => void;
     setSelectedLayerPath: (selectedLayerPath: string) => void;
+    setSelectedLayerIndex: (selectedLayerIndex: number) => void;
   };
 }
 
@@ -21,6 +23,7 @@ export function initialDetailsState(set: TypeSetStore, get: TypeGetStore): IDeta
     checkedFeatures: [],
     layerDataArray: [],
     selectedLayerPath: '',
+    selectedLayerIndex: 0,
 
     // #region ACTIONS
     actions: {
@@ -62,6 +65,14 @@ export function initialDetailsState(set: TypeSetStore, get: TypeGetStore): IDeta
           },
         });
       },
+      setSelectedLayerIndex(selectedLayerIndex: number) {
+        set({
+          detailsState: {
+            ...get().detailsState,
+            selectedLayerIndex,
+          },
+        });
+      },
     },
     // #endregion ACTIONS
   } as IDetailsState;
@@ -73,5 +84,6 @@ export function initialDetailsState(set: TypeSetStore, get: TypeGetStore): IDeta
 export const useDetailsStoreCheckedFeatures = () => useStore(useGeoViewStore(), (state) => state.detailsState.checkedFeatures);
 export const useDetailsStoreLayerDataArray = () => useStore(useGeoViewStore(), (state) => state.detailsState.layerDataArray);
 export const useDetailsStoreSelectedLayerPath = () => useStore(useGeoViewStore(), (state) => state.detailsState.selectedLayerPath);
+export const useDetailsStoreSelectedLayerIndex = () => useStore(useGeoViewStore(), (state) => state.detailsState.selectedLayerIndex);
 
 export const useDetailsStoreActions = () => useStore(useGeoViewStore(), (state) => state.detailsState.actions);

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -240,7 +240,7 @@ function findLayerByPath(layers: TypeLegendLayer[], layerPath: string): TypeLege
     if (layerPath === l.layerPath) {
       return l;
     }
-    if (layerPath.startsWith(l.layerPath) && l.children?.length > 0) {
+    if (layerPath?.startsWith(l.layerPath) && l.children?.length > 0) {
       const result: TypeLegendLayer | undefined = findLayerByPath(l.children, layerPath);
       if (result) {
         return result;

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
@@ -313,7 +313,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
                 ? []
                 : get().mapState.selectedFeatures.filter(
                     (featureInfoEntry: TypeFeatureInfoEntry) =>
-                      (featureInfoEntry.geometry as TypeGeometry).ol_uid !== (feature.geometry as TypeGeometry).ol_uid
+                      (featureInfoEntry.geometry as TypeGeometry).ol_uid !== (feature?.geometry as TypeGeometry)?.ol_uid
                   ),
           },
         });

--- a/packages/geoview-core/src/geo/utils/feature-highlight.ts
+++ b/packages/geoview-core/src/geo/utils/feature-highlight.ts
@@ -246,7 +246,7 @@ export class FeatureHighlight {
    * @param {TypeFeatureInfoEntry} feature the feature to highlight
    */
   selectFeature(feature: TypeFeatureInfoEntry) {
-    const geometry = feature.geometry!.getGeometry();
+    const geometry = feature?.geometry!.getGeometry();
     if (geometry instanceof Polygon) {
       this.animatePolygon(feature);
     } else if (geometry instanceof LineString || geometry instanceof MultiLineString) {


### PR DESCRIPTION
# Description

We need to load all layers including layers with no features. Layers with zero features will be disabled, we need to keep the same logic of pre selecting the layer, but if the previous selected layer is not in the list of new loading layer, we need to select the first layer with non zero features.

For testing purpose, there are some console.log in the code that will be removed after finalizing the changed.

Fixes #1544 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://amir-azma.github.io/geoview/raw-feature-info.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1595)
<!-- Reviewable:end -->
