### PR TITLE
feat(footer-bar-responsive): Make the footer bar responsive

### DIFF
--- a/packages/geoview-core/src/core/components/attribution/attribution.tsx
+++ b/packages/geoview-core/src/core/components/attribution/attribution.tsx
@@ -68,7 +68,7 @@ export function Attribution(): JSX.Element {
         }}
         onClose={handleClosePopover}
       >
-        <Box sx={{ padding: '15px' }}>
+        <Box sx={{ padding: '15px', width: '450px' }}>
           {mapAttribution.map((attribution) => {
             return <Typography key={generateId()}>{attribution}</Typography>;
           })}

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -43,7 +43,15 @@ export function Footerbar(): JSX.Element {
         </Grid>
 
         <Grid container item md={11} spacing={2}>
-          <Grid container justifyContent="flex-end">
+          <Grid
+            container
+            justifyContent="flex-end"
+            sx={{
+              [theme.breakpoints.down('md')]: {
+                marginTop: '-32px',
+              },
+            }}
+          >
             <Grid item md={10}>
               <Box id="mouseAndScaleControls" sx={sxClassesFooterBar.mouseScaleControlsContainer}>
                 {interaction === 'dynamic' && <MousePosition />}

--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs-style.ts
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs-style.ts
@@ -8,9 +8,4 @@ export const getSxClasses = (theme: Theme) => ({
     transition: 'height 0.2s ease-out',
     height: '55px',
   },
-  expandBtn: {
-    [theme.breakpoints.down('md')]: {
-      display: 'none',
-    },
-  },
 });

--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs-style.ts
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs-style.ts
@@ -8,4 +8,9 @@ export const getSxClasses = (theme: Theme) => ({
     transition: 'height 0.2s ease-out',
     height: '55px',
   },
+  expandBtn: {
+    [theme.breakpoints.down('md')]: {
+      display: 'none',
+    },
+  },
 });

--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
@@ -2,18 +2,7 @@ import { MutableRefObject, useCallback, useEffect, useRef, useState } from 'reac
 
 import { useTheme } from '@mui/material/styles';
 
-import {
-  Box,
-  ExpandLessIcon,
-  ExpandMoreIcon,
-  FullscreenIcon,
-  FullscreenExitIcon,
-  IconButton,
-  Tabs,
-  TypeTabs,
-  MoveDownRoundedIcon,
-  MoveUpRoundedIcon,
-} from '@/ui';
+import { Box, FullscreenIcon, FullscreenExitIcon, IconButton, Tabs, TypeTabs, MoveDownRoundedIcon, MoveUpRoundedIcon } from '@/ui';
 import { api, useGeoViewMapId } from '@/app';
 import { EVENT_NAMES } from '@/api/events/event-types';
 import { FooterTabPayload, PayloadBaseClass, payloadIsAFooterTab } from '@/api/events/payloads';
@@ -142,6 +131,9 @@ export function FooterTabs(): JSX.Element | null {
 
   const eventFooterTabsCreateListenerFunction = (payload: PayloadBaseClass) => {
     if (payloadIsAFooterTab(payload)) addTab(payload);
+    // select the first tab
+    setSelectedTab(0);
+    handleCollapse();
   };
 
   const eventFooterTabsRemoveListenerFunction = (payload: PayloadBaseClass) => {
@@ -154,7 +146,6 @@ export function FooterTabs(): JSX.Element | null {
       if (payload.tab.value === 1) {
         handleCollapse();
       }
-      setSelectedTab(undefined); // this will always trigger the tab change, needed in case user changes selection
       setSelectedTab(payload.tab.value);
     }
   };
@@ -225,11 +216,6 @@ export function FooterTabs(): JSX.Element | null {
             {!isCollapsed && (
               <IconButton onClick={() => setIsFullscreen(!isFullscreen)}>
                 {isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
-              </IconButton>
-            )}
-            {!isFullscreen && (
-              <IconButton sx={sxClasses.expandBtn} onClick={handleCollapse}>
-                {!isCollapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}
               </IconButton>
             )}
             <IconButton

--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
@@ -227,7 +227,11 @@ export function FooterTabs(): JSX.Element | null {
                 {isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
               </IconButton>
             )}
-            {!isFullscreen && <IconButton onClick={handleCollapse}>{!isCollapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}</IconButton>}
+            {!isFullscreen && (
+              <IconButton sx={sxClasses.expandBtn} onClick={handleCollapse}>
+                {!isCollapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}
+              </IconButton>
+            )}
             <IconButton
               onClick={handleDynamicFocus}
               tooltip={isFocusToMap ? 'footerTabsContainer.focusToMap' : 'footerTabsContainer.focusToFooter'}

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -126,7 +126,7 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
           })}
         </MaterialTabs>
       </Grid>
-      <Grid item xs={5} sm={2} sx={{ textAlign: 'right' }}>
+      <Grid item xs={5} sm={2} sx={{ textAlign: 'right', marginTop: '15px' }}>
         {rightButtons as ReactNode}
       </Grid>
       <Grid item xs={12} sx={{ height: '100%', borderTop: 1, borderColor: 'divider', visibility: TabContentVisibilty }}>

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -84,6 +84,9 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
       <Grid item xs={7} sm={10}>
         <MaterialTabs
           {...props.tabsProps}
+          variant="scrollable"
+          scrollButtons
+          allowScrollButtonsMobile
           value={value}
           onChange={handleChange}
           aria-label="basic tabs"


### PR DESCRIPTION
# Description

Fix some issues related to footer tab, and footer bar. Make the footer bar responsive so we can navigate and select all tabs when screen is on mobile. To minimize the number of controls, we only keep one button for focus and full screen when tab is open. Remove collapse/expand.

Fixes #1574 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

To minimize the number of controls, we only keep one button for focus and full screen when tab is open. Remove collapse/expand.

https://amir-azma.github.io/geoview/raw-feature-info.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1604)
<!-- Reviewable:end -->
