### PR TITLE
892-BUG_getFeatureInfo_getLegend_errors_fails_the_viewer

### DIFF
--- a/packages/geoview-core/public/templates/layers/layerlib.js
+++ b/packages/geoview-core/public/templates/layers/layerlib.js
@@ -59,10 +59,11 @@ const createInfoTable = (mapId, resultsSetId, resultsSet, eventType) => {
 
     // Header of the layer
     const infoH1 = document.createElement('h1');
-    infoH1.innerText = layerData.length ? layerPath : `${layerPath} (empty)`;
+    // eslint-disable-next-line no-nested-ternary
+    infoH1.innerText = !layerData ? `${layerPath} (error)` : layerData?.length ? layerPath : `${layerPath} (empty)`;
     content.appendChild(infoH1);
 
-    if (layerData.length) {
+    if (layerData?.length) {
       let infoH2 = document.createElement('h2');
       infoH2.innerText = 'Aliases and types';
       content.appendChild(infoH2);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -806,7 +806,12 @@ export abstract class AbstractGeoViewLayer {
       // Get the layer config
       const layerConfig = this.getLayerConfig(layerPath);
 
-      if (!layerConfig || !layerConfig.source?.featureInfo?.queryable) return [];
+      if (!layerConfig || !layerConfig?.source?.featureInfo?.queryable) {
+        logger.logError('Invalid usage of getFeatureInfo\nlayerConfig = ', layerConfig);
+        const queryableOrNot = layerConfig?.source?.featureInfo?.queryable ? '' : 'not';
+        logger.logError(`Layer is ${queryableOrNot} queryable`);
+        return null;
+      }
 
       // Log
       logger.logTraceCore('abstract-geoview-layers.getFeatureInfo', queryType, layerPath);
@@ -853,7 +858,7 @@ export abstract class AbstractGeoViewLayer {
     } catch (error) {
       // Log
       logger.logError(error);
-      return [];
+      return null;
     }
   }
 
@@ -868,8 +873,8 @@ export abstract class AbstractGeoViewLayer {
 
   protected getAllFeatureInfo(layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
     // Log
-    logger.logWarning('getAllFeatureInfo is not implemented!');
-    return Promise.resolve([]);
+    logger.logError('getAllFeatureInfo is not implemented!');
+    return Promise.resolve(null);
   }
 
   /** ***************************************************************************************************************************
@@ -884,8 +889,8 @@ export abstract class AbstractGeoViewLayer {
 
   protected getFeatureInfoAtPixel(location: Pixel, layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
     // Log
-    logger.logWarning('getFeatureInfoAtPixel is not implemented!');
-    return Promise.resolve([]);
+    logger.logError('getFeatureInfoAtPixel is not implemented!');
+    return Promise.resolve(null);
   }
 
   /** ***************************************************************************************************************************
@@ -900,8 +905,8 @@ export abstract class AbstractGeoViewLayer {
 
   protected getFeatureInfoAtCoordinate(location: Coordinate, layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
     // Log
-    logger.logWarning('getFeatureInfoAtCoordinate is not implemented!');
-    return Promise.resolve([]);
+    logger.logError('getFeatureInfoAtCoordinate is not implemented!');
+    return Promise.resolve(null);
   }
 
   /** ***************************************************************************************************************************
@@ -916,8 +921,8 @@ export abstract class AbstractGeoViewLayer {
 
   protected getFeatureInfoAtLongLat(location: Coordinate, layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
     // Log
-    logger.logWarning('getFeatureInfoAtLongLat is not implemented!');
-    return Promise.resolve([]);
+    logger.logError('getFeatureInfoAtLongLat is not implemented!');
+    return Promise.resolve(null);
   }
 
   /** ***************************************************************************************************************************
@@ -932,8 +937,8 @@ export abstract class AbstractGeoViewLayer {
 
   protected getFeatureInfoUsingBBox(location: Coordinate[], layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
     // Log
-    logger.logWarning('getFeatureInfoUsingBBox is not implemented!');
-    return Promise.resolve([]);
+    logger.logError('getFeatureInfoUsingBBox is not implemented!');
+    return Promise.resolve(null);
   }
 
   /** ***************************************************************************************************************************
@@ -948,8 +953,8 @@ export abstract class AbstractGeoViewLayer {
 
   protected getFeatureInfoUsingPolygon(location: Coordinate[], layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
     // Log
-    logger.logWarning('getFeatureInfoUsingPolygon is not implemented!');
-    return Promise.resolve([]);
+    logger.logError('getFeatureInfoUsingPolygon is not implemented!');
+    return Promise.resolve(null);
   }
 
   /** ***************************************************************************************************************************

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -413,34 +413,56 @@ export function parseFeatureInfoEntries(records: TypeJsonObject[]): TypeFeatureI
 
 /**
  * Asynchronously queries an Esri feature layer given the url and returns an array of `TypeFeatureInfoEntryPartial` records.
- * @param url string An Esri url indicating a feature layer to query
- * @returns TypeFeatureInfoEntryPartial[] An array of relared records of type TypeFeatureInfoEntryPartial, or an empty array.
+ * @param {url} string An Esri url indicating a feature layer to query
+ * @returns {TypeFeatureInfoEntryPartial[] | null} An array of relared records of type TypeFeatureInfoEntryPartial, or an empty array.
  */
-export async function queryRecordsByUrl(url: string): Promise<TypeFeatureInfoEntryPartial[]> {
+export async function queryRecordsByUrl(url: string): Promise<TypeFeatureInfoEntryPartial[] | null> {
   // TODO: Refactor - Suggestion to rework this function and the one in EsriDynamic.getFeatureInfoAtLongLat(), making
   // TO.DO.CONT: the latter redirect to this one here and merge some logic between the 2 functions ideally making this one here return a TypeFeatureInfoEntry[] with options to have returnGeometry=true or false and such.
   // Query the data
-  const response = await fetch(url);
-  const respJson = await response.json();
+  try {
+    const response = await fetch(url);
+    const respJson = await response.json();
+    const jsonResponse = await response.json();
+    if (jsonResponse.error) {
+      logger.logInfo('There is a problem with this query: ', url);
+      throw new Error(`Error code = ${jsonResponse.error.code} ${jsonResponse.error.message}` || '');
+    }
 
-  // Return the array of TypeFeatureInfoEntryPartial
-  return parseFeatureInfoEntries(respJson.features);
+    // Return the array of TypeFeatureInfoEntryPartial
+    return parseFeatureInfoEntries(respJson.features);
+  } catch (error) {
+    // Log
+    logger.logError('esri-layer-common.queryRelatedRecordsByUrl()\n', error);
+    return null;
+  }
 }
 
 /**
  * Asynchronously queries an Esri relationship table given the url and returns an array of `TypeFeatureInfoEntryPartial` records.
- * @param url string An Esri url indicating a relationship table to query
- * @param recordGroupIndex number The group index of the relationship layer on which to read the related records
- * @returns TypeFeatureInfoEntryPartial[] An array of relared records of type TypeFeatureInfoEntryPartial, or an empty array.
+ * @param {url} string An Esri url indicating a relationship table to query
+ * @param {recordGroupIndex} number The group index of the relationship layer on which to read the related records
+ * @returns {TypeFeatureInfoEntryPartial[] | null} An array of relared records of type TypeFeatureInfoEntryPartial, or an empty array.
  */
-export async function queryRelatedRecordsByUrl(url: string, recordGroupIndex: number): Promise<TypeFeatureInfoEntryPartial[]> {
+export async function queryRelatedRecordsByUrl(url: string, recordGroupIndex: number): Promise<TypeFeatureInfoEntryPartial[] | null> {
   // Query the data
-  const response = await fetch(url);
-  const respJson = await response.json();
+  try {
+    const response = await fetch(url);
+    const respJson = await response.json();
+    const jsonResponse = await response.json();
+    if (jsonResponse.error) {
+      logger.logInfo('There is a problem with this query: ', url);
+      throw new Error(`Error code = ${jsonResponse.error.code} ${jsonResponse.error.message}` || '');
+    }
 
-  // If any related record groups found
-  if (respJson.relatedRecordGroups.length > 0)
-    // Return the array of TypeFeatureInfoEntryPartial
-    return parseFeatureInfoEntries(respJson.relatedRecordGroups[recordGroupIndex].relatedRecords);
-  return Promise.resolve([]);
+    // If any related record groups found
+    if (respJson.relatedRecordGroups.length > 0)
+      // Return the array of TypeFeatureInfoEntryPartial
+      return parseFeatureInfoEntries(respJson.relatedRecordGroups[recordGroupIndex].relatedRecords);
+    return Promise.resolve([]);
+  } catch (error) {
+    // Log
+    logger.logError('esri-layer-common.queryRelatedRecordsByUrl()\n', error);
+    return null;
+  }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -356,6 +356,10 @@ export class EsriDynamic extends AbstractGeoViewRaster {
 
       const response = await fetch(identifyUrl);
       const jsonResponse = await response.json();
+      if (jsonResponse.error) {
+        logger.logInfo('There is a problem with this query: ', identifyUrl);
+        throw new Error(`Error code = ${jsonResponse.error.code} ${jsonResponse.error.message}` || '');
+      }
       const features = new EsriJSON().readFeatures(
         { features: jsonResponse.results },
         { dataProjection: 'EPSG:4326', featureProjection: `EPSG:${currentProjection}` }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -677,10 +677,11 @@ export class WMS extends AbstractGeoViewRaster {
         return [];
 
       const wmsSource = (layerConfig.olLayer as OlLayer).getSource() as ImageWMS;
-      let infoFormat = 'text/xml';
-      if (!(this.metadata!.Capability.Request.GetFeatureInfo.Format as TypeJsonArray).includes('text/xml' as TypeJsonObject))
-        if ((this.metadata!.Capability.Request.GetFeatureInfo.Format as TypeJsonArray).includes('text/plain' as TypeJsonObject))
-          infoFormat = 'text/plain';
+      let infoFormat = '';
+      const featureInfoFormat = this.metadata?.Capability?.Request?.GetFeatureInfo?.Format as TypeJsonArray;
+      if (featureInfoFormat)
+        if (featureInfoFormat.includes('text/xml' as TypeJsonObject)) infoFormat = 'text/xml';
+        else if (featureInfoFormat.includes('text/plain' as TypeJsonObject)) infoFormat = 'text/plain';
         else throw new Error('Parameter info_format of GetFeatureInfo only support text/xml and text/plain for WMS services.');
 
       const featureInfoUrl = wmsSource.getFeatureInfoUrl(clickCoordinate, viewResolution, crs, {
@@ -726,7 +727,7 @@ export class WMS extends AbstractGeoViewRaster {
     } catch (error) {
       // Log
       logger.logError('wms.getFeatureInfoAtLongLat()\n', error);
-      return [];
+      return null;
     }
   }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -258,9 +258,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
     } catch (error) {
       // Log
       logger.logError('abstract-geoview-vector.getAllFeatureInfo()\n', error);
-      // TODO: Check - Shouldn't this return null instead of [] to be consistent with getFeatureInfoAtPixel and others?
-      // TO.DO.CONT: If returning null is decided, the function should probably return Promise<TypeArrayOfFeatureInfoEntries | null>?
-      return [];
+      return null;
     }
   }
 


### PR DESCRIPTION
# Description

Verified and changed the code of all getFeatureInfo to make them follow the rule that says they must return a null if there is a query error.

Fixes #892

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using Chrome devtools to trace and debbug the code.

__Deploy URL__: https://ychoquet.github.io/GeoView

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1787)
<!-- Reviewable:end -->
