### PR TITLE
Move config validation to layerConfig object

### DIFF
--- a/packages/geoview-core/.babelrc
+++ b/packages/geoview-core/.babelrc
@@ -54,6 +54,12 @@
     "@babel/plugin-proposal-function-sent",
     "@babel/plugin-transform-logical-assignment-operators",
     [
+      "@babel/plugin-transform-typescript",
+      {
+        "allowDeclareFields": true
+      }
+    ],
+    [
       "@babel/plugin-transform-nullish-coalescing-operator",
       {
         "loose": false

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -133,7 +133,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
                 ? api.maps[mapId].layer.initialLayerOrder.indexOf(entryLayerPath)
                 : existingEntries.length,
             // TODO: Why do we have the following line in the store? Do we have to fetch the metadata again since the GeoView layer read and keep them?
-            metadataAccessPath: getLocalizedValue(layerConfig.geoviewRootLayer?.metadataAccessPath, mapId) || '',
+            metadataAccessPath: getLocalizedValue(layerConfig.geoviewLayerConfig?.metadataAccessPath, mapId) || '',
             layerPath: entryLayerPath,
             layerStatus: legendResultSetsEntry.layerStatus,
             layerName: getLocalizedValue(layerConfig.layerName, mapId) || layerConfig.layerId,
@@ -160,8 +160,8 @@ export class LegendEventProcessor extends AbstractEventProcessor {
           layerPath: entryLayerPath,
           layerAttribution: api.maps[mapId].layer.geoviewLayers[layerPathNodes[0]].attributions,
           // ! Why do we have metadataAccessPath here? Do we need to fetch the metadata again? The GeoView layer fetch them and store them in this.metadata.
-          metadataAccessPath: getLocalizedValue(layerConfig.geoviewRootLayer?.metadataAccessPath, mapId) || '',
-          layerName: getLocalizedValue(legendResultSetsEntry.data?.layerName, mapId) || layerConfig.layerId,
+          metadataAccessPath: getLocalizedValue(layerConfig.geoviewLayerConfig?.metadataAccessPath, mapId) || '',
+          layerName: getLocalizedValue(legendResultSetsEntry.data?.layerName, mapId) || layerConfig.layerId!,
           layerStatus: legendResultSetsEntry.layerStatus,
           layerPhase: legendResultSetsEntry.layerPhase,
           querySent: legendResultSetsEntry.querySent,

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
@@ -466,7 +466,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
         const projectedCoords = api.projection.transformPoints([marker.lnglat], `EPSG:4326`, `EPSG:${get().mapState.currentProjection}`);
 
         //! need to use state because it changes store and do action at the same time
-        get().mapState.mapElement!.getOverlayById(`${get().mapId}-clickmarker`).setPosition(projectedCoords[0]);
+        get().mapState.mapElement!.getOverlayById(`${get().mapId}-clickmarker`)!.setPosition(projectedCoords[0]);
 
         set({
           mapState: { ...get().mapState, clickMarker: { lnglat: projectedCoords[0] } },

--- a/packages/geoview-core/src/core/utils/config/config.ts
+++ b/packages/geoview-core/src/core/utils/config/config.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { TypeDisplayLanguage, TypeListOfLayerEntryConfig } from '@/geo/map/map-schema-types';
+import { TypeDisplayLanguage, TypeListOfLayerEntryConfig, layerEntryIsGroupLayer } from '@/geo/map/map-schema-types';
 import { CONST_LAYER_ENTRY_TYPE, TypeGeoviewLayerType } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { TypeMapFeaturesConfig } from '../../types/global-types';
 import { ConfigValidation } from './config-validation';
@@ -133,7 +133,7 @@ export class Config {
    */
   private setLayerEntryType(listOfLayerEntryConfig: TypeListOfLayerEntryConfig, geoviewLayerType: TypeGeoviewLayerType): void {
     listOfLayerEntryConfig?.forEach((layerConfig) => {
-      if (layerConfig.entryType === 'group') this.setLayerEntryType(layerConfig.listOfLayerEntryConfig!, geoviewLayerType);
+      if (layerEntryIsGroupLayer(layerConfig)) this.setLayerEntryType(layerConfig.listOfLayerEntryConfig!, geoviewLayerType);
       else {
         // eslint-disable-next-line no-param-reassign
         layerConfig.schemaTag = geoviewLayerType;

--- a/packages/geoview-core/src/core/utils/config/reader/uuid-config-reader.ts
+++ b/packages/geoview-core/src/core/utils/config/reader/uuid-config-reader.ts
@@ -67,7 +67,7 @@ export class UUIDmapConfigReader {
                 },
                 geoviewLayerType: 'esriDynamic',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeEsriDynamicLayerEntryConfig => {
-                  const esriDynamicLayerEntryConfig: TypeEsriDynamicLayerEntryConfig = {
+                  const esriDynamicLayerEntryConfig = new TypeEsriDynamicLayerEntryConfig({
                     schemaTag: 'esriDynamic',
                     entryType: 'raster-image',
                     layerId: `${item.index}`,
@@ -77,7 +77,7 @@ export class UUIDmapConfigReader {
                         fr: url as string,
                       },
                     },
-                  };
+                  } as TypeEsriDynamicLayerEntryConfig);
                   return esriDynamicLayerEntryConfig;
                 }),
               };
@@ -97,7 +97,7 @@ export class UUIDmapConfigReader {
                   },
                   geoviewLayerType: 'esriFeature',
                   listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeEsriFeatureLayerEntryConfig => {
-                    const esriFeatureLayerEntryConfig: TypeEsriFeatureLayerEntryConfig = {
+                    const esriFeatureLayerEntryConfig = new TypeEsriFeatureLayerEntryConfig({
                       schemaTag: 'esriFeature',
                       entryType: 'vector',
                       layerId: `${item.index}`,
@@ -108,7 +108,7 @@ export class UUIDmapConfigReader {
                           fr: url as string,
                         },
                       },
-                    };
+                    } as TypeEsriFeatureLayerEntryConfig);
                     return esriFeatureLayerEntryConfig;
                   }),
                 };
@@ -127,7 +127,7 @@ export class UUIDmapConfigReader {
                 },
                 geoviewLayerType: 'esriFeature',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeEsriFeatureLayerEntryConfig => {
-                  const esriFeatureLayerEntryConfig: TypeEsriFeatureLayerEntryConfig = {
+                  const esriFeatureLayerEntryConfig = new TypeEsriFeatureLayerEntryConfig({
                     schemaTag: 'esriFeature',
                     entryType: 'vector',
                     layerId: `${item.index}`,
@@ -138,7 +138,7 @@ export class UUIDmapConfigReader {
                         fr: url as string,
                       },
                     },
-                  };
+                  } as TypeEsriFeatureLayerEntryConfig);
                   return esriFeatureLayerEntryConfig;
                 }),
               };
@@ -156,7 +156,7 @@ export class UUIDmapConfigReader {
                 },
                 geoviewLayerType: 'ogcWms',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeOgcWmsLayerEntryConfig => {
-                  const wmsLayerEntryConfig: TypeOgcWmsLayerEntryConfig = {
+                  const wmsLayerEntryConfig = new TypeOgcWmsLayerEntryConfig({
                     schemaTag: 'ogcWms',
                     entryType: 'raster-image',
                     layerId: `${item.id}`,
@@ -167,7 +167,7 @@ export class UUIDmapConfigReader {
                       },
                       serverType: (serverType === undefined ? 'mapserver' : serverType) as TypeOfServer,
                     },
-                  };
+                  } as TypeOgcWmsLayerEntryConfig);
                   return wmsLayerEntryConfig;
                 }),
               };
@@ -185,7 +185,7 @@ export class UUIDmapConfigReader {
                 },
                 geoviewLayerType: 'ogcWfs',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeWfsLayerEntryConfig => {
-                  const wfsLayerEntryConfig: TypeWfsLayerEntryConfig = {
+                  const wfsLayerEntryConfig = new TypeWfsLayerEntryConfig({
                     schemaTag: 'ogcWfs',
                     entryType: 'vector',
                     layerId: `${item.id}`,
@@ -197,7 +197,7 @@ export class UUIDmapConfigReader {
                         fr: url as string,
                       },
                     },
-                  };
+                  } as TypeWfsLayerEntryConfig);
                   return wfsLayerEntryConfig;
                 }),
               };
@@ -215,7 +215,7 @@ export class UUIDmapConfigReader {
                 },
                 geoviewLayerType: 'ogcFeature',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeOgcFeatureLayerEntryConfig => {
-                  const ogcFeatureLayerEntryConfig: TypeOgcFeatureLayerEntryConfig = {
+                  const ogcFeatureLayerEntryConfig = new TypeOgcFeatureLayerEntryConfig({
                     schemaTag: 'ogcFeature',
                     entryType: 'vector',
                     layerId: `${item.id}`,
@@ -226,7 +226,7 @@ export class UUIDmapConfigReader {
                         fr: url as string,
                       },
                     },
-                  };
+                  } as TypeOgcFeatureLayerEntryConfig);
                   return ogcFeatureLayerEntryConfig;
                 }),
               };
@@ -244,7 +244,7 @@ export class UUIDmapConfigReader {
                 },
                 geoviewLayerType: 'GeoJSON',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeGeoJSONLayerEntryConfig => {
-                  const geoJSONLayerEntryConfig: TypeGeoJSONLayerEntryConfig = {
+                  const geoJSONLayerEntryConfig = new TypeGeoJSONLayerEntryConfig({
                     schemaTag: 'GeoJSON',
                     entryType: 'vector',
                     layerId: `${item.id}`,
@@ -255,7 +255,7 @@ export class UUIDmapConfigReader {
                         fr: url as string,
                       },
                     },
-                  };
+                  } as TypeGeoJSONLayerEntryConfig);
                   return geoJSONLayerEntryConfig;
                 }),
               };
@@ -273,7 +273,7 @@ export class UUIDmapConfigReader {
                 },
                 geoviewLayerType: 'xyzTiles',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeXYZTilesLayerEntryConfig => {
-                  const xyzTilesLayerEntryConfig: TypeXYZTilesLayerEntryConfig = {
+                  const xyzTilesLayerEntryConfig = new TypeXYZTilesLayerEntryConfig({
                     schemaTag: 'xyzTiles',
                     entryType: 'raster-tile',
                     layerId: `${item.id}`,
@@ -283,7 +283,7 @@ export class UUIDmapConfigReader {
                         fr: url as string,
                       },
                     },
-                  };
+                  } as TypeXYZTilesLayerEntryConfig);
                   return xyzTilesLayerEntryConfig;
                 }),
               };
@@ -301,7 +301,7 @@ export class UUIDmapConfigReader {
                 },
                 geoviewLayerType: 'vectorTiles',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeVectorTilesLayerEntryConfig => {
-                  const vectorTilesLayerEntryConfig: TypeVectorTilesLayerEntryConfig = {
+                  const vectorTilesLayerEntryConfig = new TypeVectorTilesLayerEntryConfig({
                     schemaTag: 'vectorTiles',
                     entryType: 'raster-tile',
                     layerId: `${item.id}`,
@@ -312,7 +312,7 @@ export class UUIDmapConfigReader {
                         fr: url as string,
                       },
                     },
-                  };
+                  } as TypeVectorTilesLayerEntryConfig);
                   return vectorTilesLayerEntryConfig;
                 }),
               };
@@ -330,7 +330,7 @@ export class UUIDmapConfigReader {
                 },
                 geoviewLayerType: 'GeoPackage',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeGeoPackageLayerEntryConfig => {
-                  const geoPackageLayerEntryConfig: TypeGeoPackageLayerEntryConfig = {
+                  const geoPackageLayerEntryConfig = new TypeGeoPackageLayerEntryConfig({
                     schemaTag: 'GeoPackage',
                     entryType: 'vector',
                     layerId: `${item.id}`,
@@ -341,7 +341,7 @@ export class UUIDmapConfigReader {
                         fr: url as string,
                       },
                     },
-                  };
+                  } as TypeGeoPackageLayerEntryConfig);
                   return geoPackageLayerEntryConfig;
                 }),
               };
@@ -359,7 +359,7 @@ export class UUIDmapConfigReader {
                 },
                 geoviewLayerType: 'imageStatic',
                 listOfLayerEntryConfig: (layerEntries as TypeJsonArray).map((item): TypeImageStaticLayerEntryConfig => {
-                  const imageStaticLayerEntryConfig: TypeImageStaticLayerEntryConfig = {
+                  const imageStaticLayerEntryConfig = new TypeImageStaticLayerEntryConfig({
                     schemaTag: 'imageStatic',
                     entryType: 'raster-image',
                     layerId: `${item.id}`,
@@ -368,9 +368,8 @@ export class UUIDmapConfigReader {
                         en: url as string,
                         fr: url as string,
                       },
-                      extent: [],
                     },
-                  };
+                  } as TypeImageStaticLayerEntryConfig);
                   return imageStaticLayerEntryConfig;
                 }),
               };

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -250,9 +250,6 @@ export abstract class AbstractGeoViewLayer {
   /** The unique identifier of the map on which the GeoView layer will be drawn. */
   mapId: string;
 
-  /** Original map layer configuration */
-  originalMapLayerConfig: TypeGeoviewLayerConfig;
-
   /** Flag used to indicate the layer's phase */
   layerPhase = '';
 
@@ -314,6 +311,10 @@ export abstract class AbstractGeoViewLayer {
   /** Date format object used to translate internal UTC ISO format to the external format, the one used by the user */
   externalFragmentsOrder: TypeDateFragments;
 
+  // LayerPath to use when we want to call a GeoView layer's method using the following syntaxe:
+  // api.maps[mapId].layer.geoviewLayer(layerPath).getVisible()
+  layerPathAssociatedToTheGeoviewLayer = '';
+
   /** ***************************************************************************************************************************
    * The class constructor saves parameters and common configuration parameters in attributes.
    *
@@ -323,7 +324,6 @@ export abstract class AbstractGeoViewLayer {
    */
   constructor(type: TypeGeoviewLayerType, mapLayerConfig: TypeGeoviewLayerConfig, mapId: string) {
     this.mapId = mapId;
-    this.originalMapLayerConfig = cloneDeep(mapLayerConfig);
     this.type = type;
     this.geoviewLayerId = mapLayerConfig.geoviewLayerId || generateId('');
     this.geoviewLayerName.en = mapLayerConfig?.geoviewLayerName?.en ? mapLayerConfig.geoviewLayerName.en : DEFAULT_LAYER_NAMES[type];
@@ -332,15 +332,15 @@ export abstract class AbstractGeoViewLayer {
     if (mapLayerConfig.metadataAccessPath?.fr) this.metadataAccessPath.fr = mapLayerConfig.metadataAccessPath.fr.trim();
     if (mapLayerConfig.listOfLayerEntryConfig.length === 1) this.listOfLayerEntryConfig = mapLayerConfig.listOfLayerEntryConfig;
     else {
-      const layerGroup: TypeLayerGroupEntryConfig = {
-        geoviewRootLayer: mapLayerConfig.listOfLayerEntryConfig[0].geoviewRootLayer,
+      const layerGroup: TypeLayerGroupEntryConfig = new TypeLayerGroupEntryConfig({
+        geoviewLayerConfig: mapLayerConfig.listOfLayerEntryConfig[0].geoviewLayerConfig,
         layerId: this.geoviewLayerId,
         layerName: this.geoviewLayerName,
         entryType: 'group',
         isMetadataLayerGroup: false,
         initialSettings: mapLayerConfig.initialSettings,
         listOfLayerEntryConfig: mapLayerConfig.listOfLayerEntryConfig,
-      };
+      } as TypeLayerGroupEntryConfig);
       this.listOfLayerEntryConfig = [layerGroup];
       mapLayerConfig.listOfLayerEntryConfig.forEach((layerConfig) => {
         layerConfig.parentLayerConfig = layerGroup;
@@ -376,9 +376,7 @@ export abstract class AbstractGeoViewLayer {
           if (layerEntryIsGroupLayer(subLayerConfig)) changeAllSublayerPhase(subLayerConfig.listOfLayerEntryConfig);
           else {
             (subLayerConfig as TypeBaseLayerEntryConfig).layerPhase = layerPhase;
-            api.event.emit(
-              LayerSetPayload.createLayerSetChangeLayerPhasePayload(this.mapId, Layer.getLayerPath(subLayerConfig), layerPhase)
-            );
+            api.event.emit(LayerSetPayload.createLayerSetChangeLayerPhasePayload(this.mapId, subLayerConfig.layerPath, layerPhase));
           }
         });
       };
@@ -393,7 +391,7 @@ export abstract class AbstractGeoViewLayer {
    * @param {string} layerPath The layer path to the layer's configuration affected by the change.
    */
   setLayerStatus(layerStatus: TypeLayerStatus, layerPath?: string) {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const layerConfig = this.getLayerConfig(layerPath) as TypeBaseLayerEntryConfig;
     layerConfig.layerStatus = layerStatus;
     api.event.emit(LayerSetPayload.createLayerSetChangeLayerStatusPayload(this.mapId, layerPath, layerStatus!));
@@ -458,8 +456,8 @@ export abstract class AbstractGeoViewLayer {
     listOfLayerEntryConfig.forEach((layerConfig: TypeLayerEntryConfig, i) => {
       if (layer.isRegistered(layerConfig)) {
         this.layerLoadError.push({
-          layer: Layer.getLayerPath(layerConfig),
-          consoleMessage: `Duplicate layerPath (mapId:  ${this.mapId}, layerPath: ${Layer.getLayerPath(layerConfig)})`,
+          layer: layerConfig.layerPath,
+          consoleMessage: `Duplicate layerPath (mapId:  ${this.mapId}, layerPath: ${layerConfig.layerPath})`,
         });
         // Duplicat layer can't be kept because it has the same layer path than the first encontered layer.
         delete listOfLayerEntryConfig[i];
@@ -483,7 +481,7 @@ export abstract class AbstractGeoViewLayer {
         if (layerEntryIsGroupLayer(layerConfig)) this.registerAllLayersToLayerSets(layerConfig.listOfLayerEntryConfig!);
         else {
           this.registerToLayerSets(layerConfig as TypeBaseLayerEntryConfig);
-          this.setLayerPhase('newInstance', Layer.getLayerPath(layerConfig));
+          this.setLayerPhase('newInstance', layerConfig.layerPath);
         }
       });
   }
@@ -654,14 +652,14 @@ export abstract class AbstractGeoViewLayer {
             return groupReturned;
           }
           this.layerLoadError.push({
-            layer: Layer.getLayerPath(listOfLayerEntryConfig[0]),
-            consoleMessage: `Unable to create group layer ${Layer.getLayerPath(listOfLayerEntryConfig[0])} on map ${this.mapId}`,
+            layer: listOfLayerEntryConfig[0].layerPath,
+            consoleMessage: `Unable to create group layer ${listOfLayerEntryConfig[0].layerPath} on map ${this.mapId}`,
           });
           return null;
         }
 
         if ((listOfLayerEntryConfig[0] as TypeBaseLayerEntryConfig).layerStatus === 'error') return null;
-        const layerPath = Layer.getLayerPath(listOfLayerEntryConfig[0]);
+        const { layerPath } = listOfLayerEntryConfig[0];
         const baseLayer = await this.processOneLayerEntry(listOfLayerEntryConfig[0] as TypeBaseLayerEntryConfig);
         if (baseLayer) {
           baseLayer.setVisible(listOfLayerEntryConfig[0].initialSettings?.visible !== 'no');
@@ -671,8 +669,8 @@ export abstract class AbstractGeoViewLayer {
           return layerGroup || baseLayer;
         }
         this.layerLoadError.push({
-          layer: Layer.getLayerPath(listOfLayerEntryConfig[0]),
-          consoleMessage: `Unable to create layer ${Layer.getLayerPath(listOfLayerEntryConfig[0])} on map ${this.mapId}`,
+          layer: listOfLayerEntryConfig[0].layerPath,
+          consoleMessage: `Unable to create layer ${listOfLayerEntryConfig[0].layerPath} on map ${this.mapId}`,
         });
         this.setLayerStatus('error', layerPath);
         return null;
@@ -695,7 +693,7 @@ export abstract class AbstractGeoViewLayer {
       });
       const listOfLayerCreated = await Promise.all(promiseOfLayerCreated);
       listOfLayerCreated.forEach((baseLayer, i) => {
-        const layerPath = Layer.getLayerPath(listOfLayerEntryConfig[i]);
+        const { layerPath } = listOfLayerEntryConfig[i];
         if (baseLayer) {
           const layerConfig = baseLayer?.get('layerConfig') as TypeBaseLayerEntryConfig;
           if (layerConfig) {
@@ -709,10 +707,10 @@ export abstract class AbstractGeoViewLayer {
           }
         } else {
           this.layerLoadError.push({
-            layer: Layer.getLayerPath(listOfLayerEntryConfig[i]),
-            consoleMessage: `Unable to create ${
-              layerEntryIsGroupLayer(listOfLayerEntryConfig[i]) ? 'group' : ''
-            } layer ${Layer.getLayerPath(listOfLayerEntryConfig[i])} on map ${this.mapId}`,
+            layer: listOfLayerEntryConfig[i].layerPath,
+            consoleMessage: `Unable to create ${layerEntryIsGroupLayer(listOfLayerEntryConfig[i]) ? 'group' : ''} layer ${
+              listOfLayerEntryConfig[i].layerPath
+            } on map ${this.mapId}`,
           });
           this.setLayerStatus('error', layerPath);
         }
@@ -872,7 +870,7 @@ export abstract class AbstractGeoViewLayer {
    * @param {TypeBaseLayerEntryConfig} layerConfig The layer config to register.
    */
   protected registerToLayerSets(layerConfig: TypeBaseLayerEntryConfig) {
-    const layerPath = Layer.getLayerPath(layerConfig);
+    const { layerPath } = layerConfig;
     if (!this.registerToLayerSetListenerFunctions[layerPath]) this.registerToLayerSetListenerFunctions[layerPath] = {};
 
     if (!this.registerToLayerSetListenerFunctions[layerPath].requestLayerInventory) {
@@ -934,7 +932,7 @@ export abstract class AbstractGeoViewLayer {
    * @param {TypeBaseLayerEntryConfig} layerConfig The layer entry to register.
    */
   unregisterFromLayerSets(layerConfig: TypeBaseLayerEntryConfig) {
-    const layerPath = Layer.getLayerPath(layerConfig);
+    const { layerPath } = layerConfig;
     api.event.emit(LayerSetPayload.createLayerRegistrationPayload(this.mapId, layerPath, 'remove'));
 
     if (this.registerToLayerSetListenerFunctions[layerPath].requestLayerInventory) {
@@ -963,10 +961,10 @@ export abstract class AbstractGeoViewLayer {
 
   /** ***************************************************************************************************************************
    * This method create a layer group.
-   * @param {TypeLayerEntryConfig | TypeGeoviewLayerConfig} layerConfig The layer configuration.
+   * @param {TypeLayerEntryConfig} layerConfig The layer configuration.
    * @returns {LayerGroup} A new layer group.
    */
-  protected createLayerGroup(layerConfig: TypeLayerEntryConfig | TypeGeoviewLayerConfig): LayerGroup {
+  protected createLayerGroup(layerConfig: TypeLayerEntryConfig): LayerGroup {
     const layerGroupOptions: LayerGroupOptions = {
       layers: new Collection(),
       properties: { layerConfig },
@@ -1075,7 +1073,7 @@ export abstract class AbstractGeoViewLayer {
    * @returns {Extent} The layer extent.
    */
   getExtent(layerPath?: string): Extent | undefined {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     return olLayer?.getExtent();
   }
@@ -1089,7 +1087,7 @@ export abstract class AbstractGeoViewLayer {
    * @param {string} layerPath The layer path to the layer's configuration.
    */
   setExtent(layerExtent: Extent, layerPath?: string) {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     if (olLayer) olLayer.setExtent(layerExtent);
   }
@@ -1102,7 +1100,7 @@ export abstract class AbstractGeoViewLayer {
    * @returns {number} The opacity of the layer.
    */
   getOpacity(layerPath?: string): number | undefined {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     return olLayer?.getOpacity();
   }
@@ -1115,7 +1113,7 @@ export abstract class AbstractGeoViewLayer {
    *
    */
   setOpacity(layerOpacity: number, layerPath?: string) {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     if (olLayer) olLayer.setOpacity(layerOpacity);
   }
@@ -1128,7 +1126,7 @@ export abstract class AbstractGeoViewLayer {
    * @returns {boolean} The visibility of the layer.
    */
   getVisible(layerPath?: string): boolean | undefined {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     return olLayer?.getVisible();
   }
@@ -1140,7 +1138,7 @@ export abstract class AbstractGeoViewLayer {
    * @param {string} layerPath The layer path to the layer's configuration.
    */
   setVisible(layerVisibility: boolean, layerPath?: string) {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     if (olLayer) {
       olLayer.setVisible(layerVisibility);
@@ -1156,7 +1154,7 @@ export abstract class AbstractGeoViewLayer {
    * @returns {boolean} The visibility of the layer.
    */
   getMinZoom(layerPath?: string): number | undefined {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     return olLayer?.getMinZoom();
   }
@@ -1168,7 +1166,7 @@ export abstract class AbstractGeoViewLayer {
    * @param {string} layerPath The layer path to the layer's configuration.
    */
   setMinZoom(minZoom: number, layerPath?: string) {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     if (olLayer) olLayer.setMinZoom(minZoom);
   }
@@ -1181,7 +1179,7 @@ export abstract class AbstractGeoViewLayer {
    * @returns {boolean} The visibility of the layer.
    */
   getMaxZoom(layerPath?: string): number | undefined {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     return olLayer?.getMaxZoom();
   }
@@ -1193,7 +1191,7 @@ export abstract class AbstractGeoViewLayer {
    * @param {string} layerPath The layer path to the layer's configuration.
    */
   setMaxZoom(maxZoom: number, layerPath?: string) {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     if (olLayer) olLayer.setMaxZoom(maxZoom);
   }
@@ -1208,7 +1206,7 @@ export abstract class AbstractGeoViewLayer {
    */
   async getLegend(layerPath?: string): Promise<TypeLegend | null> {
     try {
-      layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+      layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
       const layerConfig = this.getLayerConfig(layerPath) as
         | (TypeBaseLayerEntryConfig & {
             style: TypeStyleConfig;
@@ -1372,7 +1370,7 @@ export abstract class AbstractGeoViewLayer {
    * @returns {string | undefined} The filter associated to the layer or undefined.
    */
   getLayerFilter(layerPath?: string): string | undefined {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const layerConfig = this.getLayerConfig(layerPath);
     return layerConfig?.olLayer?.get('layerFilter');
   }
@@ -1386,7 +1384,7 @@ export abstract class AbstractGeoViewLayer {
    * @returns {TimeDimension} The temporal dimension associated to the layer or undefined.
    */
   getTemporalDimension(layerPath?: string): TimeDimension {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     return this.layerTemporalDimension[layerPath];
   }
 
@@ -1423,13 +1421,13 @@ export abstract class AbstractGeoViewLayer {
    * @returns {Extent} The layer bounding box.
    */
   calculateBounds(layerPath?: string): Extent | undefined {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     let bounds: Extent | undefined;
     const processGroupLayerBounds = (listOfLayerEntryConfig: TypeListOfLayerEntryConfig) => {
       listOfLayerEntryConfig.forEach((layerConfig) => {
         if (layerEntryIsGroupLayer(layerConfig)) processGroupLayerBounds(layerConfig.listOfLayerEntryConfig);
         else {
-          bounds = this.getBounds(Layer.getLayerPath(layerConfig), bounds);
+          bounds = this.getBounds(layerConfig.layerPath, bounds);
         }
       });
     };
@@ -1453,7 +1451,7 @@ export abstract class AbstractGeoViewLayer {
     listOfLayerEntryConfig.forEach((layerConfig: TypeLayerEntryConfig) => {
       if (layerEntryIsGroupLayer(layerConfig)) this.setAllLayerStatusToError(layerConfig.listOfLayerEntryConfig, errorMessage);
       else {
-        const layerPath = Layer.getLayerPath(layerConfig);
+        const { layerPath } = layerConfig;
         this.setLayerStatus('error', layerPath);
         this.layerLoadError.push({
           layer: layerPath,
@@ -1469,7 +1467,7 @@ export abstract class AbstractGeoViewLayer {
    * @param {string} layerPath The layerpath to the node we want to delete.
    */
   removeConfig(layerPath?: string) {
-    layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const layerConfigToRemove = this.getLayerConfig(layerPath) as TypeBaseLayerEntryConfig;
     if (layerConfigToRemove.entryType !== 'group') this.unregisterFromLayerSets(layerConfigToRemove);
     delete api.maps[this.mapId].layer.registeredLayers[layerPath];

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -67,7 +67,7 @@ export async function commonfetchServiceMetadata(this: EsriDynamic | EsriFeature
 export function commonValidateListOfLayerEntryConfig(this: EsriDynamic | EsriFeature, listOfLayerEntryConfig: TypeListOfLayerEntryConfig) {
   this.setLayerPhase('validateListOfLayerEntryConfig');
   listOfLayerEntryConfig.forEach((layerConfig: TypeLayerEntryConfig) => {
-    const layerPath = Layer.getLayerPath(layerConfig);
+    const { layerPath } = layerConfig;
     if (layerEntryIsGroupLayer(layerConfig)) {
       this.validateListOfLayerEntryConfig(layerConfig.listOfLayerEntryConfig!);
       if (!layerConfig.listOfLayerEntryConfig.length) {
@@ -160,7 +160,7 @@ export function commonGetFieldType(
   fieldName: string,
   layerConfig: TypeLayerEntryConfig
 ): 'string' | 'date' | 'number' {
-  const esriFieldDefinitions = this.layerMetadata[Layer.getLayerPath(layerConfig)].fields as TypeJsonArray;
+  const esriFieldDefinitions = this.layerMetadata[layerConfig.layerPath].fields as TypeJsonArray;
   const fieldDefinition = esriFieldDefinitions.find((metadataEntry) => metadataEntry.name === fieldName);
   if (!fieldDefinition) return 'string';
   const esriFieldType = fieldDefinition.type as string;
@@ -188,7 +188,7 @@ export function commonGetFieldDomain(
   fieldName: string,
   layerConfig: TypeLayerEntryConfig
 ): null | codedValueType | rangeDomainType {
-  const esriFieldDefinitions = this.layerMetadata[Layer.getLayerPath(layerConfig)].fields as TypeJsonArray;
+  const esriFieldDefinitions = this.layerMetadata[layerConfig.layerPath].fields as TypeJsonArray;
   const fieldDefinition = esriFieldDefinitions.find((metadataEntry) => metadataEntry.name === fieldName);
   return fieldDefinition ? Cast<codedValueType | rangeDomainType>(fieldDefinition.domain) : null;
 }
@@ -206,7 +206,7 @@ export function commonProcessTemporalDimension(
   layerConfig: TypeEsriFeatureLayerEntryConfig | TypeEsriDynamicLayerEntryConfig
 ) {
   if (esriTimeDimension !== undefined) {
-    this.layerTemporalDimension[Layer.getLayerPath(layerConfig)] = api.dateUtilities.createDimensionFromESRI(
+    this.layerTemporalDimension[layerConfig.layerPath] = api.dateUtilities.createDimensionFromESRI(
       Cast<TimeDimensionESRI>(esriTimeDimension)
     );
   }
@@ -324,7 +324,7 @@ export function commonProcessInitialSettings(
 export async function commonProcessLayerMetadata(this: EsriDynamic | EsriFeature, layerConfig: TypeLayerEntryConfig): Promise<void> {
   // User-defined groups do not have metadata provided by the service endpoint.
   if (layerEntryIsGroupLayer(layerConfig) && !layerConfig.isMetadataLayerGroup) return;
-  const layerPath = Layer.getLayerPath(layerConfig);
+  const { layerPath } = layerConfig;
 
   let queryUrl = getLocalizedValue(this.metadataAccessPath, this.mapId);
   if (queryUrl) {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable block-scoped-var, no-var, vars-on-top, no-param-reassign */
+// eslint-disable-next-line max-classes-per-file
 import View from 'ol/View';
 import Map from 'ol/Map';
 import TileLayer from 'ol/layer/Tile';
@@ -37,9 +38,26 @@ import { MapEventProcessor } from '@/api/event-processors/event-processor-childr
 
 export type TypeSourceVectorTilesInitialConfig = TypeSourceTileInitialConfig;
 
-export interface TypeVectorTilesLayerEntryConfig extends Omit<TypeTileLayerEntryConfig, 'source'> {
-  source: TypeSourceVectorTilesInitialConfig;
-  tileGrid: TypeTileGrid;
+export class TypeVectorTilesLayerEntryConfig extends TypeTileLayerEntryConfig {
+  declare source: TypeSourceVectorTilesInitialConfig;
+
+  tileGrid!: TypeTileGrid;
+
+  /**
+   * The class constructor.
+   * @param {TypeVectorTilesLayerEntryConfig} layerConfig The layer configuration we want to instanciate.
+   */
+  constructor(layerConfig: TypeVectorTilesLayerEntryConfig) {
+    super(layerConfig);
+    Object.assign(this, layerConfig);
+
+    /** layerConfig.source.dataAccessPath is mandatory. */
+    if (!layerConfig.source!.dataAccessPath) {
+      throw new Error(
+        `source.dataAccessPath on layer entry ${this.layerPath} is mandatory for GeoView layer ${this.geoviewLayerConfig.geoviewLayerId} of type ${this.geoviewLayerConfig.geoviewLayerType}`
+      );
+    }
+  }
 }
 
 export interface TypeVectorTilesConfig extends Omit<TypeGeoviewLayerConfig, 'listOfLayerEntryConfig'> {
@@ -75,7 +93,7 @@ export const geoviewLayerIsVectorTiles = (verifyIfGeoViewLayer: AbstractGeoViewL
 
 /** *****************************************************************************************************************************
  * type guard function that redefines a TypeLayerEntryConfig as a TypeVectorTilesLayerEntryConfig if the geoviewLayerType attribute
- * of the verifyIfGeoViewEntry.geoviewRootLayer attribute is VECTOR_TILES. The type ascention applies only to the true block of
+ * of the verifyIfGeoViewEntry.geoviewLayerConfig attribute is VECTOR_TILES. The type ascention applies only to the true block of
  * the if clause that use this function.
  *
  * @param {TypeLayerEntryConfig} verifyIfGeoViewEntry Polymorphic object to test in order to determine if the type ascention is
@@ -86,7 +104,7 @@ export const geoviewLayerIsVectorTiles = (verifyIfGeoViewLayer: AbstractGeoViewL
 export const geoviewEntryIsVectorTiles = (
   verifyIfGeoViewEntry: TypeLayerEntryConfig
 ): verifyIfGeoViewEntry is TypeVectorTilesLayerEntryConfig => {
-  return verifyIfGeoViewEntry?.geoviewRootLayer?.geoviewLayerType === CONST_LAYER_TYPES.VECTOR_TILES;
+  return verifyIfGeoViewEntry?.geoviewLayerConfig?.geoviewLayerType === CONST_LAYER_TYPES.VECTOR_TILES;
 };
 
 // ******************************************************************************************************************************
@@ -118,7 +136,7 @@ export class VectorTiles extends AbstractGeoViewRaster {
    * @returns {'string' | 'date' | 'number'} The type of the field.
    */
   protected getFieldType(fieldName: string, layerConfig: TypeLayerEntryConfig): 'string' | 'date' | 'number' {
-    const fieldDefinitions = this.layerMetadata[Layer.getLayerPath(layerConfig)].source.featureInfo;
+    const fieldDefinitions = this.layerMetadata[layerConfig.layerPath].source.featureInfo;
     const fieldIndex = getLocalizedValue(Cast<TypeLocalizedString>(fieldDefinitions.outfields), this.mapId)?.split(',').indexOf(fieldName);
     if (!fieldIndex || fieldIndex === -1) return 'string';
     return (fieldDefinitions.fieldTypes as string).split(',')[fieldIndex!] as 'string' | 'date' | 'number';
@@ -133,7 +151,7 @@ export class VectorTiles extends AbstractGeoViewRaster {
   protected validateListOfLayerEntryConfig(listOfLayerEntryConfig: TypeListOfLayerEntryConfig) {
     this.setLayerPhase('validateListOfLayerEntryConfig');
     listOfLayerEntryConfig.forEach((layerConfig: TypeLayerEntryConfig) => {
-      const layerPath = Layer.getLayerPath(layerConfig);
+      const { layerPath } = layerConfig;
       if (layerEntryIsGroupLayer(layerConfig)) {
         this.validateListOfLayerEntryConfig(layerConfig.listOfLayerEntryConfig!);
         if (!layerConfig?.listOfLayerEntryConfig?.length) {
@@ -159,7 +177,7 @@ export class VectorTiles extends AbstractGeoViewRaster {
    */
   protected processOneLayerEntry(layerConfig: TypeVectorTilesLayerEntryConfig): Promise<TypeBaseRasterLayer | null> {
     const promisedVectorLayer = new Promise<TypeBaseRasterLayer | null>((resolve) => {
-      const layerPath = Layer.getLayerPath(layerConfig);
+      const { layerPath } = layerConfig;
       this.setLayerPhase('processOneLayerEntry', layerPath);
       const sourceOptions: SourceOptions = {
         url: getLocalizedValue(layerConfig.source.dataAccessPath, this.mapId),
@@ -184,7 +202,8 @@ export class VectorTiles extends AbstractGeoViewRaster {
         sourceOptions.tileGrid = new TileGrid(tileGridOptions);
       }
 
-      sourceOptions.format = new MVT();
+      // TODO: The following line cause an error now.
+      // sourceOptions.format = new MVT();
       sourceOptions.projection = `EPSG:${MapEventProcessor.getMapState(this.mapId).currentProjection}`;
       sourceOptions.tileGrid = new TileGrid(layerConfig.source!.tileGrid!);
       const tileLayerOptions: TileOptions<VectorTileSource> = { source: new VectorTileSource(sourceOptions) };
@@ -199,6 +218,7 @@ export class VectorTiles extends AbstractGeoViewRaster {
       // TODO remove after demoing
       const declutter = this.mapId !== 'LYR2';
       layerConfig.olLayer = new VectorTileLayer({ ...tileLayerOptions, declutter });
+      layerConfig.geoviewLayerInstance = this;
       if (this.metadata?.defaultStyles)
         applyStyle(
           layerConfig.olLayer as VectorTileLayer,
@@ -270,7 +290,7 @@ export class VectorTiles extends AbstractGeoViewRaster {
   // See above headers for signification of the parameters. The first lines of the method select the template
   // used based on the parameter types received.
   protected getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
-    const layerPath = typeof parameter1 === 'string' ? parameter1 : api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+    const layerPath = typeof parameter1 === 'string' ? parameter1 : this.layerPathAssociatedToTheGeoviewLayer;
     let bounds = typeof parameter1 !== 'string' ? parameter1 : parameter2;
     const layerConfig = this.getLayerConfig(layerPath);
     const layerBounds = (layerConfig?.olLayer as TileLayer<VectorTileSource>).getSource()?.getTileGrid()?.getExtent();

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -1,4 +1,5 @@
 /* eslint-disable block-scoped-var, no-var, vars-on-top, no-param-reassign */
+// eslint-disable-next-line max-classes-per-file
 import { Options as SourceOptions } from 'ol/source/Vector';
 import { GeoJSON as FormatGeoJSON } from 'ol/format';
 import { ReadOptions } from 'ol/format/Feature';
@@ -21,7 +22,6 @@ import {
 } from '@/geo/map/map-schema-types';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { Cast, toJsonObject } from '@/core/types/global-types';
-import { Layer } from '../../layer';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
 import { api } from '@/app';
 
@@ -29,8 +29,50 @@ export interface TypeSourceGeoJSONInitialConfig extends Omit<TypeVectorSourceIni
   format: 'GeoJSON';
 }
 
-export interface TypeGeoJSONLayerEntryConfig extends Omit<TypeVectorLayerEntryConfig, 'source'> {
-  source: TypeSourceGeoJSONInitialConfig;
+export class TypeGeoJSONLayerEntryConfig extends TypeVectorLayerEntryConfig {
+  declare source: TypeSourceGeoJSONInitialConfig;
+
+  /**
+   * The class constructor.
+   * @param {TypeGeoJSONLayerEntryConfig} layerConfig The layer configuration we want to instanciate.
+   */
+  constructor(layerConfig: TypeGeoJSONLayerEntryConfig) {
+    super(layerConfig);
+    Object.assign(this, layerConfig);
+
+    if (!this.geoviewLayerConfig.metadataAccessPath && !this.source?.dataAccessPath) {
+      throw new Error(
+        `dataAccessPath is mandatory for GeoView layer ${this.geoviewLayerConfig.geoviewLayerId} of type GeoJSON when the metadataAccessPath is undefined.`
+      );
+    }
+    // Default value for this.entryType is vector
+    if (this.entryType === undefined) this.entryType = 'vector';
+    // Attribute 'style' must exist in layerConfig even if it is undefined
+    if (!('style' in this)) this.style = undefined;
+    // if this.source.dataAccessPath is undefined, we assign the metadataAccessPath of the GeoView layer to it
+    // and place the layerId at the end of it.
+    // Value for this.source.format can only be GeoJSON.
+    if (!this.source) this.source = { format: 'GeoJSON' };
+    if (!this.source.format) this.source.format = 'GeoJSON';
+    if (!this.source.dataAccessPath) {
+      let { en, fr } = this.geoviewLayerConfig.metadataAccessPath!;
+      en = en!.split('/').length > 1 ? en!.split('/').slice(0, -1).join('/') : './';
+      fr = fr!.split('/').length > 1 ? fr!.split('/').slice(0, -1).join('/') : './';
+      this.source.dataAccessPath = { en, fr } as TypeLocalizedString;
+    }
+    if (
+      !(this.source.dataAccessPath!.en?.startsWith('blob') && !this.source.dataAccessPath!.en?.endsWith('/')) &&
+      !this.source.dataAccessPath!.en?.toUpperCase().endsWith('.JSON' || '.GEOJSON')
+    ) {
+      this.source.dataAccessPath!.en = this.source.dataAccessPath!.en!.endsWith('/')
+        ? `${this.source.dataAccessPath!.en}${this.layerId}`
+        : `${this.source.dataAccessPath!.en}/${this.layerId}`;
+      this.source.dataAccessPath!.fr = this.source.dataAccessPath!.fr!.endsWith('/')
+        ? `${this.source.dataAccessPath!.fr}${this.layerId}`
+        : `${this.source.dataAccessPath!.fr}/${this.layerId}`;
+    }
+    if (!this.source.dataProjection) this.source.dataProjection = 'EPSG:4326';
+  }
 }
 
 export interface TypeGeoJSONLayerConfig extends Omit<TypeGeoviewLayerConfig, 'listOfLayerEntryConfig'> {
@@ -66,7 +108,7 @@ export const geoviewLayerIsGeoJSON = (verifyIfGeoViewLayer: AbstractGeoViewLayer
 
 /** *****************************************************************************************************************************
  * type guard function that redefines a TypeLayerEntryConfig as a TypeGeoJSONLayerEntryConfig if the geoviewLayerType attribute of
- * the verifyIfGeoViewEntry.geoviewRootLayer attribute is GEOJSON. The type ascention applies only to the true block of the if
+ * the verifyIfGeoViewEntry.geoviewLayerConfig attribute is GEOJSON. The type ascention applies only to the true block of the if
  * clause that use this function.
  *
  * @param {TypeLayerEntryConfig} verifyIfGeoViewEntry Polymorphic object to test in order to determine if the type ascention is
@@ -75,7 +117,7 @@ export const geoviewLayerIsGeoJSON = (verifyIfGeoViewLayer: AbstractGeoViewLayer
  * @returns {boolean} true if the type ascention is valid.
  */
 export const geoviewEntryIsGeoJSON = (verifyIfGeoViewEntry: TypeLayerEntryConfig): verifyIfGeoViewEntry is TypeGeoJSONLayerEntryConfig => {
-  return verifyIfGeoViewEntry?.geoviewRootLayer?.geoviewLayerType === CONST_LAYER_TYPES.GEOJSON;
+  return verifyIfGeoViewEntry?.geoviewLayerConfig?.geoviewLayerType === CONST_LAYER_TYPES.GEOJSON;
 };
 
 // ******************************************************************************************************************************
@@ -108,7 +150,7 @@ export class GeoJSON extends AbstractGeoViewVector {
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected getFieldType(fieldName: string, layerConfig: TypeLayerEntryConfig): 'string' | 'date' | 'number' {
-    const fieldDefinitions = this.layerMetadata[Layer.getLayerPath(layerConfig)].source.featureInfo;
+    const fieldDefinitions = this.layerMetadata[layerConfig.layerPath].source.featureInfo;
     const fieldIndex = getLocalizedValue(Cast<TypeLocalizedString>(fieldDefinitions.outfields), this.mapId)?.split(',').indexOf(fieldName);
     if (!fieldIndex || fieldIndex === -1) return 'string';
     return (fieldDefinitions.fieldTypes as string).split(',')[fieldIndex!] as 'string' | 'date' | 'number';
@@ -123,7 +165,7 @@ export class GeoJSON extends AbstractGeoViewVector {
   protected validateListOfLayerEntryConfig(listOfLayerEntryConfig: TypeListOfLayerEntryConfig) {
     this.setLayerPhase('validateListOfLayerEntryConfig');
     listOfLayerEntryConfig.forEach((layerConfig: TypeLayerEntryConfig) => {
-      const layerPath = Layer.getLayerPath(layerConfig);
+      const { layerPath } = layerConfig;
       if (layerEntryIsGroupLayer(layerConfig)) {
         this.validateListOfLayerEntryConfig(layerConfig.listOfLayerEntryConfig!);
         if (!layerConfig.listOfLayerEntryConfig.length) {
@@ -182,7 +224,7 @@ export class GeoJSON extends AbstractGeoViewVector {
           (layerMetadata) => layerMetadata.layerId === layerConfig.layerId && layerMetadata.layerPathEnding === layerConfig.layerPathEnding
         );
         if (layerMetadataFound) {
-          this.layerMetadata[Layer.getLayerPath(layerConfig)] = toJsonObject(layerMetadataFound);
+          this.layerMetadata[layerConfig.layerPath] = toJsonObject(layerMetadataFound);
           layerConfig.layerName = layerConfig.layerName || layerMetadataFound.layerName;
           layerConfig.source = defaultsDeep(layerConfig.source, layerMetadataFound.source);
           layerConfig.initialSettings = defaultsDeep(layerConfig.initialSettings, layerMetadataFound.initialSettings);
@@ -191,7 +233,7 @@ export class GeoJSON extends AbstractGeoViewVector {
           // layerId ending, chances are that it was set by the config-validation because of an empty dataAcessPath value in the config.
           // This situation means that we want to use the dataAccessPath found in the metadata if it is set, otherwise we will keep the
           // config dataAccessPath value.
-          let metadataAccessPathRoot = getLocalizedValue(layerConfig.geoviewRootLayer?.metadataAccessPath, this.mapId);
+          let metadataAccessPathRoot = getLocalizedValue(layerConfig.geoviewLayerConfig?.metadataAccessPath, this.mapId);
           if (metadataAccessPathRoot) {
             metadataAccessPathRoot =
               metadataAccessPathRoot.split('/').length > 1 ? metadataAccessPathRoot.split('/').slice(0, -1).join('/') : './';

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-var, vars-on-top, block-scoped-var, no-param-reassign */
+// eslint-disable-next-line max-classes-per-file
 import axios from 'axios';
 
 import { Options as SourceOptions } from 'ol/source/Vector';
@@ -19,10 +20,10 @@ import {
   layerEntryIsGroupLayer,
   TypeBaseLayerEntryConfig,
   TypeBaseSourceVectorInitialConfig,
+  TypeLocalizedString,
 } from '@/geo/map/map-schema-types';
 
 import { getLocalizedValue } from '@/core/utils/utilities';
-import { Layer } from '../../layer';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
 import { api } from '@/app';
 
@@ -30,8 +31,26 @@ export interface TypeSourceOgcFeatureInitialConfig extends TypeVectorSourceIniti
   format: 'featureAPI';
 }
 
-export interface TypeOgcFeatureLayerEntryConfig extends Omit<TypeVectorLayerEntryConfig, 'source'> {
-  source: TypeSourceOgcFeatureInitialConfig;
+export class TypeOgcFeatureLayerEntryConfig extends TypeVectorLayerEntryConfig {
+  declare source: TypeSourceOgcFeatureInitialConfig;
+
+  /**
+   * The class constructor.
+   * @param {TypeOgcFeatureLayerEntryConfig} layerConfig The layer configuration we want to instanciate.
+   */
+  constructor(layerConfig: TypeOgcFeatureLayerEntryConfig) {
+    super(layerConfig);
+    Object.assign(this, layerConfig);
+
+    // Attribute 'style' must exist in layerConfig even if it is undefined
+    if (!('style' in this)) this.style = undefined;
+    // if this.source.dataAccessPath is undefined, we assign the metadataAccessPath of the GeoView layer to it.
+    // Value for this.source.format can only be featureAPI.
+    if (!this.source) this.source = { format: 'featureAPI' };
+    if (!this?.source?.format) this.source.format = 'featureAPI';
+    if (!this.source.dataAccessPath) this.source.dataAccessPath = { ...this.geoviewLayerConfig.metadataAccessPath } as TypeLocalizedString;
+    if (!this.source.dataProjection) this.source.dataProjection = 'EPSG:4326';
+  }
 }
 
 export interface TypeOgcFeatureLayerConfig extends Omit<TypeGeoviewLayerConfig, 'listOfLayerEntryConfig' | 'geoviewLayerType'> {
@@ -68,7 +87,7 @@ export const geoviewLayerIsOgcFeature = (verifyIfGeoViewLayer: AbstractGeoViewLa
 
 /** *****************************************************************************************************************************
  * type guard function that redefines a TypeLayerEntryConfig as a TypeOgcFeatureLayerEntryConfig if the geoviewLayerType attribute
- * of the verifyIfGeoViewEntry.geoviewRootLayer attribute is OGC_FEATURE. The type ascention applies only to the true block of
+ * of the verifyIfGeoViewEntry.geoviewLayerConfig attribute is OGC_FEATURE. The type ascention applies only to the true block of
  * the if clause that use this function.
  *
  * @param {TypeLayerEntryConfig} verifyIfGeoViewEntry Polymorphic object to test in order to determine if the type ascention is
@@ -79,7 +98,7 @@ export const geoviewLayerIsOgcFeature = (verifyIfGeoViewLayer: AbstractGeoViewLa
 export const geoviewEntryIsOgcFeature = (
   verifyIfGeoViewEntry: TypeLayerEntryConfig
 ): verifyIfGeoViewEntry is TypeOgcFeatureLayerEntryConfig => {
-  return verifyIfGeoViewEntry?.geoviewRootLayer?.geoviewLayerType === CONST_LAYER_TYPES.OGC_FEATURE;
+  return verifyIfGeoViewEntry?.geoviewLayerConfig?.geoviewLayerType === CONST_LAYER_TYPES.OGC_FEATURE;
 };
 
 // ******************************************************************************************************************************
@@ -115,7 +134,7 @@ export class OgcFeature extends AbstractGeoViewVector {
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected getFieldType(fieldName: string, layerConfig: TypeLayerEntryConfig): 'string' | 'date' | 'number' {
-    const fieldDefinitions = this.layerMetadata[Layer.getLayerPath(layerConfig)];
+    const fieldDefinitions = this.layerMetadata[layerConfig.layerPath];
     const fieldEntryType = (fieldDefinitions[fieldName].type as string).split(':').slice(-1)[0] as string;
     if (fieldEntryType === 'date') return 'date';
     if (['int', 'number'].includes(fieldEntryType)) return 'number';
@@ -158,7 +177,7 @@ export class OgcFeature extends AbstractGeoViewVector {
   protected validateListOfLayerEntryConfig(listOfLayerEntryConfig: TypeListOfLayerEntryConfig) {
     this.setLayerPhase('validateListOfLayerEntryConfig');
     listOfLayerEntryConfig.forEach((layerConfig: TypeLayerEntryConfig) => {
-      const layerPath = Layer.getLayerPath(layerConfig);
+      const { layerPath } = layerConfig;
       if (layerEntryIsGroupLayer(layerConfig)) {
         this.validateListOfLayerEntryConfig(layerConfig.listOfLayerEntryConfig!);
         if (!layerConfig.listOfLayerEntryConfig.length) {
@@ -233,7 +252,7 @@ export class OgcFeature extends AbstractGeoViewVector {
         const queryResult = axios.get<TypeJsonObject>(queryUrl);
         queryResult.then((response) => {
           if (response.data.properties) {
-            this.layerMetadata[Layer.getLayerPath(layerConfig)] = response.data.properties;
+            this.layerMetadata[layerConfig.layerPath] = response.data.properties;
             this.processFeatureInfoConfig(response.data.properties, layerConfig);
           }
           resolve();

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -21,8 +21,8 @@ import { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geovie
 import {
   TypeGeoviewLayerConfig,
   TypeLayerEntryConfig,
-  TypeLayerGroupEntryConfig,
   TypeListOfLocalizedLanguages,
+  layerEntryIsGroupLayer,
 } from '@/geo/map/map-schema-types';
 import { GeoJSON, layerConfigIsGeoJSON } from '@/geo/layer/geoview-layers/vector/geojson';
 import { GeoPackage, layerConfigIsGeoPackage } from '@/geo/layer/geoview-layers/vector/geopackage';
@@ -54,10 +54,6 @@ export class Layer {
 
   // variable used to store all added geoview layers
   geoviewLayers: { [geoviewLayerId: string]: AbstractGeoViewLayer } = {};
-
-  // LayerPath to use when we want to call a GeoView layer's method using the following syntaxe:
-  // api.maps[mapId].layer.geoviewLayer(layerPath).getVisible()
-  layerPathAssociatedToThegeoviewLayer = '';
 
   // used to access geometry API to create and manage geometries
   geometry: Geometry | undefined;
@@ -243,25 +239,6 @@ export class Layer {
   }
 
   /**
-   * Get the layer Path of the layer configuration parameter.
-   * @param {TypeLayerEntryConfig} layerConfig The layer configuration for which we want to get the layer path.
-   * @param {string} layerPath Internal parameter used to build the layer path (should not be used by the user).
-   *
-   * @returns {string} Returns the layer path.
-   */
-  static getLayerPath(layerConfig: TypeLayerEntryConfig, layerPath?: string): string {
-    let pathEnding = layerPath;
-    if (pathEnding === undefined)
-      pathEnding =
-        layerConfig.layerPathEnding === undefined ? layerConfig.layerId : `${layerConfig.layerId}.${layerConfig.layerPathEnding}`;
-    if (!layerConfig.parentLayerConfig) return `${layerConfig.geoviewRootLayer!.geoviewLayerId!}/${pathEnding}`;
-    return this.getLayerPath(
-      layerConfig.parentLayerConfig as TypeLayerGroupEntryConfig,
-      `${(layerConfig.parentLayerConfig as TypeLayerGroupEntryConfig).layerId}/${pathEnding}`
-    );
-  }
-
-  /**
    * This method returns the GeoView instance associated to a specific layer path. The first element of the layerPath
    * is the geoviewLayerId.
    * @param {string} layerPath The layer path to the layer's configuration.
@@ -269,8 +246,9 @@ export class Layer {
    * @returns {AbstractGeoViewLayer} Returns the geoview instance associated to the layer path.
    */
   geoviewLayer(layerPath: string): AbstractGeoViewLayer {
-    this.layerPathAssociatedToThegeoviewLayer = layerPath;
-    return this.geoviewLayers[layerPath.split('/')[0]];
+    const geoviewLayerInstance = this.geoviewLayers[layerPath.split('/')[0]];
+    geoviewLayerInstance.layerPathAssociatedToTheGeoviewLayer = layerPath;
+    return geoviewLayerInstance;
   }
 
   /**
@@ -280,7 +258,7 @@ export class Layer {
    * @returns {boolean} Returns false if the layer configuration can't be registered.
    */
   registerLayerConfig(layerConfig: TypeLayerEntryConfig): boolean {
-    const layerPath = Layer.getLayerPath(layerConfig);
+    const { layerPath } = layerConfig;
     if (this.registeredLayers[layerPath]) return false;
     this.registeredLayers[layerPath] = layerConfig;
     this.geoviewLayer(layerPath).setLayerStatus('newInstance');
@@ -294,7 +272,7 @@ export class Layer {
    * @returns {boolean} Returns true if the layer configuration is registered.
    */
   isRegistered(layerConfig: TypeLayerEntryConfig): boolean {
-    const layerPath = Layer.getLayerPath(layerConfig);
+    const { layerPath } = layerConfig;
     return this.registeredLayers[layerPath] !== undefined;
   }
 
@@ -469,9 +447,9 @@ export class Layer {
     this.highlightedLayer = { layerPath, originalOpacity: this.geoviewLayer(layerPath).getOpacity() };
     this.geoviewLayer(layerPath).setOpacity(1);
     // If it is a group layer, highlight sublayers
-    if (this.registeredLayers[layerPath].entryType === 'group') {
+    if (layerEntryIsGroupLayer(this.registeredLayers[layerPath])) {
       Object.keys(this.registeredLayers).forEach((registeredLayerPath) => {
-        if (!registeredLayerPath.startsWith(layerPath) && this.registeredLayers[registeredLayerPath].entryType !== 'group') {
+        if (!registeredLayerPath.startsWith(layerPath) && layerEntryIsGroupLayer(this.registeredLayers[registeredLayerPath])) {
           const otherOpacity = this.geoviewLayer(registeredLayerPath).getOpacity();
           this.geoviewLayer(registeredLayerPath).setOpacity((otherOpacity || 1) * 0.25);
         } else this.registeredLayers[registeredLayerPath].olLayer!.setZIndex(999);
@@ -479,7 +457,7 @@ export class Layer {
     } else {
       Object.keys(this.registeredLayers).forEach((registeredLayerPath) => {
         // check for otherOlLayer is undefined. It would be undefined if a layer status is error
-        if (registeredLayerPath !== layerPath && this.registeredLayers[registeredLayerPath].entryType !== 'group') {
+        if (registeredLayerPath !== layerPath && layerEntryIsGroupLayer(this.registeredLayers[registeredLayerPath])) {
           const otherOpacity = this.geoviewLayer(registeredLayerPath).getOpacity();
           this.geoviewLayer(registeredLayerPath).setOpacity((otherOpacity || 1) * 0.25);
         }
@@ -495,9 +473,9 @@ export class Layer {
     api.maps[this.mapId].layer.featureHighlight.removeBBoxHighlight();
     if (this.highlightedLayer.layerPath !== undefined) {
       const { layerPath, originalOpacity } = this.highlightedLayer;
-      if (this.registeredLayers[layerPath].entryType === 'group') {
+      if (layerEntryIsGroupLayer(this.registeredLayers[layerPath])) {
         Object.keys(this.registeredLayers).forEach((registeredLayerPath) => {
-          if (!registeredLayerPath.startsWith(layerPath) && this.registeredLayers[registeredLayerPath].entryType !== 'group') {
+          if (!registeredLayerPath.startsWith(layerPath) && layerEntryIsGroupLayer(this.registeredLayers[registeredLayerPath])) {
             const otherOpacity = this.geoviewLayer(registeredLayerPath).getOpacity();
             this.geoviewLayer(registeredLayerPath).setOpacity(otherOpacity ? otherOpacity * 4 : 1);
           } else this.geoviewLayer(registeredLayerPath).setOpacity(originalOpacity || 1);
@@ -505,7 +483,7 @@ export class Layer {
       } else {
         Object.keys(this.registeredLayers).forEach((registeredLayerPath) => {
           // check for otherOlLayer is undefined. It would be undefined if a layer status is error
-          if (registeredLayerPath !== layerPath && this.registeredLayers[registeredLayerPath].entryType !== 'group') {
+          if (registeredLayerPath !== layerPath && layerEntryIsGroupLayer(this.registeredLayers[registeredLayerPath])) {
             const otherOpacity = this.geoviewLayer(registeredLayerPath).getOpacity();
             this.geoviewLayer(registeredLayerPath).setOpacity(otherOpacity ? otherOpacity * 4 : 1);
           } else this.geoviewLayer(registeredLayerPath).setOpacity(originalOpacity || 1);

--- a/packages/geoview-core/src/geo/layer/other/cluster-placeholder.ts
+++ b/packages/geoview-core/src/geo/layer/other/cluster-placeholder.ts
@@ -217,6 +217,7 @@
 //   };
 
 //   layerConfig.olLayer = new VectorLayer(layerOptions);
+//   layerConfig.geoviewLayerInstance = this;
 
 //   if (layerConfig.initialSettings?.extent !== undefined) this.setExtent(layerConfig.initialSettings?.extent, layerPath);
 //   if (layerConfig.initialSettings?.maxZoom !== undefined)
@@ -233,11 +234,11 @@
 // }
 
 // applyViewFilter(layerPath?: string, filter = '', CombineLegendFilter = true, checkCluster = true) {
-//   layerPath = layerPath || api.maps[this.mapId].layer.layerPathAssociatedToThegeoviewLayer;
+//   layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
 //   const layerConfig = this.getLayerConfig(layerPath) as TypeVectorLayerEntryConfig;
 //   if (layerConfig) {
-//     const layerPath = layerConfig.geoviewRootLayer
-//       ? `${layerConfig.geoviewRootLayer.geoviewLayerId}/${String(layerConfig.layerId).replace('-unclustered', '')}`
+//     const layerPath = layerConfig.geoviewLayerConfig
+//       ? `${layerConfig.geoviewLayerConfig.geoviewLayerId}/${String(layerConfig.layerId).replace('-unclustered', '')}`
 //       : String(layerConfig.layerId).replace('-unclustered', '');
 //     const unclusteredLayerPath = `${layerPath}-unclustered`;
 //     const cluster = !!api.maps[this.mapId].layer.registeredLayers[unclusteredLayerPath];
@@ -273,7 +274,7 @@
 //               baseLayer.setVisible(false);
 //               if (!layerGroup) layerGroup = this.createLayerGroup(unclusteredLayerConfig.parentLayerConfig as TypeLayerEntryConfig);
 //               layerGroup.getLayers().push(baseLayer);
-//               this.setLayerStatus('processed', Layer.getLayerPath(unclusteredLayerConfig));
+//               this.setLayerStatus('processed', unclusteredLayerConfig.layerPath);
 //             }
 //           });
 
@@ -283,15 +284,15 @@
 
 //         this.processOneGeopackageLayer(layerConfig, layers[0], slds).then((baseLayer) => {
 //           if (baseLayer) {
-//             this.setLayerStatus('processed', Layer.getLayerPath(layerConfig));
+//             this.setLayerStatus('processed', layerConfig.layerPath);
 //             if (layerGroup) layerGroup.getLayers().push(baseLayer);
 //             resolve(layerGroup || baseLayer);
 //           } else {
 //             this.layerLoadError.push({
-//               layer: Layer.getLayerPath(layerConfig),
-//               consoleMessage: `Unable to create layer ${Layer.getLayerPath(layerConfig)} on map ${this.mapId}`,
+//               layer: layerConfig.layerPath,
+//               consoleMessage: `Unable to create layer ${layerConfig.layerPath} on map ${this.mapId}`,
 //             });
-//             this.setLayerStatus('error', Layer.getLayerPath(layerConfig));
+//             this.setLayerStatus('error', layerConfig.layerPath);
 //             resolve(null);
 //           }
 //         });
@@ -314,7 +315,7 @@
 //               if (baseLayer) {
 //                 baseLayer.setVisible(false);
 //                 newLayerGroup.getLayers().push(baseLayer);
-//                 this.setLayerStatus('processed', Layer.getLayerPath(unclusteredLayerConfig));
+//                 this.setLayerStatus('processed', unclusteredLayerConfig.layerPath);
 //               }
 //             });
 
@@ -326,13 +327,13 @@
 //             if (baseLayer) {
 //               (layerConfig as unknown as TypeLayerGroupEntryConfig).listOfLayerEntryConfig!.push(newLayerEntryConfig);
 //               newLayerGroup.getLayers().push(baseLayer);
-//               this.setLayerStatus('processed', Layer.getLayerPath(newLayerEntryConfig));
+//               this.setLayerStatus('processed', newLayerEntryConfig.layerPath;
 //             } else {
 //               this.layerLoadError.push({
-//                 layer: Layer.getLayerPath(layerConfig),
-//                 consoleMessage: `Unable to create layer ${Layer.getLayerPath(layerConfig)} on map ${this.mapId}`,
+//                 layer: layerConfig.layerPath,
+//                 consoleMessage: `Unable to create layer ${layerConfig.layerPath} on map ${this.mapId}`,
 //               });
-//               this.setLayerStatus('error', Layer.getLayerPath(newLayerEntryConfig));
+//               this.setLayerStatus('error', newLayerEntryConfig.layerPath);
 //               resolve(null);
 //             }
 //           });
@@ -580,7 +581,7 @@
 //   layerConfig: TypeVectorTileLayerEntryConfig | TypeVectorLayerEntryConfig
 // ): TypeStyleConfig | undefined {
 //   if (layerConfig.style === undefined) layerConfig.style = {};
-//   const styleId = `${this.mapId}/${Layer.getLayerPath(layerConfig)}`;
+//   const styleId = `${this.mapId}/${layerConfig.layerPath}`;
 //   let label = getLocalizedValue(layerConfig.layerName, this.mapId);
 //   label = label !== undefined ? label : styleId;
 //   if (geometryType === 'Point') {

--- a/packages/geoview-core/src/geo/layer/other/geocore.ts
+++ b/packages/geoview-core/src/geo/layer/other/geocore.ts
@@ -23,7 +23,7 @@ export interface TypeGeoCoreLayerConfig extends Omit<TypeGeoviewLayerConfig, 'li
 
 /** *****************************************************************************************************************************
  * type guard function that redefines a TypeLayerEntryConfig as a TypeGeocoreLayerEntryConfig if the geoviewLayerType attribute of
- * the verifyIfGeoViewEntry.geoviewRootLayer attribute is GEOCORE. The type ascention applies only to the true block of the if
+ * the verifyIfGeoViewEntry.geoviewLayerConfig attribute is GEOCORE. The type ascention applies only to the true block of the if
  * clause that use this function.
  *
  * @param {TypeLayerEntryConfig} verifyIfGeoViewEntry Polymorphic object to test in order to determine if the type ascention is
@@ -32,7 +32,7 @@ export interface TypeGeoCoreLayerConfig extends Omit<TypeGeoviewLayerConfig, 'li
  * @returns {boolean} true if the type ascention is valid.
  */
 export const geoviewEntryIsGeocore = (verifyIfGeoViewEntry: TypeLayerEntryConfig): verifyIfGeoViewEntry is TypeGeocoreLayerEntryConfig => {
-  return verifyIfGeoViewEntry?.geoviewRootLayer?.geoviewLayerType === CONST_LAYER_TYPES.GEOCORE;
+  return verifyIfGeoViewEntry?.geoviewLayerConfig?.geoviewLayerType === CONST_LAYER_TYPES.GEOCORE;
 };
 
 /** *****************************************************************************************************************************

--- a/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/renderer/geoview-renderer.ts
@@ -706,7 +706,7 @@ export class GeoviewRenderer {
     const fillOptions: FillOptions = { color: settings.color };
     const strokeOptions: StrokeOptions = this.createStrokeOptions(settings);
     const regularShapeOptions: RegularShapeOptions = {
-      radius1: settings.size !== undefined ? settings.size : 6,
+      radius: settings.size !== undefined ? settings.size : 6,
       radius2: settings.size !== undefined ? settings.size / 3 : 2,
       angle,
       points,

--- a/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
@@ -24,13 +24,21 @@ import { FeatureInfoEventProcessor } from '@/api/event-processors/event-processo
  */
 export class FeatureInfoLayerSet {
   /** Private static variable to keep the single instance that can be created by this class for a mapId (see singleton design pattern) */
-  private static featureInfoLayerSetInstance: Record<string, FeatureInfoLayerSet> = {};
+  private static featureInfoLayerSetInstance: {
+    [mapId: string]: FeatureInfoLayerSet;
+  } = {};
 
   /** The map identifier the layer set belongs to. */
-  mapId: string;
+  private mapId: string;
 
   /** The layer set object. */
-  layerSet: LayerSet;
+  private layerSet: LayerSet;
+
+  /** Flag used to disable click event for the entire layerSet */
+  private disableClick = false;
+
+  /** Flag used to disable hover event for the entire layerSet */
+  private disableHover = false;
 
   /** An object containing the result sets indexed using the layer path */
   resultSets: TypeFeatureInfoResultSets = {};
@@ -164,7 +172,7 @@ export class FeatureInfoLayerSet {
 
   /**
    * Helper function used to instanciate a FeatureInfoLayerSet object. This function
-   * avoids the "new FeatureInfoLayerSet" syntax.
+   * must be used in place of the "new FeatureInfoLayerSet" syntax.
    *
    * @param {string} mapId The map identifier the layer set belongs to.
    *


### PR DESCRIPTION
# Description

This PR is part of #528
[Use config-validation for auto completing all kinds of GeoView layers](https://github.com/Canadian-Geospatial-Platform/geoview/issues/528).

Fixes # Part of issue 528

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using Chrome Devtools and templates from [Type of layers](https://ychoquet.github.io/GeoView/type-of-layers.html).

__Deploy URL:__ https://ychoquet.github.io/GeoView/type-of-layers.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1673)
<!-- Reviewable:end -->
