### PR TITLE
fix(geochart-height) Make sure it overflows on Y on the grid container

### DIFF
--- a/packages/geoview-core/src/core/components/common/layout-style.ts
+++ b/packages/geoview-core/src/core/components/common/layout-style.ts
@@ -66,7 +66,7 @@ export const getSxClasses = (theme: Theme) => ({
     marginBottom: '9px',
     boxShadow: `0px 12px 9px -13px ${theme.palette.geoViewColor.bgColor.dark[200]}`,
   },
-  gridContainer: { paddingLeft: '1rem', paddingRight: '1rem' },
+  gridContainer: { paddingLeft: '1rem', paddingRight: '1rem', overflowY: 'auto' },
   listPrimaryText: {
     marginLeft: '0.62rem',
     minWidth: '0',

--- a/packages/geoview-core/src/core/components/common/responsive-grid.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid.tsx
@@ -109,7 +109,7 @@ const ResponsiveGridRightPanel = forwardRef(
         {...getRightPanelSize(fullWidth, isLayersPanelVisible, isEnlarged)}
         sx={{
           position: 'relative',
-          [theme.breakpoints.up('md')]: { paddingLeft: '1rem' },
+          [theme.breakpoints.up('md')]: { paddingLeft: '1rem', overflowY: 'auto' },
           ...(!fullWidth && { [theme.breakpoints.down('md')]: { display: !isLayersPanelVisible ? 'none' : 'block' } }),
           ...(fullWidth && { display: !isLayersPanelVisible ? 'none' : 'block' }),
           ...sxProps,


### PR DESCRIPTION
# Description

Make sure it overflows on Y on the grid container

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted here as of Feb 28 17h: https://alex-nrcan.github.io/geoview/package-footer-panel-geochart.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1876)
<!-- Reviewable:end -->
