### PR TITLE
fix(footerpanel): Implement footerpanel movable on fullscreen

### DIFF
--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs-style.ts
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs-style.ts
@@ -3,7 +3,8 @@ import { Theme } from '@mui/material/styles';
 export const getSxClasses = (theme: Theme) => ({
   tabsContainer: {
     position: 'relative',
-    backgroundColor: theme.palette.background.default,
+    background: theme.footerPanel.contentBg,
+    boxShadow: theme.footerPanel.contentShadow,
     width: '100%',
     transition: 'height 0.2s ease-out',
     height: '55px',

--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs-style.ts
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs-style.ts
@@ -8,5 +8,10 @@ export const getSxClasses = (theme: Theme) => ({
     width: '100%',
     transition: 'height 0.2s ease-out',
     height: '55px',
+    cursor: 'default',
+  },
+  tabContainerFullScreenMode: {
+    zIndex: '9999999',
+    cursor: 'ns-resize',
   },
 });

--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs-style.ts
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs-style.ts
@@ -12,6 +12,5 @@ export const getSxClasses = (theme: Theme) => ({
   },
   tabContainerFullScreenMode: {
     zIndex: '9999999',
-    cursor: 'ns-resize',
   },
 });

--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
@@ -29,7 +29,8 @@ export function FooterTabs(): JSX.Element | null {
 
   const tabsContainerRef = useRef<HTMLDivElement>();
   const yPositionRef = useRef<number>(0);
-  const footerPanelFullscreenBounds = useRef({ max: -75, min: 0 });
+  const footerPanelFullscreenBounds = useRef({ max: -80, min: 0 });
+  const tabsContainerRefHeight = useRef<number>();
 
   // get map div and follow state of original map height
   const mapDiv = document.getElementById(mapId)!;
@@ -178,6 +179,15 @@ export function FooterTabs(): JSX.Element | null {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [addTab, mapId, removeTab]);
 
+  /**
+   * Calculate initial height of tabContainer when goes to fullscreen
+   */
+  useEffect(() => {
+    if (tabsContainerRef.current) {
+      tabsContainerRefHeight.current = tabsContainerRef.current.getBoundingClientRect().height;
+    }
+  }, [isMapFullscreen]);
+
   // Handle focus using dynamic focus button
   const handleDynamicFocus = () => {
     const mapIdDiv = document.getElementById(mapId);
@@ -230,6 +240,7 @@ export function FooterTabs(): JSX.Element | null {
     if (!isMapFullscreen && tabsContainerRef.current) {
       yPositionRef.current = 0;
       tabsContainerRef.current.style.transform = 'translateY(0%)';
+      tabsContainerRef.current.style.minHeight = 'fit-content';
     }
   }, [isMapFullscreen]);
 
@@ -241,6 +252,7 @@ export function FooterTabs(): JSX.Element | null {
     if (
       pressed &&
       tabsContainerRef.current &&
+      tabsContainerRefHeight.current &&
       isMapFullscreen &&
       yPositionRef.current >= footerPanelFullscreenBounds.current.max &&
       yPositionRef.current <= footerPanelFullscreenBounds.current.min
@@ -254,8 +266,10 @@ export function FooterTabs(): JSX.Element | null {
       if (yPositionRef.current > footerPanelFullscreenBounds.current.min) {
         yPositionRef.current = footerPanelFullscreenBounds.current.min;
       }
+
       tabsContainerRef.current.style.transform = `translateY(${yPositionRef.current}%)`;
-      tabsContainerRef.current.style.height = yPositionRef.current !== 0 ? `${yPositionRef.current}vh` : 'fit-content';
+      tabsContainerRef.current.style.minHeight =
+        yPositionRef.current !== 0 ? `${Math.abs(yPositionRef.current) * 2 + tabsContainerRefHeight.current}px` : 'fit-content';
     }
   };
 
@@ -286,6 +300,7 @@ export function FooterTabs(): JSX.Element | null {
                   yPositionRef.current = 0;
                   if (tabsContainerRef.current) {
                     tabsContainerRef.current.style.transform = 'translateY(0%)';
+                    tabsContainerRef.current.style.minHeight = 'fit-content';
                   }
                   setIsFullscreen(!isFullscreen);
                 }}

--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
@@ -30,6 +30,7 @@ export function FooterTabs(): JSX.Element | null {
 
   const tabsContainerRef = useRef<HTMLDivElement>();
   const yPositionRef = useRef<number>(0);
+  const footerPanelFullscreenBounds = useRef({ max: -60, min: 0 });
 
   // get map div and follow state of original map height
   const mapDiv = document.getElementById(mapId)!;
@@ -236,15 +237,21 @@ export function FooterTabs(): JSX.Element | null {
    * @param {number} yPosition y axis movementY position of mouse.
    */
   const handleMouseMove = (yPosition: number) => {
-    if (pressed && tabsContainerRef.current && isMapFullscreen && yPositionRef.current >= -50 && yPositionRef.current <= 0) {
+    if (
+      pressed &&
+      tabsContainerRef.current &&
+      isMapFullscreen &&
+      yPositionRef.current >= footerPanelFullscreenBounds.current.max &&
+      yPositionRef.current <= footerPanelFullscreenBounds.current.min
+    ) {
       yPositionRef.current += yPosition;
       // set max y axis to bound the panel.
-      if (yPositionRef.current < -50) {
-        yPositionRef.current = -50;
+      if (yPositionRef.current < footerPanelFullscreenBounds.current.max) {
+        yPositionRef.current = footerPanelFullscreenBounds.current.max;
       }
       // set min y axis to bound the panel.
-      if (yPositionRef.current > 0) {
-        yPositionRef.current = 0;
+      if (yPositionRef.current > footerPanelFullscreenBounds.current.min) {
+        yPositionRef.current = footerPanelFullscreenBounds.current.min;
       }
       tabsContainerRef.current.style.transform = `translateY(${yPositionRef.current}%)`;
     }
@@ -272,7 +279,15 @@ export function FooterTabs(): JSX.Element | null {
         rightButtons={
           <>
             {!isCollapsed && (
-              <IconButton onClick={() => setIsFullscreen(!isFullscreen)}>
+              <IconButton
+                onClick={() => {
+                  yPositionRef.current = 0;
+                  if (tabsContainerRef.current) {
+                    tabsContainerRef.current.style.transform = 'translateY(0%)';
+                  }
+                  setIsFullscreen(!isFullscreen);
+                }}
+              >
                 {isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
               </IconButton>
             )}

--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
@@ -3,7 +3,7 @@ import { MutableRefObject, useCallback, useEffect, useRef, useState } from 'reac
 import { useTheme } from '@mui/material/styles';
 
 import { Box, FullscreenIcon, FullscreenExitIcon, IconButton, Tabs, TypeTabs, MoveDownRoundedIcon, MoveUpRoundedIcon } from '@/ui';
-import { api, useAppFullscreenActive, useGeoViewMapId } from '@/app';
+import { api, useAppFullscreenActive, useGeoViewMapId, useUIFooterBarFullScreenActive, useUIStoreActions } from '@/app';
 import { EVENT_NAMES } from '@/api/events/event-types';
 import { FooterTabPayload, PayloadBaseClass, payloadIsAFooterTab } from '@/api/events/payloads';
 import { getSxClasses } from './footer-tabs-style';
@@ -24,19 +24,20 @@ export function FooterTabs(): JSX.Element | null {
   const [footerTabs, setFooterTabs] = useState<TypeTabs[]>([]);
   const [isCollapsed, setIsCollapsed] = useState(true);
 
-  const [isFullscreen, setIsFullscreen] = useState(false);
   const [isFocusToMap, setIsFocusToMap] = useState<boolean>(true);
   const [pressed, setPressed] = useState(false);
 
   const tabsContainerRef = useRef<HTMLDivElement>();
   const yPositionRef = useRef<number>(0);
-  const footerPanelFullscreenBounds = useRef({ max: -60, min: 0 });
+  const footerPanelFullscreenBounds = useRef({ max: -75, min: 0 });
 
   // get map div and follow state of original map height
   const mapDiv = document.getElementById(mapId)!;
   const [origHeight, setOrigHeight] = useState<number>(0);
 
   const isMapFullscreen = useAppFullscreenActive();
+  const isFullscreen = useUIFooterBarFullScreenActive();
+  const { setIsFooterBarFullScreenActive: setIsFullscreen } = useUIStoreActions();
 
   /**
    * Add a tab
@@ -254,6 +255,7 @@ export function FooterTabs(): JSX.Element | null {
         yPositionRef.current = footerPanelFullscreenBounds.current.min;
       }
       tabsContainerRef.current.style.transform = `translateY(${yPositionRef.current}%)`;
+      tabsContainerRef.current.style.height = yPositionRef.current !== 0 ? `${yPositionRef.current}vh` : 'fit-content';
     }
   };
 

--- a/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
@@ -5,7 +5,7 @@ import { SingleLayer } from './single-layer';
 import { getSxClasses } from './left-panel-styles';
 import { Box } from '@/ui';
 import { TypeLegendLayer } from '../types';
-import { useLayerStoreActions, useLayersDisplayState } from '@/core/stores/';
+import { useLayerStoreActions, useLayersDisplayState, useUIFooterBarFullScreenActive } from '@/core/stores/';
 
 interface LayerListProps {
   depth: number;
@@ -20,6 +20,7 @@ export function LayersList({ layersList, setIsLayersListPanelVisible, parentLaye
 
   const displayState = useLayersDisplayState();
   const { reorderLayer } = useLayerStoreActions(); // get store actions
+  const isFooterbarFullscreenActive = useUIFooterBarFullScreenActive();
 
   const isDragEnabled = displayState === 'order';
 
@@ -62,7 +63,7 @@ export function LayersList({ layersList, setIsLayersListPanelVisible, parentLaye
 
   const getListClass = () => {
     if (depth === 0) {
-      return sxClasses.list;
+      return { ...sxClasses.list, ...(!isFooterbarFullscreenActive && { maxHeight: '660px' }) };
     }
     if (depth % 2) {
       return sxClasses.evenDepthList;

--- a/packages/geoview-core/src/core/components/layers/left-panel/left-panel-styles.ts
+++ b/packages/geoview-core/src/core/components/layers/left-panel/left-panel-styles.ts
@@ -6,7 +6,6 @@ export const getSxClasses = (theme: Theme) => ({
     width: '100%',
     padding: '8px',
     overflow: 'auto',
-    maxHeight: '660px',
 
     // layer title
     '& .MuiListItemText-primary': {
@@ -111,7 +110,7 @@ export const getSxClasses = (theme: Theme) => ({
     width: 'unset',
     boxSizing: 'border-box',
     '& .layerItemContainer': {
-      backgroundColor: 'transparent',
+      backgroundColor: 'transparent !important',
       marginBottom: '0px',
     },
   },
@@ -123,7 +122,7 @@ export const getSxClasses = (theme: Theme) => ({
     width: 'unset',
     boxSizing: 'border-box',
     '& .layerItemContainer': {
-      backgroundColor: 'transparent',
+      backgroundColor: 'transparent !important',
       marginBottom: '0px',
     },
   },

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details-style.ts
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details-style.ts
@@ -10,7 +10,6 @@ export const getSxClasses = (theme: Theme) => ({
     border: '2px solid #515BA5',
     padding: '20px',
     overflow: 'auto',
-    maxHeight: '700px',
   },
   buttonDescriptionContainer: {
     display: 'flex',

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -24,7 +24,7 @@ import {
   List,
 } from '@/ui';
 import { useLayerHighlightedLayer, useLayerStoreActions } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import { useUIStoreActions } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useUIFooterBarFullScreenActive, useUIStoreActions } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { generateId } from '@/core/utils/utilities';
 import { LayerIcon } from '../layer-icon';
 
@@ -45,6 +45,8 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   const { setAllItemsVisibility, toggleItemVisibility, setLayerOpacity, setHighlightLayer, zoomToLayerExtent, getLayerBounds } =
     useLayerStoreActions();
   const { openModal } = useUIStoreActions();
+
+  const isFooterbarFullscreenActive = useUIFooterBarFullScreenActive();
 
   const handleZoomTo = () => {
     zoomToLayerExtent(layerDetails.layerPath);
@@ -221,7 +223,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   // function renderItems
 
   return (
-    <Paper sx={sxClasses.layerDetails}>
+    <Paper sx={{ ...sxClasses.layerDetails, ...(!isFooterbarFullscreenActive && { maxHeight: '700px' }) }}>
       <Box sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
         <Box sx={{ textAlign: 'left' }}>
           <Typography sx={sxClasses.categoryTitle}> {layerDetails.layerName} </Typography>

--- a/packages/geoview-core/src/core/components/legend/legend-styles.ts
+++ b/packages/geoview-core/src/core/components/legend/legend-styles.ts
@@ -2,8 +2,6 @@ import { Theme } from '@mui/material/styles';
 
 export const getSxClasses = (theme: Theme) => ({
   container: {
-    background: theme.footerPanel.contentBg,
-    boxShadow: theme.footerPanel.contentShadow,
     padding: '20px',
     display: 'flex',
     flexDirection: 'column',

--- a/packages/geoview-core/src/core/components/legend/legend.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend.tsx
@@ -35,7 +35,7 @@ export function Legend(): JSX.Element {
 
   function renderLegendLayersList() {
     return (
-      <Box display="flex" flexDirection="column" flexWrap="wrap" style={{ height: 600, overflow: 'auto' }}>
+      <Box display="flex" flexDirection="row" flexWrap="wrap">
         {legendLayers.map((item) => (
           <Box key={item!.layerPath} width={{ xs: '100%', sm: '50%', md: '33.33%', lg: '25%', xl: '25%' }} style={{ minHeight: 0 }} p={2}>
             <LegendLayer layer={item!} key={item!.layerPath} />

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
@@ -18,6 +18,7 @@ export interface IUIState {
   focusITem: focusItemProps;
   footerBarExpanded: boolean;
   geoLocatorActive: boolean;
+  isFooterBarFullScreenActive: boolean;
   navBarComponents: TypeNavBarProps;
 
   setDefaultConfigValues: (geoviewConfig: TypeMapFeaturesConfig) => void;
@@ -29,6 +30,7 @@ export interface IUIState {
     setActiveTrapGeoView: (active: boolean) => void;
     setFooterBarExpanded: (expanded: boolean) => void;
     setGeolocatorActive: (active: boolean) => void;
+    setIsFooterBarFullScreenActive: (active: boolean) => void;
   };
 }
 
@@ -40,6 +42,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
     corePackagesComponents: [],
     focusITem: { activeElementId: false, callbackElementId: false },
     footerBarExpanded: false,
+    isFooterBarFullScreenActive: false,
     geoLocatorActive: false,
     navBarComponents: [],
 
@@ -100,6 +103,14 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
           },
         });
       },
+      setIsFooterBarFullScreenActive: (active: boolean) => {
+        set({
+          uiState: {
+            ...get().uiState,
+            isFooterBarFullScreenActive: active,
+          },
+        });
+      },
       setGeolocatorActive: (active: boolean) => {
         set({
           uiState: {
@@ -127,3 +138,4 @@ export const useUIFooterBarExpanded = () => useStore(useGeoViewStore(), (state) 
 export const useUINavbarComponents = () => useStore(useGeoViewStore(), (state) => state.uiState.navBarComponents);
 
 export const useUIStoreActions = () => useStore(useGeoViewStore(), (state) => state.uiState.actions);
+export const useUIFooterBarFullScreenActive = () => useStore(useGeoViewStore(), (state) => state.uiState.isFooterBarFullScreenActive);

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable react/no-array-index-key */
 import { SyntheticEvent, useEffect, useState, ReactNode, useRef, RefObject, Dispatch, SetStateAction, MouseEvent } from 'react';
-
 import { useTranslation } from 'react-i18next';
 
 import { Grid, Tab as MaterialTab, Tabs as MaterialTabs, TabsProps, TabProps, BoxProps } from '@mui/material';
@@ -10,6 +9,7 @@ import { Grid, Tab as MaterialTab, Tabs as MaterialTabs, TabsProps, TabProps, Bo
 import { HtmlToReact } from '@/core/containers/html-to-react';
 import { TabPanel } from './tab-panel';
 import { useUIActiveTrapGeoView, useUIStoreActions } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useAppFullscreenActive } from '@/core/stores/store-interface-and-intial-values/app-state';
 
 type TypeChildren = React.ElementType;
 /**
@@ -67,6 +67,7 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
 
   // get store values and actions
   const activeTrapGeoView = useUIActiveTrapGeoView();
+  const isMapFullscreen = useAppFullscreenActive();
   const { closeModal, openModal } = useUIStoreActions();
 
   /**
@@ -110,7 +111,7 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
       <Grid
         container
         component="div"
-        sx={{ backgroundColor: 'white' }}
+        sx={{ backgroundColor: 'white', ...(isMapFullscreen && { cursor: 'ns-resize' }) }}
         id="resizing-event"
         ref={footerPanelRef}
         onMouseMove={onMouseMove}
@@ -165,7 +166,18 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
           {rightButtons as ReactNode}
         </Grid>
       </Grid>
-      <Grid item xs={12} sx={{ height: '100%', borderTop: 1, borderColor: 'divider', visibility: TabContentVisibilty }}>
+      <Grid
+        item
+        xs={12}
+        sx={{
+          height: '100%',
+          paddingTop: '0 !important',
+          borderTop: 1,
+          borderColor: 'divider',
+          visibility: TabContentVisibilty,
+          ...(isMapFullscreen && { height: '600px', paddingBottom: '40px' }),
+        }}
+      >
         {tabs.map((tab, index) => {
           const TabContent = tab.content as React.ElementType;
           return (

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/require-default-props */
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable react/no-array-index-key */
-import { SyntheticEvent, useEffect, useState, ReactNode, useRef, RefObject } from 'react';
+import { SyntheticEvent, useEffect, useState, ReactNode, useRef, RefObject, Dispatch, SetStateAction, MouseEvent } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -37,6 +37,8 @@ export interface TypeTabsProps {
   // eslint-disable-next-line @typescript-eslint/ban-types
   handleCollapse?: Function | undefined;
   TabContentVisibilty?: string | undefined;
+  setPressed: Dispatch<SetStateAction<boolean>>;
+  handleMouseMove: (yPosition: number) => void;
 }
 
 /**
@@ -46,7 +48,16 @@ export interface TypeTabsProps {
  * @returns {JSX.Element} returns the tabs ui
  */
 export function Tabs(props: TypeTabsProps): JSX.Element {
-  const { tabs, rightButtons, selectedTab, isCollapsed, handleCollapse, TabContentVisibilty = 'inherit' } = props;
+  const {
+    tabs,
+    rightButtons,
+    selectedTab,
+    isCollapsed,
+    handleCollapse,
+    TabContentVisibilty = 'inherit',
+    handleMouseMove,
+    setPressed,
+  } = props;
 
   const { t } = useTranslation<string>();
 
@@ -85,9 +96,26 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedTab]);
 
+  /**
+   * Callback handler for mouse move
+   * @param {MouseEvent} event the event emitted by mouse when it move's on screen.
+   */
+  const onMouseMove = (event: MouseEvent) => {
+    event?.stopPropagation();
+    handleMouseMove(event.movementY);
+  };
+
   return (
-    <Grid container spacing={2} sx={{ width: '100%', height: '100%' }}>
-      <Grid container component="div" sx={{ backgroundColor: 'white' }} id="resizing-event" ref={footerPanelRef}>
+    <Grid container spacing={2} onMouseUp={() => setPressed(false)}>
+      <Grid
+        container
+        component="div"
+        sx={{ backgroundColor: 'white' }}
+        id="resizing-event"
+        ref={footerPanelRef}
+        onMouseMove={onMouseMove}
+        onMouseDown={() => setPressed(true)}
+      >
         <Grid item xs={7} sm={10}>
           <MaterialTabs
             {...props.tabsProps}

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/require-default-props */
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable react/no-array-index-key */
-import { SyntheticEvent, useEffect, useState, ReactNode } from 'react';
+import { SyntheticEvent, useEffect, useState, ReactNode, useRef, RefObject } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -52,6 +52,7 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
 
   // internal state
   const [value, setValue] = useState(0);
+  const footerPanelRef = useRef() as RefObject<HTMLDivElement>;
 
   // get store values and actions
   const activeTrapGeoView = useUIActiveTrapGeoView();
@@ -86,53 +87,55 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
 
   return (
     <Grid container spacing={2} sx={{ width: '100%', height: '100%' }}>
-      <Grid item xs={7} sm={10}>
-        <MaterialTabs
-          {...props.tabsProps}
-          variant="scrollable"
-          scrollButtons
-          allowScrollButtonsMobile
-          value={value}
-          onChange={handleChange}
-          aria-label="basic tabs"
-          sx={{
-            '& .MuiTabs-indicator': {
-              backgroundColor: (theme) => theme.palette.secondary.main,
-            },
-          }}
-        >
-          {tabs.map((tab, index) => {
-            // eslint-disable-next-line prettier/prettier
-            return (
-              <MaterialTab
-                label={t(tab.label)}
-                key={index}
-                icon={tab.icon}
-                iconPosition="start"
-                {...props.tabProps}
-                id={`tab-${index}`}
-                onClick={() => handleClick(index)}
-                sx={{
-                  fontSize: 16,
-                  fontWeight: 'bold',
-                  minWidth: 'min(4vw, 24px)',
-                  padding: '16px 2%',
-                  textTransform: 'capitalize',
-                  '&.Mui-selected': {
-                    color: 'secondary.main',
-                  },
-                  '.MuiTab-iconWrapper': {
-                    marginRight: '7px',
-                    maxWidth: '18px',
-                  },
-                }}
-              />
-            );
-          })}
-        </MaterialTabs>
-      </Grid>
-      <Grid item xs={5} sm={2} sx={{ textAlign: 'right', marginTop: '15px' }}>
-        {rightButtons as ReactNode}
+      <Grid container component="div" sx={{ backgroundColor: 'white' }} id="resizing-event" ref={footerPanelRef}>
+        <Grid item xs={7} sm={10}>
+          <MaterialTabs
+            {...props.tabsProps}
+            variant="scrollable"
+            scrollButtons
+            allowScrollButtonsMobile
+            value={value}
+            onChange={handleChange}
+            aria-label="basic tabs"
+            sx={{
+              '& .MuiTabs-indicator': {
+                backgroundColor: (theme) => theme.palette.secondary.main,
+              },
+            }}
+          >
+            {tabs.map((tab, index) => {
+              // eslint-disable-next-line prettier/prettier
+              return (
+                <MaterialTab
+                  label={t(tab.label)}
+                  key={index}
+                  icon={tab.icon}
+                  iconPosition="start"
+                  {...props.tabProps}
+                  id={`tab-${index}`}
+                  onClick={() => handleClick(index)}
+                  sx={{
+                    fontSize: 16,
+                    fontWeight: 'bold',
+                    minWidth: 'min(4vw, 24px)',
+                    padding: '16px 2%',
+                    textTransform: 'capitalize',
+                    '&.Mui-selected': {
+                      color: 'secondary.main',
+                    },
+                    '.MuiTab-iconWrapper': {
+                      marginRight: '7px',
+                      maxWidth: '18px',
+                    },
+                  }}
+                />
+              );
+            })}
+          </MaterialTabs>
+        </Grid>
+        <Grid item xs={5} sm={2} sx={{ textAlign: 'right', marginTop: '15px' }}>
+          {rightButtons as ReactNode}
+        </Grid>
       </Grid>
       <Grid item xs={12} sx={{ height: '100%', borderTop: 1, borderColor: 'divider', visibility: TabContentVisibilty }}>
         {tabs.map((tab, index) => {

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -175,7 +175,7 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
           borderTop: 1,
           borderColor: 'divider',
           visibility: TabContentVisibilty,
-          ...(isMapFullscreen && { height: '600px', paddingBottom: '40px' }),
+          ...(isMapFullscreen && { paddingBottom: '40px' }),
         }}
       >
         {tabs.map((tab, index) => {


### PR DESCRIPTION
# Description
When map is on fullscreen, footerpanel have very little visibility, to resolve this, i have added draggable functionality on footer panel tab, when move up and down on `Y` axis will increase the height of footer panel.

Fixes # ([1616](https://app.zenhub.com/workspaces/geoview-web-team-6332f4560a41153d1fefbcbc/issues/gh/canadian-geospatial-platform/geoview/1616))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

__Add the URL for your deploy!__
https://kaminderpal.github.io/geoview/raw-feature-info.html
# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1655)
<!-- Reviewable:end -->
