### PR TITLE
[FIX] Fix for the feature-info-propagation to store

### DIFF
--- a/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
@@ -60,17 +60,19 @@ export class FeatureInfoLayerSet {
   private constructor(mapId: string) {
     // This function determines whether a layer can be registered.
     const registrationConditionFunction = (layerPath: string): boolean => {
+      // Log
+      logger.logTraceCore('FeatureInfoLayerSet registration condition...', layerPath, Object.keys(this.resultSets));
+
       const layerConfig = api.maps[this.mapId].layer.registeredLayers[layerPath];
       const queryable = layerConfig?.source?.featureInfo?.queryable;
-      if (queryable) {
-        FeatureInfoEventProcessor.propagateFeatureInfoToStore(mapId, layerPath, 'click', this.resultSets);
-        return true;
-      }
-      return false;
+      return !!queryable;
     };
 
     // This function is used to initialise the data property of the layer path entry.
     const registrationUserDataInitialisation = (layerPath: string) => {
+      // Log
+      logger.logTraceCore('FeatureInfoLayerSet initializing...', layerPath, Object.keys(this.resultSets));
+
       this.disableClickOnLayer[layerPath] = false;
       this.disableHoverOverLayer[layerPath] = false;
       this.resultSets[layerPath].data = {};
@@ -83,6 +85,9 @@ export class FeatureInfoLayerSet {
         };
         this.resultSets[layerPath].data[eventType] = undefined;
       });
+
+      // Propagate feature info to the store, now that the this.resultSets is more representative of the reality
+      FeatureInfoEventProcessor.propagateFeatureInfoToStore(mapId, layerPath, 'click', this.resultSets);
     };
 
     this.mapId = mapId;


### PR DESCRIPTION
# Description

Fix for the feature-info-propagation to store. To be approved before merging as not entirely sure of impacts...
Essentially moving the line `FeatureInfoEventProcessor.propagateFeatureInfoToStore(mapId, layerPath, 'click', this.resultSets);` in the other callback method, when `this.resultSet` has more layer paths.

Hosted: https://alex-nrcan.github.io/geoview/package-footer-panel-geochart.html

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted here: https://alex-nrcan.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1729)
<!-- Reviewable:end -->
