### PR TITLE
refactor(layers) - Part 10

### DIFF
--- a/packages/geoview-core/public/templates/layers/csv.html
+++ b/packages/geoview-core/public/templates/layers/csv.html
@@ -242,6 +242,12 @@
         console.log(`api is ready for ${mapId}`);
 
         if (mapId === 'allMaps') {
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['CSV1'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('CSV1', 'ResultSetId1', resultSet, eventType);
+          });
+
           createTableOfFilter('CSV1');
         }
       });
@@ -251,16 +257,6 @@
       getAllFeatureInfo1.addEventListener('click', function (e) {
             cgpv.api.event.emit({ event: 'map/get_all_features', handlerName: 'CSV1' });
           });
-
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSets, eventType } = payload;
-      //     createInfoTable('CSV1', 'ResultSetId1', resultSets, eventType);
-      //   },
-      //   'CSV1/click/FeatureInfoLayerSet'
-      // );
 
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,

--- a/packages/geoview-core/public/templates/layers/esri-dynamic.html
+++ b/packages/geoview-core/public/templates/layers/esri-dynamic.html
@@ -1066,6 +1066,22 @@
         console.log(`api is ready for ${mapId}`);
 
         if (mapId === 'allMaps') {
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR1'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
+          });
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR2'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR2', 'ResultSetId2', resultSet, eventType);
+          });
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR3'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR3', 'ResultSetId3', resultSet, eventType);
+          });
+
           createTableOfFilter('LYR1');
           createTableOfFilter('LYR2');
           createTableOfFilter('LYR3');
@@ -1133,16 +1149,6 @@
       });
 
       // LYR1 ===================================================================================================================
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
-      //   },
-      //   'LYR1/click/FeatureInfoLayerSet'
-      // );
-
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,
         (payload) => {
@@ -1155,16 +1161,6 @@
       listenToLegendLayerSetChanges('HLYR1-state', 'LYR1/LegendsLayerSet');
 
       // LYR2 ===================================================================================================================
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR2', 'ResultSetId2', resultSet, eventType);
-      //   },
-      //   'LYR2/click/FeatureInfoLayerSet'
-      // );
-
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,
         (payload) => {
@@ -1177,16 +1173,6 @@
       listenToLegendLayerSetChanges('HLYR2-state', 'LYR2/LegendsLayerSet');
 
       // LYR3 ===================================================================================================================
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR3', 'ResultSetId3', resultSet, eventType);
-      //   },
-      //   'LYR3/click/FeatureInfoLayerSet'
-      // );
-
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,
         (payload) => {

--- a/packages/geoview-core/public/templates/layers/esri-feature.html
+++ b/packages/geoview-core/public/templates/layers/esri-feature.html
@@ -365,6 +365,22 @@
         console.log(`api is ready for ${mapId}`);
 
         if (mapId === 'allMaps') {
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR1'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
+          });
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR2'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR2', 'ResultSetId2', resultSet, eventType);
+          });
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR3'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR3', 'ResultSetId3', resultSet, eventType);
+          });
+
           createTableOfFilter('LYR1');
           createTableOfFilter('LYR2');
           createTableOfFilter('LYR3');
@@ -449,16 +465,6 @@
           dropDownContent.addEventListener('click', (e) => {
             cgpv.api.maps['LYR1'].layer.allFeatureInfoLayerSet.triggerGetAllFeatureInfo(e.currentTarget.value, 'all');
           });
-
-          // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-          // cgpv.api.event.on(
-          //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-          //   (payload) => {
-          //     const { layerSetId, resultSet, eventType } = payload;
-          //     createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
-          //   },
-          //   'LYR1/all/FeatureInfoLayerSet'
-          // );
         },
         'LYR1'
       );
@@ -482,16 +488,6 @@
         cgpv.api.event.emit({ event: 'map/get_all_features', handlerName: 'LYR2' });
       });
 
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR2', 'ResultSetId2', resultSet, eventType);
-      //   },
-      //   'LYR2/click/FeatureInfoLayerSet'
-      // );
-
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,
         (payload) => {
@@ -508,16 +504,6 @@
       getAllFeatureInfo3.addEventListener('click', function (e) {
             cgpv.api.event.emit({ event: 'map/get_all_features', handlerName: 'LYR3' });
           });
-
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR3', 'ResultSetId3', resultSet, eventType);
-      //   },
-      //   'LYR3/click/FeatureInfoLayerSet'
-      // );
 
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,

--- a/packages/geoview-core/public/templates/layers/geocore.html
+++ b/packages/geoview-core/public/templates/layers/geocore.html
@@ -180,21 +180,17 @@
         console.log(`api is ready for ${mapId}`);
 
         if (mapId === 'allMaps') {
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR1'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
+          });
+
           createTableOfFilter('LYR1');
         }
       });
 
       // LYR1 ===================================================================================================================
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
-      //   },
-      //   'LYR1/click/FeatureInfoLayerSet'
-      // );
-
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,
         (payload) => {

--- a/packages/geoview-core/public/templates/layers/geojson.html
+++ b/packages/geoview-core/public/templates/layers/geojson.html
@@ -220,6 +220,12 @@
         console.log(`api is ready for ${mapId}`);
 
         if (mapId === 'allMaps') {
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR1'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
+          });
+
           createTableOfFilter('LYR1');
         }
       });
@@ -288,16 +294,6 @@
       getAllFeatureInfo1.addEventListener('click', function (e) {
             cgpv.api.event.emit({ event: 'map/get_all_features', handlerName: 'LYR1' });
           });
-
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
-      //   },
-      //   'LYR1/click/FeatureInfoLayerSet'
-      // );
 
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,

--- a/packages/geoview-core/public/templates/layers/geopackage.html
+++ b/packages/geoview-core/public/templates/layers/geopackage.html
@@ -250,6 +250,12 @@
         console.log(`api is ready for ${mapId}`);
 
         if (mapId === 'allMaps') {
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR1'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
+          });
+
           createTableOfFilter('LYR1');
         }
       });
@@ -259,16 +265,6 @@
       getAllFeatureInfo1.addEventListener('click', function (e) {
             cgpv.api.event.emit({ event: 'map/get_all_features', handlerName: 'LYR1' });
           });
-
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
-      //   },
-      //   'LYR1/click/FeatureInfoLayerSet'
-      // );
 
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,

--- a/packages/geoview-core/public/templates/layers/ogc-feature.html
+++ b/packages/geoview-core/public/templates/layers/ogc-feature.html
@@ -177,6 +177,12 @@
         console.log(`api is ready for ${mapId}`);
 
         if (mapId === 'allMaps') {
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps[mapId].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable(mapId, 'ResultSetId1', resultSet, eventType);
+          });
+
           createTableOfFilter('LYR1');
         }
       });
@@ -186,16 +192,6 @@
       getAllFeatureInfo1.addEventListener('click', function (e) {
             cgpv.api.event.emit({ event: 'map/get_all_features', handlerName: 'LYR1' });
           });
-
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
-      //   },
-      //   'LYR1/click/FeatureInfoLayerSet'
-      // );
 
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,

--- a/packages/geoview-core/public/templates/layers/wfs.html
+++ b/packages/geoview-core/public/templates/layers/wfs.html
@@ -277,11 +277,23 @@
       cgpv.init(function (mapId) {
         console.log(`api is ready for ${mapId}`);
         if (mapId === 'LYR1') {
-          createTableOfFilter('LYR1');
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps[mapId].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable(mapId, 'ResultSetId1', resultSet, eventType);
+          });
+
+          createTableOfFilter(mapId);
         }
 
         if (mapId === 'LYR2') {
-          createTableOfFilter('LYR2');
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps[mapId].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable(mapId, 'ResultSetId2', resultSet, eventType);
+          });
+
+          createTableOfFilter(mapId);
         }
       });
 
@@ -290,16 +302,6 @@
       getAllFeatureInfo1.addEventListener('click', function (e) {
             cgpv.api.event.emit({ event: 'map/get_all_features', handlerName: 'LYR1' });
           });
-
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
-      //   },
-      //   'LYR1/click/FeatureInfoLayerSet'
-      // );
 
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,
@@ -317,16 +319,6 @@
       getAllFeatureInfo2.addEventListener('click', function (e) {
             cgpv.api.event.emit({ event: 'map/get_all_features', handlerName: 'LYR2' });
           });
-
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR2', 'ResultSetId2', resultSet, eventType);
-      //   },
-      //   'LYR2/click/FeatureInfoLayerSet'
-      // );
 
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,

--- a/packages/geoview-core/public/templates/layers/wms.html
+++ b/packages/geoview-core/public/templates/layers/wms.html
@@ -584,6 +584,22 @@
         console.log(`api is ready for ${mapId}`);
 
         if (mapId === 'allMaps') {
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR1'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
+          });
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR2'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR2', 'ResultSetId2', resultSet, eventType);
+          });
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR3'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR3', 'ResultSetId3', resultSet, eventType);
+          });
+
           createTableOfFilter('LYR1');
           createTableOfFilter('LYR2');
           createTableOfFilter('LYR4');
@@ -639,17 +655,6 @@
         }
       });
 
-      //LYR1 ===================================================================================================================
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
-      //   },
-      //   'LYR1/click/FeatureInfoLayerSet'
-      // );
-
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,
         (payload) => {
@@ -668,17 +673,6 @@
 
       listenToLegendLayerSetChanges('HLYR1-state', 'LYR1/LegendsLayerSet');
 
-      // LYR2 ===================================================================================================================
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR2', 'ResultSetId2', resultSet, eventType);
-      //   },
-      //   'LYR2/click/FeatureInfoLayerSet'
-      // );
-
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,
         (payload) => {
@@ -689,17 +683,6 @@
       );
 
       listenToLegendLayerSetChanges('HLYR2-state', 'LYR2/LegendsLayerSet');
-
-      // LYR3 ===================================================================================================================
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR3', 'ResultSetId3', resultSet, eventType);
-      //   },
-      //   'LYR3/click/FeatureInfoLayerSet'
-      // );
 
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,

--- a/packages/geoview-core/public/templates/pygeoapi-processes.html
+++ b/packages/geoview-core/public/templates/pygeoapi-processes.html
@@ -140,27 +140,6 @@
     <script src="codedoc.js"></script>
     <script src="layerlib.js"></script>
     <script>
-    // GeoJson ==================================================================================================================
-    // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-    // cgpv.api.event.on(
-    //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-    //   (payload) => {
-    //     const { layerSetId, resultSet, eventType } = payload;
-    //     createInfoTable('LYR5', 'geoJsonResultSetId', resultSet, 'click');
-    //   },
-    //   'LYR5/click/FeatureInfoLayerSet'
-    // );
-
-    // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-    // cgpv.api.event.on(
-    //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-    //   (payload) => {
-    //     const { layerSetId, resultSet, eventType } = payload;
-    //     createInfoTable('LYR5', 'geoJsonResultSetId', resultSet, 'hover');
-    //   },
-    //   'LYR5/hover/FeatureInfoLayerSet'
-    // );
-
     cgpv.api.event.on(
       cgpv.api.eventNames.LAYER_SET.UPDATED,
       (payload) => {
@@ -178,6 +157,13 @@
         createCodeSnippet();
         createConfigSnippet();
 
+        if (mapId === 'allMaps') {
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR5'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR5', 'geoJsonResultSetId', resultSet, eventType);
+          });
+        }
         createTableOfFilter('LYR5');
       });
 

--- a/packages/geoview-core/public/templates/test.html
+++ b/packages/geoview-core/public/templates/test.html
@@ -503,21 +503,16 @@
         console.log(`api is ready for ${mapId}`);
 
         if (mapId === 'allMaps') {
+          // Wire a handle when all queries done after a map click
+          cgpv.api.maps['LYR1'].layer.featureInfoLayerSet.onQueryEnded((sender, payload) => {
+            const { coordinate, resultSet, eventType } = payload;
+            createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
+          });
           createTableOfFilter('LYR1');
         }
       });
 
       // LYR1 ===================================================================================================================
-      // Note: ALL_QUERIES_DONE is obsolete, a replacement is coming (upcoming PR)
-      // cgpv.api.event.on(
-      //   cgpv.api.eventNames.GET_FEATURE_INFO.ALL_QUERIES_DONE,
-      //   (payload) => {
-      //     const { layerSetId, resultSet, eventType } = payload;
-      //     createInfoTable('LYR1', 'ResultSetId1', resultSet, eventType);
-      //   },
-      //   'LYR1/click/FeatureInfoLayerSet'
-      // );
-
       cgpv.api.event.on(
         cgpv.api.eventNames.LAYER_SET.UPDATED,
         (payload) => {


### PR DESCRIPTION
# Description

This PR is part of a series of PR and has a dependency on PR https://github.com/Canadian-Geospatial-Platform/geoview/pull/1950

This PR focuses on reactivating the code that was commented out in the templates with regards to `ALL_QUERIES_DONE`. The feature-info-layer-set emits a class-event when it's done querying something.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Currently hosting the finally of the layers refactoring here: https://alex-nrcan.github.io/geoview

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1951)
<!-- Reviewable:end -->
