### PR TITLE
fix(layer-accessibility): Fix layers keyboard navigation

### DIFF
--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -132,13 +132,17 @@ const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListIte
     to: { opacity: 1 },
   });
 
+  const handleLayerKeyDown = (layaer: LayerListEntry, e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') onListItemClick(layer);
+  };
+
   const AnimatedPaper = animated(Paper);
 
   return (
     <AnimatedPaper sx={{ marginBottom: '1rem' }} style={listItemSpring} className={getContainerClass()}>
       <Tooltip title={layer.tooltip} placement="top" arrow>
         <Box>
-          <ListItem disablePadding onKeyDown={() => onListItemClick(layer)} tabIndex={0}>
+          <ListItem disablePadding onKeyDown={(e) => handleLayerKeyDown(layer, e)} tabIndex={0}>
             <ListItemButton
               tabIndex={-1}
               selected={isSelected}

--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -109,7 +109,7 @@ const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListIte
 
       default:
         return (
-          <IconButton edge="end" size="small" className="style1" disabled={isDisabled}>
+          <IconButton edge="end" size="small" className="style1" disabled={isDisabled} tabIndex={-1}>
             <ChevronRightIcon />
           </IconButton>
         );

--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -58,7 +58,7 @@ const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListIte
         // If there's a layer path
         if (layer.layerPath) {
           return (
-            <ListItemIcon>
+            <ListItemIcon aria-hidden="true">
               <LayerIcon layer={layer} />
             </ListItemIcon>
           );
@@ -109,7 +109,7 @@ const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListIte
 
       default:
         return (
-          <IconButton edge="end" size="small" className="style1" disabled={isDisabled} tabIndex={-1}>
+          <IconButton edge="end" size="small" className="style1" disabled={isDisabled} tabIndex={-1} aria-hidden="true">
             <ChevronRightIcon />
           </IconButton>
         );
@@ -144,6 +144,7 @@ const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListIte
               // disable when layer features has null value.
               disabled={isDisabled || isLoading}
               onClick={() => onListItemClick(layer)}
+              aria-label={layer.layerName}
             >
               {renderLayerIcon()}
               {renderLayerBody()}

--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -132,8 +132,8 @@ const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListIte
     to: { opacity: 1 },
   });
 
-  const handleLayerKeyDown = (layaer: LayerListEntry, e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') onListItemClick(layer);
+  const handleLayerKeyDown = (e: React.KeyboardEvent, selectedLayer: LayerListEntry) => {
+    if (e.key === 'Enter') onListItemClick(selectedLayer);
   };
 
   const AnimatedPaper = animated(Paper);
@@ -142,7 +142,7 @@ const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListIte
     <AnimatedPaper sx={{ marginBottom: '1rem' }} style={listItemSpring} className={getContainerClass()}>
       <Tooltip title={layer.tooltip} placement="top" arrow>
         <Box>
-          <ListItem disablePadding onKeyDown={(e) => handleLayerKeyDown(layer, e)} tabIndex={0}>
+          <ListItem disablePadding onKeyDown={(e) => handleLayerKeyDown(e, layer)} tabIndex={0}>
             <ListItemButton
               tabIndex={-1}
               selected={isSelected}

--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -138,8 +138,9 @@ const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListIte
     <AnimatedPaper sx={{ marginBottom: '1rem' }} style={listItemSpring} className={getContainerClass()}>
       <Tooltip title={layer.tooltip} placement="top" arrow>
         <Box>
-          <ListItem disablePadding>
+          <ListItem disablePadding onKeyDown={() => onListItemClick(layer)} tabIndex={0}>
             <ListItemButton
+              tabIndex={-1}
               selected={isSelected}
               // disable when layer features has null value.
               disabled={isDisabled || isLoading}

--- a/packages/geoview-core/src/core/components/common/layout.tsx
+++ b/packages/geoview-core/src/core/components/common/layout.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
 import { Box } from '@/ui';
 import { logger } from '@/core/utils/logger';
@@ -20,6 +21,7 @@ interface LayoutProps {
 
 export function Layout({ children, layerList, selectedLayerPath, onLayerListClicked, onIsEnlargeClicked, fullWidth }: LayoutProps) {
   const theme = useTheme();
+  const { t } = useTranslation<string>();
 
   const [isLayersPanelVisible, setIsLayersPanelVisible] = useState(false);
   const [isEnlarged, setIsEnlarged] = useState(false);
@@ -86,7 +88,8 @@ export function Layout({ children, layerList, selectedLayerPath, onLayerListClic
     <Box>
       <ResponsiveGrid.Root sx={{ pt: 8, pb: 8 }} ref={panelTitleRef}>
         {!fullWidth && (
-          <ResponsiveGrid.Left isLayersPanelVisible={isLayersPanelVisible} isEnlarged={isEnlarged}>
+          <ResponsiveGrid.Left isLayersPanelVisible={isLayersPanelVisible} isEnlarged={isEnlarged} aria-hidden={!isLayersPanelVisible}>
+            {/* This panel is hidden from screen readers when not visible */}
             {null}
           </ResponsiveGrid.Left>
         )}
@@ -110,6 +113,7 @@ export function Layout({ children, layerList, selectedLayerPath, onLayerListClic
                   isLayersPanelVisible={isLayersPanelVisible}
                   onSetIsLayersPanelVisible={setIsLayersPanelVisible}
                   fullWidth={fullWidth}
+                  aria-label={t('general.close')}
                 />
               )}
             </Box>
@@ -122,6 +126,7 @@ export function Layout({ children, layerList, selectedLayerPath, onLayerListClic
           isEnlarged={isEnlarged}
           isLayersPanelVisible={isLayersPanelVisible}
           fullWidth={fullWidth}
+          aria-hidden={!isLayersPanelVisible}
         >
           {renderLayerList()}
         </ResponsiveGrid.Left>

--- a/packages/geoview-core/src/core/components/export/export-modal.tsx
+++ b/packages/geoview-core/src/core/components/export/export-modal.tsx
@@ -210,6 +210,7 @@ export default function ExportModal(): JSX.Element {
           role="button"
           tabIndex={-1}
           autoFocus
+          aria-hidden="true"
           sx={{
             width: 'inherit',
             fontSize: theme.palette.geoViewFontSize.sm,

--- a/packages/geoview-core/src/core/components/guide/guide-panel.tsx
+++ b/packages/geoview-core/src/core/components/guide/guide-panel.tsx
@@ -137,8 +137,9 @@ export function GuidePanel({ fullWidth }: GuidePanelType): JSX.Element {
       layerList={helpItems}
       onLayerListClicked={handleGuideItemClick}
       fullWidth={fullWidth}
+      aria-label={t('guide.title')}
     >
-      <Box sx={sxClasses.rightPanelContainer}>
+      <Box sx={sxClasses.rightPanelContainer} aria-label={t('guide.title')}>
         <Box sx={{ ml: '30px', mb: '18px' }}>{helpItems[guideItemIndex]?.content}</Box>
       </Box>
     </Layout>

--- a/packages/geoview-core/src/core/components/icon-stack/icon-stack.tsx
+++ b/packages/geoview-core/src/core/components/icon-stack/icon-stack.tsx
@@ -36,6 +36,7 @@ export function IconStack({ layerPath, onIconClick, onStackIconClick }: TypeIcon
         color="primary"
         size="small"
         onClick={iconImage === 'no data' ? undefined : onIconClick}
+        aria-hidden="true"
       >
         {iconImage === 'no data' ? (
           <BrowserNotSupportedIcon />
@@ -47,19 +48,19 @@ export function IconStack({ layerPath, onIconClick, onStackIconClick }: TypeIcon
       </IconButton>
     ) : // eslint-disable-next-line no-nested-ternary
     numOfIcons && numOfIcons > 0 ? (
-      <Box tabIndex={-1} onClick={onIconClick} sx={sxClasses.stackIconsBox} onKeyPress={(e) => onStackIconClick?.(e)}>
-        <IconButton sx={sxClasses.iconPreviewStacked} color="primary" size="small" tabIndex={-1}>
+      <Box tabIndex={-1} onClick={onIconClick} sx={sxClasses.stackIconsBox} onKeyPress={(e) => onStackIconClick?.(e)} aria-hidden="true">
+        <IconButton sx={sxClasses.iconPreviewStacked} color="primary" size="small" tabIndex={-1} aria-hidden="true">
           <Box sx={sxClasses.legendIconTransparent}>
             {iconImageStacked && <img alt="icon" src={iconImageStacked} style={sxClasses.maxIconImg} />}
           </Box>
         </IconButton>
-        <IconButton sx={sxClasses.iconPreviewHoverable} color="primary" size="small" tabIndex={-1}>
+        <IconButton sx={sxClasses.iconPreviewHoverable} color="primary" size="small" tabIndex={-1} aria-hidden="true">
           <Box sx={sxClasses.legendIcon}>{iconImage && <img alt="icon" src={iconImage} style={sxClasses.maxIconImg} />}</Box>
         </IconButton>
       </Box>
     ) : layerPath !== '' && iconData.length === 0 && layerPath.charAt(0) !== '!' ? (
-      <Box tabIndex={-1} onClick={onIconClick} sx={sxClasses.stackIconsBox} onKeyPress={(e) => onStackIconClick?.(e)}>
-        <IconButton sx={sxClasses.iconPreviewStacked} color="primary" size="small" tabIndex={-1}>
+      <Box tabIndex={-1} onClick={onIconClick} sx={sxClasses.stackIconsBox} onKeyPress={(e) => onStackIconClick?.(e)} aria-hidden="true">
+        <IconButton sx={sxClasses.iconPreviewStacked} color="primary" size="small" tabIndex={-1} aria-hidden="true">
           <Box sx={sxClasses.legendIconTransparent}>
             <BrowserNotSupportedIcon />
           </Box>

--- a/packages/geoview-core/src/core/components/icon-stack/icon-stack.tsx
+++ b/packages/geoview-core/src/core/components/icon-stack/icon-stack.tsx
@@ -30,7 +30,13 @@ export function IconStack({ layerPath, onIconClick, onStackIconClick }: TypeIcon
     // TODO: refactor - try to remove the nested ternary to simplify reading
     // eslint-disable-next-line no-nested-ternary
     return numOfIcons === 1 ? (
-      <IconButton sx={sxClasses.iconPreview} color="primary" size="small" onClick={iconImage === 'no data' ? undefined : onIconClick}>
+      <IconButton
+        tabIndex={-1}
+        sx={sxClasses.iconPreview}
+        color="primary"
+        size="small"
+        onClick={iconImage === 'no data' ? undefined : onIconClick}
+      >
         {iconImage === 'no data' ? (
           <BrowserNotSupportedIcon />
         ) : (
@@ -41,7 +47,7 @@ export function IconStack({ layerPath, onIconClick, onStackIconClick }: TypeIcon
       </IconButton>
     ) : // eslint-disable-next-line no-nested-ternary
     numOfIcons && numOfIcons > 0 ? (
-      <Box tabIndex={0} onClick={onIconClick} sx={sxClasses.stackIconsBox} onKeyPress={(e) => onStackIconClick?.(e)}>
+      <Box tabIndex={-1} onClick={onIconClick} sx={sxClasses.stackIconsBox} onKeyPress={(e) => onStackIconClick?.(e)}>
         <IconButton sx={sxClasses.iconPreviewStacked} color="primary" size="small" tabIndex={-1}>
           <Box sx={sxClasses.legendIconTransparent}>
             {iconImageStacked && <img alt="icon" src={iconImageStacked} style={sxClasses.maxIconImg} />}
@@ -52,7 +58,7 @@ export function IconStack({ layerPath, onIconClick, onStackIconClick }: TypeIcon
         </IconButton>
       </Box>
     ) : layerPath !== '' && iconData.length === 0 && layerPath.charAt(0) !== '!' ? (
-      <Box tabIndex={0} onClick={onIconClick} sx={sxClasses.stackIconsBox} onKeyPress={(e) => onStackIconClick?.(e)}>
+      <Box tabIndex={-1} onClick={onIconClick} sx={sxClasses.stackIconsBox} onKeyPress={(e) => onStackIconClick?.(e)}>
         <IconButton sx={sxClasses.iconPreviewStacked} color="primary" size="small" tabIndex={-1}>
           <Box sx={sxClasses.legendIconTransparent}>
             <BrowserNotSupportedIcon />

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -153,6 +153,10 @@ export function SingleLayer({ isDragging, depth, layer, setIsLayersListPanelVisi
     }
   };
 
+  const handleLayerKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') handleLayerClick();
+  };
+
   const handleToggleVisibility = () => {
     setOrToggleLayerVisibility(layer.layerPath);
   };
@@ -282,7 +286,7 @@ export function SingleLayer({ isDragging, depth, layer, setIsLayersListPanelVisi
 
   return (
     <AnimatedPaper className={getContainerClass()} style={listItemSpring} data-layer-depth={depth}>
-      <ListItem key={layer.layerName} divider>
+      <ListItem key={layer.layerName} divider tabIndex={0} onKeyDown={(e) => handleLayerKeyDown(e)}>
         <ListItemButton selected={layerIsSelected || (layerChildIsSelected && !isGroupOpen)}>
           <LayerIcon layer={layer} />
           <Tooltip title={layer.layerName} placement="top" enterDelay={1000}>

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -286,23 +286,23 @@ export function SingleLayer({ isDragging, depth, layer, setIsLayersListPanelVisi
 
   return (
     <AnimatedPaper className={getContainerClass()} style={listItemSpring} data-layer-depth={depth}>
-      <ListItem key={layer.layerName} divider tabIndex={0} onKeyDown={(e) => handleLayerKeyDown(e)}>
-        <ListItemButton selected={layerIsSelected || (layerChildIsSelected && !isGroupOpen)}>
-          <LayerIcon layer={layer} />
-          <Tooltip title={layer.layerName} placement="top" enterDelay={1000}>
+      <Tooltip title={layer.layerName} placement="top" enterDelay={1000} arrow>
+        <ListItem key={layer.layerName} divider tabIndex={0} onKeyDown={(e) => handleLayerKeyDown(e)}>
+          <ListItemButton selected={layerIsSelected || (layerChildIsSelected && !isGroupOpen)}>
+            <LayerIcon layer={layer} />
             <ListItemText
               primary={layer.layerName !== undefined ? layer.layerName : layer.layerId}
               secondary={getLayerDescription()}
               onClick={handleLayerClick}
             />
-          </Tooltip>
-          <ListItemIcon className="rightIcons-container">
-            {renderMoreLayerButtons()}
-            {renderArrowButtons()}
-            {renderEditModeButtons()}
-          </ListItemIcon>
-        </ListItemButton>
-      </ListItem>
+            <ListItemIcon className="rightIcons-container">
+              {renderMoreLayerButtons()}
+              {renderArrowButtons()}
+              {renderEditModeButtons()}
+            </ListItemIcon>
+          </ListItemButton>
+        </ListItem>
+      </Tooltip>
       {renderCollapsible()}
     </AnimatedPaper>
   );

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -288,7 +288,7 @@ export function SingleLayer({ isDragging, depth, layer, setIsLayersListPanelVisi
     <AnimatedPaper className={getContainerClass()} style={listItemSpring} data-layer-depth={depth}>
       <Tooltip title={layer.layerName} placement="top" enterDelay={1000} arrow>
         <ListItem key={layer.layerName} divider tabIndex={0} onKeyDown={(e) => handleLayerKeyDown(e)}>
-          <ListItemButton selected={layerIsSelected || (layerChildIsSelected && !isGroupOpen)}>
+          <ListItemButton selected={layerIsSelected || (layerChildIsSelected && !isGroupOpen)} tabIndex={-1}>
             <LayerIcon layer={layer} />
             <ListItemText
               primary={layer.layerName !== undefined ? layer.layerName : layer.layerId}

--- a/packages/geoview-core/src/core/containers/shell.tsx
+++ b/packages/geoview-core/src/core/containers/shell.tsx
@@ -204,7 +204,7 @@ export function Shell(): JSX.Element {
         {t('keyboardnav.start')}
       </Link>
       <FocusTrap open={activeTrapGeoView}>
-        <Box id={`shell-${mapId}`} sx={sxClasses.shell} className="geoview-shell" key={update} tabIndex={-1}>
+        <Box id={`shell-${mapId}`} sx={sxClasses.shell} className="geoview-shell" key={update} tabIndex={-1} aria-hidden="true">
           <CircularProgress isLoaded={mapLoaded} />
           <CircularProgress isLoaded={!circularProgressActive} />
           <Box id={`map-${mapId}`} sx={sxClasses.mapShellContainer} className="mapContainer">

--- a/packages/geoview-core/src/ui/list/checkbox-list/checkbox-list.tsx
+++ b/packages/geoview-core/src/ui/list/checkbox-list/checkbox-list.tsx
@@ -96,6 +96,7 @@ export function CheckboxList(props: CheckboxListProps): JSX.Element {
                 tabIndex={-1}
                 disableRipple
                 inputProps={{ 'aria-labelledby': labelId }}
+                aria-hidden="true"
               />
             </ListItemIcon>
             <Typography sx={sxClasses.typography} variant="body2" noWrap component="ul">


### PR DESCRIPTION
# Description

In Layers tab, we can't navigate through the layer selection using keyboard tab. We should be able to use keyboard and select all layers and sub-layers, including the layer icons.

Fixes #1898 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
https://amir-azma.github.io/geoview/raw-feature-info.html


# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1959)
<!-- Reviewable:end -->
