### PR TITLE
fix(comments) - Fix comments that leaks in the cgpv-main.js built file that gets distributed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,61 @@
   "editor.renderWhitespace": "all",
   "editor.tabSize": 2,
   "editor.hover.delay": 1000,
-  "window.title": "${activeEditorMedium}${separator}${rootName}${separator}${profileName}"
+  "window.title": "${activeEditorMedium}${separator}${rootName}${separator}${profileName}",
+  "better-comments.tags": [
+    {
+      "tag": "!",
+      "color": "#FF2D00",
+      "strikethrough": false,
+      "underline": false,
+      "backgroundColor": "transparent",
+      "bold": false,
+      "italic": false
+    },
+    {
+      "tag": "?",
+      "color": "#3498DB",
+      "strikethrough": false,
+      "underline": false,
+      "backgroundColor": "transparent",
+      "bold": false,
+      "italic": false
+    },
+    {
+      "tag": "//",
+      "color": "#474747",
+      "strikethrough": true,
+      "underline": false,
+      "backgroundColor": "transparent",
+      "bold": false,
+      "italic": false
+    },
+    {
+      "tag": "todo",
+      "color": "#FF8C00",
+      "strikethrough": false,
+      "underline": false,
+      "backgroundColor": "transparent",
+      "bold": false,
+      "italic": false
+    },
+    {
+      "tag": "*",
+      "color": "#98C379",
+      "strikethrough": false,
+      "underline": false,
+      "backgroundColor": "transparent",
+      "bold": false,
+      "italic": false
+    },
+    {
+      "tag": "gv",
+      "color": "#FF00FF",
+      "strikethrough": false,
+      "underline": false,
+      "backgroundColor": "transparent",
+      "bold": false,
+      "italic": false
+    }
+  ]
 }

--- a/packages/geoview-core/src/api/api.ts
+++ b/packages/geoview-core/src/api/api.ts
@@ -132,7 +132,7 @@ export class API {
 
   /**
    * Create a new map in a given div id.
-   * !The div MUST NOT have a geoview-map class or a warning will be shown when initMapDivFromFunctionCall is called.
+   * GV The div MUST NOT have a geoview-map class or a warning will be shown when initMapDivFromFunctionCall is called.
    * If is present, the div will be created with a default config
    *
    * @param {string} divId the id of the div to create map in

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/app-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/app-event-processor.ts
@@ -5,9 +5,9 @@ import { AbstractEventProcessor } from '../abstract-event-processor';
 export class AppEventProcessor extends AbstractEventProcessor {
   // Static functions for Typescript files to access store actions
   // **********************************************************
-  //! Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
-  //! Some action does state modifications AND map actions.
-  //! ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
+  // GV Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
+  // GV Some action does state modifications AND map actions.
+  // GV ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
 
   // #region
   /**
@@ -68,6 +68,6 @@ export class AppEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Store Map State to action on API
   // **********************************************************
-  //! NEVER add a store action who does set state AND map action at a same time.
-  //! Review the action in store state to make sure
+  // GV NEVER add a store action who does set state AND map action at a same time.
+  // GV Review the action in store state to make sure
 }

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/data-table-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/data-table-processor.ts
@@ -6,9 +6,9 @@ export class DataTableProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Typescript files to access store actions
   // **********************************************************
-  //! Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
-  //! Some action does state modifications AND map actions.
-  //! ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
+  // GV Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
+  // GV Some action does state modifications AND map actions.
+  // GV ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
 
   // **********************************************************
   // Static functions for Store Map State to action on API

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/feature-info-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/feature-info-event-processor.ts
@@ -14,9 +14,9 @@ export class FeatureInfoEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Typescript files to access store actions
   // **********************************************************
-  //! Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
-  //! Some action does state modifications AND map actions.
-  //! ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
+  // GV Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
+  // GV Some action does state modifications AND map actions.
+  // GV ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
 
   // #region
   // Holds the list of layer data arrays being buffered in the propagation process for the batch
@@ -241,6 +241,6 @@ export class FeatureInfoEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Store Map State to action on API
   // **********************************************************
-  //! NEVER add a store action who does set state AND map action at a same time.
-  //! Review the action in store state to make sure
+  // GV NEVER add a store action who does set state AND map action at a same time.
+  // GV Review the action in store state to make sure
 }

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/geochart-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/geochart-event-processor.ts
@@ -54,9 +54,9 @@ export class GeochartEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Typescript files to access store actions
   // **********************************************************
-  //! Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
-  //! Some action does state modifications AND map actions.
-  //! ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
+  // GV Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
+  // GV Some action does state modifications AND map actions.
+  // GV ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
 
   // #region
   // Holds the list of layer data arrays being buffered in the propagation process for the batch
@@ -218,6 +218,6 @@ export class GeochartEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Store Map State to action on API
   // **********************************************************
-  //! NEVER add a store action who does set state AND map action at a same time.
-  //! Review the action in store state to make sure
+  // GV NEVER add a store action who does set state AND map action at a same time.
+  // GV Review the action in store state to make sure
 }

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -22,9 +22,9 @@ export class LegendEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Typescript files to access store actions
   // **********************************************************
-  //! Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
-  //! Some action does state modifications AND map actions.
-  //! ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
+  // GV Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
+  // GV Some action does state modifications AND map actions.
+  // GV ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
 
   // #region
 
@@ -216,6 +216,6 @@ export class LegendEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Store Map State to action on API
   // **********************************************************
-  //! NEVER add a store action who does set state AND map action at a same time.
-  //! Review the action in store state to make sure
+  // GV NEVER add a store action who does set state AND map action at a same time.
+  // GV Review the action in store state to make sure
 }

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -166,7 +166,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
     ];
   }
 
-  //! THIS IS THE ONLY FUNCTION TO SET STORE DIRECTLY
+  // GV THIS IS THE ONLY FUNCTION TO SET STORE DIRECTLY
   static setMapLoaded(mapId: string): void {
     // Log
     logger.logTraceCore('MAP EVENT PROCESSOR - setMapLoaded', mapId);
@@ -251,9 +251,9 @@ export class MapEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Typescript files to access store actions
   // **********************************************************
-  //! Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
-  //! Some action does state modifications AND map actions.
-  //! ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
+  // GV Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
+  // GV Some action does state modifications AND map actions.
+  // GV ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
 
   // #region
   /**
@@ -455,8 +455,8 @@ export class MapEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Store Map State to action on API
   // **********************************************************
-  //! NEVER add a store action who does set state AND map action at a same time.
-  //! Review the action in store state to make sure
+  // GV NEVER add a store action who does set state AND map action at a same time.
+  // GV Review the action in store state to make sure
   // #region
   static createEmptyBasemap(mapId: string) {
     return api.maps[mapId].basemap.createEmptyBasemap();
@@ -528,9 +528,9 @@ export class MapEventProcessor extends AbstractEventProcessor {
 
     const projectionConfig = api.projection.projections[MapEventProcessor.getMapState(mapId).currentProjection];
     if (bbox) {
-      //! There were issues with fromLonLat in rare cases in LCC projections, transformExtent seems to solve them.
-      //! fromLonLat and transformExtent give differing results in many cases, fromLonLat had issues with the first
-      //! three results from a geolocator search for "vancouver river"
+      // GV There were issues with fromLonLat in rare cases in LCC projections, transformExtent seems to solve them.
+      // GV fromLonLat and transformExtent give differing results in many cases, fromLonLat had issues with the first
+      // GV three results from a geolocator search for "vancouver river"
       const convertedExtent = api.projection.transformExtent(bbox, 'EPSG:4326', projectionConfig);
 
       // Highlight

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/swiper-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/swiper-event-processor.ts
@@ -45,9 +45,9 @@ export class SwiperEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Typescript files to access store actions
   // **********************************************************
-  //! Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
-  //! Some action does state modifications AND map actions.
-  //! ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
+  // GV Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
+  // GV Some action does state modifications AND map actions.
+  // GV ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
 
   /**
    * Shortcut to get the Swiper state for a given map id
@@ -167,6 +167,6 @@ export class SwiperEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Store Map State to action on API
   // **********************************************************
-  //! NEVER add a store action who does set state AND map action at a same time.
-  //! Review the action in store state to make sure
+  // GV NEVER add a store action who does set state AND map action at a same time.
+  // GV Review the action in store state to make sure
 }

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/time-slider-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/time-slider-event-processor.ts
@@ -92,9 +92,9 @@ export class TimeSliderEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Typescript files to access store actions
   // **********************************************************
-  //! Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
-  //! Some action does state modifications AND map actions.
-  //! ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
+  // GV Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
+  // GV Some action does state modifications AND map actions.
+  // GV ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
 
   // #region
   /**
@@ -179,8 +179,8 @@ export class TimeSliderEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Store Map State to action on API
   // **********************************************************
-  //! NEVER add a store action who does set state AND map action at a same time.
-  //! Review the action in store state to make sure
+  // GV NEVER add a store action who does set state AND map action at a same time.
+  // GV Review the action in store state to make sure
 
   // #region
   /**

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/ui-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/ui-event-processor.ts
@@ -7,9 +7,9 @@ export class UIEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Typescript files to access store actions
   // **********************************************************
-  //! Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
-  //! Some action does state modifications AND map actions.
-  //! ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
+  // GV Typescript MUST always use the defined store actions below to modify store - NEVER use setState!
+  // GV Some action does state modifications AND map actions.
+  // GV ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
 
   /**
    * Shortcut to get the UI state for a given map id
@@ -38,8 +38,8 @@ export class UIEventProcessor extends AbstractEventProcessor {
   // **********************************************************
   // Static functions for Store Map State to action on API
   // **********************************************************
-  //! NEVER add a store action who does set state AND map action at a same time.
-  //! Review the action in store state to make sure
+  // GV NEVER add a store action who does set state AND map action at a same time.
+  // GV Review the action in store state to make sure
   static setActiveFooterBarTab(mapId: string, id: string): void {
     this.getUIState(mapId).actions.setActiveFooterBarTab(id);
   }

--- a/packages/geoview-core/src/api/events/event.ts
+++ b/packages/geoview-core/src/api/events/event.ts
@@ -180,11 +180,11 @@ export class Event {
   };
 
   // #region SPECIALIZED EVENTS - IMPORTANT
-  // ! These events exists to communicate between the Shell/MapViewer and the App-Bar/Nav-Bar/Footer-Bar components.
-  // ! The laters are mounted and then 'autonomous'. They rely on events to self-manage their rendering.
-  // ! Ideally, we should get rid of those events and use props inside App-Bar/Nav-Bar/Footer-Bar and have the management
-  // ! higher in the call stack. At the time of writing this, having them explicit here was sufficient as a first step
-  // ! in cleaning generic api.event calls and payloads.
+  // GV These events exists to communicate between the Shell/MapViewer and the App-Bar/Nav-Bar/Footer-Bar components.
+  // GV The laters are mounted and then 'autonomous'. They rely on events to self-manage their rendering.
+  // GV Ideally, we should get rid of those events and use props inside App-Bar/Nav-Bar/Footer-Bar and have the management
+  // GV higher in the call stack. At the time of writing this, having them explicit here was sufficient as a first step
+  // GV in cleaning generic api.event calls and payloads.
 
   // #region EVENT_APPBAR_PANEL_CREATE --------------------------------------------------------------------------------
 
@@ -360,10 +360,10 @@ export class Event {
   // #endregion
 
   // #region SPECIALIZED EVENTS - UNSURE
-  // ! These events exists to communicate between different application code and components.
-  // ! They are annoying to have, but unsure if worth spending time to refactor. They have less reason to exist than the
-  // ! 'IMPORTANT' ones above. However, at the time of writing this having them here was sufficient
-  // ! as a first step in cleaning generic api.event calls and payloads.
+  // GV These events exists to communicate between different application code and components.
+  // GV They are annoying to have, but unsure if worth spending time to refactor. They have less reason to exist than the
+  // GV 'IMPORTANT' ones above. However, at the time of writing this having them here was sufficient
+  // GV as a first step in cleaning generic api.event calls and payloads.
 
   // #region EVENT_MODAL_OPEN -----------------------------------------------------------------------------------------
 

--- a/packages/geoview-core/src/app.tsx
+++ b/packages/geoview-core/src/app.tsx
@@ -111,7 +111,7 @@ async function renderMap(mapElement: Element): Promise<void> {
 
 /**
  * Initialize a basic div from a function call.
- * !The div MUST NOT have a geoview-map class or a warning will be shown.
+ * GV The div MUST NOT have a geoview-map class or a warning will be shown.
  * If is present, the div will be created with a default config
  *
  * @param {Element} mapDiv The basic div to initialise

--- a/packages/geoview-core/src/core/app-start.tsx
+++ b/packages/geoview-core/src/core/app-start.tsx
@@ -55,7 +55,7 @@ function AppStart(props: AppStartProps): JSX.Element {
     return { mapId };
   }, [mapId]);
 
-  //! get store values by id because context is not set.... it is the only 2 atomic selector by id
+  // GV get store values by id because context is not set.... it is the only 2 atomic selector by id
   // once context is define, map id is available
   const language = useAppDisplayLanguageById(mapId);
   const theme = useAppDisplayThemeById(mapId);

--- a/packages/geoview-core/src/core/components/details/feature-info-new.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info-new.tsx
@@ -95,7 +95,7 @@ export function FeatureInfo({ features, currentFeatureIndex }: TypeFeatureInfoPr
       })
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [checkedFeatures, feature]); // ! Check if feature is necessary in this dependency array? If so explain it in comment? Should be featurUid?
+  }, [checkedFeatures, feature]); // GV Check if feature is necessary in this dependency array? If so explain it in comment? Should be featurUid?
 
   return (
     <Paper sx={{ boxShadow: 'none', border: 'none', paddingTop: '0.5rem' }}>

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -200,7 +200,7 @@ export function FooterBar(): JSX.Element | null {
     logger.logTraceUseEffect('FOOTER-TABS - mapDiv');
 
     setOrigHeight(mapDiv!.clientHeight + 55);
-  }, [mapDiv]); // ! Is a useEffect on a dom element recommented here? Consider using useRef?
+  }, [mapDiv]); // GV Is a useEffect on a dom element recommented here? Consider using useRef?
 
   /**
    * Whenever the array layer data batch changes if we're on 'details' tab and it's collapsed, make sure we uncollapse it
@@ -219,7 +219,7 @@ export function FooterBar(): JSX.Element | null {
   // Don't add isCollapsed in the dependency array, because it'll retrigger the useEffect
 
   // TODO: need a refactor to use proper sx classes and style
-  // !https://github.com/Canadian-Geospatial-Platform/geoview/issues/1136
+  // GV https://github.com/Canadian-Geospatial-Platform/geoview/issues/1136
   /**
    * Handle the collapse/expand state effect
    */
@@ -250,7 +250,7 @@ export function FooterBar(): JSX.Element | null {
         lastChild.style.maxHeight = isCollapsed ? '0px' : '';
       }
     }
-  }, [isCollapsed, mapDiv, origHeight]); // ! Is a useEffect on a dom element recommented here? Consider using useRef?
+  }, [isCollapsed, mapDiv, origHeight]); // GV Is a useEffect on a dom element recommented here? Consider using useRef?
 
   /**
    * Handle a collapse, expand event for the tabs component

--- a/packages/geoview-core/src/core/containers/focus-trap.tsx
+++ b/packages/geoview-core/src/core/containers/focus-trap.tsx
@@ -77,7 +77,7 @@ export function FocusTrapDialog(props: FocusTrapProps): JSX.Element {
     // the user escape the trap, remove it, put back skip link in focus cycle and zoom to top link
     setActiveTrapGeoView(false);
     mapHTMLElement.classList.remove('map-focus-trap');
-    // mapHTMLElement.removeEventListener('keydown',handleExit); //! can't remove because of eslint @typescript-eslint/no-use-before-define
+    // mapHTMLElement.removeEventListener('keydown',handleExit); // GV can't remove because of eslint @typescript-eslint/no-use-before-define
     document.removeEventListener('keydown', handleScrolling);
 
     // update store and focus to top link

--- a/packages/geoview-core/src/core/stores/geoview-store.ts
+++ b/packages/geoview-core/src/core/stores/geoview-store.ts
@@ -54,7 +54,7 @@ export const geoviewStoreDefinition = (set: TypeSetStore, get: TypeGetStore) => 
       // Log (leaving the logDebug for now until more tests are done with the config 2024-02-28)
       logger.logDebug('Sending the map config to the store...', config.mapId);
 
-      // ! this is a copy of the original map configuration, no modifications is allowed
+      // GV this is a copy of the original map configuration, no modifications is allowed
       // ? this configuration is use to reload the map
       const clonedConfig = cloneDeep(config);
 

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/app-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/app-state.ts
@@ -128,7 +128,7 @@ export function initializeAppState(set: TypeSetStore, get: TypeGetStore): IAppSt
           },
         });
 
-        //! we need to keep the call to the api map object because there is a state involve
+        // GV we need to keep the call to the api map object because there is a state involve
         if (element !== undefined) api.maps[get().mapId].setFullscreen(active, element);
       },
       removeNotification: (key: string) => {
@@ -155,8 +155,8 @@ export const useAppGeolocatorServiceURL = () => useStore(useGeoViewStore(), (sta
 export const useAppNotifications = () => useStore(useGeoViewStore(), (state) => state.appState.notifications);
 export const useAppSuportedLanguages = () => useStore(useGeoViewStore(), (state) => state.appState.suportedLanguages);
 
-//! these 2 selector are use in app-start.tsx before context is assigned to the map
-//! DO NOT USE this technique elsewhere, it is only to reload language and theme
+// GV these 2 selector are use in app-start.tsx before context is assigned to the map
+// GV DO NOT USE this technique elsewhere, it is only to reload language and theme
 export const useAppDisplayLanguageById = (mapId: string) => useStore(getGeoViewStore(mapId), (state) => state.appState.displayLanguage);
 export const useAppDisplayThemeById = (mapId: string) => useStore(getGeoViewStore(mapId), (state) => state.appState.displayTheme);
 

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -221,9 +221,9 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
         });
 
         // TODO: keep reference to geoview map instance in the store or keep accessing with api - discussion
-        // ! try to make reusable store actions....
-        // ! we can have always item.... we cannot set visibility so if present we will need to trap. Need more use case
-        // ! create a function setItemVisibility called with layer path and this function set the registered layer (from store values) then apply the filter.
+        // GV try to make reusable store actions....
+        // GV we can have always item.... we cannot set visibility so if present we will need to trap. Need more use case
+        // GV create a function setItemVisibility called with layer path and this function set the registered layer (from store values) then apply the filter.
         (api.maps[get().mapId].layer.geoviewLayer(layerPath) as AbstractGeoViewVector).applyViewFilter('');
       },
       getLayerDeleteInProgress: () => get().layerState.layerDeleteInProgress,

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
@@ -549,7 +549,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
       showClickMarker: (marker: TypeClickMarker) => {
         const projectedCoords = api.projection.transformPoints([marker.lnglat], `EPSG:4326`, `EPSG:${get().mapState.currentProjection}`);
 
-        //! need to use state because it changes store and do action at the same time
+        // GV need to use state because it changes store and do action at the same time
         get().mapState.mapElement!.getOverlayById(`${get().mapId}-clickmarker`)!.setPosition(projectedCoords[0]);
 
         set({

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -466,8 +466,8 @@ export abstract class AbstractGeoViewLayer {
         } else {
           // When we get here, we know that the metadata (if the service provide some) are processed.
           // We need to signal to the layer sets that the 'processed' phase is done.
-          // ! TODO: For the moment, be aware that the layerStatus setter is doing a lot of things behind the scene.
-          // !       The layerStatus setter contains a lot of code and we will change it in favor of a method.
+          // GV TODO: For the moment, be aware that the layerStatus setter is doing a lot of things behind the scene.
+          // GV       The layerStatus setter contains a lot of code and we will change it in favor of a method.
           layerConfig.layerStatus = 'processed';
         }
       });
@@ -619,8 +619,8 @@ export abstract class AbstractGeoViewLayer {
    * @returns {Promise<BaseLayer | null>} The GeoView layer that has been created.
    */
   protected processOneLayerEntry(layerConfig: AbstractBaseLayerEntryConfig): Promise<BaseLayer | null> {
-    // ! IMPORTANT: The processOneLayerEntry method of all the children must call this method to ensure that the flow of
-    // !            layerStatus values is correctly sequenced.
+    // GV IMPORTANT: The processOneLayerEntry method of all the children must call this method to ensure that the flow of
+    // GV            layerStatus values is correctly sequenced.
     layerConfig.layerStatus = 'loading';
     return Promise.resolve(null);
   }
@@ -634,7 +634,7 @@ export abstract class AbstractGeoViewLayer {
    *
    * @returns {Promise<TypeFeatureInfoResult>} The feature info table.
    */
-  // ! Things important to know about the get feature info family of methods
+  // GV Things important to know about the get feature info family of methods
   /*
    * There's no doubt that the layerConfig is correctly defined when we call these methods. The layerConfig object is created in
    * the GeoView layer constructor and has all the necessary flags to inform programmers and users whether the layer referenced by
@@ -923,8 +923,8 @@ export abstract class AbstractGeoViewLayer {
         }
       });
     };
-    // ! The following code will need to be modified when the topmost layer of a GeoView
-    // ! layer creates dynamicaly a group out of a list of layers.
+    // GV The following code will need to be modified when the topmost layer of a GeoView
+    // GV layer creates dynamicaly a group out of a list of layers.
     const layerConfig: TypeLayerEntryConfig | TypeListOfLayerEntryConfig | undefined = layerPath.includes('/')
       ? this.getLayerConfig(layerPath)
       : this.listOfLayerEntryConfig;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -308,9 +308,9 @@ export function commonProcessInitialSettings(
   const layerMetadata = this.layerMetadata[layerConfig.layerPath];
   if (layerConfig.initialSettings?.visible === undefined)
     layerConfig.initialSettings!.visible = layerMetadata.defaultVisibility ? 'yes' : 'no';
-  // ! TODO: The solution implemented in the following two lines is not right. scale and zoom are not the same things.
-  // ! if (layerConfig.initialSettings?.minZoom === undefined && minScale !== 0) layerConfig.initialSettings.minZoom = minScale;
-  // ! if (layerConfig.initialSettings?.maxZoom === undefined && maxScale !== 0) layerConfig.initialSettings.maxZoom = maxScale;
+  // GV TODO: The solution implemented in the following two lines is not right. scale and zoom are not the same things.
+  // GV if (layerConfig.initialSettings?.minZoom === undefined && minScale !== 0) layerConfig.initialSettings.minZoom = minScale;
+  // GV if (layerConfig.initialSettings?.maxZoom === undefined && maxScale !== 0) layerConfig.initialSettings.maxZoom = maxScale;
   if (layerConfig.initialSettings?.extent)
     layerConfig.initialSettings.extent = api.projection.transformExtent(
       layerConfig.initialSettings.extent,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -228,8 +228,8 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @returns {TypeBaseRasterLayer} The GeoView raster layer that has been created.
    */
   protected processOneLayerEntry(layerConfig: EsriDynamicLayerEntryConfig): Promise<TypeBaseRasterLayer | null> {
-    // ! IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
-    // !            layerStatus values is correctly sequenced.
+    // GV IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
+    // GV            layerStatus values is correctly sequenced.
     super.processOneLayerEntry(layerConfig);
     const sourceOptions: SourceOptions = {};
     sourceOptions.attributions = [(this.metadata!.copyrightText ? this.metadata!.copyrightText : '') as string];
@@ -768,7 +768,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
 
     const layerConfig = this.getLayerConfig(layerPath) as EsriDynamicLayerEntryConfig;
     if (!layerConfig) {
-      // ! Things important to know about the applyViewFilter usage:
+      // GV Things important to know about the applyViewFilter usage:
       logger.logError(
         `
         The applyViewFilter method must never be called by GeoView code before the layer refered by the layerPath has reached the 'loaded' status.\n

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
@@ -290,8 +290,8 @@ export class EsriImage extends AbstractGeoViewRaster {
    * @returns {TypeBaseRasterLayer} The GeoView raster layer that has been created.
    */
   protected processOneLayerEntry(layerConfig: EsriImageLayerEntryConfig): Promise<TypeBaseRasterLayer | null> {
-    // ! IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
-    // !            layerStatus values is correctly sequenced.
+    // GV IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
+    // GV            layerStatus values is correctly sequenced.
     super.processOneLayerEntry(layerConfig);
     const sourceOptions: SourceOptions = {};
     sourceOptions.attributions = [(this.metadata!.copyrightText ? this.metadata!.copyrightText : '') as string];

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
@@ -268,8 +268,8 @@ export class ImageStatic extends AbstractGeoViewRaster {
     if (layerConfig.initialSettings?.maxZoom !== undefined) staticImageOptions.maxZoom = layerConfig.initialSettings?.maxZoom;
     if (layerConfig.initialSettings?.minZoom !== undefined) staticImageOptions.minZoom = layerConfig.initialSettings?.minZoom;
     if (layerConfig.initialSettings?.opacity !== undefined) staticImageOptions.opacity = layerConfig.initialSettings?.opacity;
-    // ! IMPORTANT: The initialSettings.visible flag must be set in the layerConfig.loadedFunction otherwise the layer will stall
-    // !            in the 'loading' state if the flag value is 'no'.
+    // GV IMPORTANT: The initialSettings.visible flag must be set in the layerConfig.loadedFunction otherwise the layer will stall
+    // GV            in the 'loading' state if the flag value is 'no'.
 
     // eslint-disable-next-line no-param-reassign
     layerConfig.olLayerAndLoadEndListeners = {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
@@ -152,8 +152,8 @@ export class VectorTiles extends AbstractGeoViewRaster {
    * @returns {TypeBaseRasterLayer} The GeoView raster layer that has been created.
    */
   protected processOneLayerEntry(layerConfig: VectorTilesLayerEntryConfig): Promise<TypeBaseRasterLayer | null> {
-    // ! IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
-    // !            layerStatus values is correctly sequenced.
+    // GV IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
+    // GV            layerStatus values is correctly sequenced.
     super.processOneLayerEntry(layerConfig);
     const sourceOptions: SourceOptions<Feature> = {
       url: getLocalizedValue(layerConfig.source.dataAccessPath, this.mapId),
@@ -192,8 +192,8 @@ export class VectorTiles extends AbstractGeoViewRaster {
     if (layerConfig.initialSettings?.maxZoom !== undefined) tileLayerOptions.maxZoom = layerConfig.initialSettings?.maxZoom;
     if (layerConfig.initialSettings?.minZoom !== undefined) tileLayerOptions.minZoom = layerConfig.initialSettings?.minZoom;
     if (layerConfig.initialSettings?.opacity !== undefined) tileLayerOptions.opacity = layerConfig.initialSettings?.opacity;
-    // ! IMPORTANT: The initialSettings.visible flag must be set in the layerConfig.loadedFunction otherwise the layer will stall
-    // !            in the 'loading' state if the flag value is 'no'.
+    // GV IMPORTANT: The initialSettings.visible flag must be set in the layerConfig.loadedFunction otherwise the layer will stall
+    // GV            in the 'loading' state if the flag value is 'no'.
 
     // TODO remove after demoing again
     const declutter = this.mapId !== 'LYR2';
@@ -300,8 +300,8 @@ export class VectorTiles extends AbstractGeoViewRaster {
 
   // TODO: This section needs documentation (a header at least). Also, is it normal to have things hardcoded like that?
   addVectorTileLayer() {
-    // ! from code sandbox https://codesandbox.io/s/vector-tile-info-forked-g28jud?file=/main.js it works good
-    // ! from inside GEoView, even when not use, something is wrong.
+    // GV from code sandbox https://codesandbox.io/s/vector-tile-info-forked-g28jud?file=/main.js it works good
+    // GV from inside GEoView, even when not use, something is wrong.
     olms(
       'LYR3',
       'https://tiles.arcgis.com/tiles/HsjBaDykC1mjhXz9/arcgis/rest/services/CBMT3978_v11/VectorTileServer/resources/styles/root.json?f=json'

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -483,8 +483,8 @@ export class WMS extends AbstractGeoViewRaster {
    * @returns {TypeBaseRasterLayer | null} The GeoView raster layer that has been created.
    */
   protected processOneLayerEntry(layerConfig: AbstractBaseLayerEntryConfig): Promise<TypeBaseRasterLayer | null> {
-    // ! IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
-    // !            layerStatus values is correctly sequenced.
+    // GV IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
+    // GV            layerStatus values is correctly sequenced.
     super.processOneLayerEntry(layerConfig);
     // Log
     logger.logTraceCore('WMS - processOneLayerEntry', layerConfig.layerPath);
@@ -536,8 +536,8 @@ export class WMS extends AbstractGeoViewRaster {
         if (layerConfig.initialSettings?.maxZoom !== undefined) imageLayerOptions.maxZoom = layerConfig.initialSettings?.maxZoom;
         if (layerConfig.initialSettings?.minZoom !== undefined) imageLayerOptions.minZoom = layerConfig.initialSettings?.minZoom;
         if (layerConfig.initialSettings?.opacity !== undefined) imageLayerOptions.opacity = layerConfig.initialSettings?.opacity;
-        // ! IMPORTANT: The initialSettings.visible flag must be set in the layerConfig.loadedFunction otherwise the layer will stall
-        // !            in the 'loading' state if the flag value is 'no'.
+        // GV IMPORTANT: The initialSettings.visible flag must be set in the layerConfig.loadedFunction otherwise the layer will stall
+        // GV            in the 'loading' state if the flag value is 'no'.
 
         layerConfig.olLayerAndLoadEndListeners = {
           olLayer: new ImageLayer(imageLayerOptions),
@@ -574,7 +574,7 @@ export class WMS extends AbstractGeoViewRaster {
         if (layerCapabilities.Attribution) this.attributions.push(layerCapabilities.Attribution.Title as string);
         if (!layerConfig.source.featureInfo) layerConfig.source.featureInfo = { queryable: !!layerCapabilities.queryable };
         MapEventProcessor.setMapLayerQueryable(this.mapId, layerConfig.layerPath, layerConfig.source.featureInfo.queryable);
-        // ! TODO: The solution implemented in the following lines is not right. scale and zoom are not the same things.
+        // GV TODO: The solution implemented in the following lines is not right. scale and zoom are not the same things.
         // if (layerConfig.initialSettings?.minZoom === undefined && layerCapabilities.MinScaleDenominator !== undefined)
         //   layerConfig.initialSettings.minZoom = layerCapabilities.MinScaleDenominator as number;
         // if (layerConfig.initialSettings?.maxZoom === undefined && layerCapabilities.MaxScaleDenominator !== undefined)
@@ -684,8 +684,8 @@ export class WMS extends AbstractGeoViewRaster {
         if (infoFormat === 'text/xml') {
           const xmlDomResponse = new DOMParser().parseFromString(response.data, 'text/xml');
           const jsonResponse = xmlToJson(xmlDomResponse);
-          // ! TODO: We should use a WMS format setting in the schema to decide what feature info response interpreter to use
-          // ! For the moment, we try to guess the response format based on properties returned from the query
+          // GV TODO: We should use a WMS format setting in the schema to decide what feature info response interpreter to use
+          // GV For the moment, we try to guess the response format based on properties returned from the query
           const featureCollection = this.getAttribute(jsonResponse, 'FeatureCollection');
           if (featureCollection) featureMember = this.getAttribute(featureCollection, 'featureMember');
           else {
@@ -1082,7 +1082,7 @@ export class WMS extends AbstractGeoViewRaster {
 
     const layerConfig = this.getLayerConfig(layerPath) as OgcWmsLayerEntryConfig;
     if (!layerConfig) {
-      // ! Things important to know about the applyViewFilter usage:
+      // GV Things important to know about the applyViewFilter usage:
       logger.logError(
         `
         The applyViewFilter method must never be called by GeoView code before the layer refered by the layerPath has reached the 'loaded' status.\n

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -171,8 +171,8 @@ export class XYZTiles extends AbstractGeoViewRaster {
    * @returns {TypeBaseRasterLayer} The GeoView raster layer that has been created.
    */
   protected processOneLayerEntry(layerConfig: XYZTilesLayerEntryConfig): Promise<TypeBaseRasterLayer | null> {
-    // ! IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
-    // !            layerStatus values is correctly sequenced.
+    // GV IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
+    // GV            layerStatus values is correctly sequenced.
     super.processOneLayerEntry(layerConfig);
     const sourceOptions: SourceOptions = {
       url: getLocalizedValue(layerConfig.source.dataAccessPath, this.mapId),
@@ -200,8 +200,8 @@ export class XYZTiles extends AbstractGeoViewRaster {
     if (layerConfig.initialSettings?.maxZoom !== undefined) tileLayerOptions.maxZoom = layerConfig.initialSettings?.maxZoom;
     if (layerConfig.initialSettings?.minZoom !== undefined) tileLayerOptions.minZoom = layerConfig.initialSettings?.minZoom;
     if (layerConfig.initialSettings?.opacity !== undefined) tileLayerOptions.opacity = layerConfig.initialSettings?.opacity;
-    // ! IMPORTANT: The initialSettings.visible flag must be set in the layerConfig.loadedFunction otherwise the layer will stall
-    // !            in the 'loading' state if the flag value is 'no'.
+    // GV IMPORTANT: The initialSettings.visible flag must be set in the layerConfig.loadedFunction otherwise the layer will stall
+    // GV            in the 'loading' state if the flag value is 'no'.
 
     // eslint-disable-next-line no-param-reassign
     layerConfig.olLayerAndLoadEndListeners = {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -87,8 +87,8 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * @returns {Promise<BaseLayer | null>} The GeoView base layer that has been created.
    */
   protected processOneLayerEntry(layerConfig: AbstractBaseLayerEntryConfig): Promise<BaseLayer | null> {
-    // ! IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
-    // !            layerStatus values is correctly sequenced.
+    // GV IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
+    // GV            layerStatus values is correctly sequenced.
     super.processOneLayerEntry(layerConfig);
     const vectorSource = this.createVectorSource(layerConfig);
     const vectorLayer = this.createVectorLayer(layerConfig as VectorLayerEntryConfig, vectorSource);
@@ -432,7 +432,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
 
     const layerConfig = this.getLayerConfig(layerPath) as VectorLayerEntryConfig;
     if (!layerConfig) {
-      // ! Things important to know about the applyViewFilter usage:
+      // GV Things important to know about the applyViewFilter usage:
       logger.logError(
         `
         The applyViewFilter method must never be called by GeoView code before the layer refered by the layerPath has reached the 'loaded' status.\n

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
@@ -544,8 +544,8 @@ export class GeoPackage extends AbstractGeoViewVector {
    * @returns {Promise<BaseLayer | null>} The GeoView base layer that has been created.
    */
   protected processOneLayerEntry(layerConfig: AbstractBaseLayerEntryConfig, layerGroup?: LayerGroup): Promise<BaseLayer | null> {
-    // ! IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
-    // !            layerStatus values is correctly sequenced.
+    // GV IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
+    // GV            layerStatus values is correctly sequenced.
     super.processOneLayerEntry(layerConfig);
     const promisedLayers = new Promise<BaseLayer | LayerGroup | null>((resolve) => {
       this.extractGeopackageData(layerConfig).then(([layers, slds]) => {

--- a/packages/geoview-core/src/geo/layer/other/cluster-placeholder.ts
+++ b/packages/geoview-core/src/geo/layer/other/cluster-placeholder.ts
@@ -1,6 +1,6 @@
 // src/core/components/map/map.tsx
 // TODO: do not deal with stuff not related to create the payload in the event, use the event on or store state to listen to change and do what is needed.
-// !This was in mapZoomEnd event.... listen to the event in proper place
+// GVThis was in mapZoomEnd event.... listen to the event in proper place
 // Object.keys(layers).forEach((layer) => {
 //   if (layer.endsWith('-unclustered')) {
 //     const clusterLayerId = layer.replace('-unclustered', '');

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -245,7 +245,7 @@ export class MapViewer {
           this.#mapReady = true;
           this.emitMapReady();
 
-          // TODO: Call the setMapLoaded minimaly after 1500ms has elapsed
+          // GV We added processed to layers check so this map loaded event is fired faster
           // This emits the MAP_LOADED event
           MapEventProcessor.setMapLoaded(this.mapId);
 

--- a/packages/geoview-core/src/geo/utils/all-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/all-feature-info-layer-set.ts
@@ -108,8 +108,8 @@ export class AllFeatureInfoLayerSet extends LayerSet {
   // TODO: (futur development) The queryType is a door opened to allow the triggering using a bounding box or a polygon.
   async queryLayer(layerPath: string, queryType: QueryType = 'all'): Promise<TypeAllFeatureInfoResultSet | void> {
     // TODO: REFACTOR - Watch out for code reentrancy between queries!
-    // ! Each query should be distinct as far as the resultSet goes! The 'reinitialization' below isn't sufficient.
-    // ! As it is (and was like this befor events refactor), the this.resultSet is mutating between async calls.
+    // GV Each query should be distinct as far as the resultSet goes! The 'reinitialization' below isn't sufficient.
+    // GV As it is (and was like this befor events refactor), the this.resultSet is mutating between async calls.
 
     // TODO: Refactor - Make this function throw an error instead of returning void as option of the promise
 

--- a/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
@@ -133,8 +133,8 @@ export class FeatureInfoLayerSet extends LayerSet {
    */
   queryLayers = async (longLatCoordinate: Coordinate): Promise<TypeFeatureInfoResultSet> => {
     // TODO: REFACTOR - Watch out for code reentrancy between queries!
-    // ! Each query should be distinct as far as the resultSet goes! The 'reinitialization' below isn't sufficient.
-    // ! As it is (and was like this befor events refactor), the this.resultSet is mutating between async calls.
+    // GV Each query should be distinct as far as the resultSet goes! The 'reinitialization' below isn't sufficient.
+    // GV As it is (and was like this befor events refactor), the this.resultSet is mutating between async calls.
 
     // Prepare to hold all promises of features in the loop below
     const allPromises: Promise<TypeFeatureInfoEntry[] | undefined | null>[] = [];

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -32,9 +32,9 @@ export class GeoUtilities {
    */
   geometryToWKT = (geometry: Geometry): string | null => {
     // TODO: Refactor - This method should be static
-    // ! but since it goes through the api instance to be importable
-    // ! afterwards it loses non static methods. For this reason, I've left it like this.
-    // ! See api.constructor: this.geoUtilities = new GeoUtilities();
+    // GV but since it goes through the api instance to be importable
+    // GV afterwards it loses non static methods. For this reason, I've left it like this.
+    // GV See api.constructor: this.geoUtilities = new GeoUtilities();
     if (geometry) {
       // Get the wkt for the geometry
       const format = new WKT();
@@ -52,9 +52,9 @@ export class GeoUtilities {
    */
   wktToGeometry = (wkt: string, readOptions: ReadOptions): Geometry | null => {
     // TODO: Refactor - This method should be static
-    // ! but since it goes through the api instance to be importable
-    // ! afterwards it loses non static methods. For this reason, I've left it like this.
-    // ! See api.constructor: this.geoUtilities = new GeoUtilities();
+    // GV but since it goes through the api instance to be importable
+    // GV afterwards it loses non static methods. For this reason, I've left it like this.
+    // GV See api.constructor: this.geoUtilities = new GeoUtilities();
     if (wkt) {
       // Get the feature for the wkt
       const format = new WKT();
@@ -72,9 +72,9 @@ export class GeoUtilities {
    */
   geojsonToGeometry = (geojson: string, readOptions: ReadOptions): Geometry | null => {
     // TODO: Refactor - This method should be static
-    // ! but since it goes through the api instance to be importable
-    // ! afterwards it loses non static methods. For this reason, I've left it like this.
-    // ! See api.constructor: this.geoUtilities = new GeoUtilities();
+    // GV but since it goes through the api instance to be importable
+    // GV afterwards it loses non static methods. For this reason, I've left it like this.
+    // GV See api.constructor: this.geoUtilities = new GeoUtilities();
     if (geojson) {
       // Get the feature for the geojson
       const format = new GeoJSON();
@@ -89,9 +89,9 @@ export class GeoUtilities {
    */
   defaultDrawingStyle = (strokeColor?: Color | string, strokeWidth?: number, fillColor?: Color | string): Style => {
     // TODO: Refactor - This method should be static
-    // ! but since it goes through the api instance to be importable
-    // ! afterwards it loses non static methods. For this reason, I've left it like this.
-    // ! See api.constructor: this.geoUtilities = new GeoUtilities();
+    // GV but since it goes through the api instance to be importable
+    // GV afterwards it loses non static methods. For this reason, I've left it like this.
+    // GV See api.constructor: this.geoUtilities = new GeoUtilities();
     return new Style({
       stroke: new Stroke({
         color: strokeColor || 'orange',
@@ -128,12 +128,12 @@ export class GeoUtilities {
    */
   convertTypeFeatureStyleToOpenLayersStyle = (style?: TypeFeatureStyle): Style => {
     // TODO: Refactor - This method should be static
-    // ! but since it goes through the api instance to be importable
-    // ! afterwards it loses non static methods. For this reason, I've left it like this.
-    // ! See api.constructor: this.geoUtilities = new GeoUtilities();
+    // GV but since it goes through the api instance to be importable
+    // GV afterwards it loses non static methods. For this reason, I've left it like this.
+    // GV See api.constructor: this.geoUtilities = new GeoUtilities();
     // TODO: Refactor - This function could also be used by vector class when it works with the styling
-    // ! So I'm putting it in this utilities class so that it eventually becomes shared between vector
-    // ! class and interactions classes.
+    // GV So I'm putting it in this utilities class so that it eventually becomes shared between vector
+    // GV class and interactions classes.
     // Redirect
     return this.defaultDrawingStyle(style?.strokeColor, style?.strokeWidth, style?.fillColor);
   };

--- a/packages/geoview-core/src/ui/panel/panel-types.ts
+++ b/packages/geoview-core/src/ui/panel/panel-types.ts
@@ -80,7 +80,7 @@ export interface TypeTextFieldProps extends Omit<TextFieldProps, 'type'> {
   tooltipPlacement?: TooltipProps['placement'];
 }
 
-// ! Check if it must be deleted.
+// GV Check if it must be deleted.
 // TODO: used in layer-panel packages... check if we can merge
 /** ******************************************************************************************************************************
  * Interface for the button properties used when creating a new button.


### PR DESCRIPTION
# Description

I've noticed that all comments that we have, which start with say: "// !", leak into the built `cgpv-main.js` file that is distributed.
![image](https://github.com/Canadian-Geospatial-Platform/geoview/assets/94073946/63232234-2916-4382-8a3c-5cd0fa09ddc2)

I'm guessing it has something to do with the TerserPlugin that the webpack is using? In any case, unless we change the TerserPlugin (or configure it?) - this PR changes all comments to a "// GV" equivalent. This comment shortcut, like the '!' shortcut before it, still means to indicate that it's an important "GeoView note" that should be highlighted in the code. It highlights it in magenta color. The "// !., which highlights in red, can still be used, but be mindful that it goes all the way to the cgpv-main.js file.

This PR includes a VSCode config for Better Comments that should apply to all developers. VSCode must be restarted.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Not hosted yet, waiting on another PR.

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1958)
<!-- Reviewable:end -->
