### PR TITLE
[FIX] plugins simplification and usage of app-bar for plugins

### DIFF
--- a/packages/geoview-core/public/configs/loading-packages-config.json
+++ b/packages/geoview-core/public/configs/loading-packages-config.json
@@ -14,6 +14,11 @@
   },
   "theme": "dark",
   "components": ["north-arrow", "overview-map"],
-  "corePackages": ["basemap-panel"],
+  "corePackages": [],
+  "appBarTabs": {
+    "tabs": {
+      "core": ["basemap-panel"]
+    }
+  },
   "suportedLanguages": ["en"]
 }

--- a/packages/geoview-core/public/configs/package-bp1-lcc-config.json
+++ b/packages/geoview-core/public/configs/package-bp1-lcc-config.json
@@ -12,7 +12,12 @@
       "labeled": true
     }
   },
-  "corePackages": ["basemap-panel"],
+  "corePackages": [],
+  "appBarTabs": {
+    "tabs": {
+      "core": ["basemap-panel"]
+    }
+  },
   "components": ["overview-map", "north-arrow"],
   "theme": "dark",
   "suportedLanguages": ["en", "fr"]

--- a/packages/geoview-core/public/configs/package-bp2-wm-config.json
+++ b/packages/geoview-core/public/configs/package-bp2-wm-config.json
@@ -12,7 +12,12 @@
       "labeled": true
     }
   },
-  "corePackages": ["basemap-panel"],
+  "corePackages": [],
+  "appBarTabs": {
+    "tabs": {
+      "core": ["basemap-panel"]
+    }
+  },
   "components": ["north-arrow", "overview-map"],
   "theme": "dark",
   "suportedLanguages": ["en", "fr"]

--- a/packages/geoview-core/public/configs/package-footer-panel-geochart-map1-config.json
+++ b/packages/geoview-core/public/configs/package-footer-panel-geochart-map1-config.json
@@ -149,9 +149,7 @@
       ]
     }
   },
-  "corePackages": [
-    "geochart"
-  ],
+  "corePackages": [],
   "suportedLanguages": [
     "en",
     "fr"

--- a/packages/geoview-core/public/configs/package-footer-panel-geochart-map2-config.json
+++ b/packages/geoview-core/public/configs/package-footer-panel-geochart-map2-config.json
@@ -145,9 +145,7 @@
       "core": ["legend", "layers", "details", "geochart"]
     }
   },
-  "corePackages": [
-    "geochart"
-  ],
+  "corePackages": [],
   "suportedLanguages": [
     "en",
     "fr"

--- a/packages/geoview-core/public/configs/package-geochart-map1-config.json
+++ b/packages/geoview-core/public/configs/package-geochart-map1-config.json
@@ -110,6 +110,11 @@
     ]
   },
   "theme": "dark",
-  "corePackages": ["geochart"],
+  "corePackages": [],
+  "footerTabs": {
+    "tabs": {
+      "core": ["geochart"]
+    }
+  },
   "suportedLanguages": ["en", "fr"]
 }

--- a/packages/geoview-core/public/configs/package-geochart-map2-config.json
+++ b/packages/geoview-core/public/configs/package-geochart-map2-config.json
@@ -110,6 +110,11 @@
     ]
   },
   "theme": "light",
-  "corePackages": ["geochart"],
+  "corePackages": [],
+  "footerTabs": {
+    "tabs": {
+      "core": ["geochart"]
+    }
+  },
   "suportedLanguages": ["en", "fr"]
 }

--- a/packages/geoview-core/public/configs/package-swiper-config.json
+++ b/packages/geoview-core/public/configs/package-swiper-config.json
@@ -25,6 +25,11 @@
   },
   "theme": "light",
   "components": ["north-arrow", "overview-map"],
+  "appBarTabs": {
+    "tabs": {
+      "core": ["basemap-panel"]
+    }
+  },
   "corePackages": ["swiper"],
   "externalPackages": [],
   "suportedLanguages": ["en"]

--- a/packages/geoview-core/public/configs/package-time-slider-config.json
+++ b/packages/geoview-core/public/configs/package-time-slider-config.json
@@ -64,7 +64,7 @@
       "core": ["legend", "layers", "details", "data-table", "time-slider"]
     }
   },
-  "corePackages": ["time-slider"],
+  "corePackages": [],
   "externalPackages": [],
   "suportedLanguages": ["en"]
 }

--- a/packages/geoview-core/public/configs/package-time-slider2-config.json
+++ b/packages/geoview-core/public/configs/package-time-slider2-config.json
@@ -64,7 +64,7 @@
       "core": ["legend", "layers", "details", "time-slider"]
     }
   },
-  "corePackages": ["time-slider"],
+  "corePackages": [],
   "externalPackages": [],
   "suportedLanguages": ["en"]
 }

--- a/packages/geoview-core/public/configs/raw-data-table.json
+++ b/packages/geoview-core/public/configs/raw-data-table.json
@@ -133,7 +133,6 @@
       "core": ["legend", "layers", "details", "data-table"]
     }
   },
-  "corePackages": [],
   "externalPackages": [],
   "suportedLanguages": [
     "fr",

--- a/packages/geoview-core/public/configs/sample-config.json
+++ b/packages/geoview-core/public/configs/sample-config.json
@@ -117,7 +117,12 @@
   },
   "theme": "dark",
   "components": ["north-arrow", "overview-map"],
-  "corePackages": ["basemap-panel"],
+  "corePackages": [],
+  "appBarTabs": {
+    "tabs": {
+      "core": ["basemap-panel"]
+    }
+  },
   "externalPackages": [],
   "serviceUrls": {
     "keys": "https://geocore.api.geo.ca"

--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -1576,6 +1576,63 @@
         "tabs"
       ]
     },
+    "TypeAppBarTabsProps": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tabs": {
+          "type": "object",
+          "description": "Available tabs",
+          "properties": {
+            "core": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "basemap-panel",
+                  "layers",
+                  "geochart"
+                ]
+              },
+              "minItems": 1,
+              "default": [],
+              "uniqueItems": true,
+              "description": "Default core tabs of app-bar to use"
+            },
+            "custom": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "defaultTabs": {
+                    "type": "string"
+                  },
+                  "contentHTML": {
+                    "type": "string"
+                  }
+                }
+              },
+              "minItems": 0,
+              "default": [],
+              "uniqueItems": true,
+              "description": "Custom tabs of app-bar to use"
+            }
+          },
+          "additionalProperties": false
+        },
+        "collapsed": {
+          "type": "boolean",
+          "default": false,
+          "description": "State of app-bar when map is loaded (expanded or collapsed)"
+        }
+      },
+      "required": [
+        "tabs"
+      ]
+    },
     "TypeOverviewMapProps": {
       "type": "object",
       "additionalProperties": false,
@@ -1695,6 +1752,9 @@
         },
         "footerTabs": {
           "$ref": "#/definitions/TypeFooterTabsProps"
+        },
+        "appBarTabs": {
+          "$ref": "#/definitions/TypeAppBarTabsProps"
         },
         "overviewMap": {
           "$ref": "#/definitions/TypeOverviewMapProps"

--- a/packages/geoview-core/src/api/event-processors/index.ts
+++ b/packages/geoview-core/src/api/event-processors/index.ts
@@ -19,7 +19,8 @@ export function initializeEventProcessors(store: GeoviewStoreType) {
   mapEventProcessor.onInitialize(store);
 
   // package stores, only create if needed
-  if (store.getState().mapConfig!.corePackages?.includes('time-slider')) timeSliderEventProcessor.onInitialize(store);
+  // TODO: Change this check for something more generic that checks in appBarTabs too
+  if (store.getState().mapConfig!.footerTabs?.tabs.core.includes('time-slider')) timeSliderEventProcessor.onInitialize(store);
 }
 
 export function destroyEventProcessors(store: GeoviewStoreType) {
@@ -30,5 +31,6 @@ export function destroyEventProcessors(store: GeoviewStoreType) {
   mapEventProcessor.onDestroy(store);
 
   // package stores, only destroy if created
-  if (store.getState().mapConfig!.corePackages?.includes('time-slider')) timeSliderEventProcessor.onDestroy(store);
+  // TODO: Change this check for something more generic that checks in appBarTabs too
+  if (store.getState().mapConfig!.footerTabs?.tabs.core.includes('time-slider')) timeSliderEventProcessor.onDestroy(store);
 }

--- a/packages/geoview-core/src/api/plugin/plugin.ts
+++ b/packages/geoview-core/src/api/plugin/plugin.ts
@@ -12,9 +12,7 @@ import { whenThisThen, showError } from '@/core/utils/utilities';
 import { api } from '@/app';
 import { AbstractPlugin } from './abstract-plugin';
 import { TypePluginStructure } from './plugin-types';
-import { toJsonObject, TypeJsonObject, TypeJsonValue } from '@/core/types/global-types';
-import { UIEventProcessor } from '../event-processors/event-processor-children/ui-event-processor';
-import { logger } from '@/core/utils/logger';
+import { TypeJsonObject, TypeJsonValue } from '@/core/types/global-types';
 
 /**
  * Class to manage plugins
@@ -208,16 +206,9 @@ export class Plugin {
    * @param {string} mapId the map id to remove the plugin from
    */
   removePlugin = (pluginId: string, mapId: string): void => {
-    if (mapId) {
-      if (!api.maps?.[mapId]?.plugins?.[pluginId]) {
-        const plugin = api.maps[mapId].plugins[pluginId];
-
-        // call the removed function on the plugin
-        if (typeof plugin.removed === 'function') plugin.removed();
-      }
-
-      delete api.maps[mapId].plugins[pluginId];
-    }
+    // Get the plugin and remove it
+    api.maps[mapId]?.plugins[pluginId]?.removed?.();
+    delete api.maps[mapId].plugins[pluginId];
   };
 
   /**
@@ -237,64 +228,6 @@ export class Plugin {
           this.removePlugin(pluginId, mapId);
         }
       }
-    }
-  };
-
-  /**
-   * A function that will load each plugin on a map then checks if there are a next plugin to load
-   *
-   * @param {string} mapIndex the map index to load the plugin at
-   * @param {string} pluginIndex the plugin index to load
-   */
-  loadPlugin = (mapIndex: number, pluginIndex: number) => {
-    const mapId = Object.keys(api.maps)[mapIndex];
-
-    // check if the map at this index have core packages and if there is a package at the plugin index
-    const corePackages = UIEventProcessor.getCorePackageComponents(mapId);
-    if (corePackages[pluginIndex]) {
-      const pluginId = corePackages[pluginIndex];
-
-      // load the plugin from the script tag or create it
-      this.loadScript(pluginId).then((constructor) => {
-        // add the plugin by passing in the loaded constructor from the script tag
-        this.addPlugin(
-          pluginId,
-          mapId,
-          constructor,
-          toJsonObject({
-            mapId,
-          })
-        );
-
-        // check if there is a next plugin at the current map index
-        if (corePackages[pluginIndex + 1]) {
-          // load next plugin at the same map index
-          this.loadPlugin(mapIndex, pluginIndex + 1);
-          // if no more plugins at current map index then check if there is another map
-        } else if (Object.keys(api.maps)[mapIndex + 1]) {
-          // try to load first plugin at the next map
-          this.loadPlugin(mapIndex + 1, 0);
-        }
-      });
-      // if previous map did not have any packages then try to load packages from next map
-    } else if (Object.keys(api.maps)[mapIndex + 1]) {
-      // load packages at next map if exists
-      this.loadPlugin(mapIndex + 1, 0);
-      // if no plugins loaded then call init callback function
-    }
-  };
-
-  /**
-   * Load plugins provided by map config
-   */
-  loadPlugins = (): void => {
-    // Log
-    logger.logTraceCore('loadPlugins');
-
-    // check if a map exists
-    if (Object.keys(api.maps)[0]) {
-      // start loading core packages on first map and first package
-      this.loadPlugin(0, 0);
     }
   };
 }

--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
@@ -65,7 +65,7 @@ export function FooterTabs(): JSX.Element | null {
   const footerPanelResizeValues = useUIFooterPanelResizeValues();
   const { setFooterPanelResizeValue } = useUIStoreActions();
 
-  // get store config for footer tabs to add
+  // get store config for footer tabs to add (similar logic as in app-bar)
   const footerTabsConfig = useGeoViewConfig()?.footerTabs;
 
   /**
@@ -265,7 +265,7 @@ export function FooterTabs(): JSX.Element | null {
   }, [isCollapsed, isMapFullScreen]);
 
   /**
-   * Create default tabs from configuration parameters
+   * Create default tabs from configuration parameters (similar logic as in app-bar).
    */
   useEffect(() => {
     // Log
@@ -351,9 +351,7 @@ export function FooterTabs(): JSX.Element | null {
           );
         });
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [footerTabsConfig, mapId]);
 
   // Handle focus using dynamic focus button
   const handleDynamicFocus = () => {

--- a/packages/geoview-core/src/core/stores/geoview-store.ts
+++ b/packages/geoview-core/src/core/stores/geoview-store.ts
@@ -54,7 +54,8 @@ export const geoviewStoreDefinition = (set: TypeSetStore, get: TypeGetStore) => 
       get().uiState.setDefaultConfigValues(config);
 
       // packages states, only create if needed
-      if (config.corePackages?.includes('time-slider')) set({ timeSliderState: initializeTimeSliderState(set, get) });
+      // TODO: Change this check for something more generic that checks in appBarTabs too
+      if (config.footerTabs?.tabs.core.includes('time-slider')) set({ timeSliderState: initializeTimeSliderState(set, get) });
     },
 
     // core states

--- a/packages/geoview-core/src/core/utils/config/config-validation.ts
+++ b/packages/geoview-core/src/core/utils/config/config-validation.ts
@@ -750,6 +750,8 @@ export class ConfigValidation {
       displayLanguage: this._displayLanguage,
       appBar: tempMapFeaturesConfig.appBar,
       navBar: tempMapFeaturesConfig.navBar,
+      // TODO: FEATURE #1713 Refactor - to have appBar and footer only instead of appBar, appBarTabs, footerTabs as it is now
+      appBarTabs: tempMapFeaturesConfig.appBarTabs,
       footerTabs: tempMapFeaturesConfig.footerTabs,
       overviewMap: tempMapFeaturesConfig.overviewMap,
       externalPackages: tempMapFeaturesConfig.externalPackages,

--- a/packages/geoview-core/src/core/utils/logger.ts
+++ b/packages/geoview-core/src/core/utils/logger.ts
@@ -161,9 +161,6 @@ export class ConsoleLogger {
     this.logLevel(LOG_TRACE_USE_EFFECT, 'U_EFF', 'mediumorchid', useEffectFunction, ...message);
   };
 
-  // TODO: Obsolete. Remove once geochart has been redeployed.. temporary backwards compatibility support.
-  logTraceUseEffectMount = this.logTraceUseEffect;
-
   /**
    * Logs trace information for core processing.
    * Only shows if LOG_ACTIVE is true.

--- a/packages/geoview-core/src/geo/layer/other/cluster-placeholder.ts
+++ b/packages/geoview-core/src/geo/layer/other/cluster-placeholder.ts
@@ -106,7 +106,6 @@
 //   },
 //   "theme": "dark",
 //   "components": [],
-//   "corePackages": ["layers-panel"],
 //   "suportedLanguages": ["en"]
 // }
 

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -1217,6 +1217,8 @@ export type TypeMapFeaturesInstance = {
   appBar?: TypeAppBarProps;
   /** Nav bar properies. */
   navBar?: TypeNavBarProps;
+  /** App bar properies. */
+  appBarTabs?: TypeAppBarTabsProps;
   /** Footer bar properies. */
   footerTabs?: TypeFooterTabsProps;
   /** Overview map properies. */
@@ -1382,6 +1384,17 @@ export type TypeNavBarProps = Array<'zoom' | 'fullscreen' | 'home' | 'location' 
 /** ******************************************************************************************************************************
  * Configuration available for the footer tabs component.
  */
+export type TypeAppBarTabsProps = {
+  tabs: {
+    core: Array<'basemap-panel' | 'layers-panel' | 'geochart'>;
+    custom: Array<string>; // TODO: support custom tab by creating a Typeobject for it
+  };
+  collapsed: boolean;
+};
+
+/** ******************************************************************************************************************************
+ * Configuration available for the footer tabs component.
+ */
 export type TypeFooterTabsProps = {
   tabs: {
     core: Array<'legend' | 'layers' | 'details' | 'data-table' | 'time-slider' | 'geochart'>;
@@ -1405,7 +1418,7 @@ export type TypeMapComponents = Array<'north-arrow' | 'overview-map'>;
  * the same loaction as core config (<<core config name>>-<<package name>>.json).
  * Default = [].
  */
-export type TypeMapCorePackages = Array<'basemap-panel' | 'geochart' | 'time-slider' | 'swiper'>;
+export type TypeMapCorePackages = Array<'swiper'>;
 
 /** ******************************************************************************************************************************
  * List of external packages to initialize on viewer load. Default = [].

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -203,7 +203,9 @@ export class MapViewer {
         let allGeoviewLayerReady =
           this.mapFeaturesConfig.map.listOfGeoviewLayerConfig?.length === 0 || Object.keys(geoviewLayers).length !== 0;
         Object.keys(geoviewLayers).forEach((geoviewLayerId) => {
-          allGeoviewLayerReady &&= geoviewLayers[geoviewLayerId].allLayerEntryConfigProcessed();
+          const layerIsReady = geoviewLayers[geoviewLayerId].allLayerEntryConfigProcessed();
+          logger.logTraceDetailed('map-viewer.mapReady? layer ready?', geoviewLayerId, layerIsReady);
+          allGeoviewLayerReady &&= layerIsReady;
         });
         if (allGeoviewLayerReady) {
           // Log

--- a/packages/geoview-geochart/src/geochart.tsx
+++ b/packages/geoview-geochart/src/geochart.tsx
@@ -192,7 +192,7 @@ export function GeoChart(props: GeoChartProps): JSX.Element {
   useEffect(() => {
     // Log
     const USE_EFFECT_FUNC = 'GEOVIEW-GEOCHART - storeLayerDataArray';
-    logger.logTraceUseEffectMount(USE_EFFECT_FUNC, storeLayerDataArray);
+    logger.logTraceUseEffect(USE_EFFECT_FUNC, storeLayerDataArray);
 
     // Fetches the datasources associated with the layerDataArray coming from the store - reloading the Chart in the process
     fetchDatasources(storeLayerDataArray);
@@ -207,7 +207,7 @@ export function GeoChart(props: GeoChartProps): JSX.Element {
   useEffect(() => {
     // Log
     const USE_EFFECT_FUNC = 'GEOVIEW-GEOCHART - init';
-    logger.logTraceUseEffectMount(USE_EFFECT_FUNC, mapId);
+    logger.logTraceUseEffect(USE_EFFECT_FUNC, mapId);
 
     // Wire handlers on component mount
     cgpv.api.event.on(EVENT_CHART_CONFIG, handleChartConfig, mapId);


### PR DESCRIPTION
# Description

Removed the loadPlugin(s) functions as we're now loading plugins 3 ways, not just corePackages anymore.
added support to load plugins in the app-bar similar to footer-tabs.
core packages simplified, now only for swiper at the moment.

Fixes #1699

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

__Add the URL for your deploy!__

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1712)
<!-- Reviewable:end -->
