### PR TITLE
1930-REFACTOR_geoviewLayer_using_layerPath

### DIFF
--- a/packages/geoview-core/public/templates/layers-temporal.html
+++ b/packages/geoview-core/public/templates/layers-temporal.html
@@ -222,34 +222,37 @@
     <script src="codedoc.js"></script>
     <script>
       // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
-      cgpv.init((mapId) => {
-        if (mapId === 'allMaps') {
-          var timeConsoleLyr1 = document.getElementById('LYR1TD');
-          var timeConsoleLyr2 = document.getElementById('LYR2TD');
-          var timeConsoleLyr3 = document.getElementById('LYR3TD');
-          timeConsoleLyr1.textContent = JSON.stringify(
-            cgpv.api.maps['LYR1'].layer
-              .geoviewLayer('wmsLYR1-Root/wmsLYR1-Group1/wmsLYR1-Group2/wmsLYR1-Group3/RADAR_1KM_RSNO.ending')
-              .getTemporalDimension(),
-            undefined,
-            2
-          );
-          timeConsoleLyr2.textContent = JSON.stringify(
-            cgpv.api.maps['LYR2'].layer.geoviewLayer('esriDynamicLYR3/0').getTemporalDimension(),
-            undefined,
-            2
-          );
-          timeConsoleLyr3.textContent = JSON.stringify(
-            cgpv.api.maps['LYR3'].layer.geoviewLayer('esriFeatureLYR4b/0').getTemporalDimension(),
-            undefined,
-            2
-          );
+      cgpv.init(
+        (mapId) => {},
+        (mapId) => {
+          if (mapId === 'allMaps') {
+            var timeConsoleLyr1 = document.getElementById('LYR1TD');
+            var timeConsoleLyr2 = document.getElementById('LYR2TD');
+            var timeConsoleLyr3 = document.getElementById('LYR3TD');
+            timeConsoleLyr1.textContent = JSON.stringify(
+              cgpv.api.maps['LYR1'].layer
+                .geoviewLayer('wmsLYR1-Root')
+                .getTemporalDimension('wmsLYR1-Root/wmsLYR1-Group1/wmsLYR1-Group2/wmsLYR1-Group3/RADAR_1KM_RSNO'),
+              undefined,
+              2
+            );
+            timeConsoleLyr2.textContent = JSON.stringify(
+              cgpv.api.maps['LYR2'].layer.geoviewLayer('esriDynamicLYR3/0').getTemporalDimension('esriDynamicLYR3/0'),
+              undefined,
+              2
+            );
+            timeConsoleLyr3.textContent = JSON.stringify(
+              cgpv.api.maps['LYR3'].layer.geoviewLayer('esriFeatureLYR4b/0').getTemporalDimension('esriFeatureLYR4b/0'),
+              undefined,
+              2
+            );
 
-          // create snippets
-          createCodeSnippet();
-          createConfigSnippet();
+            // create snippets
+            createCodeSnippet();
+            createConfigSnippet();
+          }
         }
-      });
+      );
     </script>
   </body>
 </html>

--- a/packages/geoview-core/public/templates/layers/esri-dynamic.html
+++ b/packages/geoview-core/public/templates/layers/esri-dynamic.html
@@ -885,7 +885,7 @@
                           'label': '0.0001 - ≤ 5,000,000 m3',
                           'minValue': 0,
                           'maxValue': 5000000,
-                          'visible': 'yes',
+                          'visible': true,
                           'settings': {
                             'symbol': 'circle',
                             'type': 'simpleSymbol',
@@ -923,7 +923,7 @@
                           'label': '> 10,000,000 - ≤ 15,000,000 m3',
                           'minValue': 10000000,
                           'maxValue': 15000000,
-                          'visible': 'yes',
+                          'visible': true,
                           'settings': {
                             'symbol': 'circle',
                             'type': 'simpleSymbol',
@@ -942,7 +942,7 @@
                           'label': '> 15,000,000 - ≤ 20,000,000 m3',
                           'minValue': 15000000,
                           'maxValue': 20000000,
-                          'visible': 'yes',
+                          'visible': true,
                           'settings': {
                             'symbol': 'circle',
                             'type': 'simpleSymbol',
@@ -961,7 +961,7 @@
                           'label': '> 20,000,000 - ≤ 25,000,000 m3',
                           'minValue': 20000000,
                           'maxValue': 25000000,
-                          'visible': 'yes',
+                          'visible': true,
                           'settings': {
                             'symbol': 'circle',
                             'type': 'simpleSymbol',
@@ -980,7 +980,7 @@
                           'label': '> 25,000,000 - ≤ 30,000,000 m3',
                           'minValue': 25000000,
                           'maxValue': 30000000,
-                          'visible': 'yes',
+                          'visible': true,
                           'settings': {
                             'symbol': 'circle',
                             'type': 'simpleSymbol',
@@ -999,7 +999,7 @@
                           'label': '> 30,000,000 - ≤ 35,000,000 m3',
                           'minValue': 30000000,
                           'maxValue': 35000000,
-                          'visible': 'yes',
+                          'visible': true,
                           'settings': {
                             'symbol': 'circle',
                             'type': 'simpleSymbol',
@@ -1018,7 +1018,7 @@
                           'label': '> 35,000,000 m3',
                           'minValue': 35000000,
                           'maxValue': 999000000,
-                          'visible': 'yes',
+                          'visible': true,
                           'settings': {
                             'symbol': 'circle',
                             'type': 'simpleSymbol',
@@ -1094,66 +1094,6 @@
           listenToLegendLayerSetChanges('HLYR3-state', 'LYR3');
           listenToLegendLayerSetChanges('HLYR4-state', 'LYR4');
 
-          if (cgpv.api.maps.LYR2.layer.registeredLayers['historical-flood/0'].layerStatus === 'loaded') {
-            const field1 = cgpv.api.maps.LYR2.layer.geoviewLayer('historical-flood/0').getTemporalDimension().field;
-            const LYR2_FILTERS = [`${field1} >= date '01/01/2018 05:00:00' and ${field1} <= date '12/31/2019 19:00:00-05:00'`,
-                                  `${field1} > date '01/01/2018 05:00:00' and ${field1} <= date '01/01/2020 05:00:00Z'`,
-                                  `${field1} >= date '01/01/2018 05:00:00' and ${field1} < date '01/01/2020 00:00:00+05:00'`];
-            let i = 0;
-            window.setInterval(() => {
-              const input = document.getElementById('filter-input-LYR2-historical-flood');
-              if (input) {
-                input.value = LYR2_FILTERS[i];
-                const layerConfig = cgpv.api.maps.LYR2.layer.registeredLayers['historical-flood/0'];
-                const checkbox = document.getElementById('checkbox-LYR2-historical-flood');
-                cgpv.api.maps.LYR2.layer.geoviewLayer('historical-flood/0').applyViewFilter(
-                  LYR2_FILTERS[i],
-                  checkbox.value !== 'true'
-                );
-                if (++i === LYR2_FILTERS.length) i = 0;
-              }
-            }, 3000)
-          }
-
-          if (cgpv.api.maps.LYR3.layer.registeredLayers['historical-flood/0'].layerStatus === 'loaded') {
-            const field2 = cgpv.api.maps.LYR3.layer.geoviewLayer('historical-flood/0').getTemporalDimension().field;
-            const LYR3_FILTERS = [`${field2} >= date '2018-01-01T00:00:00' and ${field2} <= date '2020-01-01T00:00:00'`,
-                                `${field2} > date '2018-01-01T00:00:00' and ${field2} <= date '2020-01-01T00:00:00'`,
-                                `${field2} >= date '2018-01-01T00:00:00' and ${field2} < date '2020-01-01T00:00:00'`];
-            let j = 0;
-            window.setInterval(() => {
-              const input = document.getElementById('filter-input-LYR3-historical-flood');
-              if (input) {
-                input.value = LYR3_FILTERS[j];
-                const layerConfig = cgpv.api.maps.LYR3.layer.registeredLayers['historical-flood/0'];
-                const checkbox = document.getElementById('checkbox-LYR3-historical-flood');
-                cgpv.api.maps.LYR3.layer.geoviewLayer('historical-flood/0').applyViewFilter(
-                  LYR3_FILTERS[j],
-                  checkbox.value !== 'true'
-                );
-                if (++j === LYR3_FILTERS.length) j = 0;
-              }
-            }, 3000)
-          }
-
-          if (cgpv.api.maps.LYR1.layer.registeredLayers['esriFeatureLYR1/0'].layerStatus === 'loaded') {
-            let k = 0;
-            window.setInterval(() => {
-              const input = document.getElementById('filter-input-LYR1-esriFeatureLYR1');
-              if (input) {
-                const layerConfig = cgpv.api.maps.LYR1.layer.registeredLayers['esriFeatureLYR1/0'];
-                const checkbox = document.getElementById('checkbox-LYR1-esriFeatureLYR1');
-                const temporalData = cgpv.api.maps.LYR1.layer.geoviewLayer('esriFeatureLYR1/0').getTemporalDimension();
-                cgpv.api.maps.LYR1.layer.geoviewLayer('esriFeatureLYR1/0').applyViewFilter(
-                  `Date < date '${temporalData.range.range[k]}'`,
-                  checkbox.value !== 'true'
-                );
-                input.value = `Date < date '${temporalData.range.range[k]}'`;
-                if (++k === temporalData.range.range.length) k = 0;
-              }
-            }, 1000)
-          }
-
           // create snippets
           createCodeSnippet();
           createConfigSnippet();
@@ -1164,6 +1104,60 @@
           createTableOfFilter('LYR1');
           createTableOfFilter('LYR2');
           createTableOfFilter('LYR3');
+
+          const field1 = cgpv.api.maps.LYR2.layer.geoviewLayer('historical-flood/0').getTemporalDimension('historical-flood/0').field;
+          const LYR2_FILTERS = [`${field1} >= date '01/01/2018 05:00:00' and ${field1} <= date '12/31/2019 19:00:00-05:00'`,
+                                `${field1} > date '01/01/2018 05:00:00' and ${field1} <= date '01/01/2020 05:00:00Z'`,
+                                `${field1} >= date '01/01/2018 05:00:00' and ${field1} < date '01/01/2020 00:00:00+05:00'`];
+          let i = 0;
+          window.setInterval(() => {
+            const input = document.getElementById('filter-input-LYR2-historical-flood');
+            if (input) {
+              input.value = LYR2_FILTERS[i];
+              const layerConfig = cgpv.api.maps.LYR2.layer.registeredLayers['historical-flood/0'];
+              const checkbox = document.getElementById('checkbox-LYR2-historical-flood');
+              cgpv.api.maps.LYR2.layer.geoviewLayer('historical-flood/0').applyViewFilter('historical-flood/0',
+                LYR2_FILTERS[i],
+                checkbox.value !== 'true'
+              );
+              if (++i === LYR2_FILTERS.length) i = 0;
+            }
+          }, 3000)
+
+          const field2 = cgpv.api.maps.LYR3.layer.geoviewLayer('historical-flood/0').getTemporalDimension('historical-flood/0').field;
+          const LYR3_FILTERS = [`${field2} >= date '2018-01-01T00:00:00' and ${field2} <= date '2020-01-01T00:00:00'`,
+                              `${field2} > date '2018-01-01T00:00:00' and ${field2} <= date '2020-01-01T00:00:00'`,
+                              `${field2} >= date '2018-01-01T00:00:00' and ${field2} < date '2020-01-01T00:00:00'`];
+          let j = 0;
+          window.setInterval(() => {
+            const input = document.getElementById('filter-input-LYR3-historical-flood');
+            if (input) {
+              input.value = LYR3_FILTERS[j];
+              const layerConfig = cgpv.api.maps.LYR3.layer.registeredLayers['historical-flood/0'];
+              const checkbox = document.getElementById('checkbox-LYR3-historical-flood');
+              cgpv.api.maps.LYR3.layer.geoviewLayer('historical-flood/0').applyViewFilter('historical-flood/0',
+                LYR3_FILTERS[j],
+                checkbox.value !== 'true'
+              );
+              if (++j === LYR3_FILTERS.length) j = 0;
+            }
+          }, 3000)
+
+          let k = 0;
+          window.setInterval(() => {
+            const input = document.getElementById('filter-input-LYR1-esriFeatureLYR1');
+            if (input) {
+              const layerConfig = cgpv.api.maps.LYR1.layer.registeredLayers['esriFeatureLYR1/0'];
+              const checkbox = document.getElementById('checkbox-LYR1-esriFeatureLYR1');
+              const temporalData = cgpv.api.maps.LYR1.layer.geoviewLayer('esriFeatureLYR1/0').getTemporalDimension('esriFeatureLYR1/0');
+              cgpv.api.maps.LYR1.layer.geoviewLayer('esriFeatureLYR1/0').applyViewFilter('esriFeatureLYR1/0',
+                `Date < date '${temporalData.range.range[k]}'`,
+                checkbox.value !== 'true'
+              );
+              input.value = `Date < date '${temporalData.range.range[k]}'`;
+              if (++k === temporalData.range.range.length) k = 0;
+            }
+          }, 1000)
         }
       });
     </script>

--- a/packages/geoview-core/public/templates/layers/esri-feature.html
+++ b/packages/geoview-core/public/templates/layers/esri-feature.html
@@ -406,7 +406,7 @@
           createTableOfFilter('LYR3');
 
           if (cgpv.api.maps?.LYR2?.layer?.registeredLayers?.['historical-flood/0']?.layerStatus === 'loaded') {
-            const field2 = cgpv.api.maps.LYR2.layer.geoviewLayer('historical-flood/0').getTemporalDimension().field;
+            const field2 = cgpv.api.maps.LYR2.layer.geoviewLayer('historical-flood/0').getTemporalDimension('historical-flood/0').field;
             const LYR2_FILTERS = [`${field2} >= date '01/01/2018 05:00:00' and ${field2} <= date '12/31/2019 19:00:00-05:00'`,
                                   `${field2} > date '01/01/2018 05:00:00' and ${field2} <= date '01/01/2020 05:00:00Z'`,
                                   `${field2} >= date '01/01/2018 05:00:00' and ${field2} < date '01/01/2020 00:00:00+05:00'`];
@@ -417,7 +417,7 @@
                 input.value = LYR2_FILTERS[i];
                 const layerConfig = cgpv.api.maps.LYR2.layer.registeredLayers['historical-flood/0'];
                 const checkbox = document.getElementById('checkbox-LYR2-historical-flood');
-                cgpv.api.maps.LYR2.layer.geoviewLayer('historical-flood/0').applyViewFilter(
+                cgpv.api.maps.LYR2.layer.geoviewLayer('historical-flood/0').applyViewFilter('historical-flood/0',
                   LYR2_FILTERS[i],
                   checkbox.value !== 'true'
                 );
@@ -427,7 +427,7 @@
           }
 
           if (cgpv.api.maps?.LYR3?.layer?.registeredLayers?.['historical-flood/0']?.layerStatus === 'loaded') {
-            const field3 = cgpv.api.maps.LYR3.layer.geoviewLayer('historical-flood/0').getTemporalDimension().field;
+            const field3 = cgpv.api.maps.LYR3.layer.geoviewLayer('historical-flood/0').getTemporalDimension('historical-flood/0').field;
             const LYR3_FILTERS = [`${field3} >= date '2018-01-01T00:00:00' and ${field3} <= date '2020-01-01T00:00:00'`,
                                   `${field3} > date '2018-01-01T00:00:00' and ${field3} <= date '2020-01-01T00:00:00'`,
                                   `${field3} >= date '2018-01-01T00:00:00' and ${field3} < date '2020-01-01T00:00:00'`];
@@ -438,7 +438,7 @@
                 input.value = LYR3_FILTERS[j];
                 const layerConfig = cgpv.api.maps.LYR3.layer.registeredLayers['historical-flood/0'];
                 const checkbox = document.getElementById('checkbox-LYR3-historical-flood');
-                cgpv.api.maps.LYR3.layer.geoviewLayer('historical-flood/0').applyViewFilter(
+                cgpv.api.maps.LYR3.layer.geoviewLayer('historical-flood/0').applyViewFilter('historical-flood/0',
                   LYR3_FILTERS[j],
                   checkbox.value !== 'true'
                 );
@@ -454,8 +454,8 @@
               if (input) {
                 const layerConfig = cgpv.api.maps.LYR1.layer.registeredLayers['esriFeatureLYR1/0'];
                 const checkbox = document.getElementById('checkbox-LYR1-esriFeatureLYR1');
-                const temporalData = cgpv.api.maps.LYR1.layer.geoviewLayer('esriFeatureLYR1/0').getTemporalDimension();
-                cgpv.api.maps.LYR1.layer.geoviewLayer('esriFeatureLYR1/0').applyViewFilter(
+                const temporalData = cgpv.api.maps.LYR1.layer.geoviewLayer('esriFeatureLYR1/0').getTemporalDimension('esriFeatureLYR1/0');
+                cgpv.api.maps.LYR1.layer.geoviewLayer('esriFeatureLYR1/0').applyViewFilter('esriFeatureLYR1/0',
                   `Date < date '${temporalData.range.range[k]}'`,
                   checkbox.value !== 'true'
                 );

--- a/packages/geoview-core/public/templates/layers/wms.html
+++ b/packages/geoview-core/public/templates/layers/wms.html
@@ -620,55 +620,6 @@
           listenToLegendLayerSetChanges('HLYR4-state', 'LYR4');
           listenToLegendLayerSetChanges('HLYR5-state', 'LYR5');
 
-          const intervalId = window.setInterval(() => {
-            // If metadata are processed
-            if (cgpv.api.maps.LYR3?.layer?.geoviewLayers?.['wmsLYR3-Root']?.allLayerStatusAreGreaterThanOrEqualTo('processed')) {
-              const lyr3LayerConfig = cgpv.api.maps.LYR3.layer.registeredLayers['wmsLYR3-Root/landcover_2015_19classes'];
-              if (Array.isArray(lyr3LayerConfig?.source?.style)) {
-                const dropDownContent = document.getElementById('style');
-                lyr3LayerConfig.source.style.forEach((style) => {
-                  element = document.createElement('option');
-                  element.value = style;
-                  element.innerText = style;
-                  dropDownContent.appendChild(element);
-                });
-                dropDownContent.addEventListener('click', (e) => {
-                  cgpv.api.maps.LYR3.layer.geoviewLayers['wmsLYR3-Root'].setStyle(
-                    dropDownContent.value,
-                    'wmsLYR3-Root/landcover_2015_19classes'
-                  );
-                });
-              }
-              clearInterval(intervalId);
-            }
-          }, 1000);
-
-          // ========================================================================================================================
-          // Cycle through the temporal data
-          let i = 0;
-          window.setInterval(() => {
-            const layerConfig = cgpv.api.maps.LYR1.layer.registeredLayers['wmsLYR1-spatiotemporel/RADAR_1KM_RSNO'];
-            const temporalData = cgpv.api.maps.LYR1.layer.geoviewLayer('wmsLYR1-spatiotemporel/RADAR_1KM_RSNO').getTemporalDimension();
-            if (temporalData) {
-              cgpv.api.maps.LYR1.layer.geoviewLayer('wmsLYR1-spatiotemporel/RADAR_1KM_RSNO').applyViewFilter(
-                `time=date '${temporalData.range.range[i]}'`
-              );
-              if (++i === temporalData.range.range.length) i = 0;
-            }
-          }, 2500);
-
-          let j = 0;
-          window.setInterval(() => {
-            const layerConfig = cgpv.api.maps.LYR1.layer.registeredLayers['wmsLYR1-msi/msi-94-or-more'];
-            const temporalData = cgpv.api.maps.LYR1.layer.geoviewLayer('wmsLYR1-msi/msi-94-or-more').getTemporalDimension();
-            if (temporalData) {
-              cgpv.api.maps.LYR1.layer.geoviewLayer('wmsLYR1-msi/msi-94-or-more').applyViewFilter(
-                `time=date '${temporalData.range.range[j]}'`
-              );
-              if (++j === temporalData.range.range.length) j = 0;
-            }
-          }, 2500);
-
           // create snippets
           createCodeSnippet();
           createConfigSnippet();
@@ -679,7 +630,53 @@
           createTableOfFilter('LYR1');
           createTableOfFilter('LYR2');
           createTableOfFilter('LYR4');
-        }
+
+          const intervalId = window.setInterval(() => {
+            const lyr3LayerConfig = cgpv.api.maps.LYR3.layer.registeredLayers['wmsLYR3-Root/landcover_2015_19classes'];
+            if (Array.isArray(lyr3LayerConfig?.source?.style)) {
+              const dropDownContent = document.getElementById('style');
+              lyr3LayerConfig.source.style.forEach((style) => {
+                element = document.createElement('option');
+                element.value = style;
+                element.innerText = style;
+                dropDownContent.appendChild(element);
+              });
+              dropDownContent.addEventListener('click', (e) => {
+                cgpv.api.maps.LYR3.layer.geoviewLayers['wmsLYR3-Root'].setStyle(
+                  dropDownContent.value,
+                  'wmsLYR3-Root/landcover_2015_19classes'
+                );
+              });
+            }
+            clearInterval(intervalId);
+          }, 1000);
+
+          // ========================================================================================================================
+          // Cycle through the temporal data
+          let i = 0;
+          window.setInterval(() => {
+            const layerConfig = cgpv.api.maps.LYR1.layer.registeredLayers['wmsLYR1-spatiotemporel/RADAR_1KM_RSNO'];
+            const temporalData = cgpv.api.maps.LYR1.layer.geoviewLayer('wmsLYR1-spatiotemporel/RADAR_1KM_RSNO').getTemporalDimension('wmsLYR1-spatiotemporel/RADAR_1KM_RSNO');
+            if (temporalData) {
+              cgpv.api.maps.LYR1.layer.geoviewLayer('wmsLYR1-spatiotemporel/RADAR_1KM_RSNO').applyViewFilter('wmsLYR1-spatiotemporel/RADAR_1KM_RSNO',
+                `time=date '${temporalData.range.range[i]}'`
+              );
+              if (++i === temporalData.range.range.length) i = 0;
+            }
+          }, 2500);
+
+          let j = 0;
+          window.setInterval(() => {
+            const layerConfig = cgpv.api.maps.LYR1.layer.registeredLayers['wmsLYR1-msi/msi-94-or-more'];
+            const temporalData = cgpv.api.maps.LYR1.layer.geoviewLayer('wmsLYR1-msi/msi-94-or-more').getTemporalDimension('wmsLYR1-msi/msi-94-or-more');
+            if (temporalData) {
+              cgpv.api.maps.LYR1.layer.geoviewLayer('wmsLYR1-msi/msi-94-or-more').applyViewFilter('wmsLYR1-msi/msi-94-or-more',
+                `time=date '${temporalData.range.range[j]}'`
+              );
+              if (++j === temporalData.range.range.length) j = 0;
+            }
+          }, 2500);
+       }
       });
 
       // ========================================================================================================================

--- a/packages/geoview-core/public/templates/raw-feature-info.html
+++ b/packages/geoview-core/public/templates/raw-feature-info.html
@@ -405,7 +405,7 @@
             {
               'geoviewLayerId': 'geojsonLYR1',
               'geoviewLayerName': { 'en': 'GeoJSON Sample', 'fr': 'GeoJSON Échantillon' },
-              'metadataAccessPath': { 'en': './geojson/metadata.json', 'fr': './geojson/metadata.json' },
+              'metadataAccessPath': { 'en': './datasets/geojson/metadata.json', 'fr': './datasets/geojson/metadata.json' },
               'geoviewLayerType': 'GeoJSON',
               'listOfLayerEntryConfig': [
                 {
@@ -473,88 +473,130 @@
     <script src="codedoc.js"></script>
     <script>
       // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
-      cgpv.init((mapId) => {
-        if (mapId === 'allMaps') {
-          // ========================================================================================================================
-          // Test enable/disable click and hover on layer
-          const fillTableRow = (key, tableId, disableButtonEnding, enableButtonEnding, textEnding) => {
-            const clickTable = document.getElementById(tableId);
-            const tableRowElement = document.createElement('tr');
-            tableRowElement.classList.add('info');
-            clickTable.appendChild(tableRowElement);
-            const tableDataButtons = document.createElement('td');
-            tableDataButtons.classList.add('info');
-            tableDataButtons.style.width = '15%';
-            tableRowElement.appendChild(tableDataButtons);
-            const buttonEnableElement = document.createElement('button');
-            buttonEnableElement.id = `${key}-${enableButtonEnding}`;
-            buttonEnableElement.innerText = 'Enable';
-            tableDataButtons.appendChild(buttonEnableElement);
-            const buttonDisableElement = document.createElement('button');
-            buttonDisableElement.id = `${key}-${disableButtonEnding}`;
-            buttonDisableElement.innerText = 'Disable';
-            tableDataButtons.appendChild(buttonDisableElement);
-            const tableDataText = document.createElement('td');
-            tableDataText.id = `${key}-${textEnding}`;
-            tableDataText.classList.add('info');
-            tableDataText.style.width = '85%';
-            tableRowElement.appendChild(tableDataText);
-            if (key === 'all')
-              configureTableRow(true, tableDataText.id, 'All layers are', buttonDisableElement.id, buttonEnableElement.id, '');
-            else configureTableRow(true, tableDataText.id, `layer "${key}" is`, buttonDisableElement.id, buttonEnableElement.id, key);
-          };
+      cgpv.init(
+        (mapId) => {
+          if (mapId === 'allMaps') {
+            // create snippets
+            createCodeSnippet();
+            createConfigSnippet();
+          }
+        },
+        (mapId) => {
+          if (mapId === 'allMaps') {
+            // ========================================================================================================================
+            // Test enable/disable click and hover on layer
+            const fillTableRow = (key, tableId, disableButtonEnding, enableButtonEnding, textEnding) => {
+              const clickTable = document.getElementById(tableId);
+              const tableRowElement = document.createElement('tr');
+              tableRowElement.classList.add('info');
+              clickTable.appendChild(tableRowElement);
+              const tableDataButtons = document.createElement('td');
+              tableDataButtons.classList.add('info');
+              tableDataButtons.style.width = '15%';
+              tableRowElement.appendChild(tableDataButtons);
+              const buttonEnableElement = document.createElement('button');
+              buttonEnableElement.id = `${key}-${enableButtonEnding}`;
+              buttonEnableElement.innerText = 'Enable';
+              tableDataButtons.appendChild(buttonEnableElement);
+              const buttonDisableElement = document.createElement('button');
+              buttonDisableElement.id = `${key}-${disableButtonEnding}`;
+              buttonDisableElement.innerText = 'Disable';
+              tableDataButtons.appendChild(buttonDisableElement);
+              const tableDataText = document.createElement('td');
+              tableDataText.id = `${key}-${textEnding}`;
+              tableDataText.classList.add('info');
+              tableDataText.style.width = '85%';
+              tableRowElement.appendChild(tableDataText);
+              if (key === 'all')
+                configureTableRow(true, tableDataText.id, 'All layers are', buttonDisableElement.id, buttonEnableElement.id, '');
+              else configureTableRow(true, tableDataText.id, `layer "${key}" is`, buttonDisableElement.id, buttonEnableElement.id, key);
+            };
 
-          const getEventListenerFunctions = (clickFlag) => {
-            if (clickFlag.endsWith('click-text')) {
-              return [
-                cgpv.api.maps['mapWM1'].layer.featureInfoLayerSet.isClickListenerEnabled,
-                cgpv.api.maps['mapWM1'].layer.featureInfoLayerSet.disableClickListener,
-                cgpv.api.maps['mapWM1'].layer.featureInfoLayerSet.enableClickListener,
-                cgpv.api.maps['mapWM1'].layer.featureInfoLayerSet,
-              ];
-            } else {
-              return [
-                cgpv.api.maps['mapWM1'].layer.hoverFeatureInfoLayerSet.isHoverListenerEnabled,
-                cgpv.api.maps['mapWM1'].layer.hoverFeatureInfoLayerSet.disableHoverListener,
-                cgpv.api.maps['mapWM1'].layer.hoverFeatureInfoLayerSet.enableHoverListener,
-                cgpv.api.maps['mapWM1'].layer.hoverFeatureInfoLayerSet,
-              ];
-            }
-          };
+            const getEventListenerFunctions = (clickFlag) => {
+              if (clickFlag.endsWith('click-text')) {
+                return [
+                  cgpv.api.maps['mapWM1'].layer.featureInfoLayerSet.isClickListenerEnabled,
+                  cgpv.api.maps['mapWM1'].layer.featureInfoLayerSet.disableClickListener,
+                  cgpv.api.maps['mapWM1'].layer.featureInfoLayerSet.enableClickListener,
+                  cgpv.api.maps['mapWM1'].layer.featureInfoLayerSet,
+                ];
+              } else {
+                return [
+                  cgpv.api.maps['mapWM1'].layer.hoverFeatureInfoLayerSet.isHoverListenerEnabled,
+                  cgpv.api.maps['mapWM1'].layer.hoverFeatureInfoLayerSet.disableHoverListener,
+                  cgpv.api.maps['mapWM1'].layer.hoverFeatureInfoLayerSet.enableHoverListener,
+                  cgpv.api.maps['mapWM1'].layer.hoverFeatureInfoLayerSet,
+                ];
+              }
+            };
 
-          const configureTableRow = (setClickListener, textCellId, text, disableId, enableId, layerPath) => {
-            const [isEventListenerEnabled, disableEventListener, enableEventListener, layerSet] = getEventListenerFunctions(textCellId);
-            const textCell = document.getElementById(textCellId);
-            const layerFlagDisabled = !isEventListenerEnabled.call(layerSet, layerPath);
-            const disableButton = document.getElementById(disableId);
-            const enableButton = document.getElementById(enableId);
-            if (setClickListener) {
-              disableButton.addEventListener('click', (e) => {
-                disableEventListener.call(layerSet, layerPath);
-                updateButtonTable();
+            const configureTableRow = (setClickListener, textCellId, text, disableId, enableId, layerPath) => {
+              const [isEventListenerEnabled, disableEventListener, enableEventListener, layerSet] = getEventListenerFunctions(textCellId);
+              const textCell = document.getElementById(textCellId);
+              const layerFlagDisabled = !isEventListenerEnabled.call(layerSet, layerPath);
+              const disableButton = document.getElementById(disableId);
+              const enableButton = document.getElementById(enableId);
+              if (setClickListener) {
+                disableButton.addEventListener('click', (e) => {
+                  disableEventListener.call(layerSet, layerPath);
+                  updateButtonTable();
+                });
+                enableButton.addEventListener('click', (e) => {
+                  enableEventListener.call(layerSet, layerPath);
+                  updateButtonTable();
+                });
+              }
+
+              if (layerFlagDisabled === undefined) {
+                disableButton.disabled = false;
+                enableButton.disabled = false;
+                textCell.innerText = 'The map contains a mix of enabled/disabled layers';
+              } else if (layerFlagDisabled) {
+                disableButton.disabled = true;
+                enableButton.disabled = false;
+                textCell.innerText = `${text} disabled`;
+              } else {
+                disableButton.disabled = false;
+                enableButton.disabled = true;
+                textCell.innerText = `${text} enabled`;
+              }
+            };
+
+            const updateButtonTable = () => {
+              const registeredLayers = cgpv.api.maps.mapWM1?.layer?.registeredLayers;
+              let firstpass = true;
+              Object.keys(registeredLayers).forEach((key) => {
+                if (['processed', 'loaded'].includes(registeredLayers[key].layerStatus)) {
+                  const queryable = registeredLayers[key]?.source?.featureInfo?.queryable ?? true;
+                  const isNotGroupLayerEntry = registeredLayers[key]?.entryType !== 'group';
+                  if (queryable && isNotGroupLayerEntry) {
+                    if (firstpass) {
+                      firstpass = false;
+                      configureTableRow(false, 'all-click-text', 'All layers are', 'all-click-disable', 'all-click-enable', '');
+                      configureTableRow(false, 'all-hover-text', 'All layers are', 'all-hover-disable', 'all-hover-enable', '');
+                    }
+                    configureTableRow(false, `${key}-click-text`, `layer "${key}" is`, `${key}-click-disable`, `${key}-click-enable`, key);
+                    configureTableRow(false, `${key}-hover-text`, `layer "${key}" is`, `${key}-hover-disable`, `${key}-hover-enable`, key);
+                  }
+                }
               });
-              enableButton.addEventListener('click', (e) => {
-                enableEventListener.call(layerSet, layerPath);
-                updateButtonTable();
-              });
-            }
+            };
 
-            if (layerFlagDisabled === undefined) {
-              disableButton.disabled = false;
-              enableButton.disabled = false;
-              textCell.innerText = 'The map contains a mix of enabled/disabled layers';
-            } else if (layerFlagDisabled) {
-              disableButton.disabled = true;
-              enableButton.disabled = false;
-              textCell.innerText = `${text} disabled`;
-            } else {
-              disableButton.disabled = false;
-              enableButton.disabled = true;
-              textCell.innerText = `${text} enabled`;
-            }
-          };
-
-          const updateButtonTable = () => {
+            const displayField = document.getElementById('buttonTable');
+            displayField.innerHTML = `<table id="buttonTable" style="width:100%">
+              <tr>
+                <th style="width:50%", class="info">Click event listener</th>
+                <th style="width:50%", class="info">Hover event listener</th>
+              </tr>
+              <tr>
+                <td class="info">
+                  <table id="click-table", class="info", style="width:100%"></table>
+                </td>
+                <td class="info">
+                  <table id="hover-table", class="info", style="width:100%"></table>
+                </td>
+              </tr>
+            </table>`;
             const registeredLayers = cgpv.api.maps.mapWM1?.layer?.registeredLayers;
             let firstpass = true;
             Object.keys(registeredLayers).forEach((key) => {
@@ -564,54 +606,17 @@
                 if (queryable && isNotGroupLayerEntry) {
                   if (firstpass) {
                     firstpass = false;
-                    configureTableRow(false, 'all-click-text', 'All layers are', 'all-click-disable', 'all-click-enable', '');
-                    configureTableRow(false, 'all-hover-text', 'All layers are', 'all-hover-disable', 'all-hover-enable', '');
+                    fillTableRow('all', 'click-table', 'click-disable', 'click-enable', 'click-text');
+                    fillTableRow('all', 'hover-table', 'hover-disable', 'hover-enable', 'hover-text');
                   }
-                  configureTableRow(false, `${key}-click-text`, `layer "${key}" is`, `${key}-click-disable`, `${key}-click-enable`, key);
-                  configureTableRow(false, `${key}-hover-text`, `layer "${key}" is`, `${key}-hover-disable`, `${key}-hover-enable`, key);
+                  fillTableRow(key, 'click-table', 'click-disable', 'click-enable', 'click-text');
+                  fillTableRow(key, 'hover-table', 'hover-disable', 'hover-enable', 'hover-text');
                 }
               }
             });
-          };
-
-          const displayField = document.getElementById('buttonTable');
-          displayField.innerHTML = `<table id="buttonTable" style="width:100%">
-            <tr>
-              <th style="width:50%", class="info">Click event listener</th>
-              <th style="width:50%", class="info">Hover event listener</th>
-            </tr>
-            <tr>
-              <td class="info">
-                <table id="click-table", class="info", style="width:100%"></table>
-              </td>
-              <td class="info">
-                <table id="hover-table", class="info", style="width:100%"></table>
-              </td>
-            </tr>
-          </table>`;
-          const registeredLayers = cgpv.api.maps.mapWM1?.layer?.registeredLayers;
-          let firstpass = true;
-          Object.keys(registeredLayers).forEach((key) => {
-            if (['processed', 'loaded'].includes(registeredLayers[key].layerStatus)) {
-              const queryable = registeredLayers[key]?.source?.featureInfo?.queryable ?? true;
-              const isNotGroupLayerEntry = registeredLayers[key]?.entryType !== 'group';
-              if (queryable && isNotGroupLayerEntry) {
-                if (firstpass) {
-                  firstpass = false;
-                  fillTableRow('all', 'click-table', 'click-disable', 'click-enable', 'click-text');
-                  fillTableRow('all', 'hover-table', 'hover-disable', 'hover-enable', 'hover-text');
-                }
-                fillTableRow(key, 'click-table', 'click-disable', 'click-enable', 'click-text');
-                fillTableRow(key, 'hover-table', 'hover-disable', 'hover-enable', 'hover-text');
-              }
-            }
-          });
-
-          // create snippets
-          createCodeSnippet();
-          createConfigSnippet();
+          }
         }
-      });
+      );
     </script>
   </body>
 </html>

--- a/packages/geoview-core/public/templates/ui-components.html
+++ b/packages/geoview-core/public/templates/ui-components.html
@@ -121,121 +121,128 @@
     <script src="codedoc.js"></script>
     <script>
       // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
-      cgpv.init((mapId) => {
-        if (mapId === 'allMaps') {
-          /**
-           * RANGE SLIDER UI SECTION START
-           */
-          // add a slider component and link it to a map with mapId props
-          cgpv.api.utilities.addUiComponent(
-            'UI1-rangeslider1',
-            cgpv.react.createElement(cgpv.ui.elements.Slider, {
-              mapId: 'UI1',
-              id: 'UI1-slider-flood',
-              min: 1696,
-              max: 2023,
-              value: [1696, 2023],
-              marks: [
-                { value: 1696, label: '1696' },
-                { value: 1700, label: '1700' },
-                { value: 1800, label: '1800' },
-                { value: 1900, label: '1900' },
-                { value: 2000, label: '2000' },
-                { value: 2023, label: '2023' },
-              ],
-              track: 'normal',
-              customOnChange: (dates) => {
-                const field = cgpv.api.maps.UI1.layer.geoviewLayer('historical-flood/0').getTemporalDimension().field;
-                cgpv.api.maps.UI1.layer.geoviewLayer('historical-flood/0').applyViewFilter(`${field} >= date '${dates[0]}-01-01' and ${field} <= date '${dates[1]}-12-31'`);
-              },
-            })
-          );
-          /**
-           * RANGE SLIDER UI SECTION END
-           */
-
-          /**
-           * SLIDER UI SECTION START
-           */
-          // set min max
-          function setSliderMinMax() {
-            cgpv.api.event.emit(
-              { event: cgpv.api.eventNames.SLIDER.EVENT_SLIDER_SET_MINMAX, handlerName: 'UI1-slider1', sliderValues: { min: 2, max: 16 }}
+      cgpv.init(
+        (mapId) => {
+          if (mapId === 'allMaps') {
+            // create snippets
+            createCodeSnippet();
+            createConfigSnippet();
+          }
+        },
+        (mapId) => {
+          if (mapId === 'allMaps') {
+            /**
+             * RANGE SLIDER UI SECTION START
+             */
+            // add a slider component and link it to a map with mapId props
+            cgpv.api.utilities.addUiComponent(
+              'UI1-rangeslider1',
+              cgpv.react.createElement(cgpv.ui.elements.Slider, {
+                mapId: 'UI1',
+                id: 'UI1-slider-flood',
+                min: 1696,
+                max: 2023,
+                value: [1696, 2023],
+                marks: [
+                  { value: 1696, label: '1696' },
+                  { value: 1700, label: '1700' },
+                  { value: 1800, label: '1800' },
+                  { value: 1900, label: '1900' },
+                  { value: 2000, label: '2000' },
+                  { value: 2023, label: '2023' },
+                ],
+                track: 'normal',
+                customOnChange: (dates) => {
+                  const field = cgpv.api.maps.UI1.layer.geoviewLayer('historical-flood/0').getTemporalDimension('historical-flood/0').field;
+                  cgpv.api.maps.UI1.layer.geoviewLayer('historical-flood/0').applyViewFilter('historical-flood/0', `${field} >= date '${dates[0]}-01-01' and ${field} <= date '${dates[1]}-12-31'`);
+                },
+              })
             );
-          }
-          document.getElementById('sliderminmax').addEventListener('click', setSliderMinMax, false);
+            /**
+             * RANGE SLIDER UI SECTION END
+             */
 
-          // set values
-          function setSliderValues() {
-            cgpv.api.event.emit({ event: cgpv.api.eventNames.SLIDER.EVENT_SLIDER_SET_VALUES, handlerName: 'UI1-slider1', sliderValues: { value: 8 } });
-          }
-          document.getElementById('slidervalues').addEventListener('click', setSliderValues, false);
+            /**
+             * SLIDER UI SECTION START
+             */
+            // set min max
+            function setSliderMinMax() {
+              cgpv.api.event.emit(
+                cgpv.types.sliderPayload(cgpv.api.eventNames.SLIDER.EVENT_SLIDER_SET_MINMAX, 'UI1-slider1', { min: 2, max: 16 })
+              );
+            }
+            document.getElementById('sliderminmax').addEventListener('click', setSliderMinMax, false);
 
-          // add a slider component and link it to a map with mapId props
-          cgpv.api.utilities.addUiComponent(
-            'UI1-slider1',
-            cgpv.react.createElement(cgpv.ui.elements.Slider, {
-              mapId: 'UI1',
-              id: 'UI1-slider1',
-              min: 0,
-              max: 18,
-              value: 5,
-              marks: [
-                { value: 0, label: 'Min Level 0' },
-                { value: 4, label: 'Level 4' },
-                { value: 8, label: 'Level 8' },
-                { value: 18, label: 'Max Level 18' },
-              ],
-              track: false,
-              // TODO: setting the view zoom level create bugs with the overview map
-              customOnChange: (zoomLevel) => {
-                const lat = 50;
-                const lng = -95;
-                cgpv.api.maps['UI1'].getView().animate({ zoom: zoomLevel });
+            // set values
+            function setSliderValues() {
+              cgpv.api.event.emit(cgpv.types.sliderPayload(cgpv.api.eventNames.SLIDER.EVENT_SLIDER_SET_VALUES, 'UI1-slider1', { value: 8 }));
+            }
+            document.getElementById('slidervalues').addEventListener('click', setSliderValues, false);
+
+            // add a slider component and link it to a map with mapId props
+            cgpv.api.utilities.addUiComponent(
+              'UI1-slider1',
+              cgpv.react.createElement(cgpv.ui.elements.Slider, {
+                mapId: 'UI1',
+                id: 'UI1-slider1',
+                min: 0,
+                max: 18,
+                value: 5,
+                marks: [
+                  { value: 0, label: 'Min Level 0' },
+                  { value: 4, label: 'Level 4' },
+                  { value: 8, label: 'Level 8' },
+                  { value: 18, label: 'Max Level 18' },
+                ],
+                track: false,
+                // TODO: setting the view zoom level create bugs with the overview map
+                customOnChange: (zoomLevel) => {
+                  const lat = 50;
+                  const lng = -95;
+                  cgpv.api.maps['UI1'].getView().animate({ zoom: zoomLevel });
+                },
+              })
+            );
+
+            // listen to slider value change event
+            const sliderPosition2 = document.getElementsByClassName('slider-position2');
+            cgpv.api.event.on(
+              cgpv.api.eventNames.SLIDER.EVENT_SLIDER_CHANGE,
+              (payload) => {
+                if (cgpv.types.payloadIsASlider(payload)) {
+                  sliderPosition2[0].innerHTML = `<p>Slider min ${payload.sliderValues.min}, max ${payload.sliderValues.max}, values ${
+                    payload.sliderValues.value
+                  } and active thumb ${payload.sliderValues.activeThumb === 0 ? 'left' : 'right'}</p>`;
+                }
               },
-            })
-          );
+              'UI1-slider2'
+            );
 
-          // listen to slider value change event
-          const sliderPosition2 = document.getElementsByClassName('slider-position2');
-          cgpv.api.event.on(
-            cgpv.api.eventNames.SLIDER.EVENT_SLIDER_CHANGE,
-            (payload) => {
-                sliderPosition2[0].innerHTML = `<p>Slider min ${payload.sliderValues.min}, max ${payload.sliderValues.max}, values ${
-                  payload.sliderValues.value
-                } and active thumb ${payload.sliderValues.activeThumb === 0 ? 'left' : 'right'}</p>`;
-            },
-            'UI1-slider2'
-          );
-
-          // add a slider component and DO NOT link it to a map
-          cgpv.api.utilities.addUiComponent(
-            'UI1-slider2',
-            cgpv.react.createElement(cgpv.ui.elements.Slider, {
-              id: 'UI1-slider2',
-              min: 0,
-              max: 18,
-              value: [5, 10],
-              marks: [
-                { value: 0, label: 'Min Level 0' },
-                { value: 2 },
-                { value: 4, label: 'Level 4' },
-                { value: 5, label: 'Level 5' },
-                { value: 6, label: 'Level 6' },
-                { value: 8, label: 'Level 8' },
-                { value: 18, label: 'Max Level 18' },
-              ],
-            })
-          );
-          /**
-           * SLIDER UI SECTION END
-           */
-
-          // create snippets
-          createCodeSnippet();
-          createConfigSnippet();
+            // add a slider component and DO NOT link it to a map
+            cgpv.api.utilities.addUiComponent(
+              'UI1-slider2',
+              cgpv.react.createElement(cgpv.ui.elements.Slider, {
+                id: 'UI1-slider2',
+                min: 0,
+                max: 18,
+                value: [5, 10],
+                marks: [
+                  { value: 0, label: 'Min Level 0' },
+                  { value: 2 },
+                  { value: 4, label: 'Level 4' },
+                  { value: 5, label: 'Level 5' },
+                  { value: 6, label: 'Level 6' },
+                  { value: 8, label: 'Level 8' },
+                  { value: 18, label: 'Max Level 18' },
+                ],
+              })
+            );
+            /**
+             * SLIDER UI SECTION END
+             */
+          }
         }
-      });
+      );
 
       // document.addEventListener('DOMContentLoaded', async () => {
       // get map

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/data-table-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/data-table-processor.ts
@@ -27,9 +27,9 @@ export class DataTableProcessor extends AbstractEventProcessor {
     const filterLayerConfig = api.maps[mapId].layer.registeredLayers[layerPath] as TypeLayerEntryConfig;
 
     if (isMapRecordExist && geoviewLayerInstance !== undefined && filterLayerConfig !== undefined && filterStrings.length) {
-      (api.maps[mapId].layer.geoviewLayer(layerPath) as AbstractGeoViewVector | EsriDynamic)?.applyViewFilter(filterStrings);
+      (geoviewLayerInstance as AbstractGeoViewVector | EsriDynamic)?.applyViewFilter(layerPath, filterStrings);
     } else {
-      (api.maps[mapId].layer.geoviewLayer(layerPath) as AbstractGeoViewVector | EsriDynamic)?.applyViewFilter('');
+      (geoviewLayerInstance as AbstractGeoViewVector | EsriDynamic)?.applyViewFilter(layerPath, '');
     }
   }
 }

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/time-slider-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/time-slider-event-processor.ts
@@ -129,7 +129,7 @@ export class TimeSliderEventProcessor extends AbstractEventProcessor {
   static getInitialTimeSliderValues(mapId: string, layerPath: string): TimeSliderLayerSet {
     const layerConfig = api.maps[mapId].layer.registeredLayers[layerPath];
     const name = getLocalizedValue(layerConfig.layerName, mapId) || layerConfig.layerId;
-    const temporalDimensionInfo = api.maps[mapId].layer.geoviewLayer(layerPath).getTemporalDimension();
+    const temporalDimensionInfo = api.maps[mapId].layer.geoviewLayer(layerPath).getTemporalDimension(layerPath);
     const { range } = temporalDimensionInfo.range;
     const defaultValueIsArray = Array.isArray(temporalDimensionInfo.default);
     const defaultValue = defaultValueIsArray ? temporalDimensionInfo.default[0] : temporalDimensionInfo.default;

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -63,7 +63,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
         return layer;
       },
       getLayerBounds: (layerPath: string) => {
-        const layer = api.maps[get().mapId].layer.getGeoviewLayerById(layerPath.split('/')[0]);
+        const layer = api.maps[get().mapId].layer.geoviewLayer(layerPath);
         if (layer) {
           const bounds = layer.calculateBounds(layerPath);
           if (bounds) return bounds;
@@ -162,7 +162,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
           });
 
           // apply filter to layer
-          (api.maps[get().mapId].layer.geoviewLayer(layerPath) as AbstractGeoViewVector).applyViewFilter('');
+          (api.maps[get().mapId].layer.geoviewLayer(layerPath) as AbstractGeoViewVector).applyViewFilter(layerPath, '');
         }
         set({
           layerState: {
@@ -218,7 +218,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
         // GV try to make reusable store actions....
         // GV we can have always item.... we cannot set visibility so if present we will need to trap. Need more use case
         // GV create a function setItemVisibility called with layer path and this function set the registered layer (from store values) then apply the filter.
-        (api.maps[get().mapId].layer.geoviewLayer(layerPath) as AbstractGeoViewVector).applyViewFilter('');
+        (api.maps[get().mapId].layer.geoviewLayer(layerPath) as AbstractGeoViewVector).applyViewFilter(layerPath, '');
       },
       getLayerDeleteInProgress: () => get().layerState.layerDeleteInProgress,
       setLayerDeleteInProgress: (newVal: boolean) => {

--- a/packages/geoview-core/src/core/utils/config/config.ts
+++ b/packages/geoview-core/src/core/utils/config/config.ts
@@ -10,11 +10,11 @@ import { CONST_LAYER_TYPES, TypeGeoviewLayerType } from '@/geo/layer/geoview-lay
 import { logger } from '@/core/utils/logger';
 
 import { TypeMapFeaturesConfig } from '@/core/types/global-types';
-import { ConfigValidation } from './config-validation';
-import { InlineDivConfigReader } from './reader/div-config-reader';
-import { JsonConfigReader } from './reader/json-config-reader';
-import { URLmapConfigReader } from './reader/url-config-reader';
-import { ConfigBaseClass } from './validation-classes/config-base-class';
+import { ConfigValidation } from '@/core/utils/config/config-validation';
+import { InlineDivConfigReader } from '@/core/utils/config/reader/div-config-reader';
+import { JsonConfigReader } from '@/core/utils/config/reader/json-config-reader';
+import { URLmapConfigReader } from '@/core/utils/config/reader/url-config-reader';
+import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
 
 // ******************************************************************************************************************************
 // ******************************************************************************************************************************
@@ -28,7 +28,7 @@ import { ConfigBaseClass } from './validation-classes/config-base-class';
 // ******************************************************************************************************************************
 export class Config {
   /** The element associated to the map properties configuration.. */
-  private mapElement: Element;
+  #mapElement: Element;
 
   /** Config validation object used to validate the configuration and define default values */
   configValidation: ConfigValidation;
@@ -40,25 +40,25 @@ export class Config {
    * @returns {Config} An instance of the Config class.
    */
   constructor(mapElement: Element) {
-    this.mapElement = mapElement;
+    this.#mapElement = mapElement;
 
     // Instanciate the configuration validator.
     this.configValidation = new ConfigValidation();
 
     // get the id from the map element
-    const mapId = this.mapElement.getAttribute('id');
+    const mapId = this.#mapElement.getAttribute('id');
 
     // update map id if provided in map element
     if (mapId) this.mapId = mapId;
 
     // get the triggerReadyCallback from the map element
-    const triggerReadyCallback = this.mapElement.getAttribute('triggerReadyCallback');
+    const triggerReadyCallback = this.#mapElement.getAttribute('triggerReadyCallback');
 
     // update triggerReadyCallback if provided in map element
     this.triggerReadyCallback = triggerReadyCallback ? triggerReadyCallback.toLowerCase() === 'true' : false;
 
     // get the display language from the map element
-    const displayLanguage = this.mapElement.getAttribute('data-lang');
+    const displayLanguage = this.#mapElement.getAttribute('data-lang');
 
     // update display language if provided in map element
     this.displayLanguage = (displayLanguage && displayLanguage.toLowerCase() === 'fr' ? 'fr' : 'en') as TypeDisplayLanguage;
@@ -164,18 +164,18 @@ export class Config {
     let mapFeaturesConfig: TypeMapFeaturesConfig | undefined;
 
     // check if inline div config has been passed
-    const inlineDivConfig = await InlineDivConfigReader.getMapFeaturesConfig(this.mapId, this.mapElement);
+    const inlineDivConfig = await InlineDivConfigReader.getMapFeaturesConfig(this.mapId, this.#mapElement);
 
     // use inline config if provided
     if (inlineDivConfig) mapFeaturesConfig = { ...inlineDivConfig };
 
     // check if a config file url is provided.
-    const jsonFileConfig = await JsonConfigReader.getMapFeaturesConfig(this.mapId, this.mapElement);
+    const jsonFileConfig = await JsonConfigReader.getMapFeaturesConfig(this.mapId, this.#mapElement);
 
     if (jsonFileConfig) mapFeaturesConfig = { ...jsonFileConfig };
 
     // get the value that will check if any url params passed will override existing map
-    const shared = this.mapElement.getAttribute('data-shared');
+    const shared = this.#mapElement.getAttribute('data-shared');
     if (shared === 'true') {
       // check if config params have been passed
       const urlParamsConfig = await URLmapConfigReader.getMapFeaturesConfig(this.mapId);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -974,10 +974,9 @@ export abstract class AbstractGeoViewLayer {
    *
    * @param {string} layerPath Layer path to the layer's configuration.
    *
-   * @returns {Extent} The layer extent.
+   * @returns {Extent | undefined} The layer extent.
    */
-  getExtent(layerPath?: string): Extent | undefined {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  getExtent(layerPath: string): Extent | undefined {
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     return olLayer?.getExtent();
   }
@@ -990,8 +989,7 @@ export abstract class AbstractGeoViewLayer {
    * @param {Extent} layerExtent The extent to assign to the layer.
    * @param {string} layerPath The layer path to the layer's configuration.
    */
-  setExtent(layerExtent: Extent, layerPath?: string) {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  setExtent(layerExtent: Extent, layerPath: string) {
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     if (olLayer) olLayer.setExtent(layerExtent);
   }
@@ -1001,10 +999,9 @@ export abstract class AbstractGeoViewLayer {
    *
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {number} The opacity of the layer.
+   * @returns {number | undefined} The opacity of the layer.
    */
-  getOpacity(layerPath?: string): number | undefined {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  getOpacity(layerPath: string): number | undefined {
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     return olLayer?.getOpacity();
   }
@@ -1016,8 +1013,7 @@ export abstract class AbstractGeoViewLayer {
    * @param {string} layerPath The layer path to the layer's configuration.
    *
    */
-  setOpacity(layerOpacity: number, layerPath?: string) {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  setOpacity(layerOpacity: number, layerPath: string) {
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     if (olLayer) olLayer.setOpacity(layerOpacity);
   }
@@ -1027,10 +1023,9 @@ export abstract class AbstractGeoViewLayer {
    *
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {boolean} The visibility of the layer.
+   * @returns {boolean | undefined} The visibility of the layer.
    */
-  getVisible(layerPath?: string): boolean | undefined {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  getVisible(layerPath: string): boolean | undefined {
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     return olLayer?.getVisible();
   }
@@ -1041,8 +1036,7 @@ export abstract class AbstractGeoViewLayer {
    * @param {boolean} layerVisibility The visibility of the layer.
    * @param {string} layerPath The layer path to the layer's configuration.
    */
-  setVisible(layerVisibility: boolean, layerPath?: string) {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  setVisible(layerVisibility: boolean, layerPath: string) {
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     if (olLayer) {
       olLayer.setVisible(layerVisibility);
@@ -1055,10 +1049,9 @@ export abstract class AbstractGeoViewLayer {
    *
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {boolean} The visibility of the layer.
+   * @returns {number | undefined} The min zoom of the layer.
    */
-  getMinZoom(layerPath?: string): number | undefined {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  getMinZoom(layerPath: string): number | undefined {
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     return olLayer?.getMinZoom();
   }
@@ -1066,11 +1059,10 @@ export abstract class AbstractGeoViewLayer {
   /** ***************************************************************************************************************************
    * Set the min zoom of the layer. This routine does nothing when the layerPath specified is not found.
    *
-   * @param {boolean} layerVisibility The visibility of the layer.
+   * @param {boolean} layerVisibility The min zoom of the layer.
    * @param {string} layerPath The layer path to the layer's configuration.
    */
-  setMinZoom(minZoom: number, layerPath?: string) {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  setMinZoom(minZoom: number, layerPath: string) {
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     if (olLayer) olLayer.setMinZoom(minZoom);
   }
@@ -1080,10 +1072,9 @@ export abstract class AbstractGeoViewLayer {
    *
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {boolean} The visibility of the layer.
+   * @returns {number | undefined} The max zoom of the layer.
    */
-  getMaxZoom(layerPath?: string): number | undefined {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  getMaxZoom(layerPath: string): number | undefined {
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     return olLayer?.getMaxZoom();
   }
@@ -1091,11 +1082,10 @@ export abstract class AbstractGeoViewLayer {
   /** ***************************************************************************************************************************
    * Set the max zoom of the layer. This routine does nothing when the layerPath specified is not found.
    *
-   * @param {boolean} layerVisibility The visibility of the layer.
+   * @param {boolean} layerVisibility The max zoom of the layer.
    * @param {string} layerPath The layer path to the layer's configuration.
    */
-  setMaxZoom(maxZoom: number, layerPath?: string) {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  setMaxZoom(maxZoom: number, layerPath: string) {
     const olLayer = this.getLayerConfig(layerPath)?.olLayer;
     if (olLayer) olLayer.setMaxZoom(maxZoom);
   }
@@ -1108,9 +1098,8 @@ export abstract class AbstractGeoViewLayer {
    *
    * @returns {Promise<TypeLegend | null>} The legend of the layer.
    */
-  async getLegend(layerPath?: string): Promise<TypeLegend | null> {
+  async getLegend(layerPath: string): Promise<TypeLegend | null> {
     try {
-      layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
       const layerConfig = this.getLayerConfig(layerPath) as
         | (AbstractBaseLayerEntryConfig & {
             style: TypeStyleConfig;
@@ -1276,8 +1265,7 @@ export abstract class AbstractGeoViewLayer {
    *
    * @returns {string | undefined} The filter associated to the layer or undefined.
    */
-  getLayerFilter(layerPath?: string): string | undefined {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  getLayerFilter(layerPath: string): string | undefined {
     const layerConfig = this.getLayerConfig(layerPath);
     return layerConfig?.olLayer?.get('layerFilter');
   }
@@ -1290,8 +1278,7 @@ export abstract class AbstractGeoViewLayer {
    *
    * @returns {TimeDimension} The temporal dimension associated to the layer or undefined.
    */
-  getTemporalDimension(layerPath?: string): TimeDimension {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  getTemporalDimension(layerPath: string): TimeDimension {
     return this.layerTemporalDimension[layerPath];
   }
 
@@ -1302,19 +1289,8 @@ export abstract class AbstractGeoViewLayer {
    * @param {TimeDimension} temporalDimension The value to assign to the layer temporal dimension property.
    */
   setTemporalDimension(layerPath: string, temporalDimension: TimeDimension): void {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     this.layerTemporalDimension[layerPath] = temporalDimension;
   }
-
-  /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
-   *
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
-   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
-   *
-   * @returns {Extent} The new layer bounding box.
-   */
-  protected abstract getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
 
   /** ***************************************************************************************************************************
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
@@ -1336,11 +1312,10 @@ export abstract class AbstractGeoViewLayer {
    * @param {string | number | undefined} projectionCode Optional projection code to use for the returned bounds. Default to
    * current projection.
    *
-   * @returns {Extent} The layer bounding box.
+   * @returns {Extent | undefined} The layer bounding box.
    */
-  calculateBounds(layerPath?: string): Extent | undefined {
+  calculateBounds(layerPath: string): Extent | undefined {
     try {
-      layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
       let bounds: Extent | undefined;
       const processGroupLayerBounds = (listOfLayerEntryConfig: TypeListOfLayerEntryConfig) => {
         listOfLayerEntryConfig.forEach((layerConfig) => {
@@ -1394,8 +1369,7 @@ export abstract class AbstractGeoViewLayer {
    *
    * @param {string} layerPath The layerpath to the node we want to delete.
    */
-  removeConfig(layerPath?: string) {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  removeConfig(layerPath: string) {
     const layerConfigToRemove = this.getLayerConfig(layerPath) as AbstractBaseLayerEntryConfig;
     if (layerConfigToRemove.entryType !== CONST_LAYER_ENTRY_TYPES.GROUP) this.unregisterFromLayerSets(layerConfigToRemove);
     delete api.maps[this.mapId].layer.registeredLayers[layerPath];

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -418,7 +418,8 @@ export function parseFeatureInfoEntries(records: TypeJsonObject[]): TypeFeatureI
  */
 export async function queryRecordsByUrl(url: string): Promise<TypeFeatureInfoEntryPartial[] | null> {
   // TODO: Refactor - Suggestion to rework this function and the one in EsriDynamic.getFeatureInfoAtLongLat(), making
-  // TO.DO.CONT: the latter redirect to this one here and merge some logic between the 2 functions ideally making this one here return a TypeFeatureInfoEntry[] with options to have returnGeometry=true or false and such.
+  // TO.DO.CONT: the latter redirect to this one here and merge some logic between the 2 functions ideally making this
+  // TO.DO.CONT: one here return a TypeFeatureInfoEntry[] with options to have returnGeometry=true or false and such.
   // Query the data
   try {
     const response = await fetch(url);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -536,7 +536,6 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @returns {string} the filter associated to the layerPath
    */
   getViewFilter(layerPath: string): string {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const layerConfig = this.getLayerConfig(layerPath) as EsriDynamicLayerEntryConfig;
     const layerFilter = layerConfig.olLayer?.get('layerFilter');
 
@@ -692,30 +691,6 @@ export class EsriDynamic extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Apply a view filter to the layer identified by the path stored in the layerPathAssociatedToTheGeoviewLayer property stored
-   * in the layer instance associated to the map. The legend filters are derived from the uniqueValue or classBreaks style of the
-   * layer. When the layer config is invalid, nothing is done.
-   *
-   * @param {string} filter An optional filter to be used in place of the getViewFilter value.
-   * @param {never} notUsed1 This parameter must not be provided. It is there to allow overloading of the method signature.
-   * @param {never} notUsed2 This parameter must not be provided. It is there to allow overloading of the method signature.
-   */
-  applyViewFilter(filter: string, notUsed1?: never, notUsed2?: never): void;
-
-  /** ***************************************************************************************************************************
-   * Apply a view filter to the layer identified by the path stored in the layerPathAssociatedToTheGeoviewLayer property stored
-   * in the layer instance associated to the map. When the CombineLegendFilter flag is false, the filter paramater is used alone
-   * to display the features. Otherwise, the legend filter and the filter parameter are combined together to define the view
-   * filter. The legend filters are derived from the uniqueValue or classBreaks style of the layer. When the layer config is
-   * invalid, nothing is done.
-   *
-   * @param {string} filter An optional filter to be used in place of the getViewFilter value.
-   * @param {boolean} CombineLegendFilter Flag used to combine the legend filter and the filter together (default: true)
-   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
-   */
-  applyViewFilter(filter: string, CombineLegendFilter: boolean, notUsed?: never): void;
-
-  /** ***************************************************************************************************************************
    * Apply a view filter to the layer. When the CombineLegendFilter flag is false, the filter paramater is used alone to display
    * the features. Otherwise, the legend filter and the filter parameter are combined together to define the view filter. The
    * legend filters are derived from the uniqueValue or classBreaks style of the layer. When the layer config is invalid, nothing
@@ -725,63 +700,15 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @param {string} filter An optional filter to be used in place of the getViewFilter value.
    * @param {boolean} combineLegendFilter Flag used to combine the legend filter and the filter together (default: true)
    */
-  applyViewFilter(layerPath: string, filter?: string, combineLegendFilter?: boolean): void;
-
-  // See above headers for signification of the parameters. The first lines of the method select the template
-  // used based on the parameter types received.
-
-  applyViewFilter(parameter1: string, parameter2?: string | boolean | never, parameter3?: boolean | never) {
-    // At the beginning, we assume that:
-    // 1- the layer path was saved in this.layerPathAssociatedToTheGeoviewLayer using a call to
-    //    api.maps[mapId].layer.geoviewLayer(layerPath);
-    // 2- the filter is empty;
-    // 3- the combine legend filters is true
-    let layerPath = this.layerPathAssociatedToTheGeoviewLayer;
-    let filter = '';
-    let CombineLegendFilter = true;
-
-    // Method signature detection
-    if (typeof parameter3 === 'boolean') {
-      // Signature detected is: applyViewFilter(layerPath: string, filter?: string, combineLegendFilter?: boolean): void;
-      layerPath = parameter1;
-      filter = parameter2 as string;
-      CombineLegendFilter = parameter3;
-    } else if (parameter2 !== undefined && parameter3 === undefined) {
-      if (typeof parameter2 === 'boolean') {
-        // Signature detected is: applyViewFilter(filter: string, CombineLegendFilter: boolean): void;
-        filter = parameter1;
-        CombineLegendFilter = parameter2;
-      } else {
-        // Signature detected is: applyViewFilter(layerPath: string, filter: string): void;
-        layerPath = parameter1;
-        filter = parameter2;
-      }
-    } else if (parameter2 === undefined && parameter3 === undefined) {
-      // Signature detected is: applyViewFilter(filter: string): void;
-      filter = parameter1;
-    }
-
+  applyViewFilter(layerPath: string, filter: string, combineLegendFilter = true) {
     const layerConfig = this.getLayerConfig(layerPath) as EsriDynamicLayerEntryConfig;
-    if (!layerConfig) {
-      // GV Things important to know about the applyViewFilter usage:
-      logger.logError(
-        `
-        The applyViewFilter method must never be called by GeoView code before the layer refered by the layerPath has reached the 'loaded' status.\n
-        It will never be called by the GeoView internal code except in the layerConfig.loadedFunction() that is called right after the 'loaded' signal.\n
-        If you are a user, you can set the layer filter in the configuration or using code called in the cgpv.init() method of the viewer.\n
-        It appeares that the layer refered by the layerPath "${layerPath} does not respect these rules.\n
-      `.replace(/\s+/g, ' ')
-      );
-      return;
-    }
-
     // Log
     logger.logTraceCore('ESRI-DYNAMIC - applyViewFilter', layerPath);
 
     let filterValueToUse = filter.replaceAll(/\s{2,}/g, ' ').trim();
-    layerConfig.olLayer!.set('legendFilterIsOff', !CombineLegendFilter);
+    layerConfig.olLayer!.set('legendFilterIsOff', !combineLegendFilter);
     layerConfig.olLayer?.set('layerFilter', filterValueToUse);
-    if (CombineLegendFilter) filterValueToUse = this.getViewFilter(layerPath);
+    if (combineLegendFilter) filterValueToUse = this.getViewFilter(layerPath);
 
     // Convert date constants using the externalFragmentsOrder derived from the externalDateFormat
     const searchDateEntry = [
@@ -807,30 +734,14 @@ export class EsriDynamic extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
-   *
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
-   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
-   *
-   * @returns {Extent} The new layer bounding box.
-   */
-  protected getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
-
-  /** ***************************************************************************************************************************
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
    * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
-   * @returns {Extent} The new layer bounding box.
+   * @returns {Extent | undefined} The new layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
-
-  // See above headers for signification of the parameters. The first lines of the method select the template
-  // used based on the parameter types received.
-  protected getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
-    const layerPath = typeof parameter1 === 'string' ? parameter1 : this.layerPathAssociatedToTheGeoviewLayer;
-    let bounds = typeof parameter1 !== 'string' ? parameter1 : parameter2;
+  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
     const layerConfig = this.getLayerConfig(layerPath);
     const layerBounds = layerConfig?.initialSettings?.bounds || [];
     const projection = this.metadata?.fullExtent?.spatialReference?.wkid || MapEventProcessor.getMapState(this.mapId).currentProjection;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
@@ -283,16 +283,6 @@ export class ImageStatic extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
-   *
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
-   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
-   *
-   * @returns {Extent} The new layer bounding box.
-   */
-  protected getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
-
-  /** ***************************************************************************************************************************
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
@@ -300,13 +290,7 @@ export class ImageStatic extends AbstractGeoViewRaster {
    *
    * @returns {Extent} The new layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
-
-  // See above headers for signification of the parameters. The first lines of the method select the template
-  // used based on the parameter types received.
-  protected getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
-    const layerPath = typeof parameter1 === 'string' ? parameter1 : this.layerPathAssociatedToTheGeoviewLayer;
-    let bounds = typeof parameter1 !== 'string' ? parameter1 : parameter2;
+  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
     const layerConfig = this.getLayerConfig(layerPath);
     const layerBounds = (layerConfig?.olLayer as ImageLayer<Static>).getSource()?.getImageExtent();
     const projection =
@@ -323,7 +307,9 @@ export class ImageStatic extends AbstractGeoViewRaster {
         );
       }
 
+      // eslint-disable-next-line no-param-reassign
       if (!bounds) bounds = [transformedBounds[0], transformedBounds[1], transformedBounds[2], transformedBounds[3]];
+      // eslint-disable-next-line no-param-reassign
       else bounds = getMinOrMaxExtents(bounds, transformedBounds);
     }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
@@ -251,30 +251,14 @@ export class VectorTiles extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
-   *
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
-   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
-   *
-   * @returns {Extent} The new layer bounding box.
-   */
-  protected getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
-
-  /** ***************************************************************************************************************************
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
    * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
-   * @returns {Extent} The new layer bounding box.
+   * @returns {Extent | undefined} The new layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
-
-  // See above headers for signification of the parameters. The first lines of the method select the template
-  // used based on the parameter types received.
-  protected getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
-    const layerPath = typeof parameter1 === 'string' ? parameter1 : this.layerPathAssociatedToTheGeoviewLayer;
-    let bounds = typeof parameter1 !== 'string' ? parameter1 : parameter2;
+  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
     const layerConfig = this.getLayerConfig(layerPath);
     const layerBounds = (layerConfig?.olLayer as TileLayer<VectorTileSource>).getSource()?.getTileGrid()?.getExtent();
     const projection =
@@ -291,7 +275,9 @@ export class VectorTiles extends AbstractGeoViewRaster {
         );
       }
 
+      // eslint-disable-next-line no-param-reassign
       if (!bounds) bounds = [transformedBounds[0], transformedBounds[1], transformedBounds[2], transformedBounds[3]];
+      // eslint-disable-next-line no-param-reassign
       else bounds = getMinOrMaxExtents(bounds, transformedBounds);
     }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -1011,30 +1011,6 @@ export class WMS extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Apply a view filter to the layer identified by the path stored in the layerPathAssociatedToTheGeoviewLayer property stored
-   * in the layer instance associated to the map. The legend filters are derived from the uniqueValue or classBreaks style of the
-   * layer. When the layer config is invalid, nothing is done.
-   *
-   * @param {string} filter An optional filter to be used in place of the getViewFilter value.
-   * @param {never} notUsed1 This parameter must not be provided. It is there to allow overloading of the method signature.
-   * @param {never} notUsed2 This parameter must not be provided. It is there to allow overloading of the method signature.
-   */
-  applyViewFilter(filter: string, notUsed1?: never, notUsed2?: never): void;
-
-  /** ***************************************************************************************************************************
-   * Apply a view filter to the layer identified by the path stored in the layerPathAssociatedToTheGeoviewLayer property stored
-   * in the layer instance associated to the map. When the CombineLegendFilter flag is false, the filter paramater is used alone
-   * to display the features. Otherwise, the legend filter and the filter parameter are combined together to define the view
-   * filter. The legend filters are derived from the uniqueValue or classBreaks style of the layer. When the layer config is
-   * invalid, nothing is done.
-   *
-   * @param {string} filter An optional filter to be used in place of the getViewFilter value.
-   * @param {boolean} CombineLegendFilter Flag used to combine the legend filter and the filter together (default: true)
-   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
-   */
-  applyViewFilter(filter: string, CombineLegendFilter: boolean, notUsed?: never): void;
-
-  /** ***************************************************************************************************************************
    * Apply a view filter to the layer. When the CombineLegendFilter flag is false, the filter paramater is used alone to display
    * the features. Otherwise, the legend filter and the filter parameter are combined together to define the view filter. The
    * legend filters are derived from the uniqueValue or classBreaks style of the layer. When the layer config is invalid, nothing
@@ -1045,56 +1021,8 @@ export class WMS extends AbstractGeoViewRaster {
    * @param {string} filter An optional filter to be used in place of the getViewFilter value.
    * @param {boolean} CombineLegendFilter Flag used to combine the legend filter and the filter together (default: true)
    */
-  applyViewFilter(layerPath: string, filter?: string, CombineLegendFilter?: boolean): void;
-
-  // See above headers for signification of the parameters. The first lines of the method select the template
-  // used based on the parameter types received.
-
-  applyViewFilter(parameter1: string, parameter2?: string | boolean | never, parameter3?: boolean | never) {
-    // At the beginning, we assume that:
-    // 1- the layer path was saved in this.layerPathAssociatedToTheGeoviewLayer using a call to
-    //    api.maps[mapId].layer.geoviewLayer(layerPath);
-    // 2- the filter is empty;
-    // 3- the combine legend filters is true
-    let layerPath = this.layerPathAssociatedToTheGeoviewLayer;
-    let filter = '';
-    let CombineLegendFilter = true;
-
-    // Method signature detection
-    if (typeof parameter3 === 'boolean') {
-      // Signature detected is: applyViewFilter(layerPath: string, filter?: string, combineLegendFilter?: boolean): void;
-      layerPath = parameter1;
-      filter = parameter2 as string;
-      CombineLegendFilter = parameter3;
-    } else if (parameter2 !== undefined && parameter3 === undefined) {
-      if (typeof parameter2 === 'boolean') {
-        // Signature detected is: applyViewFilter(filter: string, CombineLegendFilter: boolean): void;
-        filter = parameter1;
-        CombineLegendFilter = parameter2;
-      } else {
-        // Signature detected is: applyViewFilter(layerPath: string, filter: string): void;
-        layerPath = parameter1;
-        filter = parameter2;
-      }
-    } else if (parameter2 === undefined && parameter3 === undefined) {
-      // Signature detected is: applyViewFilter(filter: string): void;
-      filter = parameter1;
-    }
-
+  applyViewFilter(layerPath: string, filter: string, CombineLegendFilter = true) {
     const layerConfig = this.getLayerConfig(layerPath) as OgcWmsLayerEntryConfig;
-    if (!layerConfig) {
-      // GV Things important to know about the applyViewFilter usage:
-      logger.logError(
-        `
-        The applyViewFilter method must never be called by GeoView code before the layer refered by the layerPath has reached the 'loaded' status.\n
-        It will never be called by the GeoView internal code except in the layerConfig.loadedFunction() that is called right after the 'loaded' signal.\n
-        If you are a user, you can set the layer filter in the configuration or using code called in the cgpv.init() method of the viewer.\n
-        It appeares that the layer refered by the layerPath "${layerPath} does not respect these rules.\n
-      `.replace(/\s+/g, ' ')
-      );
-      return;
-    }
-
     // Log
     logger.logTraceCore('WMS - applyViewFilter', layerPath);
 
@@ -1131,30 +1059,14 @@ export class WMS extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
-   *
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
-   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
-   *
-   * @returns {Extent} The new layer bounding box.
-   */
-  protected getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
-
-  /** ***************************************************************************************************************************
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
    * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
-   * @returns {Extent} The new layer bounding box.
+   * @returns {Extent | undefined} The new layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
-
-  // See above headers for signification of the parameters. The first lines of the method select the template
-  // used based on the parameter types received.
-  protected getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
-    const layerPath = typeof parameter1 === 'string' ? parameter1 : this.layerPathAssociatedToTheGeoviewLayer;
-    let bounds = typeof parameter1 !== 'string' ? parameter1 : parameter2;
+  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
     const layerConfig = this.getLayerConfig(layerPath);
     const projection =
       (layerConfig?.olLayer as ImageLayer<Static>)?.getSource()?.getProjection()?.getCode().replace('EPSG:', '') ||

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -246,30 +246,14 @@ export class XYZTiles extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
-   *
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
-   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
-   *
-   * @returns {Extent} The new layer bounding box.
-   */
-  protected getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
-
-  /** ***************************************************************************************************************************
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
    * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
-   * @returns {Extent} The new layer bounding box.
+   * @returns {Extent | undefined} The new layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
-
-  // See above headers for signification of the parameters. The first lines of the method select the template
-  // used based on the parameter types received.
-  protected getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
-    const layerPath = typeof parameter1 === 'string' ? parameter1 : this.layerPathAssociatedToTheGeoviewLayer;
-    let bounds = typeof parameter1 !== 'string' ? parameter1 : parameter2;
+  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
     const layerConfig = this.getLayerConfig(layerPath);
     const layerBounds = (layerConfig?.olLayer as TileLayer<XYZ>)?.getSource()?.getTileGrid()?.getExtent();
     const projection =
@@ -286,7 +270,9 @@ export class XYZTiles extends AbstractGeoViewRaster {
         );
       }
 
+      // eslint-disable-next-line no-param-reassign
       if (!bounds) bounds = [transformedBounds[0], transformedBounds[1], transformedBounds[2], transformedBounds[3]];
+      // eslint-disable-next-line no-param-reassign
       else bounds = getMinOrMaxExtents(bounds, transformedBounds);
     }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -249,8 +249,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    *
    * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
-  protected async getAllFeatureInfo(layerPath?: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  protected async getAllFeatureInfo(layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     try {
       // Get the layer config in a loaded phase
       const layerConfig = this.getLayerConfig(layerPath) as VectorLayerEntryConfig;
@@ -272,8 +271,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    *
    * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table or null if an error occured.
    */
-  protected async getFeatureInfoAtPixel(location: Pixel, layerPath?: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  protected async getFeatureInfoAtPixel(location: Pixel, layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     try {
       // Get the layer config in a loaded phase
       const layerConfig = this.getLayerConfig(layerPath) as VectorLayerEntryConfig;
@@ -300,8 +298,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    *
    * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
-  protected getFeatureInfoAtCoordinate(location: Coordinate, layerPath?: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  protected getFeatureInfoAtCoordinate(location: Coordinate, layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     const { map } = api.maps[this.mapId];
     return this.getFeatureInfoAtPixel(map.getPixelFromCoordinate(location as Coordinate), layerPath);
   }
@@ -314,8 +311,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    *
    * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
-  protected getFeatureInfoAtLongLat(location: Coordinate, layerPath?: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
-    layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
+  protected getFeatureInfoAtLongLat(location: Coordinate, layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     const { map } = api.maps[this.mapId];
     const convertedLocation = api.projection.transform(
       location,
@@ -326,30 +322,14 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
   }
 
   /** ***************************************************************************************************************************
-   * Get the bounds of the layer represented in the layerConfig pointed to by the cached layerPath, returns updated bounds
-   *
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
-   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
-   *
-   * @returns {Extent} The new layer bounding box.
-   */
-  protected getBounds(bounds: Extent, notUsed?: never): Extent | undefined;
-
-  /** ***************************************************************************************************************************
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
    * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
-   * @returns {Extent} The new layer bounding box.
+   * @returns {Extent | undefined} The new layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
-
-  // See above headers for signification of the parameters. The first lines of the method select the template
-  // used based on the parameter types received.
-  protected getBounds(parameter1?: string | Extent, parameter2?: Extent): Extent | undefined {
-    const layerPath = typeof parameter1 === 'string' ? parameter1 : this.layerPathAssociatedToTheGeoviewLayer;
-    let bounds = typeof parameter1 !== 'string' ? parameter1 : parameter2;
+  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
     const layerConfig = this.getLayerConfig(layerPath);
     const layerBounds = (layerConfig?.olLayer as VectorLayer<VectorSource>)?.getSource()?.getExtent();
 
@@ -362,31 +342,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
   }
 
   /** ***************************************************************************************************************************
-   * Apply a view filter to the layer identified by the path stored in the layerPathAssociatedToTheGeoviewLayer property stored
-   * in the layer instance associated to the map. The legend filters are derived from the uniqueValue or classBreaks style of the
-   * layer. When the layer config is invalid, nothing is done.
-   *
-   * @param {string} filter A filter to be used in place of the getViewFilter value.
-   * @param {never} notUsed1 This parameter must not be provided. It is there to allow overloading of the method signature.
-   * @param {never} notUsed2 This parameter must not be provided. It is there to allow overloading of the method signature.
-   */
-  applyViewFilter(filter: string, notUsed1?: never, notUsed2?: never): void;
-
-  /** ***************************************************************************************************************************
-   * Apply a view filter to the layer identified by the path stored in the layerPathAssociatedToTheGeoviewLayer property stored
-   * in the layer instance associated to the map. When the CombineLegendFilter flag is false, the filter paramater is used alone
-   * to display the features. Otherwise, the legend filter and the filter parameter are combined together to define the view
-   * filter. The legend filters are derived from the uniqueValue or classBreaks style of the layer. When the layer config is
-   * invalid, nothing is done.
-   *
-   * @param {string} filter A filter to be used in place of the getViewFilter value.
-   * @param {boolean} CombineLegendFilter Flag used to combine the legend filter and the filter together (default: true)
-   * @param {never} notUsed This parameter must not be provided. It is there to allow overloading of the method signature.
-   */
-  applyViewFilter(filter: string, CombineLegendFilter: boolean, notUsed?: never): void;
-
-  /** ***************************************************************************************************************************
-   * Apply a view filter to the layer. When the CombineLegendFilter flag is false, the filter paramater is used alone to display
+   * Apply a view filter to the layer. When the CombineLegendFilter flag is false, the filter parameter is used alone to display
    * the features. Otherwise, the legend filter and the filter parameter are combined together to define the view filter. The
    * legend filters are derived from the uniqueValue or classBreaks style of the layer. When the layer config is invalid, nothing
    * is done.
@@ -395,56 +351,8 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * @param {string} filter A filter to be used in place of the getViewFilter value.
    * @param {boolean} CombineLegendFilter Flag used to combine the legend filter and the filter together (default: true)
    */
-  applyViewFilter(layerPath: string, filter?: string, CombineLegendFilter?: boolean): void;
-
-  // See above headers for signification of the parameters. The first lines of the method select the template
-  // used based on the parameter types received.
-
-  applyViewFilter(parameter1: string, parameter2?: string | boolean | never, parameter3?: boolean | never) {
-    // At the beginning, we assume that:
-    // 1- the layer path was saved in this.layerPathAssociatedToTheGeoviewLayer using a call to
-    //    api.maps[mapId].layer.geoviewLayer(layerPath);
-    // 2- the filter is empty;
-    // 3- the combine legend filters is true
-    let layerPath = this.layerPathAssociatedToTheGeoviewLayer;
-    let filter = '';
-    let CombineLegendFilter = true;
-
-    // Method signature detection
-    if (typeof parameter3 === 'boolean') {
-      // Signature detected is: applyViewFilter(layerPath: string, filter?: string, combineLegendFilter?: boolean): void;
-      layerPath = parameter1;
-      filter = parameter2 as string;
-      CombineLegendFilter = parameter3;
-    } else if (parameter2 !== undefined && parameter3 === undefined) {
-      if (typeof parameter2 === 'boolean') {
-        // Signature detected is: applyViewFilter(filter: string, CombineLegendFilter: boolean): void;
-        filter = parameter1;
-        CombineLegendFilter = parameter2;
-      } else {
-        // Signature detected is: applyViewFilter(layerPath: string, filter: string): void;
-        layerPath = parameter1;
-        filter = parameter2;
-      }
-    } else if (parameter2 === undefined && parameter3 === undefined) {
-      // Signature detected is: applyViewFilter(filter: string): void;
-      filter = parameter1;
-    }
-
+  applyViewFilter(layerPath: string, filter: string, CombineLegendFilter = true) {
     const layerConfig = this.getLayerConfig(layerPath) as VectorLayerEntryConfig;
-    if (!layerConfig) {
-      // GV Things important to know about the applyViewFilter usage:
-      logger.logError(
-        `
-        The applyViewFilter method must never be called by GeoView code before the layer refered by the layerPath has reached the 'loaded' status.\n
-        It will never be called by the GeoView internal code except in the layerConfig.loadedFunction() that is called right after the 'loaded' signal.\n
-        If you are a user, you can set the layer filter in the configuration or using code called in the cgpv.init() method of the viewer.\n
-        It appeares that the layer refered by the layerPath "${layerPath} does not respect these rules.\n
-      `.replace(/\s+/g, ' ')
-      );
-      return;
-    }
-
     // Log
     logger.logTraceCore('ABSTRACT-GEOVIEW-VECTOR - applyViewFilter', layerPath);
 

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -254,25 +254,15 @@ export class LayerApi {
   }
 
   /**
-   * Returns the GeoView instance associated to a specific layer path. The first element of the layerPath
+   * Returns the GeoView instance associated to the layer path. The first element of the layerPath
    * is the geoviewLayerId.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
    * @returns {AbstractGeoViewLayer} Returns the geoview instance associated to the layer path.
    */
   geoviewLayer(layerPath: string): AbstractGeoViewLayer {
-    // TODO: Refactor - Move this method next to the getGeoviewLayerByLayerPath equivalent. And then rename it?
     // The first element of the layerPath is the geoviewLayerId
-    const geoviewLayerInstance = this.geoviewLayers[layerPath.split('/')[0]];
-
-    // TODO: Check #1857 - Why set the `layerPathAssociatedToTheGeoviewLayer` property on the fly? Should likely set this somewhere else than in this function that looks more like a getter.
-    // TO.DOCONT: It seems `layerPathAssociatedToTheGeoviewLayer` is indeed used many places, notably in applyFilters logic.
-    // TO.DOCONT: If all those places rely on the `layerPathAssociatedToTheGeoviewLayer` to be set, that logic using layerPathAssociatedToTheGeoviewLayer should be moved over there.
-    // TO.DOCONT: If there's more other places relying on the `layerPathAssociatedToTheGeoviewLayer`, then it's not ideal,
-    // TO.DOCONT: because it's assuming/relying on the fact that all those other places use this specific geoviewLayer() prior to do their work.
-    // TO.DOCONT: There's likely some separation of logic to apply here. Make this function more evident that it 'sets' something, not just 'gets' a GeoViewLayer.
-    geoviewLayerInstance.layerPathAssociatedToTheGeoviewLayer = layerPath;
-    return geoviewLayerInstance;
+    return this.geoviewLayers[layerPath.split('/')[0]];
   }
 
   /**
@@ -568,7 +558,7 @@ export class LayerApi {
       const pathBeginningAreEqual = partialLayerPathNodes.reduce<boolean>((areEqual, partialLayerPathNode, nodeIndex) => {
         return areEqual && partialLayerPathNode === completeLayerPathNodes[nodeIndex];
       }, true);
-      if (pathBeginningAreEqual) this.geoviewLayer(completeLayerPath).removeConfig();
+      if (pathBeginningAreEqual) this.geoviewLayer(completeLayerPath).removeConfig(completeLayerPath);
     });
     if (listOfLayerEntryConfigAffected) listOfLayerEntryConfigAffected.splice(indexToDelete!, 1);
 
@@ -587,20 +577,10 @@ export class LayerApi {
   };
 
   /**
-   * Searches for a layer using its id and return the layer data
-   *
-   * @param {string} geoviewLayerId the layer id to look for
-   * @returns the found layer data object
-   */
-  getGeoviewLayerById = (geoviewLayerId: string): AbstractGeoViewLayer | null => {
-    return this.geoviewLayers?.[geoviewLayerId] || null;
-  };
-
-  /**
    * Asynchronously gets a layer using its id and return the layer data.
    * If the layer we're searching for has to be processed, set mustBeProcessed to true when awaiting on this method.
    * This function waits the timeout period before abandonning (or uses the default timeout when not provided).
-   * Note this function uses the 'Async' suffix to differentiate it from 'getGeoviewLayerById'.
+   * Note this function uses the 'Async' suffix to differentiate it from 'geoviewLayer()'.
    *
    * @param {string} layerID the layer id to look for
    * @param {string} mustBeProcessed indicate if the layer we're searching for must be found only once processed
@@ -616,7 +596,7 @@ export class LayerApi {
     checkFrequency?: number
   ): Promise<AbstractGeoViewLayer> => {
     // Redirects
-    const layer = this.getGeoviewLayerById(geoviewLayerId);
+    const layer = this.geoviewLayer(geoviewLayerId);
 
     // If layer was found
     if (layer) {
@@ -705,8 +685,8 @@ export class LayerApi {
    */
   highlightLayer(layerPath: string): void {
     this.removeHighlightLayer();
-    this.highlightedLayer = { layerPath, originalOpacity: this.geoviewLayer(layerPath).getOpacity() };
-    this.geoviewLayer(layerPath).setOpacity(1);
+    this.highlightedLayer = { layerPath, originalOpacity: this.geoviewLayer(layerPath).getOpacity(layerPath) };
+    this.geoviewLayer(layerPath).setOpacity(1, layerPath);
     // If it is a group layer, highlight sublayers
     if (layerEntryIsGroupLayer(this.registeredLayers[layerPath] as TypeLayerEntryConfig)) {
       Object.keys(this.registeredLayers).forEach((registeredLayerPath) => {
@@ -714,8 +694,8 @@ export class LayerApi {
           !registeredLayerPath.startsWith(layerPath) &&
           !layerEntryIsGroupLayer(this.registeredLayers[registeredLayerPath] as TypeLayerEntryConfig)
         ) {
-          const otherOpacity = this.geoviewLayer(registeredLayerPath).getOpacity();
-          this.geoviewLayer(registeredLayerPath).setOpacity((otherOpacity || 1) * 0.25);
+          const otherOpacity = this.geoviewLayer(registeredLayerPath).getOpacity(registeredLayerPath);
+          this.geoviewLayer(registeredLayerPath).setOpacity((otherOpacity || 1) * 0.25, registeredLayerPath);
         } else this.registeredLayers[registeredLayerPath].olLayer!.setZIndex(999);
       });
     } else {
@@ -725,8 +705,8 @@ export class LayerApi {
           registeredLayerPath !== layerPath &&
           !layerEntryIsGroupLayer(this.registeredLayers[registeredLayerPath] as TypeLayerEntryConfig)
         ) {
-          const otherOpacity = this.geoviewLayer(registeredLayerPath).getOpacity();
-          this.geoviewLayer(registeredLayerPath).setOpacity((otherOpacity || 1) * 0.25);
+          const otherOpacity = this.geoviewLayer(registeredLayerPath).getOpacity(registeredLayerPath);
+          this.geoviewLayer(registeredLayerPath).setOpacity((otherOpacity || 1) * 0.25, registeredLayerPath);
         }
       });
       this.registeredLayers[layerPath].olLayer!.setZIndex(999);
@@ -746,9 +726,9 @@ export class LayerApi {
             !registeredLayerPath.startsWith(layerPath) &&
             !layerEntryIsGroupLayer(this.registeredLayers[registeredLayerPath] as TypeLayerEntryConfig)
           ) {
-            const otherOpacity = this.geoviewLayer(registeredLayerPath).getOpacity();
-            this.geoviewLayer(registeredLayerPath).setOpacity(otherOpacity ? otherOpacity * 4 : 1);
-          } else this.geoviewLayer(registeredLayerPath).setOpacity(originalOpacity || 1);
+            const otherOpacity = this.geoviewLayer(registeredLayerPath).getOpacity(registeredLayerPath);
+            this.geoviewLayer(registeredLayerPath).setOpacity(otherOpacity ? otherOpacity * 4 : 1, registeredLayerPath);
+          } else this.geoviewLayer(registeredLayerPath).setOpacity(originalOpacity || 1, registeredLayerPath);
         });
       } else {
         Object.keys(this.registeredLayers).forEach((registeredLayerPath) => {
@@ -757,9 +737,9 @@ export class LayerApi {
             registeredLayerPath !== layerPath &&
             !layerEntryIsGroupLayer(this.registeredLayers[registeredLayerPath] as TypeLayerEntryConfig)
           ) {
-            const otherOpacity = this.geoviewLayer(registeredLayerPath).getOpacity();
-            this.geoviewLayer(registeredLayerPath).setOpacity(otherOpacity ? otherOpacity * 4 : 1);
-          } else this.geoviewLayer(registeredLayerPath).setOpacity(originalOpacity || 1);
+            const otherOpacity = this.geoviewLayer(registeredLayerPath).getOpacity(registeredLayerPath);
+            this.geoviewLayer(registeredLayerPath).setOpacity(otherOpacity ? otherOpacity * 4 : 1, registeredLayerPath);
+          } else this.geoviewLayer(registeredLayerPath).setOpacity(originalOpacity || 1, registeredLayerPath);
         });
       }
       MapEventProcessor.setLayerZIndices(this.mapId);


### PR DESCRIPTION
# Description

There are at least two methods in the viewer for obtaining the Geoview layer using the layer path. In addition, one of them uses a property to encapsulate the layer path and uses this encapsulated property in other methods such as getOpacity, setOpacity, getVisible, setVisible and so on. This approach is ambiguous and obscures the actual use of the layer path. We want to eliminate this dangerous behavior from our code for a single method that doesn't hide the use of the layer path.

Fixes #1930

## Type of change

- [x] Refactor (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using Chrome Devtools and the geoview templates.

__Deploy URL__: https://ychoquet.github.io/GeoView/index.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1938)
<!-- Reviewable:end -->
