### PR TITLE
fix(api) Fix the api leaking redundancy

### DIFF
--- a/packages/geoview-core/src/app.tsx
+++ b/packages/geoview-core/src/app.tsx
@@ -168,13 +168,7 @@ async function init(callback: () => void): Promise<void> {
 // cgpv object to be exported with the api for outside use
 export const cgpv: types.TypeCGPV = {
   init,
-  // TODO: Refactor - See if we can get rid of spreading the event and plugin inside the 'api' which causes leaking/duplication..
-  // TO.DOCONT: Why did we want it to be spreading? This causes duplications in the form of cgpv.api.event.emitXXX and cgpv.api.emitXXX?
-  api: types.Cast<API>({
-    ...api,
-    ...api.event,
-    ...api.plugin,
-  }),
+  api: types.Cast<API>(api),
   react: React,
   createRoot,
   ui: {


### PR DESCRIPTION
# Description

cgpv.api had the event and plugins spreaded on top of the api itself, causing redundancy. This PR fixes it and forces devs to use the correct object: cgpv.api.event or cgpv.api.plugin.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted as of March 13 16h30: https://alex-nrcan.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1920)
<!-- Reviewable:end -->
