### PR TITLE
fix(footerTabs): fixes tabs of footer panel loading  #closes1731

### DIFF
--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -97,7 +97,10 @@ export function LayerList({ layerList, isEnlargeDataTable, selectedLayerIndex, h
       {layerList.map((layer, index) => (
         <LayerListItem
           key={layer.layerPath}
-          isSelected={!!layer.numOffeatures && index === selectedLayerIndex}
+          // Reason:- (layer?.numOffeatures ?? 1) > 0
+          // Some of layers will not have numOfFeatures, so to make layer look like selected, we need to set default value to 1.
+          // Also we cant set numOfFeature initially, then it num of features will be display as sub title.
+          isSelected={(layer?.numOffeatures ?? 1) > 0 && index === selectedLayerIndex}
           layer={layer}
           handleListItemClick={handleListItemClick}
           isEnlargeDataTable={isEnlargeDataTable}

--- a/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
+++ b/packages/geoview-core/src/core/components/footer-tabs/footer-tabs.tsx
@@ -94,7 +94,7 @@ export function FooterTabs(props: FooterTabsProps): JSX.Element | null {
     // Log
     logger.logTraceUseMemo('FOOTER-TABS - defaultFooterTabs', footerTabs);
 
-    return footerTabsConfig?.tabs.core.map((tab, index) => {
+    return (footerTabsConfig?.tabs?.core ?? []).map((tab, index) => {
       return {
         id: tab,
         value: index,

--- a/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
@@ -14,6 +14,7 @@ import { api, getLocalizedValue } from '@/app';
 import { LayerSet } from './layer-set';
 import { FeatureInfoEventProcessor } from '@/api/event-processors/event-processor-children/feature-info-event-processor';
 import { logger } from '@/core/utils/logger';
+import { getGeoViewStore } from '@/core/stores/stores-managers';
 
 /** ***************************************************************************************************************************
  * A class to hold a set of layers associated with an array of TypeArrayOfFeatureInfoEntries. When this class is instantiated,
@@ -59,6 +60,7 @@ export class FeatureInfoLayerSet {
    */
   private constructor(mapId: string) {
     // This function determines whether a layer can be registered.
+    const store = getGeoViewStore(mapId);
     const registrationConditionFunction = (layerPath: string): boolean => {
       // Log
       logger.logTraceCore('FeatureInfoLayerSet registration condition...', layerPath, Object.keys(this.resultSets));
@@ -128,6 +130,7 @@ export class FeatureInfoLayerSet {
               'click'
             )
           );
+          store.getState().uiState.actions.setActiveFooterTab('details');
         }
       },
       this.mapId

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, ReactNode, useState, useEffect } from 'react';
+import { SyntheticEvent, ReactNode, useState, useEffect, useRef } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -52,7 +52,8 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
   const sxClasses = getSxClasses();
   // internal state
   const [value, setValue] = useState(0);
-
+  // reference to display tab panels on demand.
+  const tabPanelRefs = useRef([tabs[0]]);
   // get store values and actions
   const activeTrapGeoView = useUIActiveTrapGeoView();
   const { closeModal, openModal } = useUIStoreActions();
@@ -64,8 +65,11 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
    * @param {number} newValue value of the new tab
    */
   const handleChange = (event: SyntheticEvent<Element, Event>, newValue: number) => {
+    // Update panel refs when tab value is changed.
+    if (!tabPanelRefs.current[newValue]) {
+      tabPanelRefs.current[newValue] = tabs[newValue];
+    }
     setValue(newValue);
-
     // Callback
     onSelectedTabChanged?.(tabs[newValue]);
   };
@@ -138,13 +142,11 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
           visibility: TabContentVisibilty,
         }}
       >
-        <TabPanel value={value} index={value}>
-          {typeof tabs[value]?.content === 'string' ? (
-            <HtmlToReact htmlContent={(tabs[value]?.content as string) ?? ''} />
-          ) : (
-            tabs[value].content
-          )}
-        </TabPanel>
+        {tabPanelRefs.current?.map((tab, index) => (
+          <TabPanel value={value} index={index} key={tab.id}>
+            {typeof tab?.content === 'string' ? <HtmlToReact htmlContent={(tab?.content as string) ?? ''} /> : tab.content}
+          </TabPanel>
+        ))}
       </Grid>
     </Grid>
   );

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -6,7 +6,11 @@ import { Grid, Tab as MaterialTab, Tabs as MaterialTabs, TabsProps, TabProps, Bo
 
 import { HtmlToReact } from '@/core/containers/html-to-react';
 import { TabPanel } from './tab-panel';
-import { useUIActiveTrapGeoView, useUIStoreActions } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import {
+  useUIActiveFooterTabId,
+  useUIActiveTrapGeoView,
+  useUIStoreActions,
+} from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { getSxClasses } from './tabs-style';
 import { logger } from '@/core/utils/logger';
 
@@ -56,6 +60,8 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
   const tabPanelRefs = useRef([tabs[0]]);
   // get store values and actions
   const activeTrapGeoView = useUIActiveTrapGeoView();
+  const activeFooterTabId = useUIActiveFooterTabId();
+
   const { closeModal, openModal } = useUIStoreActions();
 
   /**
@@ -92,6 +98,22 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
 
     if (selectedTab && value !== selectedTab) setValue(selectedTab);
   }, [selectedTab, value]);
+
+  useEffect(() => {
+    // Log
+    logger.logTraceUseEffect('TABS - Mouse Clicked On Map');
+    //  open details tab when clicked on layer on
+    if (activeFooterTabId === 'details') {
+      const idx = tabs.findIndex((tab) => tab.id === activeFooterTabId);
+      if (!tabPanelRefs.current[idx]) {
+        tabPanelRefs.current[idx] = tabs[idx];
+      }
+      setValue(idx);
+      // open tab panel if closed.
+      if (handleCollapse && isCollapsed) handleCollapse();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeFooterTabId]);
 
   return (
     <Grid container sx={{ width: '100%', height: '100%' }}>


### PR DESCRIPTION
# Description
Fix footer tabs loading when page loads, now only one panel will load and rest will be loaded when user click on each tab.

Fixes # ([1731](https://app.zenhub.com/workspaces/geoview-web-team-6332f4560a41153d1fefbcbc/issues/gh/canadian-geospatial-platform/geoview/1731))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

__Add the URL for your deploy!__

https://kaminderpal.github.io/geoview/package-time-slider.html
https://kaminderpal.github.io/geoview/package-footer-panel-geochart.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1741)
<!-- Reviewable:end -->
