### PR TITLE
refactor(layers) - Part 5

### DIFF
--- a/packages/geoview-core/src/api/events/event.ts
+++ b/packages/geoview-core/src/api/events/event.ts
@@ -36,8 +36,6 @@ import {
   payloadIsLegendInfo,
   payloadIsQueryLegend,
   TypeQueryLegendPayload,
-  payloadIsRequestLayerInventory,
-  TypeRequestLayerInventoryPayload,
   payloadIsLayerSetChangeLayerStatus,
   TypeLayerSetChangeLayerStatusPayload,
   payloadIsLayerSetUpdated,
@@ -484,25 +482,6 @@ export class Event {
   // ! These events exists to communicate between different application code and components.
   // ! They should be fixed/removed altogether as they don't have a 'valid' reason to exist or their refactoring would be beneficial.
   // ! At the time writing this, having them here was sufficient as a first step in cleaning generic api.event calls and payloads.
-
-  // #region REQUEST_LAYER_INVENTORY ----------------------------------------------------------------------------------
-
-  emitLayerInventoryQuery = (mapId: string, layerSetId: string) => {
-    // Emit
-    this.emit(LayerSetPayload.createRequestLayerInventoryPayload(mapId, layerSetId));
-  };
-
-  onLayerInventoryQuery = (mapId: string, callback: (layerInventory: TypeRequestLayerInventoryPayload) => void) => {
-    // Wire
-    this.onMapHelperHandler(mapId, EVENT_NAMES.LAYER_SET.REQUEST_LAYER_INVENTORY, payloadIsRequestLayerInventory, callback);
-  };
-
-  offLayerInventoryQuery = (mapId: string, callback: (layerRegistration: TypeRequestLayerInventoryPayload) => void) => {
-    // Unwire
-    this.off(EVENT_NAMES.LAYER_SET.REQUEST_LAYER_INVENTORY, mapId, callback as TypeEventHandlerFunction);
-  };
-
-  // #endregion
 
   // #region LAYER_REGISTRATION ---------------------------------------------------------------------------------------
 

--- a/packages/geoview-core/src/api/events/payloads/layer-set-payload.ts
+++ b/packages/geoview-core/src/api/events/payloads/layer-set-payload.ts
@@ -6,7 +6,6 @@ import { TypeLayerStatus } from '@/geo/map/map-schema-types';
 /** Valid events that can create LayerSetPayload */
 const validEvents: EventStringId[] = [
   EVENT_NAMES.LAYER_SET.LAYER_REGISTRATION,
-  EVENT_NAMES.LAYER_SET.REQUEST_LAYER_INVENTORY,
   EVENT_NAMES.LAYER_SET.CHANGE_LAYER_STATUS,
   EVENT_NAMES.LAYER_SET.UPDATED,
 ];
@@ -43,26 +42,6 @@ export interface TypeLayerRegistrationPayload extends LayerSetPayload {
   layerSetId?: string;
   // the action to perform
   action: 'add' | 'remove';
-}
-
-/**
- * type guard function that redefines a PayloadBaseClass as a TypeRequestLayerInventoryPayload
- * if the event attribute of the verifyIfPayload parameter is valid. The type ascention
- * applies only to the true block of the if clause.
- *
- * @param {PayloadBaseClass} verifyIfPayload object to test in order to determine if the type ascention is valid
- * @returns {boolean} returns true if the payload is valid
- */
-export const payloadIsRequestLayerInventory = (verifyIfPayload: PayloadBaseClass): verifyIfPayload is TypeRequestLayerInventoryPayload => {
-  return verifyIfPayload?.event === EVENT_NAMES.LAYER_SET.REQUEST_LAYER_INVENTORY;
-};
-
-/**
- * Additional attribute needed to define a TypeRequestLayerInventoryPayload
- */
-export interface TypeRequestLayerInventoryPayload extends LayerSetPayload {
-  // The layer set identifier that will receive the inventory
-  layerSetId: string;
 }
 
 /**
@@ -165,23 +144,6 @@ export class LayerSetPayload extends PayloadBaseClass {
     layerRegistrationPayload.action = action;
     layerRegistrationPayload.layerSetId = layerSetId;
     return layerRegistrationPayload;
-  };
-
-  /**
-   * Static method used to create a layer set payload requesting a layer inventory
-   *
-   * @param {string | null} handlerName the handler Name
-   * @param {string} layerSetId the layer set identifier that will receive the inventory
-   *
-   * @returns {TypeRequestLayerInventoryPayload} the requestLayerInventoryPayload object created
-   */
-  static createRequestLayerInventoryPayload = (handlerName: string, layerSetId: string): TypeRequestLayerInventoryPayload => {
-    const requestLayerInventoryPayload = new LayerSetPayload(
-      EVENT_NAMES.LAYER_SET.REQUEST_LAYER_INVENTORY,
-      handlerName
-    ) as TypeRequestLayerInventoryPayload;
-    requestLayerInventoryPayload.layerSetId = layerSetId;
-    return requestLayerInventoryPayload;
   };
 
   /**

--- a/packages/geoview-core/src/core/utils/config/validation-classes/heatmap-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/heatmap-layer-entry-config.ts
@@ -34,11 +34,4 @@ export class VectorHeatmapLayerEntryConfig extends AbstractBaseLayerEntryConfig 
     super(layerConfig);
     Object.assign(this, layerConfig);
   }
-
-  /**
-   * Method to execute when the layer is loaded.
-   */
-  loadedFunction() {
-    super.loadedFunction();
-  }
 }

--- a/packages/geoview-core/src/core/utils/config/validation-classes/tile-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/tile-layer-entry-config.ts
@@ -19,11 +19,4 @@ export class TileLayerEntryConfig extends AbstractBaseLayerEntryConfig {
     super(layerConfig);
     Object.assign(this, layerConfig);
   }
-
-  /**
-   * Method to execute when the layer is loaded.
-   */
-  loadedFunction() {
-    super.loadedFunction();
-  }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -18,7 +18,7 @@ import {
   getLocalizedMessage,
   createLocalizedString,
 } from '@/core/utils/utilities';
-import { TypeQueryLegendPayload, TypeRequestLayerInventoryPayload } from '@/api/events/payloads';
+import { TypeQueryLegendPayload } from '@/api/events/payloads';
 import { LayerApi, api } from '@/app';
 import { TypeJsonObject, toJsonObject } from '@/core/types/global-types';
 import { TimeDimension, TypeDateFragments } from '@/core/utils/date-mgt';
@@ -223,7 +223,7 @@ export const isImageStaticLegend = (verifyIfLegend: TypeLegend): verifyIfLegend 
 };
 
 type TypeLayerSetHandlerFunctions = {
-  requestLayerInventory?: (layerInvetoryQuery: TypeRequestLayerInventoryPayload) => void;
+  // requestLayerInventory?: (layerInvetoryQuery: TypeRequestLayerInventoryPayload) => void;
   queryLegend?: (legendInfo: TypeQueryLegendPayload) => void;
   // queryLayer?: TypeEventHandlerFunction;
   updateLayerStatus?: TypeEventHandlerFunction;
@@ -901,17 +901,6 @@ export abstract class AbstractGeoViewLayer {
     const { layerPath } = layerConfig;
     if (!this.registerToLayerSetListenerFunctions[layerPath]) this.registerToLayerSetListenerFunctions[layerPath] = {};
 
-    if (!this.registerToLayerSetListenerFunctions[layerPath].requestLayerInventory) {
-      // Prep the handle
-      this.registerToLayerSetListenerFunctions[layerPath].requestLayerInventory = (payload) => {
-        // Emit the layer registration
-        api.event.emitLayerRegistration(this.mapId, layerPath, 'add', payload.layerSetId);
-      };
-
-      // Wire when a layer inventory has been queried
-      api.event.onLayerInventoryQuery(this.mapId, this.registerToLayerSetListenerFunctions[layerPath].requestLayerInventory!);
-    }
-
     if (!this.registerToLayerSetListenerFunctions[layerPath].queryLegend) {
       // Prep the handle
       this.registerToLayerSetListenerFunctions[layerPath].queryLegend = (payload) => {
@@ -941,11 +930,6 @@ export abstract class AbstractGeoViewLayer {
 
     // Emit the layer unregistration
     api.event.emitLayerRegistration(this.mapId, layerPath, 'remove');
-
-    if (this.registerToLayerSetListenerFunctions[layerPath].requestLayerInventory) {
-      api.event.offLayerInventoryQuery(this.mapId, this.registerToLayerSetListenerFunctions[layerPath].requestLayerInventory!);
-      delete this.registerToLayerSetListenerFunctions[layerPath].requestLayerInventory;
-    }
 
     if (this.registerToLayerSetListenerFunctions[layerPath].queryLegend) {
       api.event.offLayerLegendQuery(this.mapId, layerPath, this.registerToLayerSetListenerFunctions[layerPath].queryLegend!);

--- a/packages/geoview-core/src/geo/utils/layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/layer-set.ts
@@ -146,9 +146,6 @@ export class LayerSet {
         api.event.emitLayerSetUpdated(this.layerSetId, layerPath, this.resultSet);
       }
     });
-
-    // Send a request layer inventory signal to all existing layers of the map. These layers will return a layer registration event.
-    api.event.emitLayerInventoryQuery(this.mapId, this.layerSetId);
   }
 
   /**
@@ -204,8 +201,8 @@ export class LayerSet {
   };
 }
 
-export type EventType = 'click' | 'hover' | 'crosshaire-enter' | 'all-features';
-export const ArrayOfEventTypes: EventType[] = ['click', 'hover', 'crosshaire-enter', 'all-features'];
+export type EventType = 'click' | 'hover' | 'all-features';
+export const ArrayOfEventTypes: EventType[] = ['click', 'hover', 'all-features'];
 export type QueryType = 'at_pixel' | 'at_coordinate' | 'at_long_lat' | 'using_a_bounding_box' | 'using_a_polygon' | 'all';
 
 export type TypeQueryStatus = 'init' | 'processing' | 'processed' | 'error';


### PR DESCRIPTION
# Description

This PR is part of a series of PR and has a dependency on PR https://github.com/Canadian-Geospatial-Platform/geoview/pull/1945

This PR focuses on the `REQUEST_LAYER_INVENTORY` event. After reviewing the code, it turns out that since the layer sets are part of the layer-api orchestrator and the layer-api is created along with the map (before the layers are loaded), there was no need for that event at all.

- Removed the code surrounding the REQUEST_LAYER_INVENTORY event
- Removed unnecessary overrides in 2 classes

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Currently hosting the finally of the layers refactoring here: https://alex-nrcan.github.io/geoview

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1946)
<!-- Reviewable:end -->
