### PR TITLE
1866-BUG-Bad_feature_info_propagation_to_store

### DIFF
--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -1005,7 +1005,7 @@ export abstract class AbstractGeoViewLayer {
     }
 
     if (!this.registerToLayerSetListenerFunctions[layerPath].queryLayer) {
-      if ('featureInfo' in layerConfig.source! && layerConfig.source.featureInfo?.queryable) {
+      if (layerConfig?.source?.featureInfo?.queryable) {
         // Listen to events that request to query a layer and return the resultset to the requester.
         this.registerToLayerSetListenerFunctions[layerPath].queryLayer = async (payload) => {
           // Log

--- a/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
@@ -113,7 +113,22 @@ export class FeatureInfoLayerSet extends LayerSet {
       // if layer's status flag exists and is different than the new one
       if (this.resultSet?.[layerPath]?.layerStatus && this.resultSet?.[layerPath]?.layerStatus !== layerStatus) {
         if (layerStatus === 'error') delete this.resultSet[layerPath];
-        else super.changeLayerStatusListenerFunctions(payload);
+        else {
+          const layerConfig = api.maps[this.mapId].layer.registeredLayers[layerPath];
+          super.changeLayerStatusListenerFunctions(payload);
+          if (this?.resultSet?.[layerPath]?.data?.click) {
+            this.resultSet[layerPath].data.click!.layerStatus = layerStatus;
+            FeatureInfoEventProcessor.propagateFeatureInfoToStore(this.mapId, layerConfig.layerPath, 'click', this.resultSet);
+          }
+          if (this?.resultSet?.[layerPath]?.data?.hover) {
+            this.resultSet[layerPath].data.hover!.layerStatus = layerStatus;
+            FeatureInfoEventProcessor.propagateFeatureInfoToStore(this.mapId, layerConfig.layerPath, 'hover', this.resultSet);
+          }
+          if (this?.resultSet?.[layerPath]?.data?.['all-features']) {
+            this.resultSet[layerPath].data['all-features']!.layerStatus = layerStatus;
+            FeatureInfoEventProcessor.propagateFeatureInfoToStore(this.mapId, layerConfig.layerPath, 'all-features', this.resultSet);
+          }
+        }
       }
     }
   }

--- a/packages/geoview-core/src/geo/utils/legends-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/legends-layer-set.ts
@@ -10,7 +10,7 @@ import {
   payloadIsLayerSetChangeLayerStatus,
   payloadIsLayerSetUpdated,
 } from '@/api/events/payloads';
-import { api } from '@/app';
+import { TypeBaseLayerEntryConfig, api } from '@/app';
 import { LayerSet } from './layer-set';
 import { LegendEventProcessor } from '@/api/event-processors/event-processor-children/legend-event-processor';
 import { logger } from '@/core/utils/logger';
@@ -75,6 +75,9 @@ export class LegendsLayerSet extends LayerSet {
         if (layerExists && ['processed', 'loaded'].includes(layerStatus) && this.resultSet?.[layerPath]?.querySent === false) {
           api.event.emit(GetLegendsPayload.createQueryLegendPayload(`${this.mapId}/${layerPath}`, layerPath));
           this.resultSet[layerPath].querySent = true;
+          // config file could not determine if the layer is queryable, can it be done using the metadata? let's try
+          const layerConfig = api.maps[this.mapId].layer.registeredLayers[layerPath];
+          layerConfig.geoviewLayerInstance?.registerToLayerSets(layerConfig as TypeBaseLayerEntryConfig);
         }
         if (layerExists || layerStatus === 'loaded')
           LegendEventProcessor.propagateLegendToStore(this.mapId, layerPath, this.resultSet[layerPath]);
@@ -91,7 +94,7 @@ export class LegendsLayerSet extends LayerSet {
       EVENT_NAMES.GET_LEGENDS.LEGEND_INFO,
       (payload) => {
         // Log
-        logger.logTraceCoreAPIEvent('legends-layer-set - GET_LEGENDS.LEGEND_INFO', this.mapId, payload);
+        logger.logTraceCoreAPIEvent('LEGENDS-LAYER-SET - GET_LEGENDS.LEGEND_INFO', this.mapId, payload);
 
         if (payloadIsLegendInfo(payload)) {
           const { layerPath, legendInfo } = payload;
@@ -116,7 +119,7 @@ export class LegendsLayerSet extends LayerSet {
       EVENT_NAMES.LAYER_SET.UPDATED,
       (payload) => {
         // Log
-        logger.logTraceCoreAPIEvent('legends-layer-set - LAYER_SET.UPDATED', this.mapId, payload);
+        logger.logTraceCoreAPIEvent('LEGENDS-LAYER-SET - LAYER_SET.UPDATED', this.mapId, payload);
 
         if (payloadIsLayerSetUpdated(payload)) {
           const { layerPath } = payload;


### PR DESCRIPTION
# Description

Modifications to the feature-info-event-processor and the legends-layer-set files to resolve the propagation issue. The problem was that the queryable flag of a layer, if not set in the config file, was known only when the metadata were loaded. At that point in time, the registration of the queryable layers from the config file was done, but those relying on the metadata were never registered. A call to registerToLayerSets was added in the LegendsLayerSet instance to register those layers  when the metadata are loded.

Fixes #1866

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

As usual, using the Chrome Devtools

__Deploy URL__: https://ychoquet.github.io/GeoView/all-layers.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1868)
<!-- Reviewable:end -->
