### PR TITLE
[FIX] Quick fix trying to find middle-ground between changes from Jan 1st and GeoChart needs.

### DIFF
--- a/packages/geoview-core/src/ui/slider/slider-base.tsx
+++ b/packages/geoview-core/src/ui/slider/slider-base.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/require-default-props */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, SyntheticEvent } from 'react';
 
 import { Slider as MaterialSlider, SliderProps } from '@mui/material';
 
@@ -13,6 +13,8 @@ interface TypeSliderProps extends SliderProps {
   value: number | number[];
 
   // custom onChange callback
+  onChange?: (event: Event, value: number | number[], activeThumb: number) => void;
+  onChangeCommitted?: (event: Event | SyntheticEvent<Element, Event>, value: number | number[]) => void;
   onValueDisplay?: (value: number, index: number) => string;
   onValueDisplayAriaLabel?: (value: number, index: number) => string;
 }
@@ -31,6 +33,7 @@ export function SliderBase(props: TypeSliderProps): JSX.Element {
     value: parentValue,
     orientation,
     onChange,
+    onChangeCommitted,
     onValueDisplay,
     onValueDisplayAriaLabel,
     marks,
@@ -41,9 +44,24 @@ export function SliderBase(props: TypeSliderProps): JSX.Element {
   // internal state
   const [sliderValue, setValue] = useState<number[] | number>(parentValue);
 
+  /**
+   * Handles the change event of the MaterialSlider
+   * @param event Event The event
+   * @param value number | number[] The value(s)
+   * @param activeThumb number
+   */
+  const handleChange = (event: Event, value: number | number[], activeThumb: number): void => {
+    // Set the value when user is sliding the anchor
+    setValue(value);
+
+    // Callback on regular component callback
+    onChange?.(event, value, activeThumb);
+  };
+
   // Effect used to listen on the value state coming from the parent element.
   useEffect(() => {
-    setValue(parentValue); // Update child's value state when the parent's value prop changes
+    // Update child's value state when the parent's value prop changes
+    setValue(parentValue);
   }, [parentValue]);
 
   return (
@@ -54,7 +72,8 @@ export function SliderBase(props: TypeSliderProps): JSX.Element {
       marks={marks}
       orientation={orientation}
       step={step}
-      onChange={onChange}
+      onChange={(event: Event, value: number | number[], activeThumb: number) => handleChange(event, value, activeThumb)}
+      onChangeCommitted={onChangeCommitted}
       valueLabelDisplay="auto"
       valueLabelFormat={onValueDisplay}
       getAriaValueText={onValueDisplayAriaLabel}


### PR DESCRIPTION
# Description

Fixing the Slider-Base to a middle-ground of what it was before Jan 1st.
For usage from GeoChart external component which had gotten broken.

**Hosted here: https://alex-nrcan.github.io/geoview/**

***Note that the GeoChart component is broken in this host, because it's using an old version of the cgpv (circular dependency), so can't test GeoChart, but can test other Slider-Base usage.**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

In GeoChart component and in Layers opacity functionality.

# Checklist:

- [ ] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1701)
<!-- Reviewable:end -->
