### PR TITLE
refactor(layers) - Part 3

### DIFF
--- a/packages/geoview-core/src/api/event-processors/abstract-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/abstract-event-processor.ts
@@ -3,13 +3,13 @@ import { getGeoViewStore, getGeoViewStoreAsync } from '@/core/stores/stores-mana
 import { IGeoviewState } from '@/core/types/cgpv-types';
 import { logger } from '@/core/utils/logger';
 import { delay } from '@/core/utils/utilities';
-import { TypeArrayOfLayerData } from '@/geo/utils/layer-set';
+import { TypeLayerData } from '@/geo/utils/layer-set';
 
 /**
  * Holds the buffer, on a map basis, for the propagation in batch in the layer data array store
  */
 export type BatchedPropagationLayerDataArrayByMap = {
-  [mapId: string]: TypeArrayOfLayerData[];
+  [mapId: string]: TypeLayerData[][];
 };
 
 export abstract class AbstractEventProcessor {
@@ -73,10 +73,10 @@ export abstract class AbstractEventProcessor {
    * The propagation can be bypassed using 'layerPathBypass' parameter which tells the process to
    * immediately batch out the array in the store for faster triggering of the state, for faster updating of the UI.
    * @param {string} mapId The map id
-   * @param {TypeArrayOfLayerData} layerDataArray The layer data array to hold in buffer during the batch
+   * @param {TypeLayerData[]} layerDataArray The layer data array to hold in buffer during the batch
    * @param {BatchedPropagationLayerDataArrayByMap} batchPropagationObject A reference to the BatchedPropagationLayerDataArrayByMap object used to hold all the layer data arrays in the buffer
    * @param {number} timeDelayBetweenPropagations The delay between actual propagations in the store
-   * @param {(layerDataArray: TypeArrayOfLayerData) => void} onSetLayerDataArray The store action callback used to store the layerDataArray in the actual store
+   * @param {(layerDataArray: TypeLayerData[]) => void} onSetLayerDataArray The store action callback used to store the layerDataArray in the actual store
    * @param {string} traceProcessorIndication? Simple parameter for logging purposes
    * @param {string} layerPathBypass? Indicates a layer path which, when processed, should bypass the buffer period and immediately trigger an update to the store
    * @param {(layerPath: string) => void} onResetBypass? The store action callback used to reset the layerPathBypass value in the store.
@@ -87,10 +87,10 @@ export abstract class AbstractEventProcessor {
    */
   protected static async helperPropagateArrayStoreBatch(
     mapId: string,
-    layerDataArray: TypeArrayOfLayerData,
+    layerDataArray: TypeLayerData[],
     batchPropagationObject: BatchedPropagationLayerDataArrayByMap,
     timeDelayBetweenPropagations: number,
-    onSetLayerDataArray: (layerDataArray: TypeArrayOfLayerData) => void,
+    onSetLayerDataArray: (layerDataArray: TypeLayerData[]) => void,
     traceProcessorIndication?: string,
     layerPathBypass?: string,
     onResetBypass?: (layerPath: string) => void

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/feature-info-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/feature-info-event-processor.ts
@@ -2,7 +2,7 @@ import { GeoviewStoreType, IFeatureInfoState } from '@/core/stores';
 import { logger } from '@/core/utils/logger';
 import { TypeFeatureInfoResultSet } from '@/geo/utils/feature-info-layer-set';
 import { TypeHoverFeatureInfoResultSet } from '@/geo/utils/hover-feature-info-layer-set';
-import { EventType, TypeArrayOfLayerData, TypeLayerData } from '@/geo/utils/layer-set';
+import { EventType, TypeLayerData } from '@/geo/utils/layer-set';
 
 import { AbstractEventProcessor, BatchedPropagationLayerDataArrayByMap } from '../abstract-event-processor';
 import { UIEventProcessor } from './ui-event-processor';
@@ -131,15 +131,11 @@ export class FeatureInfoEventProcessor extends AbstractEventProcessor {
 
   /**
    * Helper function to delete a layer information from an array when found
-   * @param {TypeArrayOfLayerData} layerArray The layer array to work with
+   * @param {TypeLayerData[]} layerArray The layer array to work with
    * @param {string} layerPath The layer path to delete
-   * @param {(layerArray: TypeArrayOfLayerData) => void} onDeleteCallback The callback executed when the array is updated
+   * @param {(layerArray: TypeLayerData[]) => void} onDeleteCallback The callback executed when the array is updated
    */
-  private static deleteFromArray(
-    layerArray: TypeArrayOfLayerData,
-    layerPath: string,
-    onDeleteCallback: (layerArray: TypeArrayOfLayerData) => void
-  ) {
+  private static deleteFromArray(layerArray: TypeLayerData[], layerPath: string, onDeleteCallback: (layerArray: TypeLayerData[]) => void) {
     // Find the layer data info to delete from the array
     const layerDataInfoToDelIndex = layerArray.findIndex((layerInfo) => layerInfo.layerPath === layerPath);
 
@@ -223,7 +219,7 @@ export class FeatureInfoEventProcessor extends AbstractEventProcessor {
    * @param {string} layerDataArray The layer data array to batch on
    * @returns {Promise<void>} Promise upon completion
    */
-  private static propagateFeatureInfoToStoreBatch(mapId: string, layerDataArray: TypeArrayOfLayerData): Promise<void> {
+  private static propagateFeatureInfoToStoreBatch(mapId: string, layerDataArray: TypeLayerData[]): Promise<void> {
     // The feature info state
     const featureInfoState = this.getFeatureInfoState(mapId);
 

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/geochart-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/geochart-event-processor.ts
@@ -2,7 +2,7 @@ import { GeoviewStoreType } from '@/core/stores';
 import { GeoChartStoreByLayerPath, IGeochartState } from '@/core/stores/store-interface-and-intial-values/geochart-state';
 import { GeoChartConfig } from '@/core/utils/config/reader/uuid-config-reader';
 import { logger } from '@/core/utils/logger';
-import { TypeArrayOfLayerData } from '@/geo/utils/layer-set';
+import { TypeLayerData } from '@/geo/utils/layer-set';
 
 import { AbstractEventProcessor, BatchedPropagationLayerDataArrayByMap } from '../abstract-event-processor';
 
@@ -170,7 +170,7 @@ export class GeochartEventProcessor extends AbstractEventProcessor {
    * @param {string} mapId The map id
    * @param {string} layerDataArray The layer data array to propagate in the store
    */
-  static propagateArrayDataToStore(mapId: string, layerDataArray: TypeArrayOfLayerData): void {
+  static propagateArrayDataToStore(mapId: string, layerDataArray: TypeLayerData[]): void {
     // To propagate in the store, the processor needs an initialized chart store which is only initialized if the Geochart plugin exists.
     // Therefore, we validate its existence first.
     if (!this.getGeochartState(mapId)) return;
@@ -192,7 +192,7 @@ export class GeochartEventProcessor extends AbstractEventProcessor {
    * @param {string} layerDataArray The layer data array to batch on
    * @returns {Promise<void>} Promise upon completion
    */
-  private static propagateFeatureInfoToStoreBatch(mapId: string, layerDataArray: TypeArrayOfLayerData): Promise<void> {
+  private static propagateFeatureInfoToStoreBatch(mapId: string, layerDataArray: TypeLayerData[]): Promise<void> {
     // To propagate in the store, the processor needs an initialized chart store which is only initialized if the Geochart plugin exists.
     // Therefore, we validate its existence first.
     if (!this.getGeochartState(mapId)) return Promise.resolve();

--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { animated, useSpring } from '@react-spring/web';
 import { Box, ChevronRightIcon, IconButton, List, ListItem, ListItemButton, ListItemIcon, Paper, Tooltip, Typography } from '@/ui';
 
-import { TypeArrayOfFeatureInfoEntries, TypeQueryStatus } from '@/geo/utils/layer-set';
+import { TypeFeatureInfoEntry, TypeQueryStatus } from '@/geo/utils/layer-set';
 import { TypeLayerStatus } from '@/geo/map/map-schema-types';
 
 import { getSxClasses } from './layer-list-style';
@@ -19,7 +19,7 @@ export interface LayerListEntry {
   mapFilteredIcon?: ReactNode;
   tooltip?: ReactNode;
   numOffeatures?: number;
-  features?: TypeArrayOfFeatureInfoEntries;
+  features?: TypeFeatureInfoEntry[] | undefined | null;
 }
 
 interface LayerListProps {

--- a/packages/geoview-core/src/core/components/data-table/hooks/useFeatureFieldInfos.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useFeatureFieldInfos.tsx
@@ -1,13 +1,13 @@
-import { TypeArrayOfLayerData, TypeFieldEntry } from '@/geo/utils/layer-set';
+import { TypeLayerData, TypeFieldEntry } from '@/geo/utils/layer-set';
 
 import { MappedLayerDataType } from '../data-panel';
 
 /**
  * Custom hook for caching the mapping of fieldInfos aka columns for data table.
- * @param {TypeArrayOfLayerData} layerData data from the query
+ * @param {TypeLayerData[]} layerData data from the query
  * @returns {MappedLayerDataType[]} layerData with columns.
  */
-export function useFeatureFieldInfos(layerData: TypeArrayOfLayerData): MappedLayerDataType[] {
+export function useFeatureFieldInfos(layerData: TypeLayerData[]): MappedLayerDataType[] {
   const mappedLayerData = layerData?.map((layer) => {
     let fieldInfos = {} as Record<string, TypeFieldEntry | undefined>;
     if (layer.features?.length) {

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -20,7 +20,7 @@ import {
   useDetailsStoreSelectedLayerPath,
 } from '@/core/stores';
 import { logger } from '@/core/utils/logger';
-import { TypeArrayOfFeatureInfoEntries, TypeFeatureInfoEntry, TypeGeometry, TypeLayerData } from '@/geo/utils/layer-set';
+import { TypeFeatureInfoEntry, TypeGeometry, TypeLayerData } from '@/geo/utils/layer-set';
 
 import { LayerListEntry, Layout } from '../common';
 import { getSxClasses } from './details-style';
@@ -60,7 +60,7 @@ export function DetailsPanel({ fullWidth }: DetailsPanelType): JSX.Element {
   const [arrayOfLayerListLocal, setArrayOfLayerListLocal] = useState<LayerListEntry[]>([]);
 
   const prevLayerSelected = useRef<TypeLayerData>();
-  const prevLayerFeatures = useRef<TypeArrayOfFeatureInfoEntries>();
+  const prevLayerFeatures = useRef<TypeFeatureInfoEntry[] | undefined | null>();
   const prevFeatureIndex = useRef<number>(0); // 0 because that's the default index for the features
 
   // #endregion
@@ -87,10 +87,10 @@ export function DetailsPanel({ fullWidth }: DetailsPanelType): JSX.Element {
 
   /**
    * Clears the highlighed features when they are not checked.
-   * @param {TypeArrayOfFeatureInfoEntries} arrayToClear The array to clear of the unchecked features
+   * @param {TypeFeatureInfoEntry[] | undefined | null} arrayToClear The array to clear of the unchecked features
    */
   const clearHighlightsUnchecked = useCallback(
-    (arrayToClear: TypeArrayOfFeatureInfoEntries | undefined) => {
+    (arrayToClear: TypeFeatureInfoEntry[] | undefined | null) => {
       // Log
       logger.logTraceUseCallback('DETAILS-PANEL - clearHighlightsUnchecked');
 

--- a/packages/geoview-core/src/core/components/details/feature-info-new.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info-new.tsx
@@ -8,13 +8,13 @@ import { useDetailsStoreCheckedFeatures, useDetailsStoreActions } from '@/core/s
 import { useMapStoreActions } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
 import { delay } from '@/core/utils/utilities';
-import { TypeArrayOfFeatureInfoEntries, TypeFieldEntry, TypeGeometry } from '@/geo/utils/layer-set';
+import { TypeFeatureInfoEntry, TypeFieldEntry, TypeGeometry } from '@/geo/utils/layer-set';
 
 import { FeatureInfoTable } from './feature-info-table';
 import { getSxClasses } from './details-style';
 
 export interface TypeFeatureInfoProps {
-  features: TypeArrayOfFeatureInfoEntries;
+  features: TypeFeatureInfoEntry[] | undefined | null;
   currentFeatureIndex: number;
 }
 

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
@@ -2,7 +2,7 @@ import { useStore } from 'zustand';
 import { type MRT_ColumnFiltersState as MRTColumnFiltersState } from 'material-react-table';
 import { TypeSetStore, TypeGetStore } from '@/core/stores/geoview-store';
 import { DataTableProcessor } from '@/api/event-processors/event-processor-children/data-table-processor';
-import { TypeArrayOfLayerData } from '@/geo/utils/layer-set';
+import { TypeLayerData } from '@/geo/utils/layer-set';
 
 import { useGeoViewStore } from '../stores-managers';
 
@@ -13,7 +13,7 @@ interface IMapDataTableStateActions {
   setRowsFilteredEntry: (rows: number, layerPath: string) => void;
   setSelectedLayerPath: (layerPath: string) => void;
   setToolbarRowSelectedMessageEntry: (message: string, layerPath: string) => void;
-  setLayersData: (layers: TypeArrayOfLayerData) => void;
+  setLayersData: (layers: TypeLayerData[]) => void;
   applyMapFilters: (filterStrings: string) => void;
   setTableHeight: (tableHeight: number) => void;
 }
@@ -24,7 +24,7 @@ export interface IMapDataTableState {
   rowsFilteredRecord: Record<string, number>;
   selectedLayerPath: string;
   toolbarRowSelectedMessageRecord: Record<string, string>;
-  layersData: TypeArrayOfLayerData;
+  layersData: TypeLayerData[];
   tableHeight: number;
   actions: IMapDataTableStateActions;
 }
@@ -42,7 +42,7 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IMa
 
     // #region ACTIONS
     actions: {
-      setLayersData: (layersData: TypeArrayOfLayerData) => {
+      setLayersData: (layersData: TypeLayerData[]) => {
         set({
           dataTableState: {
             ...get().dataTableState,
@@ -131,8 +131,7 @@ export const useDataTableStoreMapFilteredRecord = (): Record<string, boolean> =>
   useStore(useGeoViewStore(), (state) => state.dataTableState.mapFilteredRecord);
 export const useDataTableStoreRowsFiltered = (): Record<string, number> =>
   useStore(useGeoViewStore(), (state) => state.dataTableState.rowsFilteredRecord);
-export const useDatatableStoreLayersData = (): TypeArrayOfLayerData =>
-  useStore(useGeoViewStore(), (state) => state.dataTableState.layersData);
+export const useDatatableStoreLayersData = (): TypeLayerData[] => useStore(useGeoViewStore(), (state) => state.dataTableState.layersData);
 export const useDatatableStoreTableHeight = (): number => useStore(useGeoViewStore(), (state) => state.dataTableState.tableHeight);
 
 export const useDataTableStoreActions = (): IMapDataTableStateActions =>

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
@@ -1,27 +1,27 @@
 import { useStore } from 'zustand';
 import { TypeSetStore, TypeGetStore } from '@/core/stores/geoview-store';
 import { api } from '@/app';
-import { QueryType, TypeArrayOfLayerData, TypeFeatureInfoEntry, TypeGeometry } from '@/geo/utils/layer-set';
+import { QueryType, TypeLayerData, TypeFeatureInfoEntry, TypeGeometry } from '@/geo/utils/layer-set';
 
 import { useGeoViewStore } from '../stores-managers';
 
 export interface IFeatureInfoState {
   checkedFeatures: Array<TypeFeatureInfoEntry>;
-  layerDataArray: TypeArrayOfLayerData;
-  layerDataArrayBatch: TypeArrayOfLayerData;
+  layerDataArray: TypeLayerData[];
+  layerDataArrayBatch: TypeLayerData[];
   layerDataArrayBatchLayerPathBypass: string;
-  hoverDataArray: TypeArrayOfLayerData;
-  allFeaturesDataArray: TypeArrayOfLayerData;
+  hoverDataArray: TypeLayerData[];
+  allFeaturesDataArray: TypeLayerData[];
   selectedLayerPath: string;
 
   actions: {
     addCheckedFeature: (feature: TypeFeatureInfoEntry) => void;
     removeCheckedFeature: (feature: TypeFeatureInfoEntry | 'all') => void;
-    setLayerDataArray: (layerDataArray: TypeArrayOfLayerData) => void;
-    setLayerDataArrayBatch: (layerDataArray: TypeArrayOfLayerData) => void;
+    setLayerDataArray: (layerDataArray: TypeLayerData[]) => void;
+    setLayerDataArrayBatch: (layerDataArray: TypeLayerData[]) => void;
     setLayerDataArrayBatchLayerPathBypass: (layerPath: string) => void;
-    setHoverDataArray: (hoverDataArray: TypeArrayOfLayerData) => void;
-    setAllFeaturesDataArray: (allFeaturesDataArray: TypeArrayOfLayerData) => void;
+    setHoverDataArray: (hoverDataArray: TypeLayerData[]) => void;
+    setAllFeaturesDataArray: (allFeaturesDataArray: TypeLayerData[]) => void;
     setSelectedLayerPath: (selectedLayerPath: string) => void;
     triggerGetAllFeatureInfo: (layerPath: string, queryType: QueryType) => void;
   };
@@ -61,7 +61,7 @@ export function initFeatureInfoState(set: TypeSetStore, get: TypeGetStore): IFea
           },
         });
       },
-      setLayerDataArray(layerDataArray: TypeArrayOfLayerData) {
+      setLayerDataArray(layerDataArray: TypeLayerData[]) {
         set({
           detailsState: {
             ...get().detailsState,
@@ -69,7 +69,7 @@ export function initFeatureInfoState(set: TypeSetStore, get: TypeGetStore): IFea
           },
         });
       },
-      setLayerDataArrayBatch(layerDataArrayBatch: TypeArrayOfLayerData) {
+      setLayerDataArrayBatch(layerDataArrayBatch: TypeLayerData[]) {
         set({
           detailsState: {
             ...get().detailsState,
@@ -85,7 +85,7 @@ export function initFeatureInfoState(set: TypeSetStore, get: TypeGetStore): IFea
           },
         });
       },
-      setHoverDataArray(hoverDataArray: TypeArrayOfLayerData) {
+      setHoverDataArray(hoverDataArray: TypeLayerData[]) {
         set({
           detailsState: {
             ...get().detailsState,
@@ -93,7 +93,7 @@ export function initFeatureInfoState(set: TypeSetStore, get: TypeGetStore): IFea
           },
         });
       },
-      setAllFeaturesDataArray(allFeaturesDataArray: TypeArrayOfLayerData) {
+      setAllFeaturesDataArray(allFeaturesDataArray: TypeLayerData[]) {
         set({
           detailsState: {
             ...get().detailsState,

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/geochart-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/geochart-state.ts
@@ -1,6 +1,6 @@
 import { useStore } from 'zustand';
 import { GeoChartConfig } from '@/core/utils/config/reader/uuid-config-reader';
-import { TypeArrayOfLayerData } from '@/geo/utils/layer-set';
+import { TypeLayerData } from '@/geo/utils/layer-set';
 
 import { useGeoViewStore } from '../stores-managers';
 import { TypeGetStore, TypeSetStore } from '../geoview-store';
@@ -13,15 +13,15 @@ export type GeoChartStoreByLayerPath = {
 
 export interface IGeochartState {
   geochartChartsConfig: GeoChartStoreByLayerPath;
-  layerDataArray: TypeArrayOfLayerData;
-  layerDataArrayBatch: TypeArrayOfLayerData;
+  layerDataArray: TypeLayerData[];
+  layerDataArrayBatch: TypeLayerData[];
   layerDataArrayBatchLayerPathBypass: string;
   selectedLayerPath: string;
 
   actions: {
     setGeochartCharts: (charts: GeoChartStoreByLayerPath) => void;
-    setLayerDataArray: (layerDataArray: TypeArrayOfLayerData) => void;
-    setLayerDataArrayBatch: (layerDataArray: TypeArrayOfLayerData) => void;
+    setLayerDataArray: (layerDataArray: TypeLayerData[]) => void;
+    setLayerDataArrayBatch: (layerDataArray: TypeLayerData[]) => void;
     setLayerDataArrayBatchLayerPathBypass: (layerPath: string) => void;
     setSelectedLayerPath: (selectedLayerPath: string) => void;
   };
@@ -54,7 +54,7 @@ export function initializeGeochartState(set: TypeSetStore, get: TypeGetStore): I
           },
         });
       },
-      setLayerDataArray(layerDataArray: TypeArrayOfLayerData) {
+      setLayerDataArray(layerDataArray: TypeLayerData[]) {
         set({
           geochartState: {
             ...get().geochartState,
@@ -62,7 +62,7 @@ export function initializeGeochartState(set: TypeSetStore, get: TypeGetStore): I
           },
         });
       },
-      setLayerDataArrayBatch(layerDataArrayBatch: TypeArrayOfLayerData) {
+      setLayerDataArrayBatch(layerDataArrayBatch: TypeLayerData[]) {
         set({
           geochartState: {
             ...get().geochartState,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -42,14 +42,7 @@ import {
   TypeStyleGeometry,
   CONST_LAYER_ENTRY_TYPES,
 } from '@/geo/map/map-schema-types';
-import {
-  QueryType,
-  TypeArrayOfFeatureInfoEntries,
-  TypeFeatureInfoEntry,
-  TypeLocation,
-  codedValueType,
-  rangeDomainType,
-} from '@/geo/utils/layer-set';
+import { QueryType, TypeFeatureInfoEntry, TypeLocation, codedValueType, rangeDomainType } from '@/geo/utils/layer-set';
 
 export type TypeLegend = {
   layerPath: string;
@@ -738,7 +731,11 @@ export abstract class AbstractGeoViewLayer {
    * users can't expect anything to be returned after a click. They have to wait until they see something on the map to know where
    * the features are so they can click on them.
    */
-  async getFeatureInfo(queryType: QueryType, layerPath: string, location: TypeLocation = null): Promise<TypeArrayOfFeatureInfoEntries> {
+  async getFeatureInfo(
+    queryType: QueryType,
+    layerPath: string,
+    location: TypeLocation = null
+  ): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     try {
       // TODO: Refactor - Rework this function to not need a layer path in the param, nor a need to get a layer config here..
       // TO.DOCONT: For example, this call seems to have logic redundancy: `layerConfig.geoviewLayerInstance.getFeatureInfo(queryType, layerPath, location)`
@@ -757,7 +754,7 @@ export abstract class AbstractGeoViewLayer {
       const logMarkerKey = `${queryType} | ${layerPath}`;
       logger.logMarkerStart(logMarkerKey);
 
-      let promiseGetFeature: Promise<TypeArrayOfFeatureInfoEntries>;
+      let promiseGetFeature: Promise<TypeFeatureInfoEntry[] | undefined | null>;
       switch (queryType) {
         case 'all':
           promiseGetFeature = this.getAllFeatureInfo(layerPath);
@@ -807,10 +804,10 @@ export abstract class AbstractGeoViewLayer {
    *
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
 
-  protected getAllFeatureInfo(layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected getAllFeatureInfo(layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     // Log
     logger.logError(`getAllFeatureInfo is not implemented! for ${layerPath}`);
     return Promise.resolve(null);
@@ -823,10 +820,10 @@ export abstract class AbstractGeoViewLayer {
    * @param {Coordinate} location The pixel coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
 
-  protected getFeatureInfoAtPixel(location: Pixel, layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected getFeatureInfoAtPixel(location: Pixel, layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     // Log
     logger.logError(`getFeatureInfoAtPixel is not implemented! for ${layerPath} - ${location}`);
     return Promise.resolve(null);
@@ -839,10 +836,10 @@ export abstract class AbstractGeoViewLayer {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
 
-  protected getFeatureInfoAtCoordinate(location: Coordinate, layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected getFeatureInfoAtCoordinate(location: Coordinate, layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     // Log
     logger.logError(`getFeatureInfoAtCoordinate is not implemented! for ${layerPath} - ${location}`);
     return Promise.resolve(null);
@@ -855,10 +852,10 @@ export abstract class AbstractGeoViewLayer {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
 
-  protected getFeatureInfoAtLongLat(location: Coordinate, layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected getFeatureInfoAtLongLat(location: Coordinate, layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     // Log
     logger.logError(`getFeatureInfoAtLongLat is not implemented for ${layerPath} - ${location}!`);
     return Promise.resolve(null);
@@ -871,10 +868,10 @@ export abstract class AbstractGeoViewLayer {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
 
-  protected getFeatureInfoUsingBBox(location: Coordinate[], layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected getFeatureInfoUsingBBox(location: Coordinate[], layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     // Log
     logger.logError(`getFeatureInfoUsingBBox is not implemented! for ${layerPath} - ${location}`);
     return Promise.resolve(null);
@@ -887,10 +884,10 @@ export abstract class AbstractGeoViewLayer {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
 
-  protected getFeatureInfoUsingPolygon(location: Coordinate[], layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected getFeatureInfoUsingPolygon(location: Coordinate[], layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     // Log
     logger.logError(`getFeatureInfoUsingPolygon is not implemented! for ${layerPath} - ${location}`);
     return Promise.resolve(null);
@@ -1303,17 +1300,17 @@ export abstract class AbstractGeoViewLayer {
   }
 
   /** ***************************************************************************************************************************
-   * Convert the feature information to an array of TypeArrayOfFeatureInfoEntries.
+   * Convert the feature information to an array of TypeFeatureInfoEntry[] | undefined | null.
    *
    * @param {Feature[]} features The array of features to convert.
    * @param {ImageLayerEntryConfig | VectorLayerEntryConfig} layerConfig The layer configuration.
    *
-   * @returns {TypeArrayOfFeatureInfoEntries} The Array of feature information.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The Array of feature information.
    */
   protected async formatFeatureInfoResult(
     features: Feature[],
     layerConfig: OgcWmsLayerEntryConfig | EsriDynamicLayerEntryConfig | VectorLayerEntryConfig
-  ): Promise<TypeArrayOfFeatureInfoEntries> {
+  ): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     try {
       if (!features.length) return [];
 
@@ -1321,7 +1318,7 @@ export abstract class AbstractGeoViewLayer {
       const fieldTypes = featureInfo?.fieldTypes?.split(',') as ('string' | 'number' | 'date')[];
       const outfields = getLocalizedValue(featureInfo?.outfields, this.mapId)?.split(',');
       const aliasFields = getLocalizedValue(featureInfo?.aliasFields, this.mapId)?.split(',');
-      const queryResult: TypeArrayOfFeatureInfoEntries = [];
+      const queryResult: TypeFeatureInfoEntry[] = [];
       let featureKeyCounter = 0;
       let fieldKeyCounter = 0;
       const promisedAllCanvasFound: Promise<{ feature: Feature; canvas: HTMLCanvasElement | undefined }>[] = [];

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -33,7 +33,7 @@ import {
   TypeFeatureInfoLayerConfig,
   TypeVisibilityFlags,
 } from '@/geo/map/map-schema-types';
-import { TypeArrayOfFeatureInfoEntries, codedValueType, rangeDomainType } from '@/geo/utils/layer-set';
+import { TypeFeatureInfoEntry, codedValueType, rangeDomainType } from '@/geo/utils/layer-set';
 
 import {
   commonGetFieldDomain,
@@ -273,9 +273,9 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @param {Coordinate} location The pixel coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
-  protected getFeatureInfoAtPixel(location: Pixel, layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected getFeatureInfoAtPixel(location: Pixel, layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     const { map } = api.maps[this.mapId];
     return this.getFeatureInfoAtCoordinate(map.getCoordinateFromPixel(location), layerPath);
   }
@@ -286,9 +286,9 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The promised feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The promised feature info table.
    */
-  protected getFeatureInfoAtCoordinate(location: Coordinate, layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected getFeatureInfoAtCoordinate(location: Coordinate, layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     const convertedLocation = api.projection.transform(
       location,
       `EPSG:${MapEventProcessor.getMapState(this.mapId).currentProjection}`,
@@ -303,9 +303,9 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @param {Coordinate} lnglat The coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The promised feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The promised feature info table.
    */
-  protected async getFeatureInfoAtLongLat(lnglat: Coordinate, layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected async getFeatureInfoAtLongLat(lnglat: Coordinate, layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     try {
       // Get the layer config in a loaded phase
       const layerConfig = (await this.getLayerConfig(layerPath)) as EsriDynamicLayerEntryConfig;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -38,7 +38,7 @@ import { logger } from '@/core/utils/logger';
 import { OgcWmsLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config';
 import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
 import { GroupLayerEntryConfig } from '@/core/utils/config/validation-classes/group-layer-entry-config';
-import { TypeArrayOfFeatureInfoEntries, TypeFeatureInfoEntry } from '@/geo/utils/layer-set';
+import { TypeFeatureInfoEntry } from '@/geo/utils/layer-set';
 
 export interface TypeWMSLayerConfig extends Omit<TypeGeoviewLayerConfig, 'listOfLayerEntryConfig'> {
   geoviewLayerType: typeof CONST_LAYER_TYPES.WMS;
@@ -618,9 +618,9 @@ export class WMS extends AbstractGeoViewRaster {
    * @param {Coordinate} location The pixel coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
-  protected getFeatureInfoAtPixel(location: Pixel, layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected getFeatureInfoAtPixel(location: Pixel, layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     const { map } = api.maps[this.mapId];
     return this.getFeatureInfoAtCoordinate(map.getCoordinateFromPixel(location), layerPath);
   }
@@ -631,9 +631,9 @@ export class WMS extends AbstractGeoViewRaster {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The promised feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The promised feature info table.
    */
-  protected getFeatureInfoAtCoordinate(location: Coordinate, layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected getFeatureInfoAtCoordinate(location: Coordinate, layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     const convertedLocation = api.projection.transform(
       location,
       `EPSG:${MapEventProcessor.getMapState(this.mapId).currentProjection}`,
@@ -648,9 +648,9 @@ export class WMS extends AbstractGeoViewRaster {
    * @param {Coordinate} lnglat The coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The promised feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The promised feature info table.
    */
-  protected async getFeatureInfoAtLongLat(lnglat: Coordinate, layerPath: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected async getFeatureInfoAtLongLat(lnglat: Coordinate, layerPath: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     try {
       // Get the layer config in a loaded phase
       const layerConfig = this.getLayerConfig(layerPath) as OgcWmsLayerEntryConfig;
@@ -912,24 +912,24 @@ export class WMS extends AbstractGeoViewRaster {
   }
 
   /** ***************************************************************************************************************************
-   * Translate the get feature information result set to the TypeArrayOfFeatureInfoEntries used by GeoView.
+   * Translate the get feature information result set to the TypeFeatureInfoEntry[] used by GeoView.
    *
    * @param {TypeJsonObject} featureMember An object formatted using the query syntax.
    * @param {OgcWmsLayerEntryConfig} layerConfig The layer configuration.
    * @param {Coordinate} clickCoordinate The coordinate where the user has clicked.
    *
-   * @returns {TypeArrayOfFeatureInfoEntries} The feature info table.
+   * @returns {TypeFeatureInfoEntry[]} The feature info table.
    */
   private formatWmsFeatureInfoResult(
     featureMember: TypeJsonObject,
     layerConfig: OgcWmsLayerEntryConfig,
     clickCoordinate: Coordinate
-  ): TypeArrayOfFeatureInfoEntries {
+  ): TypeFeatureInfoEntry[] {
     const featureInfo = layerConfig?.source?.featureInfo;
     const outfields = getLocalizedValue(featureInfo?.outfields, this.mapId)?.split(',');
     const fieldTypes = featureInfo?.fieldTypes?.split(',');
     const aliasFields = getLocalizedValue(featureInfo?.aliasFields, this.mapId)?.split(',');
-    const queryResult: TypeArrayOfFeatureInfoEntries = [];
+    const queryResult: TypeFeatureInfoEntry[] = [];
 
     let featureKeyCounter = 0;
     let fieldKeyCounter = 0;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -28,7 +28,7 @@ import { logger } from '@/core/utils/logger';
 import { CSV } from './csv';
 import { VectorLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-layer-entry-config';
 import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
-import { TypeArrayOfFeatureInfoEntries } from '@/geo/utils/layer-set';
+import { TypeFeatureInfoEntry } from '@/geo/utils/layer-set';
 
 /* *******************************************************************************************************************************
  * AbstractGeoViewVector types
@@ -246,9 +246,9 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    *
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {TypeArrayOfFeatureInfoEntries} The feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
-  protected async getAllFeatureInfo(layerPath?: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected async getAllFeatureInfo(layerPath?: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     try {
       // Get the layer config in a loaded phase
@@ -269,9 +269,9 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * @param {Coordinate} location The pixel coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries> | null} The feature info table or null if an error occured.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table or null if an error occured.
    */
-  protected async getFeatureInfoAtPixel(location: Pixel, layerPath?: string): Promise<TypeArrayOfFeatureInfoEntries | null> {
+  protected async getFeatureInfoAtPixel(location: Pixel, layerPath?: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     try {
       // Get the layer config in a loaded phase
@@ -297,11 +297,9 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * @param {Coordinate} location The pixel coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
-  protected getFeatureInfoAtCoordinate(location: Coordinate, layerPath?: string): Promise<TypeArrayOfFeatureInfoEntries> {
-    // TODO: Check - The return type of this function should maybe be Promise<TypeArrayOfFeatureInfoEntries | null>
-    // TO.DD.CONT: and standardize this across all layer classes and all getFeatureInfo functions.
+  protected getFeatureInfoAtCoordinate(location: Coordinate, layerPath?: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const { map } = api.maps[this.mapId];
     return this.getFeatureInfoAtPixel(map.getPixelFromCoordinate(location as Coordinate), layerPath);
@@ -313,9 +311,9 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * @param {Coordinate} location The coordinate that will be used by the query.
    * @param {string} layerPath The layer path to the layer's configuration.
    *
-   * @returns {Promise<TypeArrayOfFeatureInfoEntries>} The feature info table.
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The feature info table.
    */
-  protected getFeatureInfoAtLongLat(location: Coordinate, layerPath?: string): Promise<TypeArrayOfFeatureInfoEntries> {
+  protected getFeatureInfoAtLongLat(location: Coordinate, layerPath?: string): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     layerPath = layerPath || this.layerPathAssociatedToTheGeoviewLayer;
     const { map } = api.maps[this.mapId];
     const convertedLocation = api.projection.transform(

--- a/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
@@ -7,7 +7,7 @@ import { logger } from '@/core/utils/logger';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { TypeLayerStatus } from '@/core/types/cgpv-types';
 
-import { LayerSet, TypeArrayOfFeatureInfoEntries, TypeLayerData } from './layer-set';
+import { LayerSet, TypeFeatureInfoEntry, TypeLayerData } from './layer-set';
 
 export type TypeFeatureInfoResultSetEntry = {
   layerName?: string;
@@ -125,7 +125,7 @@ export class FeatureInfoLayerSet extends LayerSet {
     // ! As it is (and was like this befor events refactor), the this.resultSet is mutating between async calls.
 
     // Prepare to hold all promises of features in the loop below
-    const allPromises: Promise<TypeArrayOfFeatureInfoEntries>[] = [];
+    const allPromises: Promise<TypeFeatureInfoEntry[] | undefined | null>[] = [];
 
     // Reinitialize the resultSet
     // Loop on each layer path in the resultSet

--- a/packages/geoview-core/src/geo/utils/layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/layer-set.ts
@@ -203,6 +203,8 @@ export class LayerSet {
    * @param {string} layerPath
    * @param {QueryType} queryType
    * @param {TypeLocation} location
+   *
+   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} promise of the results
    */
   processQueryResultSetData = (
     data: TypeLayerData | TypeHoverLayerData,
@@ -210,7 +212,7 @@ export class LayerSet {
     layerPath: string,
     queryType: QueryType,
     location: TypeLocation
-  ): Promise<TypeArrayOfFeatureInfoEntries | null> => {
+  ): Promise<TypeFeatureInfoEntry[] | undefined | null> => {
     // If event listener is enabled, query status isn't in error, and geoview layer instance is defined
     if (data.eventListenerEnabled && data.queryStatus !== 'error' && layerConfig.geoviewLayerInstance) {
       // If source is queryable
@@ -241,7 +243,7 @@ export type TypeLayerData = {
   // when Array.isArray(features) is true, the features property contains the query result.
   // when property features is null, the query ended with an error.
   queryStatus: TypeQueryStatus;
-  features: TypeArrayOfFeatureInfoEntries;
+  features: TypeFeatureInfoEntry[] | undefined | null;
 };
 
 export type TypeFeatureInfoByEventTypes = {
@@ -294,5 +296,3 @@ export type TypeFeatureInfoEntry = {
  * to add more information on one or the other and keep things loosely linked together.
  */
 export type TypeFeatureInfoEntryPartial = Pick<TypeFeatureInfoEntry, 'fieldInfo'>;
-
-export type TypeArrayOfFeatureInfoEntries = TypeFeatureInfoEntry[] | undefined | null;

--- a/packages/geoview-core/src/geo/utils/layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/layer-set.ts
@@ -243,7 +243,6 @@ export type TypeLayerData = {
   queryStatus: TypeQueryStatus;
   features: TypeArrayOfFeatureInfoEntries;
 };
-export type TypeArrayOfLayerData = TypeLayerData[];
 
 export type TypeFeatureInfoByEventTypes = {
   [eventName in EventType]?: TypeLayerData;


### PR DESCRIPTION
# Description

This quick PR is part of a series of PR and has a dependency on PR #1942 

This particular one focuses on removing 2 types:
- TypeArrayOfLayerData => TypeLayerData[]
- TypeArrayOfFeatureInfoEntries => TypeFeatureInfoEntry[] | undefined | null

The second type, especially, was causing gotchas for developers and some issues. Having both types like this is much more straightforward and will help when we need to refactor further code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

__Add the URL for your deploy!__

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1943)
<!-- Reviewable:end -->
