### PR TITLE
ConfigApi Phase 1

### DIFF
--- a/packages/geoview-core/src/api/api.ts
+++ b/packages/geoview-core/src/api/api.ts
@@ -21,6 +21,9 @@ import { initMapDivFromFunctionCall } from '@/app';
  * @class API
  */
 export class API {
+  // object used to validate the configurations against the schema.
+  configApi = new ConfigApi();
+
   // event object used to handle triggering events, subscribing to an event etc...
   event: Event;
 

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -14,7 +14,6 @@ import { getLocalizedValue } from '@/core/utils/utilities';
 import { AbstractEventProcessor } from '@/api/event-processors/abstract-event-processor';
 import {
   TypeLayerControls,
-  TypeLayerEntryConfig,
   TypeStyleGeometry,
   isClassBreakStyleConfig,
   isSimpleStyleConfig,
@@ -22,6 +21,9 @@ import {
   layerEntryIsGroupLayer,
 } from '@/geo/map/map-schema-types';
 import { AppEventProcessor } from './app-event-processor';
+import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
+import { GroupLayerEntryConfig } from '@/core/utils/config/validation-classes/group-layer-entry-config';
+import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
 
 export class LegendEventProcessor extends AbstractEventProcessor {
   // **********************************************************
@@ -136,7 +138,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
    */
   public static propagateLegendToStore(mapId: string, layerPath: string, legendResultSetEntry: TypeLegendResultSetEntry) {
     const layerPathNodes = layerPath.split('/');
-    const setLayerControls = (layerConfig: TypeLayerEntryConfig): TypeLayerControls => {
+    const setLayerControls = (layerConfig: AbstractBaseLayerEntryConfig | GroupLayerEntryConfig): TypeLayerControls => {
       const controls: TypeLayerControls = {
         highlight: layerConfig.initialSettings?.controls?.highlight !== undefined ? layerConfig.initialSettings?.controls?.highlight : true,
         hover: layerConfig.initialSettings?.controls?.hover !== undefined ? layerConfig.initialSettings?.controls?.hover : true,
@@ -152,7 +154,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
     };
     const createNewLegendEntries = (layerPathBeginning: string, currentLevel: number, existingEntries: TypeLegendLayer[]) => {
       const entryLayerPath = `${layerPathBeginning}/${layerPathNodes[currentLevel]}`;
-      const layerConfig = api.maps[mapId].layer.registeredLayers[entryLayerPath] as TypeLayerEntryConfig;
+      const layerConfig = api.maps[mapId].layer.registeredLayers[entryLayerPath] as ConfigBaseClass;
       let entryIndex = existingEntries.findIndex((entry) => entry.layerPath === entryLayerPath);
       if (layerEntryIsGroupLayer(layerConfig)) {
         const controls: TypeLayerControls = setLayerControls(layerConfig);
@@ -181,7 +183,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
         else existingEntries[entryIndex].layerStatus = layerConfig.layerStatus;
         createNewLegendEntries(entryLayerPath, currentLevel + 1, existingEntries[entryIndex].children);
       } else if (layerConfig) {
-        const controls: TypeLayerControls = setLayerControls(layerConfig);
+        const controls: TypeLayerControls = setLayerControls(layerConfig as AbstractBaseLayerEntryConfig);
         const newLegendLayer: TypeLegendLayer = {
           bounds: undefined,
           controls,
@@ -197,7 +199,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
           styleConfig: legendResultSetEntry.data?.styleConfig,
           type: legendResultSetEntry.data?.type,
           canToggle: legendResultSetEntry.data?.type !== CONST_LAYER_TYPES.ESRI_IMAGE,
-          opacity: layerConfig.initialSettings?.states?.opacity || 1,
+          opacity: (layerConfig as AbstractBaseLayerEntryConfig).initialSettings?.states?.opacity || 1,
           items: [] as TypeLegendItem[],
           children: [] as TypeLegendLayer[],
           icons: LegendEventProcessor.getLayerIconImage(mapId, layerPath, legendResultSetEntry.data!),

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -29,6 +29,7 @@ import { TypeMapFeaturesConfig } from '@/core/types/global-types';
 import { TypeClickMarker } from '@/core/components';
 import { TypeOrderedLayerInfo, TypeScaleInfo } from '@/core/stores';
 import { TypeBasemapOptions, TypeBasemapProps } from '@/geo/layer/basemap/basemap-types';
+import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
 
 // GV The paradigm when working with MapEventProcessor vs MapState goes like this:
 // GV MapState provides: 'state values', 'actions' and 'setterActions'.
@@ -527,9 +528,10 @@ export class MapEventProcessor extends AbstractEventProcessor {
     layerPathToReplace?: string
   ): void {
     const { orderedLayerInfo } = this.getMapStateProtected(mapId);
-    const layerPath = (geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId
-      ? `${(geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId}/${(geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId}`
-      : (geoviewLayerConfig as TypeLayerEntryConfig).layerPath;
+    const layerPath =
+      'geoviewLayerId' in geoviewLayerConfig
+        ? `${geoviewLayerConfig.geoviewLayerId}/${(geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId}`
+        : geoviewLayerConfig.layerPath;
     const index = this.getMapIndexFromOrderedLayerInfo(mapId, layerPathToReplace || layerPath);
     const replacedLayers = orderedLayerInfo.filter((layerInfo) => layerInfo.layerPath.startsWith(layerPathToReplace || layerPath));
     const newOrderedLayerInfo = api.maps[mapId].layer.generateArrayOfLayerOrderInfo(geoviewLayerConfig);
@@ -725,8 +727,8 @@ export class MapEventProcessor extends AbstractEventProcessor {
   static setLayerZIndices = (mapId: string) => {
     const reversedLayers = [...this.getMapStateProtected(mapId).orderedLayerInfo].reverse();
     reversedLayers.forEach((orderedLayerInfo, index) => {
-      if (api.maps[mapId].layer.registeredLayers[orderedLayerInfo.layerPath]?.olLayer)
-        api.maps[mapId].layer.registeredLayers[orderedLayerInfo.layerPath].olLayer?.setZIndex(index + 10);
+      if ((api.maps[mapId].layer.registeredLayers[orderedLayerInfo.layerPath] as AbstractBaseLayerEntryConfig)?.olLayer)
+        (api.maps[mapId].layer.registeredLayers[orderedLayerInfo.layerPath] as AbstractBaseLayerEntryConfig).olLayer?.setZIndex(index + 10);
     });
   };
 

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/time-slider-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/time-slider-event-processor.ts
@@ -11,6 +11,7 @@ import { api } from '@/app';
 import { TypeFeatureInfoLayerConfig } from '@/geo/map/map-schema-types';
 import { EsriImage } from '@/geo/layer/geoview-layers/raster/esri-image';
 import { AppEventProcessor } from './app-event-processor';
+import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
 
 export class TimeSliderEventProcessor extends AbstractEventProcessor {
   /**
@@ -128,7 +129,7 @@ export class TimeSliderEventProcessor extends AbstractEventProcessor {
    * @returns {TimeSliderLayer}
    */
   static getInitialTimeSliderValues(mapId: string, layerPath: string): TimeSliderLayerSet {
-    const layerConfig = api.maps[mapId].layer.registeredLayers[layerPath];
+    const layerConfig = api.maps[mapId].layer.registeredLayers[layerPath] as AbstractBaseLayerEntryConfig;
     const name = getLocalizedValue(layerConfig.layerName, AppEventProcessor.getDisplayLanguage(mapId)) || layerConfig.layerId;
     const temporalDimensionInfo = api.maps[mapId].layer.geoviewLayer(layerPath).getTemporalDimension(layerPath);
     const { range } = temporalDimensionInfo.range;

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -466,7 +466,7 @@ export function AddNewLayer(): JSX.Element {
           : new EsriFeature(mapId, esriGeoviewLayerConfig as TypeEsriFeatureLayerConfig);
       // Synchronize the geoviewLayerId.
       esriGeoviewLayerConfig.geoviewLayerId = esriGeoviewLayerInstance.geoviewLayerId;
-      setGeoviewLayerInstance(esriGeoviewLayerInstance);
+      setGeoviewLayerInstance(esriGeoviewLayerInstance as AbstractGeoViewLayer);
       await esriGeoviewLayerInstance.createGeoViewLayers();
       const esriMetadata = esriGeoviewLayerInstance.metadata!;
       if (!esriMetadata) throw new Error('Cannot get metadata');

--- a/packages/geoview-core/src/core/containers/focus-trap.tsx
+++ b/packages/geoview-core/src/core/containers/focus-trap.tsx
@@ -13,6 +13,7 @@ import { useAppStoreActions } from '@/core/stores/store-interface-and-intial-val
 import { useUIStoreActions } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { useMapElement } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
+import { disableScrolling } from '../utils/utilities';
 
 /**
  * Interface for the focus trap properties

--- a/packages/geoview-core/src/core/utils/config/config.ts
+++ b/packages/geoview-core/src/core/utils/config/config.ts
@@ -15,6 +15,7 @@ import { InlineDivConfigReader } from '@/core/utils/config/reader/div-config-rea
 import { JsonConfigReader } from '@/core/utils/config/reader/json-config-reader';
 import { URLmapConfigReader } from '@/core/utils/config/reader/url-config-reader';
 import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
+import { AbstractBaseLayerEntryConfig } from './validation-classes/abstract-base-layer-entry-config';
 
 // ******************************************************************************************************************************
 // ******************************************************************************************************************************
@@ -144,7 +145,7 @@ export class Config {
   private setLayerEntryType(listOfLayerEntryConfig: TypeListOfLayerEntryConfig, geoviewLayerType: TypeGeoviewLayerType): void {
     listOfLayerEntryConfig?.forEach((layerConfig) => {
       if (layerEntryIsGroupLayer(layerConfig as ConfigBaseClass))
-        this.setLayerEntryType(layerConfig.listOfLayerEntryConfig!, geoviewLayerType);
+        this.setLayerEntryType((layerConfig as AbstractBaseLayerEntryConfig).listOfLayerEntryConfig!, geoviewLayerType);
       else {
         // eslint-disable-next-line no-param-reassign
         layerConfig.schemaTag = geoviewLayerType;

--- a/packages/geoview-core/src/core/utils/config/validation-classes/abstract-base-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/abstract-base-layer-entry-config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 // ? we escape all private attribute in this file
 import BaseLayer from 'ol/layer/Base';
 import LayerGroup from 'ol/layer/Group';
@@ -8,7 +7,6 @@ import {
   TypeBaseSourceVectorInitialConfig,
   TypeLayerAndListenerType,
   TypeLayerInitialSettings,
-  TypeLocalizedString,
   TypeSourceImageEsriInitialConfig,
   TypeSourceImageInitialConfig,
   TypeSourceImageStaticInitialConfig,
@@ -19,18 +17,18 @@ import {
   layerEntryIsGroupLayer,
 } from '@/geo/map/map-schema-types';
 import { logger } from '@/core/utils/logger';
-import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
 import { TypeJsonValue } from '@/core/types/global-types';
+import { GroupLayerEntryConfig } from './group-layer-entry-config';
 
 /** ******************************************************************************************************************************
  * Base type used to define a GeoView layer to display on the map.
  */
-export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
-  /** The ending element of the layer configuration path. */
-  layerIdExtension?: string | undefined = undefined;
-
-  /** The display name of the layer (English/French). */
-  layerName?: TypeLocalizedString;
+export abstract class AbstractBaseLayerEntryConfig extends GroupLayerEntryConfig {
+  // TODO: Remove this property and explain in the doc how users can do the same with only the layerId in the config.
+  // TO.DOCONT: Developers often forget that the complete layerID is the concatenation of layerId.layerIdExtension.
+  // TO.DOCONT: The users can do that in the configuration using only layerId: 'theLayerId.TheExtension'
+  /** The ending extension (element) of the layer identifier. This element is part of the schema. */
+  private privateLayerIdExtension?: string;
 
   /**
    * Initial settings to apply to the GeoView layer entry at creation time. Initial settings are inherited from the parent in the
@@ -55,10 +53,28 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
   /**
    * The class constructor.
    * @param {AbstractBaseLayerEntryConfig} layerConfig The layer configuration we want to instanciate.
+   * @param {string} parentLayerPath The layer path to the parent configuration.
    */
-  constructor(layerConfig: AbstractBaseLayerEntryConfig) {
-    super(layerConfig);
+  constructor(layerConfig: AbstractBaseLayerEntryConfig, parentLayerPath?: string) {
+    super(layerConfig, parentLayerPath);
     Object.assign(this, layerConfig);
+  }
+
+  /**
+   * The layerId getter method for the ConfigBaseClass class and its descendant classes.
+   */
+  get layerIdExtension(): string | undefined {
+    return this.privateLayerIdExtension;
+  }
+
+  /**
+   * The layerId setter method for the ConfigBaseClass class and its descendant classes.
+   * @param {string} newLayerId The new layerId value.
+   */
+  set layerIdExtension(newLayerIdExtension: string | undefined) {
+    this.privateLayerIdExtension = newLayerIdExtension;
+    const completeLayerId = this.privateLayerIdExtension ? `${this.layerId}.${this.privateLayerIdExtension}` : this.layerId;
+    this.layerPath = `${this.layerPath.split('/').slice(0, -1).join('/')}/${completeLayerId}`;
   }
 
   /**
@@ -69,6 +85,7 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
   // TODO: Replace the setter/getter functions with methods acting on private properties.
   set olLayerAndLoadEndListeners(layerAndListenerType: TypeLayerAndListenerType) {
     const { olLayer, loadEndListenerType } = layerAndListenerType;
+    // eslint-disable-next-line no-underscore-dangle
     this._olLayer = olLayer;
     // Group layers have no listener
     if (olLayer && this.entryType !== CONST_LAYER_ENTRY_TYPES.GROUP) {
@@ -79,20 +96,20 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
         const loadEndListener = () => {
           this.loadedFunction();
           this.layerStatus = 'loaded';
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-underscore-dangle
           (this._olLayer! as any).get('source').un(`${loadEndListenerType}loaderror`, loadErrorListener);
         };
 
         loadErrorListener = () => {
           this.layerStatus = 'error';
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-underscore-dangle
           (this._olLayer! as any).get('source').un(`${loadEndListenerType}loadend`, loadEndListener);
         };
 
         // Activation of the load end listeners
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-underscore-dangle
         (this._olLayer! as any).get('source').once(`${loadEndListenerType}loaderror`, loadErrorListener);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-underscore-dangle
         (this._olLayer! as any).get('source').once(`${loadEndListenerType}loadend`, loadEndListener);
       } else logger.logError(`Provision of a load end listener type is mandatory for layer path "${this.layerPath}".`);
     }
@@ -103,6 +120,7 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
    * All layerConfig has an olLayer property, but the olLayer setter can only be use on group layers.
    */
   get olLayer() {
+    // eslint-disable-next-line no-underscore-dangle
     return this._olLayer;
   }
 
@@ -114,8 +132,14 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
    * @param {LayerGroup} olLayerValue The new olLayerd value.
    */
   set olLayer(olLayerValue: BaseLayer | LayerGroup | null) {
+    // eslint-disable-next-line no-underscore-dangle
     if (layerEntryIsGroupLayer(this)) this._olLayer = olLayerValue;
-    else logger.logError(`The olLayer setter can only be used on layer group and layerPath refers to a layer of type "${this.entryType}".`);
+    else
+      logger.logError(
+        `The olLayer setter can only be used on layer group and layerPath refers to a layer of type "${
+          (this as AbstractBaseLayerEntryConfig).entryType
+        }".`
+      );
   }
 
   /**

--- a/packages/geoview-core/src/core/utils/config/validation-classes/config-base-class.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/config-base-class.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import BaseLayer from 'ol/layer/Base';
 import LayerGroup from 'ol/layer/Group';
 import EventHelper, { EventDelegateBase } from '@/api/events/event-helper';
@@ -19,11 +20,8 @@ import { api } from '@/app';
  * Base type used to define a GeoView layer to display on the map. Unless specified,its properties are not part of the schema.
  */
 export class ConfigBaseClass {
-  /** The identifier of the layer to display on the map. This element is part of the schema. */
-  private _layerId = '';
-
-  /** The ending extension (element) of the layer identifier. This element is part of the schema. */
-  layerIdExtension?: string;
+  /** The display name of the layer (English/French). */
+  layerName?: TypeLocalizedString;
 
   /** Tag used to link the entry to a specific schema. This element is part of the schema. */
   schemaTag?: TypeGeoviewLayerType;
@@ -44,10 +42,13 @@ export class ConfigBaseClass {
   isMetadataLayerGroup?: boolean;
 
   /** It is used to link the layer entry config to the parent's layer config. */
-  parentLayerConfig?: TypeGeoviewLayerConfig | GroupLayerEntryConfig;
+  parentLayerConfig?: string;
+
+  /** The identifier of the layer to display on the map. This element is part of the schema. */
+  private _layerId = '';
 
   /** The layer path to this instance. */
-  protected _layerPath = '';
+  private _layerPath = '';
 
   // TODO: Refactor - There shouldn't be a coupling to an OpenLayers `BaseLayer` inside a Configuration class.
   // TO.DOCONT: That logic should be elsewhere so that the Configuration class remains portable and immutable.
@@ -57,7 +58,7 @@ export class ConfigBaseClass {
   /** It is used to identified unprocessed layers and shows the final layer state */
   protected _layerStatus: TypeLayerStatus = 'newInstance';
 
-  protected layerStatusWeight = {
+  layerStatusWeight = {
     newInstance: 10,
     registered: 20,
     processing: 30,
@@ -76,41 +77,31 @@ export class ConfigBaseClass {
   /**
    * The class constructor.
    * @param {ConfigBaseClass} layerConfig The layer configuration we want to instanciate.
+   * @param {string} parentLayerPath The layer path to the parent configuration.
    */
-  constructor(layerConfig: ConfigBaseClass) {
+  constructor(layerConfig: ConfigBaseClass, parentLayerPath?: string) {
     Object.assign(this, layerConfig);
-    // eslint-disable-next-line no-underscore-dangle
-    if (this.geoviewLayerConfig) this._layerPath = ConfigBaseClass.evaluateLayerPath(layerConfig);
-    else logger.logError("Couldn't calculate layerPath because geoviewLayerConfig has an invalid value");
+    this.parentLayerConfig = parentLayerPath;
+    if ('layerIdExtension' in this) {
+      const completeLayerId = this.layerIdExtension ? `${this._layerId}.${this.layerIdExtension}` : this._layerId;
+      this._layerPath = `${parentLayerPath}/${completeLayerId}`;
+    } else {
+      this._layerPath = `${parentLayerPath}/${this._layerId}`;
+    }
   }
 
   /**
    * The layerPath getter method for the ConfigBaseClass class and its descendant classes.
    */
   get layerPath() {
-    // eslint-disable-next-line no-underscore-dangle
-    this._layerPath = ConfigBaseClass.evaluateLayerPath(this);
-    // eslint-disable-next-line no-underscore-dangle
     return this._layerPath;
   }
 
   /**
-   * Getter for the layer Path of the layer configuration parameter.
-   * @param {ConfigBaseClass} layerConfig The layer configuration for which we want to get the layer path.
-   * @param {string} layerPath Internal parameter used to build the layer path (should not be used by the user).
-   *
-   * @returns {string} Returns the layer path.
+   * The layerPath setter method for the ConfigBaseClass class and its descendant classes.
    */
-  static evaluateLayerPath(layerConfig: ConfigBaseClass, layerPath?: string): string {
-    let pathEnding = layerPath;
-    if (pathEnding === undefined)
-      pathEnding =
-        layerConfig.layerIdExtension === undefined ? layerConfig.layerId : `${layerConfig.layerId}.${layerConfig.layerIdExtension}`;
-    if (!layerConfig.parentLayerConfig) return `${layerConfig.geoviewLayerConfig!.geoviewLayerId!}/${pathEnding}`;
-    return this.evaluateLayerPath(
-      layerConfig.parentLayerConfig as GroupLayerEntryConfig,
-      `${(layerConfig.parentLayerConfig as GroupLayerEntryConfig).layerId}/${pathEnding}`
-    );
+  protected set layerPath(newLayerPath) {
+    this._layerPath = newLayerPath;
   }
 
   /**
@@ -126,14 +117,15 @@ export class ConfigBaseClass {
    * @param {string} newLayerId The new layerId value.
    */
   set layerId(newLayerId: string) {
-    // eslint-disable-next-line no-underscore-dangle
     this._layerId = newLayerId;
-    // eslint-disable-next-line no-underscore-dangle
-    this._layerPath = ConfigBaseClass.evaluateLayerPath(this);
+    if ('layerIdExtension' in this) {
+      const completeLayerId = this.layerIdExtension ? `${this._layerId}.${this.layerIdExtension}` : this._layerId;
+      this._layerPath = `${this.parentLayerConfig}/${completeLayerId}`;
+    } else this._layerPath = `${this.parentLayerConfig}/${this._layerId}`;
   }
 
   /**
-   * The layerId getter method for the ConfigBaseClass class and its descendant classes.
+   * The layerStatus getter method for the ConfigBaseClass class and its descendant classes.
    */
   get layerStatus() {
     // eslint-disable-next-line no-underscore-dangle
@@ -163,13 +155,17 @@ export class ConfigBaseClass {
     }
     if (newLayerStatus === 'processed' && this.waitForProcessedBeforeSendingLoaded) this.layerStatus = 'loaded';
 
+    const parentConfig = this.geoviewLayerInstance!.getParentConfig(this.parentLayerConfig!);
     if (
       // eslint-disable-next-line no-underscore-dangle
       this._layerStatus === 'loaded' &&
-      this.parentLayerConfig &&
-      this.geoviewLayerInstance!.allLayerStatusAreGreaterThanOrEqualTo('loaded', [this.parentLayerConfig as GroupLayerEntryConfig])
+      parentConfig &&
+      this.geoviewLayerInstance!.allLayerStatusAreGreaterThanOrEqualTo('loaded', [parentConfig])
     )
-      (this.parentLayerConfig as GroupLayerEntryConfig).layerStatus = 'loaded';
+      // TODO: To keep things working, this is how we retreive the parent configuration.
+      // TO.DOCONT: We must find a way to do that without using this.geoviewLayerInstance! because
+      // TO.DOCONT: layer Config in ConfigApi are not supposed to be linked to a map or a geoviewLayerInstance.
+      this.geoviewLayerInstance!.getParentConfig(this._layerPath)!.layerStatus = 'loaded';
   }
 
   /**
@@ -207,8 +203,8 @@ export class ConfigBaseClass {
    */
   registerLayerConfig(): boolean {
     const { registeredLayers } = api.maps[this.geoviewLayerInstance!.mapId].layer;
-    if (registeredLayers[this.layerPath]) return false;
-    (registeredLayers[this.layerPath] as ConfigBaseClass) = this;
+    if (registeredLayers[this._layerPath]) return false;
+    (registeredLayers[this._layerPath] as ConfigBaseClass) = this;
 
     // TODO: Check - Move this registerToLayerSets closer to the others, when I comment the line it seems good, except
     // TO.DOCONT: for an 'Anonymous' group layer that never got 'loaded'. See if we can fix this elsewhere and remove this.
@@ -260,7 +256,6 @@ export class ConfigBaseClass {
    */
   onSerialize(): TypeJsonValue {
     return {
-      layerIdExtension: this.layerIdExtension,
       schemaTag: this.schemaTag,
       entryType: this.entryType,
       layerStatus: this.layerStatus,

--- a/packages/geoview-core/src/core/utils/config/validation-classes/group-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/group-layer-entry-config.ts
@@ -4,7 +4,6 @@ import {
   CONST_LAYER_ENTRY_TYPES,
   TypeLayerInitialSettings,
   TypeListOfLayerEntryConfig,
-  TypeLocalizedString,
   layerEntryIsGroupLayer,
 } from '@/geo/map/map-schema-types';
 import { logger } from '@/core/utils/logger';
@@ -14,17 +13,8 @@ import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-b
  * Type used to define a layer group.
  */
 export class GroupLayerEntryConfig extends ConfigBaseClass {
-  /** Tag used to link the entry to a specific schema is not used by groups. */
-  declare schemaTag: never;
-
   /** Layer entry data type. */
   entryType = CONST_LAYER_ENTRY_TYPES.GROUP;
-
-  /** The ending element of the layer configuration path is not used on groups. */
-  declare layerIdExtension: never;
-
-  /** The display name of the layer (English/French). */
-  layerName?: TypeLocalizedString;
 
   /**
    * Initial settings to apply to the GeoView layer entry at creation time. Initial settings are inherited from the parent in the
@@ -32,18 +22,16 @@ export class GroupLayerEntryConfig extends ConfigBaseClass {
    */
   initialSettings?: TypeLayerInitialSettings;
 
-  /** Source settings to apply to the GeoView vector layer source at creation time is not used by groups. */
-  declare source: never;
-
   /** The list of layer entry configurations to use from the GeoView layer group. */
   listOfLayerEntryConfig: TypeListOfLayerEntryConfig = [];
 
   /**
    * The class constructor.
    * @param {GroupLayerEntryConfig} layerConfig The layer configuration we want to instanciate.
+   * @param {string} parentLayerPath The layer path to the parent configuration.
    */
-  constructor(layerConfig: GroupLayerEntryConfig) {
-    super(layerConfig);
+  constructor(layerConfig: GroupLayerEntryConfig, parentLayerPath?: string) {
+    super(layerConfig, parentLayerPath);
     Object.assign(this, layerConfig);
   }
 

--- a/packages/geoview-core/src/core/utils/new-config/configApi.ts
+++ b/packages/geoview-core/src/core/utils/new-config/configApi.ts
@@ -1,0 +1,167 @@
+import cloneDeep from 'lodash/cloneDeep';
+
+import {
+  convertLayerTypeToEntry,
+  TypeDisplayLanguage,
+  TypeListOfLayerEntryConfig,
+  layerEntryIsGroupLayer,
+  mapConfigLayerEntryIsGeoCore,
+} from '@/geo/map/map-schema-types';
+import { CONST_LAYER_TYPES, TypeGeoviewLayerType } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
+import { logger } from '@/core/utils/logger';
+
+import { TypeGeoviewLayerConfig, TypeMapFeaturesConfig } from '@/core/types/global-types';
+import { ConfigValidation } from '@/core/utils/config/config-validation';
+import { InlineDivConfigReader } from '@/core/utils/config/reader/div-config-reader';
+import { JsonConfigReader } from '@/core/utils/config/reader/json-config-reader';
+import { URLmapConfigReader } from '@/core/utils/config/reader/url-config-reader';
+import { ConfigBaseClass } from '../config/validation-classes/config-base-class';
+
+// ******************************************************************************************************************************
+// ******************************************************************************************************************************
+/** *****************************************************************************************************************************
+ * This class groups together all configuration validation methods. It is used to create JSON structures that respect the data
+ * format used by the GeoView viewer. Configuration parameters are validated as and when the necessary information becomes
+ * available. Users are responsible for persisting the configuration data returned to complete the work they have started.
+ *
+ * @exports
+ * @class ConfigApi
+ */
+// ******************************************************************************************************************************
+export class ConfigApi {
+  /** Config validation object used to validate the configuration and define default values */
+  configValidation = new ConfigValidation();
+
+  /** ***************************************************************************************************************************
+   * The Config class constructor used to instanciate an object of this type.
+   * @param {Element | string} mapElement The map element or the string Id of the map.
+   *
+   * @returns {Promise<TypeMapFeaturesConfig | undefined>} The initialized valid map config.
+   */
+  /** ***************************************************************************************************************************
+   * GetMapConfig returns a validated configuration computed from the map Element passed as a parameter.
+   *
+   * @param {Element} mapElement The map Element that contains the map configuration to extract and validate.
+   *
+   * @returns {TypeJsonMapConfig} The validated JSON map configuration associated to the map Element.
+   */
+  getMapConfig(mapElement: Element): Promise<TypeMapFeaturesConfig | undefined> {
+    const defaultMapFeaturesConfig = cloneDeep(this.configValidation.defaultMapFeaturesConfig);
+
+    // get the id from the map element
+    const mapId = mapElement.getAttribute('id');
+
+    // update map id if provided in map element
+    if (mapId) defaultMapFeaturesConfig.mapId = mapId;
+
+    // get the triggerReadyCallback from the map element
+    const triggerReadyCallback = mapElement.getAttribute('triggerReadyCallback');
+    if (triggerReadyCallback && !['true', 'false'].includes(triggerReadyCallback.toLowerCase()))
+      logger.logError(
+        `Invalid value of triggerReadyCallback (${triggerReadyCallback}) on map "${this.configValidation.mapId}".\nDefault value false used.`
+      );
+
+    // update triggerReadyCallback if provided in map element
+    defaultMapFeaturesConfig.triggerReadyCallback = triggerReadyCallback?.toLowerCase() === 'true' || false;
+
+    // get the display language from the map element
+    const displayLanguage = mapElement.getAttribute('data-lang');
+    if (displayLanguage && !['fr', 'en'].includes(displayLanguage.toLowerCase()))
+      logger.logError(
+        `Invalid value of displayLanguage (${displayLanguage}) on map "${this.configValidation.mapId}".\nDefault value "en" used.`
+      );
+
+    // update display language if provided in map element
+    defaultMapFeaturesConfig.displayLanguage = (displayLanguage?.toLowerCase() === 'fr' ? 'fr' : 'en') as TypeDisplayLanguage;
+
+    return this.extractConfigFromElement(mapElement, defaultMapFeaturesConfig);
+  }
+
+  /** ***************************************************************************************************************************
+   * Initialize a map config from either inline div, url params, json file. Inline config has precedence on JSON file config that
+   * has precedence on URL config.
+   *
+   * @param {Element | string} mapElement The map element or the string Id of the map.
+   *
+   * @returns {Promise<TypeMapFeaturesConfig | undefined>} The initialized valid map config.
+   */
+  async extractConfigFromElement(
+    mapElement: Element,
+    defaultMapFeaturesConfig: TypeMapFeaturesConfig
+  ): Promise<TypeMapFeaturesConfig | undefined> {
+    // create a new config object to store provided config by user
+    let mapFeaturesConfig: TypeMapFeaturesConfig | undefined;
+
+    // check if inline div config has been passed
+    const inlineDivConfig = await InlineDivConfigReader.getMapFeaturesConfig(defaultMapFeaturesConfig.mapId, mapElement);
+
+    // use inline config if provided
+    if (inlineDivConfig) mapFeaturesConfig = { ...inlineDivConfig };
+    else {
+      // check if a config file url is provided.
+      const jsonFileConfig = await JsonConfigReader.getMapFeaturesConfig(defaultMapFeaturesConfig.mapId, mapElement);
+
+      if (jsonFileConfig) mapFeaturesConfig = { ...jsonFileConfig };
+      else {
+        // get the value that will check if any url params are passed
+        const shared = mapElement.getAttribute('data-shared');
+        if (shared && !['true', 'false'].includes(shared.toLowerCase()))
+          logger.logError(
+            `Invalid value of data-shared (${shared}) on map "${defaultMapFeaturesConfig.mapId}".\nDefault value false used.`
+          );
+
+        if (shared?.toLowerCase() === 'true') {
+          // check if config params have been passed
+          const urlParamsConfig = await URLmapConfigReader.getMapFeaturesConfig(defaultMapFeaturesConfig.mapId);
+
+          // use the url params config if provided
+          if (urlParamsConfig) mapFeaturesConfig = { ...urlParamsConfig };
+        }
+      }
+    }
+    if (mapFeaturesConfig) return this.getValidMapConfig(defaultMapFeaturesConfig, mapFeaturesConfig);
+
+    if (!mapFeaturesConfig) logger.logInfo(`- Map: ${defaultMapFeaturesConfig.mapId} - Empty JSON configuration object, using default -`);
+
+    return Promise.resolve(defaultMapFeaturesConfig);
+  }
+
+  /** ***************************************************************************************************************************
+   * Get a valid map configuration.
+   *
+   * @param {TypeMapFeaturesConfig} defaultMapFeaturesConfig The default Config object that has the field's default values.
+   * @param {TypeMapFeaturesConfig} mapFeaturesConfig Config object to validate.
+   *
+   * @returns {TypeMapFeaturesConfig} A valid map config.
+   */
+  getValidMapConfig(defaultMapFeaturesConfig: TypeMapFeaturesConfig, mapFeaturesConfig: TypeMapFeaturesConfig): TypeMapFeaturesConfig {
+    if (mapFeaturesConfig?.map?.listOfGeoviewLayerConfig) {
+      mapFeaturesConfig.map.listOfGeoviewLayerConfig.forEach((geoviewLayerEntry) => {
+        if (mapConfigLayerEntryIsGeoCore(geoviewLayerEntry)) {
+          //  Skip it, because we don't validate the GeoCore configuration anymore. Not the same way as typical GeoView Layer Types at least.
+        } else if (Object.values(CONST_LAYER_TYPES).includes((geoviewLayerEntry as TypeGeoviewLayerConfig).geoviewLayerType)) {
+          const geoViewLayerEntryCasted = geoviewLayerEntry as TypeGeoviewLayerConfig;
+          this.setLayerEntryType(geoViewLayerEntryCasted.listOfLayerEntryConfig!, geoViewLayerEntryCasted.geoviewLayerType);
+        } else throw new Error(`Invalid GeoView Layer Type ${geoviewLayerEntry.geoviewLayerType}`);
+      });
+    }
+    return this.configValidation.validateMapConfigAgainstSchema(mapFeaturesConfig);
+  }
+
+  /** ***************************************************************************************************************************
+   * Initialize all layer entry type fields accordingly to the GeoView layer type.
+   * @param {TypeListOfLayerEntryConfig} listOfLayerEntryConfig The list of layer entry configuration to adjust.
+   * @param {TypeGeoviewLayerType} geoviewLayerType The GeoView layer type.
+   */
+  private setLayerEntryType(listOfLayerEntryConfig: TypeListOfLayerEntryConfig, geoviewLayerType: TypeGeoviewLayerType): void {
+    listOfLayerEntryConfig?.forEach((layerConfig) => {
+      if (layerEntryIsGroupLayer(layerConfig)) this.setLayerEntryType(layerConfig.listOfLayerEntryConfig!, geoviewLayerType);
+      else {
+        // eslint-disable-next-line no-param-reassign
+        (layerConfig as ConfigBaseClass).schemaTag = geoviewLayerType;
+        // eslint-disable-next-line no-param-reassign
+        (layerConfig as ConfigBaseClass).entryType = convertLayerTypeToEntry(geoviewLayerType);
+      }
+    });
+  }
+}

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -15,8 +15,6 @@ import { LayerApi } from '@/geo/layer/layer';
 import { TypeJsonObject, toJsonObject } from '@/core/types/global-types';
 import { TimeDimension, TypeDateFragments } from '@/core/utils/date-mgt';
 import { logger } from '@/core/utils/logger';
-import { EsriDynamicLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/esri-dynamic-layer-entry-config';
-import { OgcWmsLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config';
 import { VectorLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-layer-entry-config';
 import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
 import { GroupLayerEntryConfig } from '@/core/utils/config/validation-classes/group-layer-entry-config';
@@ -32,6 +30,7 @@ import {
   TypeLayerStatus,
   TypeStyleGeometry,
   CONST_LAYER_ENTRY_TYPES,
+  TypeFeatureInfoLayerConfig,
 } from '@/geo/map/map-schema-types';
 import { QueryType, TypeFeatureInfoEntry, TypeLocation, codedValueType, rangeDomainType } from '@/geo/utils/layer-set';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
@@ -160,21 +159,35 @@ export abstract class AbstractGeoViewLayer {
    * @param {TypeGeoviewLayer} mapLayerConfig The GeoView layer configuration options.
    * @param {TypeListOfLayerEntryConfig} listOfLayerEntryConfig The list of layer's configuration
    */
+  // TODO: Have a discussion concerning the necessity to have this method to create a group when the user doesn't create one.
+  // TO.DOCONT: I think the reason why the geoviewLayer is not displayed is because we do not use the information provided in
+  // TO.DOCONT: the TypeGeoviewLayerConfig correctly. In the legend, the topmost layer name should be the one provided in the
+  // TO.DOCONT: TypeGeoviewLayerConfig instead of the one provided in this group. Then, in the legend, below this geoviewLayerName,
+  // TO.DOCONT: if we have a group we display it. If we have a single layer, we display its legend or 'Map has no legend' if the
+  // TO.DOCONT: layer doesn't have one.
   private setListOfLayerEntryConfig(mapLayerConfig: TypeGeoviewLayerConfig, listOfLayerEntryConfig: TypeListOfLayerEntryConfig) {
     if (listOfLayerEntryConfig.length === 0) return;
     if (listOfLayerEntryConfig.length === 1) this.listOfLayerEntryConfig = listOfLayerEntryConfig;
     else {
-      const layerGroup = new GroupLayerEntryConfig({
-        geoviewLayerConfig: listOfLayerEntryConfig[0].geoviewLayerConfig,
-        layerId: this.geoviewLayerId,
-        layerName: this.geoviewLayerName,
-        isMetadataLayerGroup: false,
-        initialSettings: mapLayerConfig.initialSettings,
-        listOfLayerEntryConfig,
-      } as GroupLayerEntryConfig);
+      const layerGroup = new GroupLayerEntryConfig(
+        {
+          geoviewLayerConfig: listOfLayerEntryConfig[0].geoviewLayerConfig,
+          layerId: this.geoviewLayerId,
+          layerName: this.geoviewLayerName,
+          isMetadataLayerGroup: false,
+          initialSettings: mapLayerConfig.initialSettings,
+          listOfLayerEntryConfig,
+        } as GroupLayerEntryConfig,
+        this.geoviewLayerId
+      );
       this.listOfLayerEntryConfig = [layerGroup];
       layerGroup.listOfLayerEntryConfig.forEach((layerConfig, i) => {
-        (layerGroup.listOfLayerEntryConfig[i] as AbstractBaseLayerEntryConfig).parentLayerConfig = layerGroup;
+        (
+          layerGroup.listOfLayerEntryConfig[i] as AbstractBaseLayerEntryConfig
+        ).parentLayerConfig = `${this.geoviewLayerId}/${this.geoviewLayerId}`;
+        (layerGroup.listOfLayerEntryConfig[i] as AbstractBaseLayerEntryConfig).layerId = (
+          layerGroup.listOfLayerEntryConfig[i] as AbstractBaseLayerEntryConfig
+        ).layerId;
       });
     }
     this.listOfLayerEntryConfig[0].geoviewLayerConfig.listOfLayerEntryConfig = listOfLayerEntryConfig;
@@ -278,7 +291,7 @@ export abstract class AbstractGeoViewLayer {
     listOfLayerEntryConfig: TypeListOfLayerEntryConfig = this.listOfLayerEntryConfig
   ): boolean {
     // Try to find a layer that is not greater than or equal to the layerStatus parameter. If you can, return false
-    return !listOfLayerEntryConfig.find((layerConfig: TypeLayerEntryConfig) => {
+    return !listOfLayerEntryConfig.find((layerConfig: ConfigBaseClass) => {
       if (layerEntryIsGroupLayer(layerConfig))
         return !this.allLayerStatusAreGreaterThanOrEqualTo(layerStatus, layerConfig.listOfLayerEntryConfig);
       return !layerConfig.IsGreaterThanOrEqualTo(layerStatus || 'newInstance');
@@ -452,7 +465,7 @@ export abstract class AbstractGeoViewLayer {
           if (layerConfig.isMetadataLayerGroup) promisedAllLayerDone.push(this.processMetadataGroupLayer(layerConfig));
           // eslint-disable-next-line no-await-in-loop
           else await this.processListOfLayerEntryMetadata(layerConfig.listOfLayerEntryConfig);
-        else promisedAllLayerDone.push(this.processLayerMetadata(layerConfig));
+        else promisedAllLayerDone.push(this.processLayerMetadata(layerConfig as AbstractBaseLayerEntryConfig));
       }
       const arrayOfLayerConfigs = await Promise.all(promisedAllLayerDone);
       arrayOfLayerConfigs.forEach((layerConfig) => {
@@ -479,21 +492,23 @@ export abstract class AbstractGeoViewLayer {
    * layer (i.e. they have extent, visibility and query flag definition). Metadata group layers can be identified by
    * the presence of an isMetadataLayerGroup attribute set to true.
    *
-   * @param {GroupLayerEntryConfig} layerConfig The layer entry configuration to process.
+   * @param {GroupLayerEntryConfig | AbstractBaseLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
    * @returns {Promise<GroupLayerEntryConfig>} A promise that the vector layer configuration has its metadata and group layers processed.
    */
-  private async processMetadataGroupLayer(layerConfig: GroupLayerEntryConfig): Promise<GroupLayerEntryConfig> {
+  private async processMetadataGroupLayer(
+    layerConfig: GroupLayerEntryConfig | AbstractBaseLayerEntryConfig
+  ): Promise<GroupLayerEntryConfig> {
     try {
-      await this.processLayerMetadata(layerConfig);
+      await this.processLayerMetadata(layerConfig as AbstractBaseLayerEntryConfig);
       await this.processListOfLayerEntryMetadata(layerConfig.listOfLayerEntryConfig!);
       layerConfig.layerStatus = 'processed';
-      return layerConfig;
+      return layerConfig as GroupLayerEntryConfig;
     } catch (error) {
       // Log
       logger.logError(error);
     }
-    return layerConfig;
+    return layerConfig as GroupLayerEntryConfig;
   }
 
   /** ***************************************************************************************************************************
@@ -504,7 +519,7 @@ export abstract class AbstractGeoViewLayer {
    *
    * @returns {Promise<TypeLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
    */
-  protected processLayerMetadata(layerConfig: TypeLayerEntryConfig): Promise<TypeLayerEntryConfig> {
+  protected processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<TypeLayerEntryConfig> {
     if (!layerConfig.source) layerConfig.source = {};
     if (!layerConfig.source.featureInfo) layerConfig.source.featureInfo = { queryable: false };
 
@@ -514,16 +529,13 @@ export abstract class AbstractGeoViewLayer {
   /** ***************************************************************************************************************************
    * Process recursively the list of layer Entries to create the layers and the layer groups.
    *
-   * @param {TypeListOfLayerEntryConfig} listOfLayerEntryConfig The list of layer entries to process.
+   * @param {ConfigBaseClass[]} listOfLayerEntryConfig The list of layer entries to process.
    * @param {LayerGroup} layerGroup Optional layer group to use when we have many layers. The very first call to
    *  processListOfLayerEntryConfig must not provide a value for this parameter. It is defined for internal use.
    *
    * @returns {Promise<BaseLayer | null>} The promise that the layers were processed.
    */
-  async processListOfLayerEntryConfig(
-    listOfLayerEntryConfig: TypeListOfLayerEntryConfig,
-    layerGroup?: LayerGroup
-  ): Promise<BaseLayer | null> {
+  async processListOfLayerEntryConfig(listOfLayerEntryConfig: ConfigBaseClass[], layerGroup?: LayerGroup): Promise<BaseLayer | null> {
     // Log
     logger.logTraceCore('ABSTRACT-GEOVIEW-LAYERS - processListOfLayerEntryConfig', listOfLayerEntryConfig);
 
@@ -563,14 +575,19 @@ export abstract class AbstractGeoViewLayer {
       if (!layerGroup) {
         // All children of this level in the tree have the same parent, so we use the first element of the array to retrieve the parent node.
         layerGroup = this.createLayerGroup(
-          (listOfLayerEntryConfig[0] as AbstractBaseLayerEntryConfig).parentLayerConfig as TypeLayerEntryConfig,
-          listOfLayerEntryConfig[0].initialSettings!
+          (listOfLayerEntryConfig[0] as AbstractBaseLayerEntryConfig).geoviewLayerInstance?.getParentConfig(
+            listOfLayerEntryConfig[0].layerPath
+          ) as TypeLayerEntryConfig,
+          (listOfLayerEntryConfig[0] as AbstractBaseLayerEntryConfig).initialSettings!
         );
       }
       const promiseOfLayerCreated: Promise<BaseLayer | LayerGroup | null>[] = [];
       listOfLayerEntryConfig.forEach((layerConfig, i) => {
         if (layerEntryIsGroupLayer(layerConfig)) {
-          const newLayerGroup = this.createLayerGroup(listOfLayerEntryConfig[i], listOfLayerEntryConfig[i].initialSettings!);
+          const newLayerGroup = this.createLayerGroup(
+            listOfLayerEntryConfig[i],
+            (listOfLayerEntryConfig[i] as AbstractBaseLayerEntryConfig).initialSettings!
+          );
           promiseOfLayerCreated.push(this.processListOfLayerEntryConfig(layerConfig.listOfLayerEntryConfig!, newLayerGroup));
         } else if ((listOfLayerEntryConfig[i] as AbstractBaseLayerEntryConfig).layerStatus === 'error')
           promiseOfLayerCreated.push(Promise.resolve(null));
@@ -651,9 +668,9 @@ export abstract class AbstractGeoViewLayer {
       // Get the layer config
       const layerConfig = this.getLayerConfig(layerPath);
 
-      if (!layerConfig || !layerConfig?.source?.featureInfo?.queryable) {
+      if (!layerConfig || !(layerConfig as AbstractBaseLayerEntryConfig)?.source?.featureInfo?.queryable) {
         logger.logError('Invalid usage of getFeatureInfo\nlayerConfig = ', layerConfig);
-        const queryableOrNot = layerConfig?.source?.featureInfo?.queryable ? '' : 'not';
+        const queryableOrNot = (layerConfig as AbstractBaseLayerEntryConfig)?.source?.featureInfo?.queryable ? '' : 'not';
         logger.logError(`Layer is ${queryableOrNot} queryable`);
         return null;
       }
@@ -854,7 +871,7 @@ export abstract class AbstractGeoViewLayer {
    * @param {TypeLayerInitialSettings } initialSettings Initial settings to apply to the layer.
    * @returns {LayerGroup} A new layer group.
    */
-  protected createLayerGroup(layerConfig: TypeLayerEntryConfig, initialSettings: TypeLayerInitialSettings): LayerGroup {
+  protected createLayerGroup(layerConfig: ConfigBaseClass, initialSettings: TypeLayerInitialSettings): LayerGroup {
     const layerGroupOptions: LayerGroupOptions = {
       layers: new Collection(),
       properties: { layerConfig },
@@ -865,8 +882,8 @@ export abstract class AbstractGeoViewLayer {
     if (initialSettings?.states?.opacity !== undefined) layerGroupOptions.opacity = initialSettings.states.opacity;
     if (initialSettings?.states?.visible !== undefined) layerGroupOptions.visible = initialSettings.states.visible;
     // You dont have to provide the loadEndListenerType when you set the olLayer of an entryType to CONST_LAYER_ENTRY_TYPES.GROUP.
-    layerConfig.olLayer = new LayerGroup(layerGroupOptions);
-    return layerConfig.olLayer as LayerGroup;
+    (layerConfig as AbstractBaseLayerEntryConfig).olLayer = new LayerGroup(layerGroupOptions);
+    return (layerConfig as AbstractBaseLayerEntryConfig).olLayer as LayerGroup;
   }
 
   /** ***************************************************************************************************************************
@@ -876,8 +893,22 @@ export abstract class AbstractGeoViewLayer {
    *
    * @returns {TypeLayerEntryConfig | undefined} The layer configuration or undefined if not found.
    */
-  getLayerConfig(layerPath: string): TypeLayerEntryConfig | undefined {
-    return api.maps?.[this.mapId]?.layer?.registeredLayers?.[layerPath] as TypeLayerEntryConfig;
+  getLayerConfig(layerPath: string): AbstractBaseLayerEntryConfig | undefined {
+    return api.maps?.[this.mapId]?.layer?.registeredLayers?.[layerPath] as AbstractBaseLayerEntryConfig;
+  }
+
+  /** ***************************************************************************************************************************
+   * Get the parent configuration of the specified layer path.
+   *
+   * @param {string} layerPath The layer path.
+   *
+   * @returns {GroupLayerEntryConfig | undefined} The parent layer configuration or undefined if not found.
+   */
+  getParentConfig(layerPath: string): GroupLayerEntryConfig | undefined {
+    const parentConfiguration = layerPath.split('/').slice(0, -1);
+    if (parentConfiguration.length)
+      return api.maps?.[this.mapId]?.layer?.registeredLayers?.[parentConfiguration.join('/')] as GroupLayerEntryConfig;
+    return undefined;
   }
 
   /** ***************************************************************************************************************************
@@ -896,20 +927,20 @@ export abstract class AbstractGeoViewLayer {
     const processGroupLayerBounds = (listOfLayerEntryConfig: TypeListOfLayerEntryConfig) => {
       listOfLayerEntryConfig.forEach((layerConfig) => {
         if (layerEntryIsGroupLayer(layerConfig)) processGroupLayerBounds(layerConfig.listOfLayerEntryConfig);
-        else if (layerConfig.initialSettings?.bounds) {
+        else if ((layerConfig as AbstractBaseLayerEntryConfig).initialSettings?.bounds) {
           if (!bounds)
             bounds = [
-              layerConfig.initialSettings.bounds[0],
-              layerConfig.initialSettings.bounds[1],
-              layerConfig.initialSettings.bounds[2],
-              layerConfig.initialSettings.bounds[3],
+              (layerConfig as AbstractBaseLayerEntryConfig).initialSettings!.bounds![0],
+              (layerConfig as AbstractBaseLayerEntryConfig).initialSettings!.bounds![1],
+              (layerConfig as AbstractBaseLayerEntryConfig).initialSettings!.bounds![2],
+              (layerConfig as AbstractBaseLayerEntryConfig).initialSettings!.bounds![3],
             ];
           else
             bounds = [
-              Math.min(layerConfig.initialSettings.bounds[0], bounds[0]),
-              Math.min(layerConfig.initialSettings.bounds[1], bounds[1]),
-              Math.max(layerConfig.initialSettings.bounds[2], bounds[2]),
-              Math.max(layerConfig.initialSettings.bounds[3], bounds[3]),
+              Math.min((layerConfig as AbstractBaseLayerEntryConfig).initialSettings!.bounds![0], bounds[0]),
+              Math.min((layerConfig as AbstractBaseLayerEntryConfig).initialSettings!.bounds![1], bounds[1]),
+              Math.max((layerConfig as AbstractBaseLayerEntryConfig).initialSettings!.bounds![2], bounds[2]),
+              Math.max((layerConfig as AbstractBaseLayerEntryConfig).initialSettings!.bounds![3], bounds[3]),
             ];
         }
       });
@@ -1173,12 +1204,12 @@ export abstract class AbstractGeoViewLayer {
    */
   protected async formatFeatureInfoResult(
     features: Feature[],
-    layerConfig: OgcWmsLayerEntryConfig | EsriDynamicLayerEntryConfig | VectorLayerEntryConfig
+    layerConfig: AbstractBaseLayerEntryConfig
   ): Promise<TypeFeatureInfoEntry[] | undefined | null> {
     try {
       if (!features.length) return [];
 
-      const featureInfo = layerConfig?.source?.featureInfo;
+      const featureInfo = layerConfig?.source?.featureInfo as TypeFeatureInfoLayerConfig;
       const fieldTypes = featureInfo?.fieldTypes?.split(',') as ('string' | 'number' | 'date')[];
       const outfields = getLocalizedValue(
         featureInfo?.outfields as TypeLocalizedString,
@@ -1318,7 +1349,7 @@ export abstract class AbstractGeoViewLayer {
     try {
       let bounds: Extent | undefined;
       const processGroupLayerBounds = (listOfLayerEntryConfig: TypeListOfLayerEntryConfig) => {
-        listOfLayerEntryConfig.forEach((layerConfig) => {
+        listOfLayerEntryConfig.forEach((layerConfig: ConfigBaseClass) => {
           if (layerEntryIsGroupLayer(layerConfig)) processGroupLayerBounds(layerConfig.listOfLayerEntryConfig);
           else {
             bounds = this.getBounds(layerConfig.layerPath, bounds);
@@ -1344,11 +1375,11 @@ export abstract class AbstractGeoViewLayer {
    * Set the layerStatus code of all layers in the listOfLayerEntryConfig.
    *
    * @param {TypeLayerStatus} newStatus The new status to assign to the layers.
-   * @param {TypeListOfLayerEntryConfig} listOfLayerEntryConfig The list of layer's configuration.
+   * @param {ConfigBaseClass[]} listOfLayerEntryConfig The list of layer's configuration.
    * @param {string} errorMessage The error message.
    */
-  setAllLayerStatusTo(newStatus: TypeLayerStatus, listOfLayerEntryConfig: TypeListOfLayerEntryConfig, errorMessage?: string) {
-    listOfLayerEntryConfig.forEach((layerConfig: TypeLayerEntryConfig) => {
+  setAllLayerStatusTo(newStatus: TypeLayerStatus, listOfLayerEntryConfig: ConfigBaseClass[], errorMessage?: string) {
+    listOfLayerEntryConfig.forEach((layerConfig) => {
       if (layerEntryIsGroupLayer(layerConfig)) this.setAllLayerStatusTo(newStatus, layerConfig.listOfLayerEntryConfig, errorMessage);
       else {
         if (layerConfig.layerStatus === 'error') return;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -61,10 +61,10 @@ export async function commonfetchServiceMetadata(this: EsriDynamic | EsriFeature
  * with a numeric layerId and creates a group entry when a layer is a group.
  *
  * @param {EsriDynamic | EsriFeature} this The ESRI layer instance pointer.
- * @param {TypeListOfLayerEntryConfig} listOfLayerEntryConfig The list of layer entries configuration to validate.
+ * @param {ConfigBaseClass[]} listOfLayerEntryConfig The list of layer entries configuration to validate.
  */
-export function commonValidateListOfLayerEntryConfig(this: EsriDynamic | EsriFeature, listOfLayerEntryConfig: TypeListOfLayerEntryConfig) {
-  listOfLayerEntryConfig.forEach((layerConfig: TypeLayerEntryConfig, i) => {
+export function commonValidateListOfLayerEntryConfig(this: EsriDynamic | EsriFeature, listOfLayerEntryConfig: ConfigBaseClass[]) {
+  listOfLayerEntryConfig.forEach((layerConfig: ConfigBaseClass, i) => {
     if (layerConfig.layerStatus === 'error') return;
     const { layerPath } = layerConfig;
 
@@ -126,7 +126,7 @@ export function commonValidateListOfLayerEntryConfig(this: EsriDynamic | EsriFea
         const subLayerEntryConfig: TypeLayerEntryConfig = geoviewEntryIsEsriDynamic(layerConfig)
           ? new EsriDynamicLayerEntryConfig(layerConfig as EsriDynamicLayerEntryConfig)
           : new EsriFeatureLayerEntryConfig(layerConfig as EsriFeatureLayerEntryConfig);
-        subLayerEntryConfig.parentLayerConfig = groupLayerConfig;
+        subLayerEntryConfig.parentLayerConfig = groupLayerConfig.layerPath;
         subLayerEntryConfig.layerId = `${layerId}`;
         subLayerEntryConfig.layerName = {
           en: this.metadata!.layers[layerId as number].name as string,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
@@ -23,6 +23,7 @@ import {
   layerEntryIsGroupLayer,
   TypeUniqueValueStyleInfo,
   TypeStyleConfig,
+  TypeSourceImageEsriInitialConfig,
 } from '@/geo/map/map-schema-types';
 
 import {
@@ -96,7 +97,7 @@ export const geoviewLayerIsEsriImage = (verifyIfGeoViewLayer: AbstractGeoViewLay
  *
  * @returns {boolean} true if the type ascention is valid.
  */
-export const geoviewEntryIsEsriImage = (verifyIfGeoViewEntry: TypeLayerEntryConfig): verifyIfGeoViewEntry is EsriImageLayerEntryConfig => {
+export const geoviewEntryIsEsriImage = (verifyIfGeoViewEntry: ConfigBaseClass): verifyIfGeoViewEntry is EsriImageLayerEntryConfig => {
   return verifyIfGeoViewEntry?.geoviewLayerConfig?.geoviewLayerType === CONST_LAYER_TYPES.ESRI_IMAGE;
 };
 
@@ -294,22 +295,23 @@ export class EsriImage extends AbstractGeoViewRaster {
    *
    * @returns {TypeBaseRasterLayer} The GeoView raster layer that has been created.
    */
-  protected processOneLayerEntry(layerConfig: EsriImageLayerEntryConfig): Promise<TypeBaseRasterLayer | null> {
+  protected processOneLayerEntry(layerConfig: AbstractBaseLayerEntryConfig): Promise<TypeBaseRasterLayer | null> {
     // GV IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
     // GV            layerStatus values is correctly sequenced.
     super.processOneLayerEntry(layerConfig);
+    const layerConfigSource = layerConfig.source as TypeSourceImageEsriInitialConfig;
     const sourceOptions: SourceOptions = {};
     sourceOptions.attributions = [(this.metadata!.copyrightText ? this.metadata!.copyrightText : '') as string];
     sourceOptions.url = getLocalizedValue(layerConfig.source.dataAccessPath!, AppEventProcessor.getDisplayLanguage(this.mapId));
     sourceOptions.params = { LAYERS: `show:${layerConfig.layerId}` };
-    if (layerConfig.source.transparent) Object.defineProperty(sourceOptions.params, 'transparent', layerConfig.source.transparent!);
-    if (layerConfig.source.format) Object.defineProperty(sourceOptions.params, 'format', layerConfig.source.format!);
-    if (layerConfig.source.crossOrigin) {
-      sourceOptions.crossOrigin = layerConfig.source.crossOrigin;
+    if (layerConfigSource.transparent) Object.defineProperty(sourceOptions.params, 'transparent', layerConfigSource.transparent!);
+    if (layerConfigSource.format) Object.defineProperty(sourceOptions.params, 'format', layerConfigSource.format!);
+    if (layerConfigSource.crossOrigin) {
+      sourceOptions.crossOrigin = layerConfigSource.crossOrigin;
     } else {
       sourceOptions.crossOrigin = 'Anonymous';
     }
-    if (layerConfig.source.projection) sourceOptions.projection = `EPSG:${layerConfig.source.projection}`;
+    if (layerConfigSource.projection) sourceOptions.projection = `EPSG:${layerConfigSource.projection}`;
 
     const imageLayerOptions: ImageOptions<ImageArcGISRest> = {
       source: new ImageArcGISRest(sourceOptions),

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
@@ -13,6 +13,7 @@ import {
   TypeGeoviewLayerConfig,
   TypeListOfLayerEntryConfig,
   layerEntryIsGroupLayer,
+  TypeSourceImageStaticInitialConfig,
 } from '@/geo/map/map-schema-types';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { getMinOrMaxExtents } from '@/geo/utils/utilities';
@@ -62,9 +63,7 @@ export const geoviewLayerIsImageStatic = (verifyIfGeoViewLayer: AbstractGeoViewL
  *
  * @returns {boolean} true if the type ascention is valid.
  */
-export const geoviewEntryIsImageStatic = (
-  verifyIfGeoViewEntry: TypeLayerEntryConfig
-): verifyIfGeoViewEntry is ImageStaticLayerEntryConfig => {
+export const geoviewEntryIsImageStatic = (verifyIfGeoViewEntry: ConfigBaseClass): verifyIfGeoViewEntry is ImageStaticLayerEntryConfig => {
   return verifyIfGeoViewEntry?.geoviewLayerConfig?.geoviewLayerType === CONST_LAYER_TYPES.IMAGE_STATIC;
 };
 
@@ -244,27 +243,28 @@ export class ImageStatic extends AbstractGeoViewRaster {
   /** ****************************************************************************************************************************
    * This method creates a GeoView Image Static layer using the definition provided in the layerConfig parameter.
    *
-   * @param {ImageStaticLayerEntryConfig} layerConfig Information needed to create the GeoView layer.
+   * @param {AbstractBaseLayerEntryConfig} layerConfig Information needed to create the GeoView layer.
    *
    * @returns {TypeBaseRasterLayer} The GeoView raster layer that has been created.
    */
-  processOneLayerEntry(layerConfig: ImageStaticLayerEntryConfig): Promise<TypeBaseRasterLayer | null> {
+  processOneLayerEntry(layerConfig: AbstractBaseLayerEntryConfig): Promise<TypeBaseRasterLayer | null> {
     super.processOneLayerEntry(layerConfig);
+    const layerConfigSource = layerConfig?.source as TypeSourceImageStaticInitialConfig;
 
-    if (!layerConfig?.source?.extent) throw new Error('Parameter extent is not defined in source element of layerConfig.');
+    if (!layerConfigSource?.extent) throw new Error('Parameter extent is not defined in source element of layerConfig.');
     const sourceOptions: SourceOptions = {
       url: getLocalizedValue(layerConfig.source.dataAccessPath, AppEventProcessor.getDisplayLanguage(this.mapId)) || '',
       imageExtent: layerConfig.source.extent,
     };
 
-    if (layerConfig?.source?.crossOrigin) {
-      sourceOptions.crossOrigin = layerConfig.source.crossOrigin;
+    if (layerConfigSource?.crossOrigin) {
+      sourceOptions.crossOrigin = layerConfigSource.crossOrigin;
     } else {
       sourceOptions.crossOrigin = 'Anonymous';
     }
 
-    if (layerConfig?.source?.projection) {
-      sourceOptions.projection = `EPSG:${layerConfig.source.projection}`;
+    if (layerConfigSource?.projection) {
+      sourceOptions.projection = `EPSG:${layerConfigSource.projection}`;
     } else throw new Error('Parameter projection is not define in source element of layerConfig.');
 
     const staticImageOptions: ImageOptions<Static> = { source: new Static(sourceOptions) };

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
@@ -78,9 +78,7 @@ export const geoviewLayerIsVectorTiles = (verifyIfGeoViewLayer: AbstractGeoViewL
  *
  * @returns {boolean} true if the type ascention is valid.
  */
-export const geoviewEntryIsVectorTiles = (
-  verifyIfGeoViewEntry: TypeLayerEntryConfig
-): verifyIfGeoViewEntry is VectorTilesLayerEntryConfig => {
+export const geoviewEntryIsVectorTiles = (verifyIfGeoViewEntry: ConfigBaseClass): verifyIfGeoViewEntry is VectorTilesLayerEntryConfig => {
   return verifyIfGeoViewEntry?.geoviewLayerConfig?.geoviewLayerType === CONST_LAYER_TYPES.VECTOR_TILES;
 };
 
@@ -322,6 +320,9 @@ export class VectorTiles extends AbstractGeoViewRaster {
    * @param {string} styleUrl The url of the styles to apply.
    */
   setVectorTileStyle(layerPath: string, styleUrl: string) {
-    applyStyle(api.maps[this.mapId].layer.registeredLayers[layerPath].olLayer as VectorTileLayer, styleUrl);
+    applyStyle(
+      (api.maps[this.mapId].layer.registeredLayers[layerPath] as AbstractBaseLayerEntryConfig).olLayer as VectorTileLayer,
+      styleUrl
+    );
   }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -75,7 +75,7 @@ export const geoviewLayerIsXYZTiles = (verifyIfGeoViewLayer: AbstractGeoViewLaye
  *
  * @returns {boolean} true if the type ascention is valid.
  */
-export const geoviewEntryIsXYZTiles = (verifyIfGeoViewEntry: TypeLayerEntryConfig): verifyIfGeoViewEntry is XYZTilesLayerEntryConfig => {
+export const geoviewEntryIsXYZTiles = (verifyIfGeoViewEntry: ConfigBaseClass): verifyIfGeoViewEntry is XYZTilesLayerEntryConfig => {
   return verifyIfGeoViewEntry?.geoviewLayerConfig?.geoviewLayerType === CONST_LAYER_TYPES.XYZ_TILES;
 };
 
@@ -225,11 +225,11 @@ export class XYZTiles extends AbstractGeoViewRaster {
    * This method is used to process the layer's metadata. It will fill the empty fields of the layer's configuration (renderer,
    * initial settings, fields and aliases).
    *
-   * @param {TypeLayerEntryConfig} layerConfig The layer entry configuration to process.
+   * @param {AbstractBaseLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
    * @returns {Promise<TypeLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
    */
-  protected processLayerMetadata(layerConfig: TypeLayerEntryConfig): Promise<TypeLayerEntryConfig> {
+  protected processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<TypeLayerEntryConfig> {
     if (this.metadata) {
       const metadataLayerConfigFound = Cast<XYZTilesLayerEntryConfig[]>(this.metadata?.listOfLayerEntryConfig).find(
         (metadataLayerConfig) => metadataLayerConfig.layerId === layerConfig.layerId

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -130,7 +130,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
       if (typeof url === 'function') url = url(extent, resolution, projection);
 
       const xhr = new XMLHttpRequest();
-      if ((layerConfig?.source as TypeBaseSourceVectorInitialConfig)?.postSettings) {
+      if (((layerConfig as AbstractBaseLayerEntryConfig)?.source as TypeBaseSourceVectorInitialConfig)?.postSettings) {
         const { postSettings } = layerConfig.source as TypeBaseSourceVectorInitialConfig;
         xhr.open('POST', url as string);
         if (postSettings!.header)
@@ -284,7 +284,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
       const layerConfig = this.getLayerConfig(layerPath) as VectorLayerEntryConfig;
       const layerFilter = (layer: BaseLayer) => {
         const layerSource = layer.get('layerConfig')?.source;
-        const configSource = layerConfig?.source;
+        const configSource = (layerConfig as AbstractBaseLayerEntryConfig)?.source;
         return layerSource !== undefined && configSource !== undefined && layerSource === configSource;
       };
       const { map } = api.maps[this.mapId];

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/csv.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/csv.ts
@@ -73,7 +73,7 @@ export const geoviewLayerIsCSV = (verifyIfGeoViewLayer: AbstractGeoViewLayer): v
  *
  * @returns {boolean} true if the type ascention is valid.
  */
-export const geoviewEntryIsCSV = (verifyIfGeoViewEntry: TypeLayerEntryConfig): verifyIfGeoViewEntry is CsvLayerEntryConfig => {
+export const geoviewEntryIsCSV = (verifyIfGeoViewEntry: ConfigBaseClass): verifyIfGeoViewEntry is CsvLayerEntryConfig => {
   return verifyIfGeoViewEntry?.geoviewLayerConfig?.geoviewLayerType === CONST_LAYER_TYPES.CSV;
 };
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -75,9 +75,7 @@ export const geoviewLayerIsEsriFeature = (verifyIfGeoViewLayer: AbstractGeoViewL
  *
  * @returns {boolean} true if the type ascention is valid.
  */
-export const geoviewEntryIsEsriFeature = (
-  verifyIfGeoViewEntry: TypeLayerEntryConfig
-): verifyIfGeoViewEntry is EsriFeatureLayerEntryConfig => {
+export const geoviewEntryIsEsriFeature = (verifyIfGeoViewEntry: ConfigBaseClass): verifyIfGeoViewEntry is EsriFeatureLayerEntryConfig => {
   return verifyIfGeoViewEntry?.geoviewLayerConfig?.geoviewLayerType === CONST_LAYER_TYPES.ESRI_FEATURE;
 };
 
@@ -127,7 +125,7 @@ export class EsriFeature extends AbstractGeoViewVector {
    *
    * @returns {boolean} true if an error is detected.
    */
-  esriChildHasDetectedAnError(layerConfig: TypeLayerEntryConfig, esriIndex: number): boolean {
+  esriChildHasDetectedAnError(layerConfig: ConfigBaseClass, esriIndex: number): boolean {
     if (this.metadata!.layers[esriIndex].type !== 'Feature Layer') {
       this.layerLoadError.push({
         layer: layerConfig.layerPath,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -72,7 +72,7 @@ export const geoviewLayerIsGeoJSON = (verifyIfGeoViewLayer: AbstractGeoViewLayer
  *
  * @returns {boolean} true if the type ascention is valid.
  */
-export const geoviewEntryIsGeoJSON = (verifyIfGeoViewEntry: TypeLayerEntryConfig): verifyIfGeoViewEntry is GeoJSONLayerEntryConfig => {
+export const geoviewEntryIsGeoJSON = (verifyIfGeoViewEntry: ConfigBaseClass): verifyIfGeoViewEntry is GeoJSONLayerEntryConfig => {
   return verifyIfGeoViewEntry?.geoviewLayerConfig?.geoviewLayerType === CONST_LAYER_TYPES.GEOJSON;
 };
 
@@ -103,7 +103,7 @@ export class GeoJSON extends AbstractGeoViewVector {
    * @param {TypeListOfLayerEntryConfig} listOfLayerEntryConfig The list of layer entries configuration to validate.
    */
   protected validateListOfLayerEntryConfig(listOfLayerEntryConfig: TypeListOfLayerEntryConfig) {
-    listOfLayerEntryConfig.forEach((layerConfig: TypeLayerEntryConfig) => {
+    listOfLayerEntryConfig.forEach((layerConfig: ConfigBaseClass) => {
       const { layerPath } = layerConfig;
       if (layerEntryIsGroupLayer(layerConfig)) {
         this.validateListOfLayerEntryConfig(layerConfig.listOfLayerEntryConfig!);
@@ -128,7 +128,9 @@ export class GeoJSON extends AbstractGeoViewVector {
         const metadataLayerList = Cast<TypeLayerEntryConfig[]>(this.metadata?.listOfLayerEntryConfig);
         const foundEntry = metadataLayerList.find(
           (layerMetadata) =>
-            layerMetadata.layerId === layerConfig.layerId && layerMetadata.layerIdExtension === layerConfig.layerIdExtension
+            layerMetadata.layerId === layerConfig.layerId &&
+            (layerMetadata as AbstractBaseLayerEntryConfig).layerIdExtension ===
+              (layerConfig as AbstractBaseLayerEntryConfig).layerIdExtension
         );
         if (!foundEntry) {
           this.layerLoadError.push({

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
@@ -98,9 +98,7 @@ export const geoviewLayerIsGeoPackage = (verifyIfGeoViewLayer: AbstractGeoViewLa
  *
  * @returns {boolean} true if the type ascention is valid.
  */
-export const geoviewEntryIsGeoPackage = (
-  verifyIfGeoViewEntry: TypeLayerEntryConfig
-): verifyIfGeoViewEntry is GeoPackageLayerEntryConfig => {
+export const geoviewEntryIsGeoPackage = (verifyIfGeoViewEntry: ConfigBaseClass): verifyIfGeoViewEntry is GeoPackageLayerEntryConfig => {
   return verifyIfGeoViewEntry?.geoviewLayerConfig?.geoviewLayerType === CONST_LAYER_TYPES.GEOPACKAGE;
 };
 
@@ -193,11 +191,11 @@ export class GeoPackage extends AbstractGeoViewVector {
       } else if (listOfLayerEntryConfig.length > 1) {
         if (!layerGroup)
           layerGroup = this.createLayerGroup(
-            listOfLayerEntryConfig[0].parentLayerConfig as TypeLayerEntryConfig,
-            listOfLayerEntryConfig[0].initialSettings!
+            listOfLayerEntryConfig[0].geoviewLayerInstance?.getParentConfig(listOfLayerEntryConfig[0].layerPath) as TypeLayerEntryConfig,
+            (listOfLayerEntryConfig[0] as AbstractBaseLayerEntryConfig).initialSettings!
           );
 
-        listOfLayerEntryConfig.forEach((layerConfig) => {
+        listOfLayerEntryConfig.forEach((layerConfig: ConfigBaseClass) => {
           if (layerEntryIsGroupLayer(layerConfig)) {
             const newLayerGroup = this.createLayerGroup(layerConfig, layerConfig.initialSettings!);
             this.processListOfLayerEntryConfig(layerConfig.listOfLayerEntryConfig!, newLayerGroup).then((groupReturned) => {
@@ -567,14 +565,14 @@ export class GeoPackage extends AbstractGeoViewVector {
           });
         } else {
           layerConfig.entryType = CONST_LAYER_ENTRY_TYPES.GROUP;
-          (layerConfig as TypeLayerEntryConfig).listOfLayerEntryConfig = [];
+          (layerConfig as GroupLayerEntryConfig).listOfLayerEntryConfig = [];
           const newLayerGroup = this.createLayerGroup(layerConfig, layerConfig.initialSettings!);
           for (let i = 0; i < layers.length; i++) {
             const newLayerEntryConfig = cloneDeep(layerConfig) as AbstractBaseLayerEntryConfig;
             newLayerEntryConfig.layerId = layers[i].name;
             newLayerEntryConfig.layerName = createLocalizedString(layers[i].name);
             newLayerEntryConfig.entryType = CONST_LAYER_ENTRY_TYPES.VECTOR;
-            newLayerEntryConfig.parentLayerConfig = Cast<GroupLayerEntryConfig>(layerConfig);
+            newLayerEntryConfig.parentLayerConfig = layerConfig.layerPath;
 
             this.processOneGeopackageLayer(newLayerEntryConfig, layers[i], slds).then((baseLayer) => {
               if (baseLayer) {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -27,6 +27,7 @@ import { WfsLayerEntryConfig } from '@/core/utils/config/validation-classes/vect
 import { VectorLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-layer-entry-config';
 import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
+import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
 
 export interface TypeSourceWFSVectorInitialConfig extends TypeVectorSourceInitialConfig {
   format: 'WFS';
@@ -72,7 +73,7 @@ export const geoviewLayerIsWFS = (verifyIfGeoViewLayer: AbstractGeoViewLayer): v
  *
  * @returns {boolean} true if the type ascention is valid.
  */
-export const geoviewEntryIsWFS = (verifyIfGeoViewEntry: TypeLayerEntryConfig): verifyIfGeoViewEntry is WfsLayerEntryConfig => {
+export const geoviewEntryIsWFS = (verifyIfGeoViewEntry: ConfigBaseClass): verifyIfGeoViewEntry is WfsLayerEntryConfig => {
   return verifyIfGeoViewEntry?.geoviewLayerConfig?.geoviewLayerType === CONST_LAYER_TYPES.WFS;
 };
 
@@ -167,20 +168,20 @@ export class WFS extends AbstractGeoViewVector {
    */
   protected validateListOfLayerEntryConfig(listOfLayerEntryConfig: TypeListOfLayerEntryConfig) {
     listOfLayerEntryConfig.forEach((layerConfig: TypeLayerEntryConfig) => {
-      const { layerPath } = layerConfig;
-      if (layerEntryIsGroupLayer(layerConfig)) {
-        this.validateListOfLayerEntryConfig(layerConfig.listOfLayerEntryConfig!);
-        if (!layerConfig.listOfLayerEntryConfig.length) {
+      const castLayerConfig = layerConfig as AbstractBaseLayerEntryConfig;
+      const { layerPath } = castLayerConfig;
+      if (layerEntryIsGroupLayer(castLayerConfig)) {
+        this.validateListOfLayerEntryConfig(castLayerConfig.listOfLayerEntryConfig!);
+        if (!layerEntryIsGroupLayer(castLayerConfig)) {
           this.layerLoadError.push({
             layer: layerPath,
             loggerMessage: `Empty layer group (mapId:  ${this.mapId}, layerPath: ${layerPath})`,
           });
-          layerConfig.layerStatus = 'error';
           return;
         }
       }
 
-      layerConfig.layerStatus = 'processing';
+      castLayerConfig.layerStatus = 'processing';
 
       // Note that the code assumes wfs feature type list does not contains metadata layer group. If you need layer group,
       // you can define them in the configuration section.
@@ -192,7 +193,7 @@ export class WFS extends AbstractGeoViewVector {
         const metadataLayerList = this.metadata?.FeatureTypeList.FeatureType as Array<TypeJsonObject>;
         const foundMetadata = metadataLayerList.find((layerMetadata) => {
           const metadataLayerId = (layerMetadata.Name && layerMetadata.Name['#text']) as string;
-          return metadataLayerId.includes(layerConfig.layerId!);
+          return metadataLayerId.includes(castLayerConfig.layerId!);
         });
 
         if (!foundMetadata) {
@@ -200,7 +201,7 @@ export class WFS extends AbstractGeoViewVector {
             layer: layerPath,
             loggerMessage: `WFS feature layer not found (mapId:  ${this.mapId}, layerPath: ${layerPath})`,
           });
-          layerConfig.layerStatus = 'error';
+          castLayerConfig.layerStatus = 'error';
           return;
         }
 
@@ -212,7 +213,7 @@ export class WFS extends AbstractGeoViewVector {
             `EPSG:${currentProjection}`
           );
 
-        if (!layerConfig.initialSettings?.bounds && foundMetadata['ows:WGS84BoundingBox']) {
+        if (!castLayerConfig.initialSettings?.bounds && foundMetadata['ows:WGS84BoundingBox']) {
           const lowerCorner = (foundMetadata['ows:WGS84BoundingBox']['ows:LowerCorner']['#text'] as string).split(' ');
           const upperCorner = (foundMetadata['ows:WGS84BoundingBox']['ows:UpperCorner']['#text'] as string).split(' ');
           const bounds = [Number(lowerCorner[0]), Number(lowerCorner[1]), Number(upperCorner[0]), Number(upperCorner[1])];

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -42,6 +42,8 @@ import EventHelper, { EventDelegateBase } from '@/api/events/event-helper';
 import { TypeOrderedLayerInfo } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { MapViewer } from '@/geo/map/map-viewer';
 import { api } from '@/app';
+import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
+import { GroupLayerEntryConfig } from '@/core/utils/config/validation-classes/group-layer-entry-config';
 
 export type TypeRegisteredLayers = { [layerPath: string]: TypeLayerEntryConfig };
 
@@ -123,41 +125,52 @@ export class LayerApi {
   generateArrayOfLayerOrderInfo(geoviewLayerConfig: TypeGeoviewLayerConfig | TypeLayerEntryConfig): TypeOrderedLayerInfo[] {
     const newOrderedLayerInfos: TypeOrderedLayerInfo[] = [];
 
-    const addSubLayerPathToLayerOrder = (layerEntryConfig: TypeLayerEntryConfig, layerPath: string): void => {
-      const subLayerPath = layerPath.endsWith(layerEntryConfig.layerId) ? layerPath : `${layerPath}/${layerEntryConfig.layerId}`;
+    const addSubLayerPathToLayerOrder = (layerConfig: AbstractBaseLayerEntryConfig | TypeGeoviewLayerConfig, layerPath: string): void => {
+      // GV: In very rare cases (~ 0.0001%), the complete layerPath ends with layerId.layerIdExtension and
+      // GV: TypeGeoviewLayerConfig doesn't have a layerPath.
+      let subLayerPath: string;
+      if ('geoviewLayerId' in layerConfig) subLayerPath = layerPath;
+      else {
+        const layerEntryConfig = layerConfig as AbstractBaseLayerEntryConfig;
+        const completeLayerId = layerEntryConfig.layerIdExtension
+          ? `${layerEntryConfig.layerId}.${layerEntryConfig.layerIdExtension}`
+          : layerEntryConfig.layerId;
+        subLayerPath = layerPath.endsWith(completeLayerId) ? layerPath : `${layerPath}/${completeLayerId}`;
+      }
       const layerInfo: TypeOrderedLayerInfo = {
         layerPath: subLayerPath,
-        visible: layerEntryConfig.initialSettings?.states?.visible !== false,
-        queryable: layerEntryConfig.source?.featureInfo?.queryable !== undefined ? layerEntryConfig.source?.featureInfo?.queryable : true,
-        hoverable:
-          layerEntryConfig.initialSettings?.states?.hoverable !== undefined ? layerEntryConfig.initialSettings?.states?.hoverable : true,
+        visible: layerConfig.initialSettings?.states?.visible !== false,
+        queryable:
+          (layerConfig as AbstractBaseLayerEntryConfig).source?.featureInfo?.queryable !== undefined
+            ? (layerConfig as AbstractBaseLayerEntryConfig).source?.featureInfo?.queryable
+            : true,
+        hoverable: layerConfig.initialSettings?.states?.hoverable !== undefined ? layerConfig.initialSettings?.states?.hoverable : true,
       };
       newOrderedLayerInfos.push(layerInfo);
-      if (layerEntryConfig.listOfLayerEntryConfig?.length) {
-        layerEntryConfig.listOfLayerEntryConfig?.forEach((subLayerEntryConfig) => {
-          addSubLayerPathToLayerOrder(subLayerEntryConfig, subLayerPath);
+      if (layerEntryIsGroupLayer(layerConfig as AbstractBaseLayerEntryConfig)) {
+        (layerConfig as GroupLayerEntryConfig).listOfLayerEntryConfig?.forEach((subLayerEntryConfig) => {
+          addSubLayerPathToLayerOrder(subLayerEntryConfig as AbstractBaseLayerEntryConfig, subLayerPath);
         });
       }
     };
 
-    if ((geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId) {
-      if ((geoviewLayerConfig as TypeGeoviewLayerConfig).listOfLayerEntryConfig.length > 1) {
-        const layerPath = `${(geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId}/${
-          (geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId
-        }`;
+    if ('geoviewLayerId' in geoviewLayerConfig) {
+      const castedGeoviewLayerConfig = geoviewLayerConfig as TypeGeoviewLayerConfig;
+      if (castedGeoviewLayerConfig.listOfLayerEntryConfig.length > 1) {
+        const layerPath = `${castedGeoviewLayerConfig.geoviewLayerId}/${castedGeoviewLayerConfig.geoviewLayerId}`;
         const layerInfo: TypeOrderedLayerInfo = {
           layerPath,
-          visible: geoviewLayerConfig.initialSettings?.states?.visible !== false,
+          visible: castedGeoviewLayerConfig.initialSettings?.states?.visible !== false,
         };
         newOrderedLayerInfos.push(layerInfo);
-        (geoviewLayerConfig as TypeGeoviewLayerConfig).listOfLayerEntryConfig.forEach((layerEntryConfig) => {
-          addSubLayerPathToLayerOrder(layerEntryConfig, layerPath);
+        castedGeoviewLayerConfig.listOfLayerEntryConfig.forEach((layerEntryConfig) => {
+          addSubLayerPathToLayerOrder(layerEntryConfig as AbstractBaseLayerEntryConfig, layerPath);
         });
       } else {
-        const layerEntryConfig = (geoviewLayerConfig as TypeGeoviewLayerConfig).listOfLayerEntryConfig[0];
-        addSubLayerPathToLayerOrder(layerEntryConfig, layerEntryConfig.layerPath);
+        const layerEntryConfig = geoviewLayerConfig.listOfLayerEntryConfig[0];
+        addSubLayerPathToLayerOrder(layerEntryConfig as AbstractBaseLayerEntryConfig, layerEntryConfig.layerPath);
       }
-    } else addSubLayerPathToLayerOrder(geoviewLayerConfig as TypeLayerEntryConfig, (geoviewLayerConfig as TypeLayerEntryConfig).layerPath);
+    } else addSubLayerPathToLayerOrder(geoviewLayerConfig as AbstractBaseLayerEntryConfig, geoviewLayerConfig.layerPath);
 
     return newOrderedLayerInfos;
   }
@@ -556,11 +569,12 @@ export class LayerApi {
 
     // initialize these two constant now because we will delete the information used to get their values.
     const indexToDelete = this.registeredLayers[partialLayerPath]
-      ? this.registeredLayers[partialLayerPath].parentLayerConfig?.listOfLayerEntryConfig.findIndex(
-          (layerConfig) => layerConfig === this.registeredLayers?.[partialLayerPath]
-        )
+      ? this.registeredLayers[partialLayerPath].geoviewLayerInstance
+          ?.getParentConfig(partialLayerPath)
+          ?.listOfLayerEntryConfig.findIndex((layerConfig) => layerConfig === this.registeredLayers?.[partialLayerPath])
       : undefined;
-    const listOfLayerEntryConfigAffected = this.registeredLayers[partialLayerPath]?.parentLayerConfig?.listOfLayerEntryConfig;
+    const listOfLayerEntryConfigAffected =
+      this.registeredLayers[partialLayerPath]?.geoviewLayerInstance?.getParentConfig(partialLayerPath)?.listOfLayerEntryConfig;
 
     Object.keys(this.registeredLayers).forEach((completeLayerPath) => {
       const completeLayerPathNodes = completeLayerPath.split('/');
@@ -634,7 +648,7 @@ export class LayerApi {
    */
   getOLLayerByLayerPath(layerPath: string): BaseLayer | LayerGroup {
     // Return the olLayer object from the registered layers
-    const olLayer = this.registeredLayers[layerPath]?.olLayer;
+    const olLayer = (this.registeredLayers[layerPath] as AbstractBaseLayerEntryConfig)?.olLayer;
     if (olLayer) return olLayer;
     throw new Error(`Layer at path ${layerPath} not found.`);
   }
@@ -651,7 +665,7 @@ export class LayerApi {
     // Make sure the open layer has been created, sometimes it can still be in the process of being created
     const promisedLayer = await whenThisThen(
       () => {
-        return this.registeredLayers[layerPath]?.olLayer;
+        return (this.registeredLayers[layerPath] as AbstractBaseLayerEntryConfig)?.olLayer;
       },
       timeout,
       checkFrequency
@@ -718,7 +732,7 @@ export class LayerApi {
           this.geoviewLayer(registeredLayerPath).setOpacity((otherOpacity || 1) * 0.25, registeredLayerPath);
         }
       });
-      this.registeredLayers[layerPath].olLayer!.setZIndex(999);
+      (this.registeredLayers[layerPath] as AbstractBaseLayerEntryConfig).olLayer!.setZIndex(999);
     }
   }
 
@@ -729,7 +743,7 @@ export class LayerApi {
     this.featureHighlight.removeBBoxHighlight();
     if (this.highlightedLayer.layerPath !== undefined) {
       const { layerPath, originalOpacity } = this.highlightedLayer;
-      if (layerEntryIsGroupLayer(this.registeredLayers[layerPath] as TypeLayerEntryConfig)) {
+      if (layerEntryIsGroupLayer(this.registeredLayers[layerPath])) {
         Object.keys(this.registeredLayers).forEach((registeredLayerPath) => {
           if (
             !registeredLayerPath.startsWith(layerPath) &&

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -431,7 +431,7 @@ export interface TypeSourceImageWmsInitialConfig extends TypeBaseSourceImageInit
 /** ******************************************************************************************************************************
  * Initial settings for static image sources.
  */
-export interface TypeSourceImageStaticInitialConfig extends Omit<TypeBaseSourceImageInitialConfig, 'featureInfo'> {
+export interface TypeSourceImageStaticInitialConfig extends TypeBaseSourceImageInitialConfig {
   /** Definition of the feature information structure that will be used by the getFeatureInfo method. We only use queryable and
    * it must be set to false if specified.
    */
@@ -479,7 +479,7 @@ export type TypeTileGrid = {
 /** ******************************************************************************************************************************
  * Initial settings for tile image sources.
  */
-export interface TypeSourceTileInitialConfig extends Omit<TypeBaseSourceImageInitialConfig, 'featureInfo'> {
+export interface TypeSourceTileInitialConfig extends TypeBaseSourceImageInitialConfig {
   /** Definition of the feature information structure that will be used by the getFeatureInfo method. We only use queryable and
    * it must be set to false if specified.
    */
@@ -500,16 +500,18 @@ export interface TypeVectorTileSourceInitialConfig extends TypeBaseSourceVectorI
  * Layer config type.
  */
 export type TypeLayerEntryConfig =
-  | AbstractBaseLayerEntryConfig
-  | VectorHeatmapLayerEntryConfig
-  | VectorLayerEntryConfig
-  | VectorLayerEntryConfig
-  | OgcWmsLayerEntryConfig
-  | EsriDynamicLayerEntryConfig
-  | EsriImageLayerEntryConfig
-  | ImageStaticLayerEntryConfig
-  | TileLayerEntryConfig
-  | GroupLayerEntryConfig;
+  | (ConfigBaseClass & GroupLayerEntryConfig)
+  | (ConfigBaseClass &
+      AbstractBaseLayerEntryConfig &
+      (
+        | VectorHeatmapLayerEntryConfig
+        | VectorLayerEntryConfig
+        | OgcWmsLayerEntryConfig
+        | EsriDynamicLayerEntryConfig
+        | EsriImageLayerEntryConfig
+        | ImageStaticLayerEntryConfig
+        | TileLayerEntryConfig
+      ));
 
 /** ******************************************************************************************************************************
  * List of layers. Corresponds to the layerList defined in the schema.
@@ -544,6 +546,17 @@ export type TypeGeoviewLayerConfig = {
   serviceDateFormat?: string;
   /** Date format used by the getFeatureInfo to output date variable. */
   externalDateFormat?: string;
+  /**
+   * Initial settings to apply to the GeoView layer at creation time.
+   * This attribute is allowed only if listOfLayerEntryConfig.length > 1.
+   */
+  initialSettings?: TypeLayerInitialSettings;
+
+  /** The layer entries to use from the GeoView layer. */
+  listOfLayerEntryConfig: TypeListOfLayerEntryConfig;
+};
+
+export type TypeSharedLayerProps = {
   /**
    * Initial settings to apply to the GeoView layer at creation time.
    * This attribute is allowed only if listOfLayerEntryConfig.length > 1.

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -568,7 +568,7 @@ export class MapViewer {
           let allGood = true;
           Object.entries(this.layer.registeredLayers).forEach(([layerPath, registeredLayer]) => {
             // If not queryable, don't expect a result set
-            if (!registeredLayer.source?.featureInfo?.queryable) return;
+            if (!(registeredLayer as AbstractBaseLayerEntryConfig).source?.featureInfo?.queryable) return;
 
             const { resultSet } = this.layer.featureInfoLayerSet;
             const layerResultSetReady = Object.keys(resultSet).includes(layerPath);

--- a/packages/geoview-core/src/geo/utils/all-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/all-feature-info-layer-set.ts
@@ -41,7 +41,7 @@ export class AllFeatureInfoLayerSet extends LayerSet {
       return false;
 
     const layerConfig = this.layerApi.registeredLayers[layerPath];
-    const queryable = layerConfig?.source?.featureInfo?.queryable;
+    const queryable = (layerConfig as AbstractBaseLayerEntryConfig)?.source?.featureInfo?.queryable;
     return !!queryable;
   }
 
@@ -119,7 +119,7 @@ export class AllFeatureInfoLayerSet extends LayerSet {
     // If valid layer path
     if (this.layerApi.registeredLayers[layerPath] && this.resultSet[layerPath]) {
       const { data } = this.resultSet[layerPath];
-      const layerConfig = this.layerApi.registeredLayers[layerPath];
+      const layerConfig = this.layerApi.registeredLayers[layerPath] as AbstractBaseLayerEntryConfig;
 
       // Query and event types of what we're doing
       const eventType = 'all-features';

--- a/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/feature-info-layer-set.ts
@@ -48,7 +48,7 @@ export class FeatureInfoLayerSet extends LayerSet {
     logger.logTraceCore('FEATURE-INFO-LAYER-SET - onRegisterLayerCheck', layerPath, Object.keys(this.resultSet));
 
     const layerConfig = this.layerApi.registeredLayers[layerPath];
-    const queryable = layerConfig?.source?.featureInfo?.queryable;
+    const queryable = (layerConfig as AbstractBaseLayerEntryConfig)?.source?.featureInfo?.queryable;
     return !!queryable;
   }
 
@@ -149,7 +149,7 @@ export class FeatureInfoLayerSet extends LayerSet {
     // Reinitialize the resultSet
     // Loop on each layer path in the resultSet
     Object.keys(this.resultSet).forEach((layerPath) => {
-      const layerConfig = this.layerApi.registeredLayers[layerPath];
+      const layerConfig = this.layerApi.registeredLayers[layerPath] as AbstractBaseLayerEntryConfig;
       const { data } = this.resultSet[layerPath];
       if (!data.eventListenerEnabled) return;
       if (layerConfig.layerStatus === 'loaded') {

--- a/packages/geoview-core/src/geo/utils/hover-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/hover-feature-info-layer-set.ts
@@ -49,7 +49,7 @@ export class HoverFeatureInfoLayerSet extends LayerSet {
     logger.logTraceCore('HOVER-FEATURE-INFO-LAYER-SET - onRegisterLayerCheck', layerPath, Object.keys(this.resultSet));
 
     const layerConfig = this.layerApi.registeredLayers[layerPath];
-    const queryable = layerConfig?.source?.featureInfo?.queryable;
+    const queryable = (layerConfig as AbstractBaseLayerEntryConfig)?.source?.featureInfo?.queryable;
     return !!queryable;
   }
 
@@ -113,7 +113,7 @@ export class HoverFeatureInfoLayerSet extends LayerSet {
     // Reinitialize the resultSet
     // Loop on each layer path in the resultSet
     Object.keys(this.resultSet).forEach((layerPath) => {
-      const layerConfig = this.layerApi.registeredLayers[layerPath];
+      const layerConfig = this.layerApi.registeredLayers[layerPath] as AbstractBaseLayerEntryConfig;
       const { data } = this.resultSet[layerPath];
       if (!data.eventListenerEnabled) return;
       if (layerConfig.layerStatus === 'loaded') {

--- a/packages/geoview-core/src/geo/utils/layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/layer-set.ts
@@ -5,7 +5,7 @@ import Feature from 'ol/Feature';
 import RenderFeature from 'ol/render/Feature';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
 import EventHelper, { EventDelegateBase } from '@/api/events/event-helper';
-import { TypeLayerStatus, TypeLayerEntryConfig } from '@/geo/map/map-schema-types';
+import { TypeLayerStatus } from '@/geo/map/map-schema-types';
 import { AbstractGeoViewLayer, TypeGeoviewLayerType } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { createLocalizedString, getLocalizedValue } from '@/core/utils/utilities';
 import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
@@ -169,7 +169,7 @@ export class LayerSet {
    */
   protected queryLayerFeatures(
     data: TypeLayerData | TypeHoverLayerData,
-    layerConfig: TypeLayerEntryConfig,
+    layerConfig: AbstractBaseLayerEntryConfig,
     layerPath: string,
     queryType: QueryType,
     location: TypeLocation
@@ -177,7 +177,7 @@ export class LayerSet {
     // If event listener is enabled, query status isn't in error, and geoview layer instance is defined
     if (data.eventListenerEnabled && data.queryStatus !== 'error' && layerConfig.geoviewLayerInstance) {
       // If source is queryable
-      if (layerConfig?.source?.featureInfo?.queryable) {
+      if ((layerConfig as AbstractBaseLayerEntryConfig)?.source?.featureInfo?.queryable) {
         // Get Feature Info
         return Promise.resolve(layerConfig.geoviewLayerInstance.getFeatureInfo(queryType, layerPath, location));
       }

--- a/packages/geoview-core/src/geo/utils/legends-layer-set.ts
+++ b/packages/geoview-core/src/geo/utils/legends-layer-set.ts
@@ -95,11 +95,10 @@ export class LegendsLayerSet extends LayerSet {
    */
   #changeLayerStatusOfParentsRecursive(currentLayerConfig: TypeLayerEntryConfig, currentLayerStatus: TypeLayerStatus): void {
     // If layer has a parent
-    if (currentLayerConfig.parentLayerConfig) {
+    if (parentGroupLayer) {
       // If the current status to set is at least loaded (or error), make the parent loaded
       if (['loaded', 'error'].includes(currentLayerStatus)) {
         // Get the parent config
-        const parentGroupLayer = currentLayerConfig.parentLayerConfig as GroupLayerEntryConfig;
 
         // Update the status on the parent
         parentGroupLayer.layerStatus = 'loaded';
@@ -120,9 +119,12 @@ export class LegendsLayerSet extends LayerSet {
   protected onLayerSetUpdatedProcess(layerPath: string): void {
     if (MapEventProcessor.getMapIndexFromOrderedLayerInfo(this.mapId, layerPath) === -1) {
       const layerConfig = this.layerApi.registeredLayers[layerPath];
+      const parentLayerConfig = (layerConfig as AbstractBaseLayerEntryConfig).geoviewLayerInstance!.getParentConfig(
+        layerConfig.layerPath
+      ) as TypeLayerEntryConfig;
       if (MapEventProcessor.getMapIndexFromOrderedLayerInfo(this.mapId, layerPath.split('.')[1]) !== -1) {
         MapEventProcessor.replaceOrderedLayerInfo(this.mapId, layerConfig, layerPath.split('.')[1]);
-      } else if (layerConfig.parentLayerConfig) {
+      } else if (parentLayerConfig) {
         const parentLayerPathArray = layerPath.split('/');
         parentLayerPathArray.pop();
         const parentLayerPath = parentLayerPathArray.join('/');
@@ -131,7 +133,13 @@ export class LegendsLayerSet extends LayerSet {
           layerInfo.layerPath.startsWith(parentLayerPath)
         ).length;
         if (parentLayerIndex !== -1) MapEventProcessor.addOrderedLayerInfo(this.mapId, layerConfig, parentLayerIndex + numberOfLayers);
-        else MapEventProcessor.addOrderedLayerInfo(this.mapId, layerConfig.parentLayerConfig!);
+        else
+          MapEventProcessor.addOrderedLayerInfo(
+            this.mapId,
+            (layerConfig as AbstractBaseLayerEntryConfig).geoviewLayerInstance!.getParentConfig(
+              layerConfig.layerPath
+            ) as TypeLayerEntryConfig
+          );
       } else MapEventProcessor.addOrderedLayerInfo(this.mapId, layerConfig);
     }
 


### PR DESCRIPTION
# Description

1- Creation of the ConfigApi class. This new class uses the old Config class as a starting point. The aim of phase 1 is to produce a configuration map similar to the one currently used internally.
2- This PR also modifies the configuration type, which will slowly lose the complex objects stored in it. The first phase will remove circular configuration references, which will be replaced by layer paths.

Fixes # Phase 1 of issue 1963

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using Chrome Devtools

__Deploy URL__ : https://ychoquet.github.io/GeoView/type-of-layers.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/1986)
<!-- Reviewable:end -->
