### PR TITLE
fix appbar in mobile/small screens

### DIFF
--- a/packages/geoview-core/public/css/style.css
+++ b/packages/geoview-core/public/css/style.css
@@ -11,7 +11,7 @@ html {
 
 body {
   margin: 0;
-  padding: 50px;
+  padding: 0px 50px;
   background-color: #ffffff !important;
 }
 
@@ -69,6 +69,7 @@ td {
   text-align: center;
   position: absolute;
   left: 0;
+  font-size: 0.7rem !important;
 }
 
 .header-table {
@@ -77,17 +78,34 @@ td {
   margin: 0 auto;
 }
 
+.header-table > table:first-child {
+  width: 100%;
+}
+.header-table > table:first-child tr:first-child {
+  box-shadow: 0px 15px 10px -15px #2e2e2e;
+  background-color: #f8f8f8;
+  margin-bottom: 100px;
+  vertical-align: top;
+}
+
+.header-table > table:first-child tr:first-child td {
+  padding: 10px;
+}
+
+.header-table > table:first-child tr:nth-child(2) td {
+  padding-top: 40px;
+}
+
+img.header-logo {
+  height: 60px;
+  width: 60px;
+}
+
 .center-logo {
   margin-left: auto;
   margin-right: auto;
 }
 
-.header-logo {
-  display: block;
-  height: 120px;
-  width: 120px;
-  text-align: left;
-}
 
 .page-link {
   display: block;
@@ -209,4 +227,24 @@ table.state {
   body {
     padding: 2px; /* Adjust the value as needed */
   }
+
+  img.header-logo {
+    height: 40px;
+    width: 40px;
+  }
+
+  .header-title {
+    font-size: 0.6rem !important;
+  }
+
+  .header-table {
+    width: 100%;
+  }
+}
+
+@media only screen and (max-width: 300px) {
+  img.header-logo {
+    visibility: hidden; /* remove header image when screen is too small */
+  }
+
 }

--- a/packages/geoview-core/public/css/style.css
+++ b/packages/geoview-core/public/css/style.css
@@ -72,7 +72,7 @@ td {
 }
 
 .header-table {
-  width: 1180px;
+  width: 100%;
   text-align: left;
   margin: 0 auto;
 }
@@ -96,7 +96,7 @@ td {
 .geoview-map {
   height: 800px;
   border: gray 1px solid;
-
+  width: calc(100%);
 }
 
 

--- a/packages/geoview-core/src/ui/panel/panel.tsx
+++ b/packages/geoview-core/src/ui/panel/panel.tsx
@@ -69,6 +69,10 @@ export function Panel(props: TypePanelAppProps): JSX.Element {
     ...(panelStyles?.panelContainer && { ...panelStyles.panelContainer }),
     width: panelStatus ? panelWidth : 0,
     maxWidth: 400,
+    [theme.breakpoints.down('sm')]: {
+      width: 'calc(100% - 64px)',
+      maxWidth: 'calc(100% - 64px)',
+    },
     transition: `width ${theme.transitions.duration.standard}ms ease`,
     position: 'absolute',
     left: '64px',


### PR DESCRIPTION
# Description

This PR fixes how app-bar is displayed in small screens.

Fixes #1819 

This is what it looks like in mobile now.
![image](https://github.com/Canadian-Geospatial-Platform/geoview/assets/4933232/05cc8230-3c13-43cc-afa7-927054e5c17d)


Also notice the minor changes to the demo header (CSS changes). Now demo pages look like this at the top.

![image](https://github.com/Canadian-Geospatial-Platform/geoview/assets/4933232/68d42ceb-6844-4b83-b738-8433748a0c97)


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

__Add the URL for your deploy!__

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1895)
<!-- Reviewable:end -->
