### PR TITLE
refactor(hover): use store and map state

### DIFF
--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -29,6 +29,7 @@ import { TypeMapFeaturesConfig } from '@/core/types/global-types';
 import { TypeClickMarker } from '@/core/components';
 import { TypeOrderedLayerInfo, TypeScaleInfo } from '@/core/stores';
 import { TypeBasemapOptions, TypeBasemapProps } from '@/geo/layer/basemap/basemap-types';
+import { TypeHoverFeatureInfo } from '@/geo/utils/hover-feature-info-layer-set';
 
 // GV The paradigm when working with MapEventProcessor vs MapState goes like this:
 // GV MapState provides: 'state values', 'actions' and 'setterActions'.
@@ -442,6 +443,10 @@ export class MapEventProcessor extends AbstractEventProcessor {
 
   static setMapLayerHoverable(mapId: string, layerPath: string, hoverable: boolean): void {
     this.getMapStateProtected(mapId).setterActions.setHoverable(layerPath, hoverable);
+  }
+
+  static setMapHoverFeatureInfo(mapId: string, hoverFeatureInfo: TypeHoverFeatureInfo): void {
+    this.getMapStateProtected(mapId).setterActions.setHoverFeatureInfo(hoverFeatureInfo);
   }
 
   static setMapOrderedLayerInfo(mapId: string, orderedLayerInfo: TypeOrderedLayerInfo[]): void {

--- a/packages/geoview-core/src/core/components/hover-tooltip/hover-tooltip.tsx
+++ b/packages/geoview-core/src/core/components/hover-tooltip/hover-tooltip.tsx
@@ -3,10 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { useTheme, Theme } from '@mui/material/styles';
 
 import { Box } from '@/ui';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
-import { getGeoViewStore } from '@/core/stores/stores-managers';
 import { logger } from '@/core/utils/logger';
-import { useMapHoverFeatureInfo } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useMapHoverFeatureInfo, useMapPointerPosition } from '@/core/stores/store-interface-and-intial-values/map-state';
 
 /**
  * Hover tooltip component to show name field information on hover
@@ -14,10 +12,8 @@ import { useMapHoverFeatureInfo } from '@/core/stores/store-interface-and-intial
  * @returns {JSX.Element} the hover tooltip component
  */
 export function HoverTooltip(): JSX.Element {
-  // Log too annoying
+  // Log, commented too annoying
   // logger.logTraceRender('components/hover-tooltip/hover-tooltip');
-
-  const mapId = useGeoViewMapId();
 
   const { t } = useTranslation<string>();
 
@@ -59,7 +55,9 @@ export function HoverTooltip(): JSX.Element {
 
   // store state
   const hoverFeatureInfo = useMapHoverFeatureInfo();
+  const pointerPosition = useMapPointerPosition();
 
+  // Update tooltip when store value change from propagation by hover-layer-set to map-event-processor
   useEffect(() => {
     // Log
     logger.logTraceUseEffect('HOVER-TOOLTIP - hoverFeatureInfo', hoverFeatureInfo);
@@ -71,30 +69,17 @@ export function HoverTooltip(): JSX.Element {
     }
   }, [hoverFeatureInfo]);
 
+  // clear the tooltip and mouse move and set pixel location
   useEffect(() => {
-    // Log
-    logger.logTraceUseEffect('HOVER-TOOLTIP - mount');
+    // Log, commented too annoying
+    // logger.logTraceUseEffect('HOVER-TOOLTIP - pointerPosition', pointerPosition);
 
-    // if pointer position changed, reset tooltip
-    const unsubPointerPosition = getGeoViewStore(mapId).subscribe(
-      (state) => state.mapState.pointerPosition,
-      (curPos, prevPos) => {
-        // Log - commented, too anoying
-        // logger.logTraceCoreStoreSubscription('HOVER-TOOLTIP - pointer position', curPos);
+    setTooltipValue('');
+    setTooltipIcon('');
+    setShowTooltip(false);
 
-        setPixel(curPos!.pixel as [number, number]);
-        if (curPos !== prevPos) {
-          setTooltipValue('');
-          setTooltipIcon('');
-          setShowTooltip(false);
-        }
-      }
-    );
-
-    return () => {
-      unsubPointerPosition();
-    };
-  }, [mapId]);
+    if (pointerPosition !== undefined) setPixel(pointerPosition.pixel as [number, number]);
+  }, [pointerPosition]);
 
   return (
     <Box

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
@@ -3,14 +3,12 @@ import { TypeSetStore, TypeGetStore } from '@/core/stores/geoview-store';
 import { useGeoViewStore } from '@/core/stores/stores-managers';
 import { api } from '@/app';
 import { QueryType, TypeLayerData, TypeFeatureInfoEntry, TypeGeometry } from '@/geo/utils/layer-set';
-import { TypeHoverLayerData } from '@/geo/utils/hover-feature-info-layer-set';
 
 export interface IFeatureInfoState {
   checkedFeatures: Array<TypeFeatureInfoEntry>;
   layerDataArray: TypeLayerData[];
   layerDataArrayBatch: TypeLayerData[];
   layerDataArrayBatchLayerPathBypass: string;
-  hoverDataArray: TypeHoverLayerData[];
   allFeaturesDataArray: TypeLayerData[];
   selectedLayerPath: string;
 
@@ -20,7 +18,6 @@ export interface IFeatureInfoState {
     setLayerDataArray: (layerDataArray: TypeLayerData[]) => void;
     setLayerDataArrayBatch: (layerDataArray: TypeLayerData[]) => void;
     setLayerDataArrayBatchLayerPathBypass: (layerPath: string) => void;
-    setHoverDataArray: (hoverDataArray: TypeHoverLayerData[]) => void;
     setAllFeaturesDataArray: (allFeaturesDataArray: TypeLayerData[]) => void;
     setSelectedLayerPath: (selectedLayerPath: string) => void;
     triggerGetAllFeatureInfo: (layerPath: string, queryType: QueryType) => void;
@@ -33,7 +30,6 @@ export function initFeatureInfoState(set: TypeSetStore, get: TypeGetStore): IFea
     layerDataArray: [],
     layerDataArrayBatch: [],
     layerDataArrayBatchLayerPathBypass: '',
-    hoverDataArray: [],
     allFeaturesDataArray: [],
     selectedLayerPath: '',
 
@@ -85,14 +81,6 @@ export function initFeatureInfoState(set: TypeSetStore, get: TypeGetStore): IFea
           },
         });
       },
-      setHoverDataArray(hoverDataArray: TypeHoverLayerData[]) {
-        set({
-          detailsState: {
-            ...get().detailsState,
-            hoverDataArray,
-          },
-        });
-      },
       setAllFeaturesDataArray(allFeaturesDataArray: TypeLayerData[]) {
         set({
           detailsState: {
@@ -125,6 +113,5 @@ export const useDetailsStoreLayerDataArray = () => useStore(useGeoViewStore(), (
 export const useDetailsStoreLayerDataArrayBatch = () => useStore(useGeoViewStore(), (state) => state.detailsState.layerDataArrayBatch);
 export const useDetailsStoreSelectedLayerPath = () => useStore(useGeoViewStore(), (state) => state.detailsState.selectedLayerPath);
 export const useDetailsStoreAllFeaturesDataArray = () => useStore(useGeoViewStore(), (state) => state.detailsState.allFeaturesDataArray);
-export const useDetailsStoreHoverDataArray = () => useStore(useGeoViewStore(), (state) => state.detailsState.hoverDataArray);
 
 export const useDetailsStoreActions = () => useStore(useGeoViewStore(), (state) => state.detailsState.actions);

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
@@ -17,6 +17,7 @@ import { api } from '@/app';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
 import { TypeClickMarker } from '@/core/components/click-marker/click-marker';
 import { TypeBasemapOptions } from '@/geo/layer/basemap/basemap-types';
+import { TypeHoverFeatureInfo } from '@/geo/utils/hover-feature-info-layer-set';
 
 // GV Important: See notes in header of MapEventProcessor file for information on the paradigm to apply when working with MapEventProcessor vs MapState
 
@@ -30,6 +31,7 @@ export interface IMapState {
   fixNorth: boolean;
   highlightColor?: TypeHighlightColors;
   highlightedFeatures: TypeFeatureInfoEntry[];
+  hoverFeatureInfo: TypeHoverFeatureInfo | undefined | null;
   interaction: TypeInteraction;
   mapElement?: OLMap;
   mapExtent: Extent | undefined;
@@ -106,6 +108,7 @@ export interface IMapState {
     setHoverable: (layerPath: string, hoverable: boolean) => void;
     setQueryable: (layerPath: string, queryable: boolean) => void;
     setClickMarker: (coord: number[] | undefined) => void;
+    setHoverFeatureInfo: (hoverFeatureInfo: TypeHoverFeatureInfo) => void;
   };
 }
 
@@ -124,6 +127,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
     currentProjection: 3857 as TypeValidMapProjectionCodes,
     fixNorth: false,
     highlightedFeatures: [],
+    hoverFeatureInfo: undefined,
     interaction: 'static',
     mapExtent: undefined,
     mapLoaded: false,
@@ -406,7 +410,6 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
     setterActions: {
       // #region SETTER ACTIONS
-
       /**
        * Sets the map size and scale.
        * @param {[number, number]} size - The size of the map.
@@ -714,6 +717,14 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
         });
       },
 
+      setHoverFeatureInfo(hoverFeatureInfo: TypeHoverFeatureInfo) {
+        set({
+          mapState: {
+            ...get().mapState,
+            hoverFeatureInfo,
+          },
+        });
+      },
       // #endregion SETTER ACTIONS
     },
   } as IMapState;
@@ -752,6 +763,7 @@ export const useMapExtent = () => useStore(useGeoViewStore(), (state) => state.m
 export const useMapFixNorth = () => useStore(useGeoViewStore(), (state) => state.mapState.fixNorth);
 export const useMapInteraction = () => useStore(useGeoViewStore(), (state) => state.mapState.interaction);
 export const useMapHiglightColor = () => useStore(useGeoViewStore(), (state) => state.mapState.highlightColor);
+export const useMapHoverFeatureInfo = () => useStore(useGeoViewStore(), (state) => state.mapState.hoverFeatureInfo);
 export const useMapLoaded = () => useStore(useGeoViewStore(), (state) => state.mapState.mapLoaded);
 export const useMapNorthArrow = () => useStore(useGeoViewStore(), (state) => state.mapState.northArrow);
 export const useMapNorthArrowElement = () => useStore(useGeoViewStore(), (state) => state.mapState.northArrowElement);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -118,10 +118,6 @@ export abstract class AbstractGeoViewLayer {
   /** Date format object used to translate internal UTC ISO format to the external format, the one used by the user */
   externalFragmentsOrder: TypeDateFragments;
 
-  // LayerPath to use when we want to call a GeoView layer's method using the following syntaxe:
-  // api.maps[mapId].layer.geoviewLayer(layerPath).getVisible()
-  layerPathAssociatedToTheGeoviewLayer = '';
-
   // Keep all callback delegate references
   #onGeoViewLayerRegistrationHandlers: GeoViewLayerRegistrationDelegate[] = [];
 


### PR DESCRIPTION
Closes #1767

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

refactor hover to move it to map-state and propagate to the store only the values, no result set.

Fixes #1767

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

hosted April, 3 - 5pm: https://jolevesq.github.io/geoview/raw-feature-info.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1985)
<!-- Reviewable:end -->
