### PR TITLE
1802 implement trigger get all feature info and simplify event processor

### DIFF
--- a/packages/geoview-core/public/templates/layers/esri-feature.html
+++ b/packages/geoview-core/public/templates/layers/esri-feature.html
@@ -108,31 +108,38 @@
                 'metadataAccessPath': { 'en': 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/DMS/DEU_CSO_Volume/MapServer/' },
                 'geoviewLayerType': 'esriFeature',
                 'listOfLayerEntryConfig': [
-                  {
-                    'layerId': '8',
-                    'layerFilter': 'Total_CSO_Volume > 5000000',
-                    'initialSettings': { 'visible': 'yes' }
-                  }
-                ]
-              }
-            ]
-          },
-          'components': ['overview-map', 'north-arrow'],
-          'corePackages': [],
-          'theme': 'dark',
-          'suportedLanguages': ['en']
-        }"
-    ></div>
-    <button type="button" class="collapsible">Visibility and filters</button>
-    <pre id="layer1-buttons-pre" class="panel"></pre>
-    <button class="collapsible">Get Legend</button>
-    <pre id="LegendsId1-table-pre" class="panel"></pre>
-    <button type="button" class="collapsible">Get Feature Info</button>
-    <pre id="ResultSetId1-click" class="panel">Click on feature on the map</pre>
-    <button type="button" class="collapsible" id="AllFeatureInfo1">Get All Feature Info</button>
-    <pre id="ResultSetId1-all" class="panel"></pre>
-    <hr />
-    <p>This map has a wms layer added from configuration.</p>
+                {
+                  'layerId': '8',
+                  'layerFilter': 'Total_CSO_Volume > 5000000',
+                  'initialSettings': { 'visible': 'yes' },
+                  'source': { 'featureInfo': { 'queryable': true } }
+                }
+              ]
+            }
+          ]
+        },
+        'components': ['overview-map', 'north-arrow'],
+        'corePackages': [],
+        'theme': 'dark',
+        'suportedLanguages': ['en']
+      }"
+  ></div>
+  <button type="button" class="collapsible">Visibility and filters</button>
+  <pre id="layer1-buttons-pre" class="panel"></pre>
+
+  <button class="collapsible">Get Legend</button>
+  <pre id="LegendsId1-table-pre" class="panel"></pre>
+
+  <button type="button" class="collapsible">Get Feature Info</button>
+  <pre id="ResultSetId1-click" class="panel">Click on feature on the map</pre>
+
+  <button type="button" class="collapsible" id="AllFeatureInfo1">Get All Feature Info</button>
+  <pre class="panel">
+    <select name="dropdown1" id="dropdown1"></select>
+    <div id="ResultSetId1-all-features"></div>
+  </pre>
+  <hr />
+  <p>This map has a wms layer added from configuration.</p>
     <button type="button" class="collapsible">Configuration Snippet</button>
     <pre id="LYR1CS" class="panel"></pre>
     <hr />
@@ -375,7 +382,7 @@
                 const layerConfig = cgpv.api.maps.LYR2.layer.registeredLayers['historical-flood/0'];
                 const checkbox = document.getElementById('checkbox-LYR2-historical-flood');
                 cgpv.api.maps.LYR2.layer.geoviewLayer('historical-flood/0').applyViewFilter(
-                  LYR2_FILTERS[j],
+                  LYR2_FILTERS[i],
                   checkbox.value !== 'true'
                 );
                 if (++i === LYR2_FILTERS.length) i = 0;
@@ -425,27 +432,44 @@
       });
 
       // LYR1 ===================================================================================================================
-      const getAllFeatureInfo1 = document.getElementById('AllFeatureInfo1');
-      getAllFeatureInfo1.addEventListener('click', function (e) {
-            cgpv.api.event.emit({ event: 'map/get_all_features', handlerName: 'LYR1' });
+      cgpv.api.event.on(
+        cgpv.api.eventNames.MAP.EVENT_MAP_LOADED,
+        (payload) => {
+          const lyr1RegisteredLayers = cgpv.api.maps.LYR1.layer.registeredLayers;
+          const dropDownContent = document.getElementById('dropdown1');
+          Object.keys(lyr1RegisteredLayers).forEach((layerPath) => {
+            if (lyr1RegisteredLayers[layerPath].layerStatus === 'loaded') {
+              const layerName = lyr1RegisteredLayers[layerPath]?.layerName?.en;
+              element = document.createElement('option');
+              element.value = layerPath;
+              element.innerText = layerName ? layerName : lyr1RegisteredLayers[layerPath].layerId;
+              dropDownContent.appendChild(element);
+            }
+          });
+          dropDownContent.addEventListener('click', (e) => {
+            cgpv.api.getFeatureInfoLayerSet('LYR1').triggerGetAllFeatureInfo(e.currentTarget.value, 'all');
           });
 
-      cgpv.api.event.on(
-        cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-        (payload) => {
-          const { layerSetId, resultsSet, eventType } = payload;
-          createInfoTable('LYR1', 'ResultSetId1', resultsSet, eventType);
-        },
-        'LYR1/FeatureInfoLayerSet'
-      );
+          cgpv.api.event.on(
+            cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
+            (payload) => {
+              const { layerSetId, resultsSet, eventType } = payload;
+              createInfoTable('LYR1', 'ResultSetId1', resultsSet, eventType);
+            },
+            'LYR1/FeatureInfoLayerSet'
+          );
 
-      cgpv.api.event.on(
-        cgpv.api.eventNames.GET_LEGENDS.LEGENDS_LAYERSET_UPDATED,
-        (payload) => {
-          const { resultsSet } = payload;
-          displayLegend('LegendsId1', resultsSet);
-        },
-        'LYR1/LegendsLayerSet'
+          cgpv.api.event.on(
+            cgpv.api.eventNames.GET_LEGENDS.LEGENDS_LAYERSET_UPDATED,
+            (payload) => {
+              const { resultsSet } = payload;
+              displayLegend('LegendsId1', resultsSet);
+            },
+            'LYR1/LegendsLayerSet'
+          );
+
+          },
+          'LYR1'
       );
 
       listenToLegendLayerSetChanges('HLYR1-state', 'LYR1/LegendsLayerSet');

--- a/packages/geoview-core/public/templates/layers/layerlib.js
+++ b/packages/geoview-core/public/templates/layers/layerlib.js
@@ -45,7 +45,7 @@ const addBoundsPolygon = (mapId, bbox) => {
 
 // ==========================================================================================================================
 const createInfoTable = (mapId, resultsSetId, resultsSet, eventType) => {
-  if (eventType !== 'click') return;
+  if (!['click', 'all-features'].includes(eventType)) return;
   const infoTable = document.getElementById(`${resultsSetId}-${eventType}`);
   infoTable.textContent = '';
   const oldContent = document.getElementById(`layer${mapId.slice(-1)}-${eventType}-info`);

--- a/packages/geoview-core/src/api/events/constants/get-feature-info-constants.ts
+++ b/packages/geoview-core/src/api/events/constants/get-feature-info-constants.ts
@@ -6,7 +6,12 @@ import { EventStringId } from '../event-types';
  */
 
 /** Valid keys for the GET_FEATURE_INFO category */
-export type GetFeatureInfoEventKey = 'QUERY_LAYER' | 'ALL_QUERIES_DONE' | 'GET_ALL_LAYER_FEATURES' | 'QUERY_RESULT';
+export type GetFeatureInfoEventKey =
+  | 'QUERY_LAYER'
+  | 'ALL_QUERIES_DONE'
+  | 'GET_ALL_LAYER_FEATURES'
+  | 'QUERY_RESULT'
+  | 'FEATURE_INFO_LAYERSET_UPDATED';
 
 /** Record that associates GET_FEATURE_INFO's event keys to their event string id */
 export const GET_FEATURE_INFO: Record<GetFeatureInfoEventKey, EventStringId> = {
@@ -29,4 +34,9 @@ export const GET_FEATURE_INFO: Record<GetFeatureInfoEventKey, EventStringId> = {
    * Event triggered to send the result of the query
    */
   QUERY_RESULT: 'get_feature_info/query_result',
+
+  /**
+   * Event triggered to send the result of the query
+   */
+  FEATURE_INFO_LAYERSET_UPDATED: 'get_feature_info/feature_info_layerset_updated',
 };

--- a/packages/geoview-core/src/api/events/event-types.ts
+++ b/packages/geoview-core/src/api/events/event-types.ts
@@ -59,6 +59,7 @@ export type EventStringId =
   | 'get_feature_info/get_all_layer_features'
   | 'get_feature_info/query_layer'
   | 'get_feature_info/query_result'
+  | 'get_feature_info/feature_info_layerset_updated'
   | 'get_legends/legends_layerset_updated'
   | 'get_legends/legend_info'
   | 'get_legends/query_legends'

--- a/packages/geoview-core/src/api/events/payloads/get-feature-info-payload.ts
+++ b/packages/geoview-core/src/api/events/payloads/get-feature-info-payload.ts
@@ -9,6 +9,7 @@ import { PayloadBaseClass } from './payload-base-class';
 import { EventStringId, EVENT_NAMES } from '../event-types';
 import { TypeGeoviewLayerType } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { TypeLayerStatus } from '@/geo/map/map-schema-types';
+import { TypeResultsSet } from './layer-set-payload';
 
 /** Valid events that can create GetFeatureInfoPayload */
 const validEvents: EventStringId[] = [
@@ -16,6 +17,7 @@ const validEvents: EventStringId[] = [
   EVENT_NAMES.GET_FEATURE_INFO.GET_ALL_LAYER_FEATURES,
   EVENT_NAMES.GET_FEATURE_INFO.ALL_QUERIES_DONE,
   EVENT_NAMES.GET_FEATURE_INFO.QUERY_RESULT,
+  EVENT_NAMES.GET_FEATURE_INFO.FEATURE_INFO_LAYERSET_UPDATED,
 ];
 
 export type EventType = 'click' | 'hover' | 'crosshaire-enter' | 'all-features';
@@ -115,6 +117,18 @@ export const payloadIsQueryLayer = (verifyIfPayload: PayloadBaseClass): verifyIf
 };
 
 /**
+ * type guard function that redefines a PayloadBaseClass as a TypeQueryAllLayerFeaturesPayload
+ * if the event attribute of the verifyIfPayload parameter is valid. The type assertion
+ * applies only to the true block of the if clause.
+ *
+ * @param {PayloadBaseClass} verifyIfPayload object to test in order to determine if the type assertion is valid
+ * @returns {boolean} returns true if the payload is valid
+ */
+export const payloadIsGetAllLayerFeatures = (verifyIfPayload: PayloadBaseClass): verifyIfPayload is TypeQueryAllLayerFeaturesPayload => {
+  return verifyIfPayload?.event === EVENT_NAMES.GET_FEATURE_INFO.GET_ALL_LAYER_FEATURES;
+};
+
+/**
  * Returns true if the payload is a TypeQueryLayerPayload with queryType equal to 'at_long_lat'.
  *
  * @param {PayloadBaseClass} verifyIfPayload object to test in order to determine if the type assertion and property are valid
@@ -122,6 +136,20 @@ export const payloadIsQueryLayer = (verifyIfPayload: PayloadBaseClass): verifyIf
  */
 export const payloadIsQueryLayerQueryTypeAtLongLat = (verifyIfPayload: PayloadBaseClass): verifyIfPayload is TypeQueryLayerPayload => {
   return payloadIsQueryLayer(verifyIfPayload) && verifyIfPayload.queryType === 'at_long_lat';
+};
+
+/**
+ * type guard function that redefines a PayloadBaseClass as a TypeFeatureInfoLayersetUpdatedPayload
+ * if the event attribute of the verifyIfPayload parameter is valid. The type assertion
+ * applies only to the true block of the if clause.
+ *
+ * @param {PayloadBaseClass} verifyIfPayload object to test in order to determine if the type assertion is valid
+ * @returns {boolean} returns true if the payload is valid
+ */
+export const payloadIsFeatureInfoLayersetUpdated = (
+  verifyIfPayload: PayloadBaseClass
+): verifyIfPayload is TypeFeatureInfoLayersetUpdatedPayload => {
+  return verifyIfPayload?.event === EVENT_NAMES.GET_FEATURE_INFO.FEATURE_INFO_LAYERSET_UPDATED;
 };
 
 /**
@@ -135,6 +163,8 @@ export interface TypeQueryLayerPayload extends GetFeatureInfoPayload {
   // Event type that triggered the query. It can be a click, a hover, a crosshair enter, all ...
   eventType: EventType;
 }
+
+export type TypeQueryAllLayerFeaturesPayload = TypeQueryLayerPayload;
 
 /**
  * type guard function that redefines a PayloadBaseClass as a TypeAllQueriesDonePayload
@@ -213,6 +243,18 @@ export const payloadIsGetFeatureInfo = (verifyIfPayload: PayloadBaseClass): veri
 };
 
 /**
+ * Additional attributes needed to define a TypeAllLegendsDonePayload
+ */
+export interface TypeFeatureInfoLayersetUpdatedPayload extends GetFeatureInfoPayload {
+  // the layer path updated
+  layerPath: string;
+  // The result set containing all the legends of the layers loaded on the map.
+  resultsSet: TypeFeatureInfoResultsSet;
+  // The layer status that is associated to the layer path.
+  layerStatus: TypeLayerStatus;
+}
+
+/**
  * Class definition for GetFeatureInfoPayload
  *
  * @exports
@@ -263,7 +305,11 @@ export class GetFeatureInfoPayload extends PayloadBaseClass {
    *
    * @returns {TypeQueryLayerPayload} the queryLayerPayload object created
    */
-  static createGetAllLayerFeaturesPayload = (handlerName: string, queryType: QueryType, location: string): TypeQueryLayerPayload => {
+  static createGetAllLayerFeaturesPayload = (
+    handlerName: string,
+    queryType: QueryType,
+    location?: string
+  ): TypeQueryAllLayerFeaturesPayload => {
     const queryLayerPayload = new GetFeatureInfoPayload(
       EVENT_NAMES.GET_FEATURE_INFO.GET_ALL_LAYER_FEATURES,
       handlerName
@@ -330,5 +376,30 @@ export class GetFeatureInfoPayload extends PayloadBaseClass {
     queryResultPayload.arrayOfRecords = arrayOfRecords;
     queryResultPayload.eventType = eventType;
     return queryResultPayload;
+  };
+
+  /**
+   * Static method used to create a "feature info updated" payload.
+   *
+   * @param {string | null} handlerName the handler Name
+   * @param {string} layerPath the layer path updated
+   * @param {TypeResultsSet | TypeFeatureInfoResultsSet} resultsSet the feature info resultset
+   *
+   * @returns {TypeFeatureInfoLayersetUpdatedPayload} the TypeFeatureInfoLayersetUpdatedPayload object created
+   */
+  static createFeatureInfoLayersetUpdatedPayload = (
+    handlerName: string,
+    layerPath: string,
+    resultsSet: TypeResultsSet | TypeFeatureInfoResultsSet,
+    layerStatus: TypeLayerStatus
+  ): TypeFeatureInfoLayersetUpdatedPayload => {
+    const featureInfoLayersetUpdatedPayload = new GetFeatureInfoPayload(
+      EVENT_NAMES.GET_FEATURE_INFO.FEATURE_INFO_LAYERSET_UPDATED,
+      handlerName
+    ) as TypeFeatureInfoLayersetUpdatedPayload;
+    featureInfoLayersetUpdatedPayload.layerPath = layerPath;
+    featureInfoLayersetUpdatedPayload.resultsSet = resultsSet as TypeFeatureInfoResultsSet;
+    featureInfoLayersetUpdatedPayload.layerStatus = layerStatus;
+    return featureInfoLayersetUpdatedPayload;
   };
 }

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
@@ -1,7 +1,8 @@
 import { useStore } from 'zustand';
 import { TypeSetStore, TypeGetStore } from '@/core/stores/geoview-store';
-import { TypeArrayOfLayerData, TypeFeatureInfoEntry, TypeGeometry } from '@/api/events/payloads/get-feature-info-payload';
+import { QueryType, TypeArrayOfLayerData, TypeFeatureInfoEntry, TypeGeometry } from '@/api/events/payloads/get-feature-info-payload';
 import { useGeoViewStore } from '../stores-managers';
+import { api } from '@/app';
 
 export interface IFeatureInfoState {
   checkedFeatures: Array<TypeFeatureInfoEntry>;
@@ -21,6 +22,7 @@ export interface IFeatureInfoState {
     setHoverDataArray: (hoverDataArray: TypeArrayOfLayerData) => void;
     setAllFeaturesDataArray: (allFeaturesDataArray: TypeArrayOfLayerData) => void;
     setSelectedLayerPath: (selectedLayerPath: string) => void;
+    triggerGetAllFeatureInfo: (layerPath: string, queryType: QueryType) => void;
   };
 }
 
@@ -105,6 +107,9 @@ export function initFeatureInfoState(set: TypeSetStore, get: TypeGetStore): IFea
             selectedLayerPath,
           },
         });
+      },
+      triggerGetAllFeatureInfo(layerPath: string, queryType: QueryType = 'all') {
+        api.getFeatureInfoLayerSet(get().mapId).triggerGetAllFeatureInfo(layerPath, queryType);
       },
     },
     // #endregion ACTIONS

--- a/packages/geoview-core/src/geo/utils/legends-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/legends-layer-set.ts
@@ -45,7 +45,7 @@ export class LegendsLayerSet {
     };
 
     // This function is used to initialise the date property of the layer path entry.
-    const registrationUserDataInitialisation = (layerPath: string) => {
+    const registrationUserInitialisation = (layerPath: string) => {
       this.resultsSet[layerPath].querySent = false;
       this.resultsSet[layerPath].data = undefined;
     };
@@ -56,7 +56,7 @@ export class LegendsLayerSet {
       `${mapId}/LegendsLayerSet`,
       this.resultsSet as TypeResultsSet,
       registrationConditionFunction,
-      registrationUserDataInitialisation
+      registrationUserInitialisation
     );
 
     api.event.on(
@@ -65,7 +65,7 @@ export class LegendsLayerSet {
         if (payloadIsLayerSetUpdated(layerUpdatedPayload)) {
           // Log
           logger.logTraceDetailed(
-            'legends-layer-set on EVENT_NAMES.LAYER_SET.UPDATED (LegendsLayerSetStatusOrPhaseChanged)',
+            'legends-layer-set on EVENT_NAMES.LAYER_SET.UPDATED (LegendsLayerSetStatusChanged)',
             this.mapId,
             layerUpdatedPayload
           );
@@ -74,7 +74,7 @@ export class LegendsLayerSet {
           api.event.emit(GetLegendsPayload.createLegendsLayersetUpdatedPayload(`${this.mapId}/LegendsLayerSet`, layerPath, resultsSet));
         }
       },
-      `${mapId}/LegendsLayerSetStatusOrPhaseChanged`
+      `${mapId}/LegendsLayerSetStatusChanged`
     );
 
     // This listener receives the legend information returned by the layer's getLegend call and store it in the resultsSet.


### PR DESCRIPTION
# Description

Added a triggerGetAllFeatureInfo to the feature info layer set and simplified the logic of the propagateFeatureInfoToStore static method of the feature-info-event-processor. The store also have a triggerGetAllFeatureInfo action.

Fixes #1802

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using Chrome Devtools and the esri-feature.html template. The Get All Feature Info below the first map has a dropdown to test the new code.

__Deploy URL__: https://ychoquet.github.io/GeoView/esri-feature.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1804)
<!-- Reviewable:end -->
