### PR TITLE
1637-Wrong-group-name

### DIFF
--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -161,7 +161,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
           layerAttribution: api.maps[mapId].layer.geoviewLayers[layerPathNodes[0]].attributions,
           // ! Why do we have metadataAccessPath here? Do we need to fetch the metadata again? The GeoView layer fetch them and store them in this.metadata.
           metadataAccessPath: getLocalizedValue(layerConfig.geoviewRootLayer?.metadataAccessPath, mapId),
-          layerName: getLocalizedValue(legendResultSetsEntry.data?.layerName, mapId)!,
+          layerName: getLocalizedValue(legendResultSetsEntry.data?.layerName, mapId) || '',
           layerStatus: legendResultSetsEntry.layerStatus,
           layerPhase: legendResultSetsEntry.layerPhase,
           querySent: legendResultSetsEntry.querySent,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -1396,14 +1396,24 @@ export abstract class AbstractGeoViewLayer {
   }
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig, returns updated bounds
+   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
+   *
+   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
+   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
+   *
+   * @returns {Extent} The new layer bounding box.
+   */
+  protected abstract getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
+
+  /** ***************************************************************************************************************************
+   * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
    * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
-   * @returns {Extent} The layer bounding box.
+   * @returns {Extent} The new layer bounding box.
    */
-  protected abstract getBounds(layerPath?: string, bounds?: Extent): Extent | undefined;
+  protected abstract getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
 
   /** ***************************************************************************************************************************
    * Compute the layer bounds or undefined if the result can not be obtained from the feature extents that compose the layer. If
@@ -1424,7 +1434,7 @@ export abstract class AbstractGeoViewLayer {
       listOfLayerEntryConfig.forEach((layerConfig) => {
         if (layerEntryIsGroupLayer(layerConfig)) processGroupLayerBounds(layerConfig.listOfLayerEntryConfig);
         else {
-          bounds = this.getBounds(layerPath, bounds);
+          bounds = this.getBounds(layerPath!, bounds);
         }
       });
     };

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -723,6 +723,8 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * layer. When the layer config is invalid, nothing is done.
    *
    * @param {string} filter An optional filter to be used in place of the getViewFilter value.
+   * @param {never} notUsed1 This parameter must not be provided. It is there to allow overloading of the method signature.
+   * @param {never} notUsed2 This parameter must not be provided. It is there to allow overloading of the method signature.
    */
   applyViewFilter(filter: string, notUsed1?: never, notUsed2?: never): void;
 
@@ -735,6 +737,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    *
    * @param {string} filter An optional filter to be used in place of the getViewFilter value.
    * @param {boolean} CombineLegendFilter Flag used to combine the legend filter and the filter together (default: true)
+   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
    */
   applyViewFilter(filter: string, CombineLegendFilter: boolean, notUsed?: never): void;
 
@@ -750,6 +753,8 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    */
   applyViewFilter(layerPath: string, filter?: string, combineLegendFilter?: boolean): void;
 
+  // See above headers for signification of the parameters. The first lines of the method select the template
+  // used based on the parameter types received.
   applyViewFilter(parameter1: string, parameter2?: string | boolean | never, parameter3?: boolean | never) {
     let layerPath = api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
     let filter = '';
@@ -800,14 +805,30 @@ export class EsriDynamic extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig, returns updated bounds
+   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
+   *
+   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
+   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
+   *
+   * @returns {Extent} The new layer bounding box.
+   */
+  protected getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
+
+  /** ***************************************************************************************************************************
+   * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
    * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
-   * @returns {Extent} The layer bounding box.
+   * @returns {Extent} The new layer bounding box.
    */
-  getBounds(layerPath: string, bounds: Extent | undefined): Extent | undefined {
+  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
+
+  // See above headers for signification of the parameters. The first lines of the method select the template
+  // used based on the parameter types received.
+  protected getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
+    const layerPath = typeof parameter1 === 'string' ? parameter1 : api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    let bounds = typeof parameter1 !== 'string' ? parameter1 : parameter2;
     const layerConfig = this.getLayerConfig(layerPath);
     const layerBounds = layerConfig?.initialSettings?.bounds || [];
     const projection = this.metadata?.fullExtent?.spatialReference?.wkid || MapEventProcessor.getMapState(this.mapId).currentProjection;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
@@ -283,14 +283,30 @@ export class ImageStatic extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig, returns updated bounds
+   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
+   *
+   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
+   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
+   *
+   * @returns {Extent} The new layer bounding box.
+   */
+  protected getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
+
+  /** ***************************************************************************************************************************
+   * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
    * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
-   * @returns {Extent} The layer bounding box.
+   * @returns {Extent} The new layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds: Extent | undefined): Extent | undefined {
+  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
+
+  // See above headers for signification of the parameters. The first lines of the method select the template
+  // used based on the parameter types received.
+  protected getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
+    const layerPath = typeof parameter1 === 'string' ? parameter1 : api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    let bounds = typeof parameter1 !== 'string' ? parameter1 : parameter2;
     const layerConfig = this.getLayerConfig(layerPath);
     const layerBounds = (layerConfig?.olLayer as ImageLayer<Static>).getSource()?.getImageExtent();
     const projection =

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
@@ -249,14 +249,30 @@ export class VectorTiles extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig, returns updated bounds
+   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
+   *
+   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
+   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
+   *
+   * @returns {Extent} The new layer bounding box.
+   */
+  protected getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
+
+  /** ***************************************************************************************************************************
+   * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
    * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
-   * @returns {Extent} The layer bounding box.
+   * @returns {Extent} The new layer bounding box.
    */
-  getBounds(layerPath: string, bounds: Extent | undefined): Extent | undefined {
+  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
+
+  // See above headers for signification of the parameters. The first lines of the method select the template
+  // used based on the parameter types received.
+  protected getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
+    const layerPath = typeof parameter1 === 'string' ? parameter1 : api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    let bounds = typeof parameter1 !== 'string' ? parameter1 : parameter2;
     const layerConfig = this.getLayerConfig(layerPath);
     const layerBounds = (layerConfig?.olLayer as TileLayer<VectorTileSource>).getSource()?.getTileGrid()?.getExtent();
     const projection =

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -1001,6 +1001,8 @@ export class WMS extends AbstractGeoViewRaster {
    * layer. When the layer config is invalid, nothing is done.
    *
    * @param {string} filter An optional filter to be used in place of the getViewFilter value.
+   * @param {never} notUsed1 This parameter must not be provided. It is there to allow overloading of the method signature.
+   * @param {never} notUsed2 This parameter must not be provided. It is there to allow overloading of the method signature.
    */
   applyViewFilter(filter: string, notUsed1?: never, notUsed2?: never): void;
 
@@ -1013,6 +1015,7 @@ export class WMS extends AbstractGeoViewRaster {
    *
    * @param {string} filter An optional filter to be used in place of the getViewFilter value.
    * @param {boolean} CombineLegendFilter Flag used to combine the legend filter and the filter together (default: true)
+   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
    */
   applyViewFilter(filter: string, CombineLegendFilter: boolean, notUsed?: never): void;
 
@@ -1029,6 +1032,8 @@ export class WMS extends AbstractGeoViewRaster {
    */
   applyViewFilter(layerPath: string, filter?: string, CombineLegendFilter?: boolean): void;
 
+  // See above headers for signification of the parameters. The first lines of the method select the template
+  // used based on the parameter types received.
   applyViewFilter(parameter1: string, parameter2?: string | boolean | never, parameter3?: boolean | never) {
     let layerPath = api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
     let filter = '';
@@ -1080,14 +1085,30 @@ export class WMS extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig, returns updated bounds
+   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
+   *
+   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
+   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
+   *
+   * @returns {Extent} The new layer bounding box.
+   */
+  protected getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
+
+  /** ***************************************************************************************************************************
+   * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
    * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
-   * @returns {Extent} The layer bounding box.
+   * @returns {Extent} The new layer bounding box.
    */
-  getBounds(layerPath: string, bounds: Extent | undefined): Extent | undefined {
+  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
+
+  // See above headers for signification of the parameters. The first lines of the method select the template
+  // used based on the parameter types received.
+  protected getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
+    const layerPath = typeof parameter1 === 'string' ? parameter1 : api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    let bounds = typeof parameter1 !== 'string' ? parameter1 : parameter2;
     const layerConfig = this.getLayerConfig(layerPath);
     const projection =
       (layerConfig?.olLayer as ImageLayer<Static>).getSource()?.getProjection()?.getCode().replace('EPSG:', '') ||

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -258,14 +258,30 @@ export class XYZTiles extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig, returns updated bounds
+   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
+   *
+   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
+   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
+   *
+   * @returns {Extent} The new layer bounding box.
+   */
+  protected getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
+
+  /** ***************************************************************************************************************************
+   * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
    * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
-   * @returns {Extent} The layer bounding box.
+   * @returns {Extent} The new layer bounding box.
    */
-  getBounds(layerPath: string, bounds: Extent | undefined): Extent | undefined {
+  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
+
+  // See above headers for signification of the parameters. The first lines of the method select the template
+  // used based on the parameter types received.
+  protected getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
+    const layerPath = typeof parameter1 === 'string' ? parameter1 : api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    let bounds = typeof parameter1 !== 'string' ? parameter1 : parameter2;
     const layerConfig = this.getLayerConfig(layerPath);
     const layerBounds = (layerConfig?.olLayer as TileLayer<XYZ>)?.getSource()?.getTileGrid()?.getExtent();
     const projection =

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -305,25 +305,28 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
   }
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig, returns updated bounds
+   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
    *
    * @param {Extent | undefined} bounds The current bounding box to be adjusted.
+   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
    *
    * @returns {Extent} The new layer bounding box.
    */
-  getBounds(bounds?: Extent, notUsed?: never): Extent | undefined;
+  protected getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig, returns updated bounds
+   * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
    * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
    * @returns {Extent} The new layer bounding box.
    */
-  getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
+  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
 
-  getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
+  // See above headers for signification of the parameters. The first lines of the method select the template
+  // used based on the parameter types received.
+  protected getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
     const layerPath = typeof parameter1 === 'string' ? parameter1 : api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
     let bounds = typeof parameter1 !== 'string' ? parameter1 : parameter2;
     const layerConfig = this.getLayerConfig(layerPath);
@@ -343,6 +346,8 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * layer. When the layer config is invalid, nothing is done.
    *
    * @param {string} filter A filter to be used in place of the getViewFilter value.
+   * @param {never} notUsed1 This parameter must not be provided. It is there to allow overloading of the method signature.
+   * @param {never} notUsed2 This parameter must not be provided. It is there to allow overloading of the method signature.
    */
   applyViewFilter(filter: string, notUsed1?: never, notUsed2?: never): void;
 
@@ -355,6 +360,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    *
    * @param {string} filter A filter to be used in place of the getViewFilter value.
    * @param {boolean} CombineLegendFilter Flag used to combine the legend filter and the filter together (default: true)
+   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
    */
   applyViewFilter(filter: string, CombineLegendFilter: boolean, notUsed?: never): void;
 
@@ -370,6 +376,8 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    */
   applyViewFilter(layerPath: string, filter?: string, CombineLegendFilter?: boolean): void;
 
+  // See above headers for signification of the parameters. The first lines of the method select the template
+  // used based on the parameter types received.
   applyViewFilter(parameter1: string, parameter2?: string | boolean | never, parameter3?: boolean | never) {
     let layerPath = api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
     let filter = '';


### PR DESCRIPTION
# Description

A single line correction to use the group name instead of the layer name. This PR also includes a correction to the getBounds implementation.

Fixes #1637

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using Chrome Devtools to trace and debug the geojson.html template.

__Deploy URL to test:__ https://ychoquet.github.io/GeoView/geojson.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1639)
<!-- Reviewable:end -->
