### PR TITLE
fix(geocore): refactor layerOrder to keep geocore in proper order

### DIFF
--- a/.github/workflows/type-build.yml
+++ b/.github/workflows/type-build.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: "42 21 * * 5"
 
+env:
+  NODE_VERSION: "20.11.0"
+  PNPM_VERSION: "8.15.0"
+
 jobs:
   update_types:
     runs-on: ubuntu-latest

--- a/docs/app/geoview-layer/map-config/draw.io/TypeMapConfig.drawio.svg
+++ b/docs/app/geoview-layer/map-config/draw.io/TypeMapConfig.drawio.svg
@@ -1097,7 +1097,7 @@
                                 <div style="line-height: 19px;">
                                     <div style="line-height: 19px;">
                                         <b>
-                                            TypeGeocoreLayerEntryConfig
+                                            TypeGeoCoreLayerEntryConfig
                                         </b>
                                     </div>
                                 </div>
@@ -1106,7 +1106,7 @@
                     </div>
                 </foreignObject>
                 <text x="636" y="980" fill="#000000" font-family="Helvetica" font-size="14px" text-anchor="middle">
-                    TypeGeocoreLayerEntryConfig
+                    TypeGeoCoreLayerEntryConfig
                 </text>
             </switch>
         </g>

--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -157,7 +157,8 @@
       "loadfailed": "Layer [__param__] failed to load on map __param__.",
       "notfound": "The sublayer __param__ of the GeoView layer __param__ does not exist on the server",
       "createtwice": "Can not execute twice the createGeoViewRasterLayers method for the map __param__",
-      "usedtwice": "Duplicate use of geoview layer identifier [__param__] on map __param__"
+      "usedtwice": "Duplicate use of geoview layer identifier [__param__] on map __param__",
+      "multipleUUID": "GeoCore layers may only have one GeoCore UUID per layer"
     },
     "schema": {
       "notFound": "A schema error was found, check the console to see what is wrong.",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -157,7 +157,8 @@
       "loadfailed": "Le chargement de la couche [__param__] a échoué sur la carte __param__.",
       "notfound": "La sous couche __param__ de la couche GeoView __param__ n'existe pas sur le sereur",
       "createtwice": "On ne peut exécuter deux fois la méthode createGeoViewRasterLayers pour la carte __param__",
-      "usedtwice": "Utilisation en double de l'identifiant de couche geoview [__param__] sur la carte __param__"
+      "usedtwice": "Utilisation en double de l'identifiant de couche geoview [__param__] sur la carte __param__",
+      "multipleUUID": "Les couches GeoCore ne peuvent avoir qu'un seul UUID GeoCore par couche."
     },
     "schema": {
       "notFound": "Une erreur de schéma a été trouvée, vérifiez la console pour voir ce qui ne va pas.",

--- a/packages/geoview-core/public/templates/layers/geocore.html
+++ b/packages/geoview-core/public/templates/layers/geocore.html
@@ -76,20 +76,23 @@
             'listOfGeoviewLayerConfig': [
               {
                 'geoviewLayerType': 'geoCore',
+                'geoviewLayerId': 'airborneRad',
                 'listOfLayerEntryConfig': [
                   {
-                    'layerId': '0fe65119-e96e-4a57-8bfe-9d9245fba06b',
-                    'geocoreLayerName': { 'en': 'HRDEM Mosaic Hillshade' },
+                    'layerId': '21b821cf-0f1c-40ee-8925-eab12d357668',
+                    'geocoreLayerName': { 'en': 'Airborne Radioactivity' },
                     'listOfLayerEntryConfig': [
                       {
-                        'layerId': 'dsm-hillshade',
-                        'layerName': { 'en': 'Map' },
-                        'source': {
-                          'style': 'hillshade'
-                        }
+                        'layerId': '0'
                       }
                     ]
-                  },
+                  }
+                ]
+              },
+              {
+                'geoviewLayerType': 'geoCore',
+                'geoviewLayerId': 'commem',
+                'listOfLayerEntryConfig': [
                   {
                     'layerId': 'ccc75c12-5acc-4a6a-959f-ef6f621147b9',
                     'geocoreLayerName': { 'en': 'Commemorative Map' },
@@ -98,7 +101,13 @@
                         'layerId': '0'
                       }
                     ]
-                  },
+                  }
+                ]
+              },
+              {
+                'geoviewLayerType': 'geoCore',
+                'geoviewLayerId': 'MWQ',
+                'listOfLayerEntryConfig': [
                   {
                     'layerId': '0fca08b5-e9d0-414b-a3c4-092ff9c5e326',
                     'geocoreLayerName': { 'en': 'Marine Water Quality' },
@@ -107,8 +116,13 @@
                         'layerId': '6'
                       }
                     ]
-
-                  },
+                  }
+                ]
+              },
+              {
+                'geoviewLayerType': 'geoCore',
+                'geoviewLayerId': 'napl',
+                'listOfLayerEntryConfig': [
                   {
                     'layerId': '03ccfb5c-a06e-43e3-80fd-09d4f8f69703',
                     'geocoreLayerName': { 'en': 'NAPL Temporal Series' },
@@ -160,65 +174,86 @@
       triggerReadyCallback="true"
       data-lang="en"
       data-config="{
-          'map': {
-            'interaction': 'dynamic',
-            'viewSettings': {
-              'zoom': 4,
-              'center': [-100, 60],
-              'projection': 3978
-            },
-            'basemapOptions': {
-              'basemapId': 'transport',
-              'shaded': false,
-              'labeled': true
-            },
-            'listOfGeoviewLayerConfig': [
-              {
-                'geoviewLayerType': 'geoCore',
-                'listOfLayerEntryConfig': [
-                  {
-                    'layerId': 'ccc75c12-5acc-4a6a-959f-ef6f621147b9',
-                    'geocoreLayerName': { 'en': 'Commemorative Map' },
-                    'listOfLayerEntryConfig': [
-                      {
-                        'layerId': '0'
-                      }
-                    ]
-                  },
-                  {
-                    'layerId': '0fca08b5-e9d0-414b-a3c4-092ff9c5e326',
-                    'geocoreLayerName': { 'en': 'Marine Water Quality' },
-                    'listOfLayerEntryConfig': [
-                      {
-                        'layerId': '6'
-                      }
-                    ]
-
-                  },
-                  {
-                    'layerId': '03ccfb5c-a06e-43e3-80fd-09d4f8f69703',
-                    'geocoreLayerName': { 'en': 'NAPL Temporal Series' },
-                    'listOfLayerEntryConfig': [
-                      {
-                        'layerId': 'regina',
-                        'layerName': { 'en': 'Map of Regina' }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+        'map': {
+          'interaction': 'dynamic',
+          'viewSettings': {
+            'zoom': 4,
+            'center': [-100, 60],
+            'projection': 3978
           },
-          'components': ['overview-map'],
-          'footerBar': {
-            'tabs': {
-              'core': ['legend', 'layers', 'details', 'data-table']
+          'basemapOptions': {
+            'basemapId': 'transport',
+            'shaded': false,
+            'labeled': true
+          },
+          'listOfGeoviewLayerConfig': [
+            {
+              'geoviewLayerType': 'geoCore',
+              'geoviewLayerId': 'airborneRad',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': '21b821cf-0f1c-40ee-8925-eab12d357668',
+                  'geocoreLayerName': { 'en': 'Airborne Radioactivity' },
+                  'listOfLayerEntryConfig': [
+                    {
+                      'layerId': '0'
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              'geoviewLayerType': 'geoCore',
+              'geoviewLayerId': 'commem',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': 'ccc75c12-5acc-4a6a-959f-ef6f621147b9',
+                  'geocoreLayerName': { 'en': 'Commemorative Map' },
+                  'listOfLayerEntryConfig': [
+                    {
+                      'layerId': '0'
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              'geoviewLayerType': 'geoCore',
+              'geoviewLayerId': 'MWQ',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': '0fca08b5-e9d0-414b-a3c4-092ff9c5e326',
+                  'geocoreLayerName': { 'en': 'Marine Water Quality' },
+                  'listOfLayerEntryConfig': [
+                    {
+                      'layerId': '6'
+                    }
+                  ]
+                },
+                {
+                  'layerId': '03ccfb5c-a06e-43e3-80fd-09d4f8f69703',
+                  'geocoreLayerName': { 'en': 'NAPL Temporal Series' },
+                  'listOfLayerEntryConfig': [
+                    {
+                      'layerId': 'regina',
+                      'layerName': { 'en': 'Map of Regina' }
+                    }
+                  ]
+                }
+              ]
             }
-          },
-          'corePackages': [],
-          'theme': 'geo.ca',
-          'suportedLanguages': ['en']
-        }"
+          ]
+        },
+        'components': ['overview-map'],
+        'footerBar': {
+          'tabs': {
+            'core': ['legend', 'layers', 'details', 'data-table']
+          }
+        },
+        'corePackages': [],
+        'theme': 'geo.ca',
+        'suportedLanguages': ['en']
+      }"
     ></div>
 
     <script src="codedoc.js"></script>

--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -1110,7 +1110,7 @@
       },
       "required": ["schemaTag", "entryType", "layerId"]
     },
-    "TypeGeocoreLayerEntryConfig": {
+    "TypeGeoCoreLayerEntryConfig": {
       "additionalProperties": false,
       "type": "object",
       "description": "Layer where configration is extracted by a configuration snippet stored on a server. The server configuration will handle bilangual informations.",
@@ -1221,7 +1221,7 @@
           "$ref": "#/definitions/TypeTileLayerEntryConfig"
         },
         {
-          "$ref": "#/definitions/TypeGeocoreLayerEntryConfig"
+          "$ref": "#/definitions/TypeGeoCoreLayerEntryConfig"
         }
       ]
     },
@@ -1396,7 +1396,7 @@
             "$ref": "#/definitions/TypeLayerGroupEntryConfig"
           },
           {
-            "$ref": "#/definitions/TypeGeocoreLayerEntryConfig"
+            "$ref": "#/definitions/TypeGeoCoreLayerEntryConfig"
           }
         ]
       }

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -11,8 +11,8 @@ import {
   useDetailsStoreActions,
   useDetailsStoreAllFeaturesDataArray,
   useUIActiveFooterBarTabId,
-  useMapOrderedLayerInfo,
   useDatatableStoreTableHeight,
+  useMapVisibleLayers,
 } from '@/core/stores';
 import { LayerListEntry, Layout } from '../common';
 import { logger } from '@/core/utils/logger';
@@ -48,7 +48,7 @@ export function Datapanel({ fullWidth }: DataPanelType) {
   const { setSelectedLayerPath } = useDataTableStoreActions();
   const { triggerGetAllFeatureInfo } = useDetailsStoreActions();
   const selectedTab = useUIActiveFooterBarTabId();
-  const orderedLayerInfo = useMapOrderedLayerInfo();
+  const visibleLayers = useMapVisibleLayers();
 
   // Create columns for data table.
   const mappedLayerData = useFeatureFieldInfos(layerData);
@@ -57,17 +57,10 @@ export function Datapanel({ fullWidth }: DataPanelType) {
    * Order the layers by visible layer order.
    */
   const orderedLayerData = useMemo(() => {
-    const visibleLayers = orderedLayerInfo
-      .map((layerInfo) => {
-        if (layerInfo.visible) return layerInfo.layerPath;
-        return undefined;
-      })
-      .filter((layerPath) => layerPath !== undefined);
-
     return visibleLayers
       .map((layerPath) => mappedLayerData.filter((data) => data.layerPath === layerPath)[0])
       .filter((layer) => layer !== undefined);
-  }, [mappedLayerData, orderedLayerInfo]);
+  }, [mappedLayerData, visibleLayers]);
 
   /**
    * Update local states when layer is changed from layer list.

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -14,7 +14,7 @@ import {
 import { TypeFeatureInfoEntry, TypeLayerData, TypeGeometry, TypeArrayOfFeatureInfoEntries } from '@/api/events/payloads';
 import {
   useMapStoreActions,
-  useMapOrderedLayerInfo,
+  useMapVisibleLayers,
   useDetailsStoreActions,
   useDetailsStoreCheckedFeatures,
   useDetailsStoreLayerDataArrayBatch,
@@ -48,7 +48,7 @@ export function DetailsPanel({ fullWidth }: DetailsPanelType): JSX.Element {
   const selectedLayerPath = useDetailsStoreSelectedLayerPath();
   const arrayOfLayerDataBatch = useDetailsStoreLayerDataArrayBatch();
   const checkedFeatures = useDetailsStoreCheckedFeatures();
-  const orderedLayerInfo = useMapOrderedLayerInfo();
+  const visibleLayers = useMapVisibleLayers();
   const { setSelectedLayerPath, removeCheckedFeature, setLayerDataArrayBatchLayerPathBypass } = useDetailsStoreActions();
   const { addSelectedFeature, removeSelectedFeature } = useMapStoreActions();
 
@@ -122,16 +122,7 @@ export function DetailsPanel({ fullWidth }: DetailsPanelType): JSX.Element {
    */
   const memoLayersList = useMemo(() => {
     // Log
-    logger.logTraceUseMemo('DETAILS-PANEL - memoLayersList', orderedLayerInfo, arrayOfLayerDataBatch);
-
-    const visibleLayers = orderedLayerInfo
-      .map((layerInfo) => {
-        if (layerInfo.visible) return layerInfo.layerPath;
-        return undefined;
-      })
-      .filter((layerPath) => layerPath !== undefined);
-
-    if (!visibleLayers.includes(selectedLayerPath)) setSelectedLayerPath('');
+    logger.logTraceUseMemo('DETAILS-PANEL - memoLayersList', visibleLayers, arrayOfLayerDataBatch);
 
     // Set the layers list
     const layerListEntries = visibleLayers
@@ -151,7 +142,7 @@ export function DetailsPanel({ fullWidth }: DetailsPanelType): JSX.Element {
       );
     if (!layerListEntries.length) setSelectedLayerPath('');
     return layerListEntries;
-  }, [orderedLayerInfo, arrayOfLayerDataBatch, selectedLayerPath, setSelectedLayerPath, getNumFeaturesLabel]);
+  }, [visibleLayers, arrayOfLayerDataBatch, setSelectedLayerPath, getNumFeaturesLabel]);
 
   /**
    * Memoizes the selected layer for the LayerList component.

--- a/packages/geoview-core/src/core/components/layers/hooks/helpers.ts
+++ b/packages/geoview-core/src/core/components/layers/hooks/helpers.ts
@@ -1,3 +1,4 @@
+// TODO Remove when no longer needed
 import _ from 'lodash';
 import { TypeVectorLayerStyles } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { api } from '@/app';

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -415,11 +415,11 @@ export function AddNewLayer(): JSX.Element {
       const geoCoreGeoviewLayerInstance = new GeoCore(mapId);
       const layers = await geoCoreGeoviewLayerInstance.createLayersFromUUID(layerURL);
       if (layers.length === 1) {
-        if (layers[0].length === 1) {
-          setLayerName(layers[0][0].geoviewLayerName!.en! as string);
-          setLayerEntries(layers[0]);
+        if (layers.length === 1) {
+          setLayerName(layers[0].geoviewLayerName!.en! as string);
+          setLayerEntries(layers);
         } else {
-          setLayerList(layers[0]);
+          setLayerList(layers);
         }
       }
     } catch (err) {

--- a/packages/geoview-core/src/core/components/legend/legend.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend.tsx
@@ -2,7 +2,7 @@ import { useTheme } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box, Paper, Typography } from '@/ui';
-import { useLayerLegendLayers, useMapOrderedLayerInfo, useLayerStoreActions } from '@/core/stores/';
+import { useLayerLegendLayers, useMapVisibleLayers, useLayerStoreActions } from '@/core/stores/';
 import { logger } from '@/core/utils/logger';
 
 import { getSxClasses } from './legend-styles';
@@ -28,7 +28,7 @@ export function Legend({ fullWidth }: LegendType): JSX.Element {
   const [formattedLegendLayerList, setFormattedLegendLayersList] = useState<TypeLegendLayer[][]>([]);
 
   // store state
-  const orderedLayerInfo = useMapOrderedLayerInfo();
+  const visibleLayers = useMapVisibleLayers();
   const layersList = useLayerLegendLayers();
   const { getLayer } = useLayerStoreActions();
 
@@ -73,15 +73,7 @@ export function Legend({ fullWidth }: LegendType): JSX.Element {
 
   useEffect(() => {
     // Log
-    logger.logTraceUseEffect('LEGEND - orderedLayerInfo', orderedLayerInfo.length, orderedLayerInfo);
-
-    const visibleLayers = orderedLayerInfo
-      .map((layerInfo) => {
-        if (layerInfo.visible) return layerInfo.layerPath;
-        return undefined;
-      })
-      .filter((layerPath) => layerPath !== undefined);
-
+    logger.logTraceUseEffect('LEGEND - visibleLayers', visibleLayers.length, visibleLayers);
     // Loop on the visible layers to retrieve the valid TypeLegendLayer objects
     const parentPaths: string[] = [];
 
@@ -100,7 +92,7 @@ export function Legend({ fullWidth }: LegendType): JSX.Element {
     updateLegendLayerListByWindowSize(layers);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orderedLayerInfo, layersList]);
+  }, [visibleLayers, layersList]);
 
   useEffect(() => {
     // Log

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
@@ -65,6 +65,7 @@ export interface IMapState {
   scale: TypeScaleInfo;
   selectedFeatures: Array<TypeFeatureInfoEntry>;
   size: [number, number];
+  visibleLayers: string[];
   zoom: number;
 
   setDefaultConfigValues: (config: TypeMapFeaturesConfig) => void;
@@ -109,6 +110,7 @@ export interface IMapState {
     setProjection: (projectionCode: TypeValidMapProjectionCodes, view: View) => void;
     setQueryable: (layerPath: string, queryable: boolean) => void;
     setRotation: (degree: number) => void;
+    setVisibleLayers: (newOrder: string[]) => void;
     setZoom: (zoom: number, duration?: number) => void;
     showClickMarker: (marker: TypeClickMarker) => void;
     transformPoints: (coords: Coordinate[], outputProjection: number) => Coordinate[];
@@ -151,6 +153,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
     scale: { lineWidth: '', labelGraphic: '', labelNumeric: '' } as TypeScaleInfo,
     selectedFeatures: [],
     size: [0, 0] as [number, number],
+    visibleLayers: [],
     zoom: 0,
 
     // initialize default stores section from config information when store receive configuration file
@@ -548,6 +551,14 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
         // State is set by the map state store event 'onMapRotation'
         get().mapState.mapElement!.getView().animate({ rotation: degree });
       },
+      setVisibleLayers: (newOrder: string[]) => {
+        set({
+          mapState: {
+            ...get().mapState,
+            visibleLayers: newOrder,
+          },
+        });
+      },
       setZoom: (zoom: number, duration?: number) => {
         // set ol map zoom
         // State is set by the map state store event 'onMapZoomEnd'
@@ -627,6 +638,7 @@ export const useMapRotation = () => useStore(useGeoViewStore(), (state) => state
 export const useMapSelectedFeatures = () => useStore(useGeoViewStore(), (state) => state.mapState.selectedFeatures);
 export const useMapScale = () => useStore(useGeoViewStore(), (state) => state.mapState.scale);
 export const useMapSize = () => useStore(useGeoViewStore(), (state) => state.mapState.size);
+export const useMapVisibleLayers = () => useStore(useGeoViewStore(), (state) => state.mapState.visibleLayers);
 export const useMapZoom = () => useStore(useGeoViewStore(), (state) => state.mapState.zoom);
 
 export const useMapStoreActions = () => useStore(useGeoViewStore(), (state) => state.mapState.actions);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -249,7 +249,7 @@ export const CONST_GEOVIEW_SCHEMA_BY_TYPE: Record<TypeGeoviewLayerType, string> 
   esriFeature: 'TypeVectorLayerEntryConfig',
   esriImage: 'TypeEsriImageLayerEntryConfig',
   GeoJSON: 'TypeVectorLayerEntryConfig',
-  geoCore: 'TypeGeocoreLayerEntryConfig',
+  geoCore: 'TypeGeoCoreLayerEntryConfig',
   GeoPackage: 'TypeVectorLayerEntryConfig',
   xyzTiles: 'TypeTileLayerEntryConfig',
   vectorTiles: 'TypeTileLayerEntryConfig',

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -9,7 +9,7 @@ import { EVENT_NAMES } from '@/api/events/event-types';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
 
 import { Config } from '@/core/utils/config/config';
-import { generateId, showError, replaceParams, getLocalizedMessage, whenThisThen } from '@/core/utils/utilities';
+import { generateId, showError, replaceParams, getLocalizedMessage, whenThisThen, addNotificationError } from '@/core/utils/utilities';
 import {
   layerConfigPayload,
   payloadIsALayerConfig,
@@ -21,6 +21,7 @@ import { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geovie
 import {
   TypeGeoviewLayerConfig,
   TypeLayerEntryConfig,
+  TypeListOfGeoviewLayerConfig,
   TypeListOfLocalizedLanguages,
   layerEntryIsGroupLayer,
 } from '@/geo/map/map-schema-types';
@@ -100,11 +101,9 @@ export class Layer {
 
           if (layerConfigIsGeoCore(layerConfig)) {
             const geoCore = new GeoCore(this.mapId);
-            geoCore.createLayers(layerConfig).then((arrayOfListOfGeoviewLayerConfig) => {
-              arrayOfListOfGeoviewLayerConfig.forEach((listOfGeoviewLayerConfig) => {
-                listOfGeoviewLayerConfig.forEach((geoviewLayerConfig) => {
-                  this.addGeoviewLayer(geoviewLayerConfig);
-                });
+            geoCore.createLayers(layerConfig).then((listOfGeoviewLayerConfig: TypeListOfGeoviewLayerConfig) => {
+              listOfGeoviewLayerConfig.forEach((geoviewLayerConfig) => {
+                this.addGeoviewLayer(geoviewLayerConfig);
               });
             });
           } else if (layerConfigIsGeoJSON(layerConfig)) {
@@ -202,9 +201,23 @@ export class Layer {
    * @returns {TypeOrderedLayerInfo[]} The array of ordered layer info.
    */
   generateArrayOfLayerOrderInfo(geoviewLayerConfig: TypeGeoviewLayerConfig | TypeLayerEntryConfig): TypeOrderedLayerInfo[] {
-    // TODO Add placeholder for geocore and the replacement when the layer is created in geocore.ts
-    if ((geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerType === 'geoCore') return [];
-    const newOrderedLayerInfos = [];
+    const newOrderedLayerInfos: TypeOrderedLayerInfo[] = [];
+
+    if ((geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerType === 'geoCore') {
+      geoviewLayerConfig.listOfLayerEntryConfig?.forEach((layerEntryConfig) => {
+        const layerInfo: TypeOrderedLayerInfo = {
+          layerPath: layerEntryConfig.layerId,
+          alwaysVisible: false,
+          visible: true,
+          removable: true,
+          queryable: true,
+          hoverable: true,
+        };
+        newOrderedLayerInfos.push(layerInfo);
+      });
+      return newOrderedLayerInfos;
+    }
+
     const addSubLayerPathToLayerOrder = (layerEntryConfig: TypeLayerEntryConfig, layerPath: string): void => {
       const subLayerPath = layerPath.endsWith(layerEntryConfig.layerId) ? layerPath : `${layerPath}/${layerEntryConfig.layerId}`;
       const layerInfo: TypeOrderedLayerInfo = {
@@ -222,6 +235,7 @@ export class Layer {
         });
       }
     };
+
     if ((geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId) {
       if ((geoviewLayerConfig as TypeGeoviewLayerConfig).listOfLayerEntryConfig.length > 1) {
         const layerPath = `${(geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId}/${
@@ -252,7 +266,7 @@ export class Layer {
    * @param {TypeGeoviewLayerConfig[]} geoviewLayerConfigs an optional array containing layers passed within the map config
    */
   loadListOfGeoviewLayer(geoviewLayerConfigs?: TypeGeoviewLayerConfig[]) {
-    const validGeoviewLayerConfigs = this.deleteDuplicatGeoviewLayerConfig(geoviewLayerConfigs);
+    const validGeoviewLayerConfigs = this.deleteDuplicatAndMultipleUuidGeoviewLayerConfig(geoviewLayerConfigs);
 
     // set order for layers to appear on the map according to config
     const orderedLayerInfos: TypeOrderedLayerInfo[] = [];
@@ -271,18 +285,24 @@ export class Layer {
    *
    * @returns {TypeGeoviewLayerConfig} The new configuration with duplicate entries eliminated.
    */
-  private deleteDuplicatGeoviewLayerConfig(geoviewLayerConfigs?: TypeGeoviewLayerConfig[]): TypeGeoviewLayerConfig[] {
+  private deleteDuplicatAndMultipleUuidGeoviewLayerConfig(geoviewLayerConfigs?: TypeGeoviewLayerConfig[]): TypeGeoviewLayerConfig[] {
     if (geoviewLayerConfigs && geoviewLayerConfigs.length > 0) {
       const validGeoviewLayerConfigs = geoviewLayerConfigs.filter((geoviewLayerConfigToCreate, configToCreateIndex) => {
-        for (let configToTestIndex = 0; configToTestIndex < geoviewLayerConfigs.length; configToTestIndex++)
+        for (let configToTestIndex = 0; configToTestIndex < geoviewLayerConfigs.length; configToTestIndex++) {
+          if (layerConfigIsGeoCore(geoviewLayerConfigToCreate) && geoviewLayerConfigToCreate.listOfLayerEntryConfig.length > 1) {
+            logger.logError('GeoCore layers may only have one GeoCore UUID per layer');
+            addNotificationError(this.mapId, getLocalizedMessage(this.mapId, 'validation.layer.multipleUUID'));
+            return false;
+          }
           if (
             geoviewLayerConfigToCreate.geoviewLayerId === geoviewLayerConfigs[configToTestIndex].geoviewLayerId &&
-            // We keep the first instance of the duplicat entry.
+            // We keep the first instance of the duplicate entry.
             configToCreateIndex > configToTestIndex
           ) {
             this.printDuplicateGeoviewLayerConfigError(geoviewLayerConfigToCreate);
             return false;
           }
+        }
         return true;
       });
       return validGeoviewLayerConfigs;
@@ -441,7 +461,7 @@ export class Layer {
   addGeoviewLayerByGeoCoreUUID = async (uuid: string): Promise<void> => {
     const geoCoreGeoviewLayerInstance = new GeoCore(this.mapId);
     const layers = await geoCoreGeoviewLayerInstance.createLayersFromUUID(uuid);
-    layers[0].forEach((geoviewLayerConfig) => {
+    layers.forEach((geoviewLayerConfig) => {
       api.maps[this.mapId].layer.addGeoviewLayer(geoviewLayerConfig);
     });
   };

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -611,7 +611,7 @@ export const layerEntryIsRasterTile = (verifyIfLayer: TypeLayerEntryConfig): ver
 };
 
 /** ******************************************************************************************************************************
- * type guard function that redefines a TypeLayerEntryConfig as a TypeGeocoreLayerEntryConfig if the entryType attribute of
+ * type guard function that redefines a TypeLayerEntryConfig as a TypeGeoCoreLayerEntryConfig if the entryType attribute of
  * the verifyIfLayer parameter is 'geocore'. The type ascention applies only to the true block of the if clause that use
  * this function.
  *
@@ -619,7 +619,7 @@ export const layerEntryIsRasterTile = (verifyIfLayer: TypeLayerEntryConfig): ver
  *
  * @returns {boolean} true if the type ascention is valid.
  */
-export const layerEntryIsGeocore = (verifyIfLayer: TypeLayerEntryConfig): verifyIfLayer is TypeGeocoreLayerEntryConfig => {
+export const layerEntryIsGeocore = (verifyIfLayer: TypeLayerEntryConfig): verifyIfLayer is TypeGeoCoreLayerEntryConfig => {
   return verifyIfLayer?.entryType === ('geoCore' as TypeLayerEntryType);
 };
 
@@ -1385,7 +1385,7 @@ export class TypeTileLayerEntryConfig extends TypeBaseLayerEntryConfig {
  * Type used to define a GeoView layer where configration is extracted by a configuration snippet stored on a server. The server
  * configuration will handle bilangual informations.
  */
-export class TypeGeocoreLayerEntryConfig extends ConfigBaseClass {
+export class TypeGeoCoreLayerEntryConfig extends ConfigBaseClass {
   /** This attribute from ConfigBaseClass is not used by groups. */
   declare isMetadataLayerGroup: never;
 
@@ -1418,9 +1418,9 @@ export class TypeGeocoreLayerEntryConfig extends ConfigBaseClass {
 
   /**
    * The class constructor.
-   * @param {TypeGeocoreLayerEntryConfig} layerConfig The layer configuration we want to instanciate.
+   * @param {TypeGeoCoreLayerEntryConfig} layerConfig The layer configuration we want to instanciate.
    */
-  constructor(layerConfig: TypeGeocoreLayerEntryConfig) {
+  constructor(layerConfig: TypeGeoCoreLayerEntryConfig) {
     super(layerConfig);
     Object.assign(this, layerConfig);
   }
@@ -1531,7 +1531,7 @@ export type TypeLayerEntryConfig =
   | TypeImageStaticLayerEntryConfig
   | TypeTileLayerEntryConfig
   | TypeLayerGroupEntryConfig
-  | TypeGeocoreLayerEntryConfig;
+  | TypeGeoCoreLayerEntryConfig;
 
 /** ******************************************************************************************************************************
  * List of layers. Corresponds to the layerList defined in the schema.

--- a/packages/geoview-core/src/geo/utils/layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/layer-set.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
 import { EVENT_NAMES } from '@/api/events/event-types';
 import {
   LayerSetPayload,
@@ -144,6 +145,7 @@ export class LayerSet {
               };
               if (this.registrationUserInitialisation) this.registrationUserInitialisation(layerPath);
             } else if (action === 'remove' && layerPath in this.resultSet) {
+              MapEventProcessor.removeOrderedLayerInfo(this.mapId, layerPath);
               delete this.resultSet[layerPath];
             }
             api.event.emit(LayerSetPayload.createLayerSetUpdatedPayload(this.layerSetId, this.resultSet, layerPath));

--- a/packages/geoview-core/src/geo/utils/legends-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/legends-layer-set.ts
@@ -125,7 +125,9 @@ export class LegendsLayerSet extends LayerSet {
           const { layerPath } = payload;
           if (MapEventProcessor.getMapIndexFromOrderedLayerInfo(this.mapId, layerPath) === -1) {
             const layerConfig = api.maps[this.mapId].layer.registeredLayers[layerPath];
-            if (layerConfig.parentLayerConfig) {
+            if (MapEventProcessor.getMapIndexFromOrderedLayerInfo(this.mapId, layerPath.split('.')[1]) !== -1) {
+              MapEventProcessor.replaceOrderedLayerInfo(this.mapId, layerConfig, layerPath.split('.')[1]);
+            } else if (layerConfig.parentLayerConfig) {
               const parentLayerPathArray = layerPath.split('/');
               parentLayerPathArray.pop();
               const parentLayerPath = parentLayerPathArray.join('/');

--- a/packages/geoview-geochart/src/geochart-panel.tsx
+++ b/packages/geoview-geochart/src/geochart-panel.tsx
@@ -1,12 +1,12 @@
 import { useTheme } from '@mui/material/styles';
-import { TypeOrderedLayerInfo, TypeWindow, getLocalizedMessage } from 'geoview-core';
+import { TypeWindow, getLocalizedMessage } from 'geoview-core';
 import { ChartType, SchemaValidator } from 'geochart';
 import { LayerListEntry, Layout } from 'geoview-core/src/core/components/common';
 import { TypeLayerData, TypeArrayOfLayerData } from 'geoview-core/src/api/events/payloads/get-feature-info-payload';
 import { Typography } from 'geoview-core/src/ui/typography/typography';
 import { Paper } from 'geoview-core/src/ui';
 import {
-  useMapOrderedLayerInfo,
+  useMapVisibleLayers,
   useGeochartConfigs,
   useGeochartStoreActions,
   useGeochartStoreLayerDataArrayBatch,
@@ -42,7 +42,7 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
 
   // Get states and actions from store
   const configObj = useGeochartConfigs();
-  const orderedLayerInfo = useMapOrderedLayerInfo() as TypeOrderedLayerInfo[];
+  const visibleLayers = useMapVisibleLayers() as string[];
   const storeArrayOfLayerData = useGeochartStoreLayerDataArrayBatch() as TypeArrayOfLayerData;
   const selectedLayerPath = useGeochartStoreSelectedLayerPath() as string;
   const { setSelectedLayerPath, setLayerDataArrayBatchLayerPathBypass } = useGeochartStoreActions();
@@ -102,13 +102,6 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
     // Log
     logger.logTraceUseMemo('GEOCHART-PANEL - memoLayersList', storeArrayOfLayerData);
 
-    const visibleLayers = orderedLayerInfo
-      .map((layerInfo) => {
-        if (layerInfo.visible) return layerInfo.layerPath;
-        return undefined;
-      })
-      .filter((layerPath) => layerPath !== undefined);
-
     // Set the layers list
     return visibleLayers
       .map((layerPath) => storeArrayOfLayerData.find((layerData) => layerData.layerPath === layerPath))
@@ -125,7 +118,7 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
             tooltip: `${layer!.layerName}, ${getNumFeaturesLabel(layer!)}`,
           } as LayerListEntry)
       );
-  }, [orderedLayerInfo, storeArrayOfLayerData, configObj, getNumFeaturesLabel]);
+  }, [visibleLayers, storeArrayOfLayerData, configObj, getNumFeaturesLabel]);
 
   /**
    * Memoizes the selected layer for the LayerList component.

--- a/packages/geoview-time-slider/src/time-slider-panel.tsx
+++ b/packages/geoview-time-slider/src/time-slider-panel.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@mui/material/styles';
-import { TypeOrderedLayerInfo, TypeWindow, getLocalizedMessage } from 'geoview-core';
+import { TypeWindow, getLocalizedMessage } from 'geoview-core';
 import { LayerListEntry, Layout } from 'geoview-core/src/core/components/common';
-import { useMapOrderedLayerInfo, useTimeSliderLayers } from 'geoview-core/src/core/stores';
+import { useMapVisibleLayers, useTimeSliderLayers } from 'geoview-core/src/core/stores';
 import { Paper, Typography } from 'geoview-core/src/ui';
 import { logger } from 'geoview-core/src/core/utils/logger';
 
@@ -33,7 +33,7 @@ export function TimeSliderPanel(props: TypeTimeSliderProps): JSX.Element {
   const [selectedLayerPath, setSelectedLayerPath] = useState<string>();
 
   // get values from store
-  const orderedLayerInfo = useMapOrderedLayerInfo() as TypeOrderedLayerInfo[];
+  const visibleLayers = useMapVisibleLayers() as string[];
   const timeSliderLayers = useTimeSliderLayers();
 
   /**
@@ -53,13 +53,6 @@ export function TimeSliderPanel(props: TypeTimeSliderProps): JSX.Element {
     // Log
     logger.logTraceUseMemo('TIME-SLIDER-PANEL - memoLayersList', timeSliderLayers);
 
-    const visibleLayers = orderedLayerInfo
-      .map((layerInfo) => {
-        if (layerInfo.visible) return layerInfo.layerPath;
-        return undefined;
-      })
-      .filter((layerPath) => layerPath !== undefined);
-
     // Return the layers
     return visibleLayers
       .map((layerPath) => {
@@ -75,7 +68,7 @@ export function TimeSliderPanel(props: TypeTimeSliderProps): JSX.Element {
           queryStatus: 'processed',
         } as LayerListEntry;
       });
-  }, [orderedLayerInfo, timeSliderLayers]);
+  }, [visibleLayers, timeSliderLayers]);
 
   useEffect(() => {
     // Log


### PR DESCRIPTION
Closes #1852

# Description

Layer order now maintains geocore layers in the proper location when they switch to the actual layer type.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/all-layers.html
https://damonu2.github.io/geoview/geocore.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1861)
<!-- Reviewable:end -->
