### PR TITLE
refactor(icon-stack): Fix icon stack resolution

### DIFF
--- a/packages/geoview-core/src/core/components/icon-stack/icon-stack-style.ts
+++ b/packages/geoview-core/src/core/components/icon-stack/icon-stack-style.ts
@@ -7,13 +7,13 @@ export const getSxClasses = () => ({
     height: 24,
   },
   iconPreviewHoverable: {
+    width: 24,
+    height: 24,
     position: 'absolute',
     left: -3,
     top: -2,
     padding: 0,
     borderRadius: 0,
-    border: '1px solid',
-    borderColor: 'grey.600',
     boxShadow: 'rgb(0 0 0 / 20%) 0px 3px 1px -2px, rgb(0 0 0 / 14%) 0px 2px 2px 0px, rgb(0 0 0 / 12%) 0px 1px 5px 0px',
     transition: 'transform .3s ease-in-out',
     '&:hover': {
@@ -21,6 +21,8 @@ export const getSxClasses = () => ({
     },
   },
   iconPreviewStacked: {
+    width: 24,
+    height: 24,
     padding: 0,
     borderRadius: 0,
     border: '1px solid',
@@ -31,8 +33,6 @@ export const getSxClasses = () => ({
   maxIconImg: {
     maxWidth: 24,
     maxHeight: 24,
-    width: 24,
-    height: 24,
   },
   legendIcon: {
     display: 'flex',
@@ -41,8 +41,12 @@ export const getSxClasses = () => ({
     width: 24,
     height: 24,
     background: '#fff',
+    border: '1px solid',
+    borderColor: 'grey.600',
   },
   stackIconsBox: {
+    width: 24,
+    height: 24,
     position: 'relative',
     '&:focus': {
       outlineColor: 'grey',
@@ -51,8 +55,6 @@ export const getSxClasses = () => ({
   iconPreview: {
     padding: 0,
     borderRadius: 0,
-    border: '1px solid',
-    borderColor: 'palette.grey.600',
     boxShadow: 'rgb(0 0 0 / 20%) 0px 3px 1px -2px, rgb(0 0 0 / 14%) 0px 2px 2px 0px, rgb(0 0 0 / 12%) 0px 1px 5px 0px',
     '&:focus': {
       border: 'revert',


### PR DESCRIPTION
# Description

The images in icon stack component have bad resolutions, because we tried to change the size of original image, and in cases the image is so small, we will see the small pixels on image that makes it in bad resolution.

Fixes #1680 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please visit Legend, Layers and Details tab that include the icon stack. We needed to apply the image width and height to the correct image container.

https://amir-azma.github.io/geoview/raw-feature-info.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1696)
<!-- Reviewable:end -->
