### PR TITLE
making popper dissapear on esc click

### DIFF
--- a/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
@@ -51,7 +51,6 @@ export default function Version(): JSX.Element {
       borderRadius: '5px',
       boxShadow: 2,
       marginLeft: '15px',
-      zIndex: 300,
       padding: '10px',
       '& a': {
         color: (theme: Theme) =>
@@ -84,7 +83,7 @@ export default function Version(): JSX.Element {
           </SvgIcon>
         </IconButton>
 
-        <Popper sx={{ zIndex: '150' }} open={open} anchorEl={anchorEl} placement="right-end" onClose={handleClickAway} container={mapElem}>
+        <Popper open={open} anchorEl={anchorEl} placement="right-end" onClose={handleClickAway} container={mapElem}>
           <Paper sx={sxClasses.versionInfoPanel}>
             <Typography sx={sxClasses.versionsInfoTitle} component="h3">
               {t('appbar.version')}

--- a/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
@@ -84,7 +84,7 @@ export default function Version(): JSX.Element {
           </SvgIcon>
         </IconButton>
 
-        <Popper sx={{ zIndex: '150' }} open={open} anchorEl={anchorEl} placement="right-end" container={mapElem}>
+        <Popper sx={{ zIndex: '150' }} open={open} anchorEl={anchorEl} placement="right-end" onClose={handleClickAway} container={mapElem}>
           <Paper sx={sxClasses.versionInfoPanel}>
             <Typography sx={sxClasses.versionsInfoTitle} component="h3">
               {t('appbar.version')}

--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -38,7 +38,14 @@ const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListIte
   const sxClasses = getSxClasses(theme);
   const { t } = useTranslation<string>();
 
-  const isDisabled = layer.numOffeatures === 0;
+  const isDisabled = layer?.numOffeatures === 0 || layer?.features === null;
+
+  const isLoading =
+    layer?.numOffeatures === 0 ||
+    layer?.features === null ||
+    layer.queryStatus === 'processing' ||
+    layer.layerStatus === 'loading' ||
+    layer.layerStatus === 'processing';
 
   const renderLayerIcon = () => {
     switch (layer.layerStatus) {
@@ -126,7 +133,7 @@ const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListIte
             <ListItemButton
               selected={isSelected}
               // disable when layer features has null value.
-              disabled={layer?.numOffeatures === 0 || layer?.features === null}
+              disabled={isDisabled || isLoading}
               onClick={() => onListItemClick(layer)}
             >
               {renderLayerIcon()}

--- a/packages/geoview-core/src/core/components/notifications/notifications.tsx
+++ b/packages/geoview-core/src/core/components/notifications/notifications.tsx
@@ -125,7 +125,7 @@ export default function Notifications(): JSX.Element {
           </IconButton>
         </Badge>
 
-        <Popper open={open} anchorEl={anchorEl} placement="right-end" container={mapElem}>
+        <Popper open={open} anchorEl={anchorEl} placement="right-end" onClose={handleClickAway} container={mapElem}>
           <Paper sx={sxClasses.notificationPanel}>
             <Typography component="h3" sx={sxClasses.notificationsTitle}>
               {t('appbar.notifications')}

--- a/packages/geoview-core/src/ui/popper/popper.tsx
+++ b/packages/geoview-core/src/ui/popper/popper.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/function-component-definition */
 import React, { useEffect, useRef } from 'react';
 import { Popper as MaterialPopper, PopperProps } from '@mui/material';
 
@@ -12,6 +11,7 @@ interface EnhancedPopperProps extends PopperProps {
  * @param {EnhancedPopperProps} props popover properties
  * @returns {JSX.Element} returns popover component
  */
+/* eslint-disable-next-line react/function-component-definition */
 export const Popper: React.FC<EnhancedPopperProps> = ({ open, onClose, ...restProps }) => {
   const popperRef = useRef<HTMLDivElement>(null);
 

--- a/packages/geoview-core/src/ui/popper/popper.tsx
+++ b/packages/geoview-core/src/ui/popper/popper.tsx
@@ -1,12 +1,34 @@
-/* eslint-disable react-hooks/exhaustive-deps */
+/* eslint-disable react/function-component-definition */
+import React, { useEffect, useRef } from 'react';
 import { Popper as MaterialPopper, PopperProps } from '@mui/material';
+
+interface EnhancedPopperProps extends PopperProps {
+  onClose?: () => void;
+}
 
 /**
  * Create a popover component
  *
- * @param {PopperProps} props popover properties
+ * @param {EnhancedPopperProps} props popover properties
  * @returns {JSX.Element} returns popover component
  */
-export function Popper(props: PopperProps): JSX.Element {
-  return <MaterialPopper {...props} />;
-}
+export const Popper: React.FC<EnhancedPopperProps> = ({ open, onClose, ...restProps }) => {
+  const popperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleEscapeKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && open && onClose) {
+        // Close the Popper when 'Escape' key is pressed
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscapeKey);
+
+    return () => {
+      document.removeEventListener('keydown', handleEscapeKey);
+    };
+  }, [open, onClose]);
+
+  return <MaterialPopper sx={{ zIndex: '150' }} {...restProps} open={open} ref={popperRef} />;
+};

--- a/packages/geoview-core/src/ui/popper/popper.tsx
+++ b/packages/geoview-core/src/ui/popper/popper.tsx
@@ -30,5 +30,5 @@ export const Popper: React.FC<EnhancedPopperProps> = ({ open, onClose, ...restPr
     };
   }, [open, onClose]);
 
-  return <MaterialPopper sx={{ zIndex: '150' }} {...restProps} open={open} ref={popperRef} />;
+  return <MaterialPopper sx={{ zIndex: '2000' }} {...restProps} open={open} ref={popperRef} />;
 };


### PR DESCRIPTION
# Description

This PR does two things;
* Make Popper dissapear when user click ESC key.
* Disable clicking layers when they are in loading mode.


Fixes #1870


https://cphelefu.github.io/geoview


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.


# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1869)
<!-- Reviewable:end -->
