### PR TITLE
fix(footer): fix style issues of footer layout

### DIFF
--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -2,7 +2,7 @@ import { ReactNode, memo } from 'react';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { animated, useSpring } from '@react-spring/web';
-import { Box, ChevronRightIcon, IconButton, List, ListItem, ListItemButton, ListItemIcon, Paper, Tooltip, Typography } from '@/ui';
+import { Box, List, ListItem, ListItemButton, ListItemIcon, Paper, Tooltip, Typography } from '@/ui';
 import { TypeFeatureInfoEntry, TypeQueryStatus } from '@/geo/utils/layer-set';
 import { getSxClasses } from './layer-list-style';
 import { LayerIcon } from './layer-icon';
@@ -22,7 +22,6 @@ export interface LayerListEntry {
 }
 
 interface LayerListProps {
-  isEnlarged: boolean;
   layerList: LayerListEntry[];
   selectedLayerPath: string | undefined;
   onListItemClick: (layer: LayerListEntry) => void;
@@ -31,12 +30,11 @@ interface LayerListProps {
 interface LayerListItemProps {
   isSelected: boolean;
   layer: LayerListEntry;
-  isEnlarged: boolean;
   onListItemClick: (layer: LayerListEntry) => void;
   layerIndex: number;
 }
 
-const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListItemClick, isEnlarged, layerIndex }: LayerListItemProps) {
+const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListItemClick, layerIndex }: LayerListItemProps) {
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
   const { t } = useTranslation<string>();
@@ -105,20 +103,6 @@ const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListIte
     );
   };
 
-  const renderLayerButton = (): JSX.Element | null => {
-    switch (layer.layerStatus) {
-      case 'error':
-        return null;
-
-      default:
-        return (
-          <IconButton edge="end" size="small" className="style1" disabled={isDisabled} tabIndex={-1} aria-hidden="true">
-            <ChevronRightIcon />
-          </IconButton>
-        );
-    }
-  };
-
   function getContainerClass(): string {
     const result: string[] = ['layer-panel', 'bordered', layer.layerStatus ?? '', `query-${layer.queryStatus}`];
 
@@ -156,20 +140,6 @@ const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListIte
             >
               {renderLayerIcon()}
               {renderLayerBody()}
-              <Box
-                sx={{
-                  padding: isEnlarged ? '0.25rem' : '1rem',
-                  paddingRight: isEnlarged ? '0.25rem' : '1rem',
-                  [theme.breakpoints.down('xl')]: {
-                    display: isEnlarged ? 'none !important' : 'block',
-                  },
-                  [theme.breakpoints.down('sm')]: {
-                    display: 'none',
-                  },
-                }}
-              >
-                {renderLayerButton()}
-              </Box>
             </ListItemButton>
           </ListItem>
         </Box>
@@ -187,7 +157,7 @@ const LayerListItem = memo(function LayerListItem({ isSelected, layer, onListIte
  * @param {Function} onListItemClick  Callback function excecuted when list item is clicked.
  * @returns {JSX.Element}
  */
-export function LayerList({ layerList, isEnlarged, selectedLayerPath, onListItemClick }: LayerListProps): JSX.Element {
+export function LayerList({ layerList, selectedLayerPath, onListItemClick }: LayerListProps): JSX.Element {
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
   const { t } = useTranslation<string>();
@@ -202,7 +172,6 @@ export function LayerList({ layerList, isEnlarged, selectedLayerPath, onListItem
             // Some of layers will not have numOfFeatures, so to make layer look like selected, we need to set default value to 1.
             // Also we cant set numOfFeature initially, then it num of features will be display as sub title.
             isSelected={(layer?.numOffeatures ?? 1) > 0 && layer.layerPath === selectedLayerPath}
-            isEnlarged={isEnlarged}
             layer={layer}
             onListItemClick={onListItemClick}
             layerIndex={ind}
@@ -212,7 +181,6 @@ export function LayerList({ layerList, isEnlarged, selectedLayerPath, onListItem
         <LayerListItem
           key="dummyPath"
           isSelected={false}
-          isEnlarged
           layerIndex={0}
           layer={
             {

--- a/packages/geoview-core/src/core/components/common/layout-style.ts
+++ b/packages/geoview-core/src/core/components/common/layout-style.ts
@@ -8,12 +8,8 @@ export const getSxClasses = (theme: Theme): any => ({
     borderRadius: '5px',
     backgroundColor: theme.palette.geoViewColor.white,
     width: '100%',
-    overflow: 'auto',
-    maxHeight: '600px',
-
     '&.fullscreen-mode': {
       maxHeight: 'calc(100vh - 150px)',
-
       '& .MuiTableContainer-root': {
         maxHeight: 'calc(100vh - 260px)',
       },
@@ -32,6 +28,13 @@ export const getSxClasses = (theme: Theme): any => ({
       th: {
         textAlign: 'left',
         paddingLeft: '15px',
+      },
+      '& h3': {
+        '&:first-child': {
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.325rem',
+        },
       },
     },
   },

--- a/packages/geoview-core/src/core/components/common/layout.tsx
+++ b/packages/geoview-core/src/core/components/common/layout.tsx
@@ -82,10 +82,8 @@ export function Layout({
     // Log
     logger.logTraceUseCallback('LAYOUT - renderLayerList');
 
-    return (
-      <LayerList isEnlarged={isEnlarged} selectedLayerPath={selectedLayerPath} onListItemClick={handleLayerChange} layerList={layerList} />
-    );
-  }, [isEnlarged, selectedLayerPath, layerList, handleLayerChange]);
+    return <LayerList selectedLayerPath={selectedLayerPath} onListItemClick={handleLayerChange} layerList={layerList} />;
+  }, [selectedLayerPath, layerList, handleLayerChange]);
 
   // // If we're on mobile
   if (theme.breakpoints.down('md')) {
@@ -96,7 +94,7 @@ export function Layout({
   }
 
   return (
-    <Box>
+    <Box sx={sxClasses.layoutContainer}>
       <ResponsiveGrid.Root sx={{ pt: 8, pb: 8 }} ref={panelTitleRef}>
         {!fullWidth && (
           <ResponsiveGrid.Left isLayersPanelVisible={isLayersPanelVisible} isEnlarged={isEnlarged} aria-hidden={!isLayersPanelVisible}>
@@ -155,6 +153,7 @@ export function Layout({
           isEnlarged={isEnlarged}
           isLayersPanelVisible={isLayersPanelVisible}
           fullWidth={fullWidth}
+          className="right-panel-content"
         >
           <FullScreenDialog open={isFullScreen} onClose={() => setIsFullScreen(false)}>
             <Box sx={sxClasses.rightGridContent} className="fullscreen-mode">

--- a/packages/geoview-core/src/core/components/common/use-footer-panel-height.tsx
+++ b/packages/geoview-core/src/core/components/common/use-footer-panel-height.tsx
@@ -54,6 +54,16 @@ export function useFooterPanelHeight({ footerPanelTab }: UseFooterPanelHeightTyp
 
       if (activeFooterBarTabId === TABS.DATA_TABLE) {
         setTableHeight(leftPanelHeight - 10);
+        const rightPanelGuideContainer = (rightPanelRef.current?.querySelector('.guidebox-container') ?? null) as HTMLElement | null;
+        if (rightPanelGuideContainer) {
+          rightPanelGuideContainer.style.maxHeight = `${leftPanelHeight}px`;
+          rightPanelGuideContainer.style.paddingBottom = `24px`;
+          rightPanelGuideContainer.style.overflowY = 'auto';
+        }
+        const rightPanel = (rightPanelRef.current?.firstElementChild ?? null) as HTMLElement | null;
+        if (rightPanel) {
+          rightPanel.removeAttribute('style');
+        }
       } else if (activeFooterBarTabId === TABS.GEO_CHART && rightPanelRef.current) {
         rightPanelRef.current.style.maxHeight = `${leftPanelHeight}px`;
         rightPanelRef.current.style.overflowY = footerPanelResizeValue !== 100 ? 'auto' : 'visible';

--- a/packages/geoview-core/src/core/components/common/use-footer-panel-height.tsx
+++ b/packages/geoview-core/src/core/components/common/use-footer-panel-height.tsx
@@ -64,6 +64,7 @@ export function useFooterPanelHeight({ footerPanelTab }: UseFooterPanelHeightTyp
         if (rightPanel) {
           rightPanel.style.maxHeight = `${leftPanelHeight}px`;
           rightPanel.style.paddingBottom = `24px`;
+          rightPanel.style.overflowY = 'auto';
         }
       }
     }
@@ -73,6 +74,18 @@ export function useFooterPanelHeight({ footerPanelTab }: UseFooterPanelHeightTyp
       leftPanelRef.current.style.overflow = 'auto';
       if (activeFooterBarTabId === TABS.DATA_TABLE) {
         setTableHeight(defaultHeight);
+
+        const rightPanelGuideContainer = (rightPanelRef.current?.querySelector('.guidebox-container') ?? null) as HTMLElement | null;
+        if (rightPanelGuideContainer) {
+          rightPanelGuideContainer.style.maxHeight = `${defaultHeight}px`;
+          rightPanelGuideContainer.style.paddingBottom = `24px`;
+          rightPanelGuideContainer.style.overflow = 'auto';
+        }
+        const rightPanel = (rightPanelRef.current?.firstElementChild ?? null) as HTMLElement | null;
+        if (rightPanel) {
+          rightPanel.removeAttribute('style');
+        }
+        // check if table exist as child in right panel.
       } else if (activeFooterBarTabId === TABS.GEO_CHART && rightPanelRef.current) {
         rightPanelRef.current.style.maxHeight = `${defaultHeight}px`;
         rightPanelRef.current.style.overflowY = 'auto';
@@ -80,6 +93,8 @@ export function useFooterPanelHeight({ footerPanelTab }: UseFooterPanelHeightTyp
         const rightPanel = (rightPanelRef.current?.firstElementChild ?? null) as HTMLElement | null;
         if (rightPanel) {
           rightPanel.style.maxHeight = `${defaultHeight}px`;
+          rightPanel.style.paddingBottom = `24px`;
+          rightPanel.style.overflow = 'auto';
         }
       }
     }

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
 import Markdown from 'markdown-to-jsx';
-import { Box, FilterAltIcon, Paper, Skeleton } from '@/ui';
+import { Box, FilterAltIcon, Skeleton } from '@/ui';
 import DataTable from './data-table';
 import {
   useDataTableSelectedLayerPath,
@@ -211,21 +211,16 @@ export function Datapanel({ fullWidth }: DataPanelType): JSX.Element {
       {/* show data table instructions when all layers has no features */}
       {((!isLoading && isAllLayersNoFeatures()) || isLayerDisabled() || selectedLayerPath === '') && (
         <Box
-          sx={
-            fullWidth
-              ? { ...sxClasses.rightPanelContainer, overflowY: 'none' }
-              : { ...sxClasses.rightPanelContainer, maxHeight: '600px', overflowY: 'none' }
-          }
+          className="guidebox-container"
+          sx={fullWidth ? { ...sxClasses.rightPanelContainer, overflowY: 'hidden' } : { ...sxClasses.rightPanelContainer }}
         >
-          <Paper sx={{ padding: '2rem' }}>
-            <Box className="guideBox">
-              <Markdown options={{ wrapper: 'article' }}>{`${guide!.footerPanel!.children!.dataTable!.content}\n${
-                guide!.footerPanel!.children!.dataTable!.children!.filterData!.content
-              }\n${guide!.footerPanel!.children!.dataTable!.children!.sortingAndReordering!.content}\n\n${
-                guide!.footerPanel!.children!.dataTable!.children!.keyboardNavigation!.content
-              }`}</Markdown>
-            </Box>
-          </Paper>
+          <Box className="guideBox">
+            <Markdown options={{ wrapper: 'article' }}>{`${guide!.footerPanel!.children!.dataTable!.content}\n${
+              guide!.footerPanel!.children!.dataTable!.children!.filterData!.content
+            }\n${guide!.footerPanel!.children!.dataTable!.children!.sortingAndReordering!.content}\n\n${
+              guide!.footerPanel!.children!.dataTable!.children!.keyboardNavigation!.content
+            }`}</Markdown>
+          </Box>
         </Box>
       )}
     </Layout>

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -2,16 +2,7 @@ import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
 import Markdown from 'markdown-to-jsx';
-import {
-  IconButton,
-  Grid,
-  Typography,
-  ArrowForwardIosOutlinedIcon,
-  ArrowBackIosOutlinedIcon,
-  LayersClearOutlinedIcon,
-  Box,
-  Paper,
-} from '@/ui';
+import { IconButton, Grid, Typography, ArrowForwardIosOutlinedIcon, ArrowBackIosOutlinedIcon, LayersClearOutlinedIcon, Box } from '@/ui';
 import {
   useDetailsStoreActions,
   useDetailsCheckedFeatures,
@@ -446,11 +437,9 @@ export function DetailsPanel({ fullWidth }: DetailsPanelType): JSX.Element {
           )}
           {!memoSelectedLayerDataFeatures && guide?.footerPanel && (
             <Box sx={fullWidth ? sxClasses.rightPanelContainer : { ...sxClasses.rightPanelContainer, maxHeight: '600px' }}>
-              <Paper sx={{ padding: '20px' }}>
-                <Box className="guideBox">
-                  <Markdown options={{ wrapper: 'article' }}>{guide!.footerPanel!.children!.details!.content}</Markdown>
-                </Box>
-              </Paper>
+              <Box className="guideBox">
+                <Markdown options={{ wrapper: 'article' }}>{guide!.footerPanel!.children!.details!.content}</Markdown>
+              </Box>
             </Box>
           )}
         </Layout>

--- a/packages/geoview-core/src/core/components/legend/legend-layer.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer.tsx
@@ -94,41 +94,42 @@ export function LegendLayer(props: LegendLayerProps): JSX.Element {
     if (getLayerChildren().length) {
       return <>{t('legend.subLayersCount').replace('{count}', getLayerChildren().length.toString())}</>;
     }
+    if (layer.items.length) {
+      let itemsCountStr = '';
+      if (layer.items.length > 1) {
+        itemsCountStr = t('legend.itemsCount')
+          .replace('{count}', layer.items.length.toString())
+          .replace('{totalCount}', layer.items.length.toString());
+      }
 
-    let itemsCountStr = '';
-    if (layer.items.length > 1) {
-      itemsCountStr = t('legend.itemsCount')
-        .replace('{count}', layer.items.length.toString())
-        .replace('{totalCount}', layer.items.length.toString());
+      return (
+        <Stack direction="row" alignItems="center" sx={sxClasses.layerStackIcons}>
+          <Typography component="span" fontSize={14}>
+            {itemsCountStr}
+          </Typography>
+          <IconButton
+            edge="end"
+            tooltip="layers.visibilityIsAlways"
+            className="style1"
+            onClick={(e) => handleToggleVisibility(e)}
+            disabled={!isLayerVisible}
+          >
+            {visibility ? <VisibilityOffOutlinedIcon /> : <VisibilityOutlinedIcon />}
+          </IconButton>
+          <IconButton
+            tooltip="legend.highlightLayer"
+            sx={{ marginTop: '-0.3125rem' }}
+            className="style1"
+            onClick={(e) => handleHighlightLayer(e)}
+          >
+            {highlightedLayer === layer.layerPath ? <HighlightIcon /> : <HighlightOutlinedIcon />}
+          </IconButton>
+          <IconButton tooltip="legend.zoomTo" className="style1" onClick={(e) => handleZoomTo(e)}>
+            <ZoomInSearchIcon />
+          </IconButton>
+        </Stack>
+      );
     }
-
-    return (
-      <Stack direction="row" alignItems="center" sx={sxClasses.layerStackIcons}>
-        <Typography component="span" fontSize={14}>
-          {itemsCountStr}
-        </Typography>
-        <IconButton
-          edge="end"
-          tooltip="layers.visibilityIsAlways"
-          className="style1"
-          onClick={(e) => handleToggleVisibility(e)}
-          disabled={!isLayerVisible}
-        >
-          {visibility ? <VisibilityOffOutlinedIcon /> : <VisibilityOutlinedIcon />}
-        </IconButton>
-        <IconButton
-          tooltip="legend.highlightLayer"
-          sx={{ marginTop: '-0.3125rem' }}
-          className="style1"
-          onClick={(e) => handleHighlightLayer(e)}
-        >
-          {highlightedLayer === layer.layerPath ? <HighlightIcon /> : <HighlightOutlinedIcon />}
-        </IconButton>
-        <IconButton tooltip="legend.zoomTo" className="style1" onClick={(e) => handleZoomTo(e)}>
-          <ZoomInSearchIcon />
-        </IconButton>
-      </Stack>
-    );
 
     return <Box />;
   };

--- a/packages/geoview-core/src/ui/tooltip/tooltip.tsx
+++ b/packages/geoview-core/src/ui/tooltip/tooltip.tsx
@@ -8,7 +8,7 @@ import React from 'react';
  * @returns {JSX.Element} the tooltip ui component
  */
 export const Tooltip = React.forwardRef((props: TooltipProps, ref): JSX.Element => {
-  return <MaterialTooltip enterDelay={1000} leaveDelay={200} {...props} ref={ref} />;
+  return <MaterialTooltip enterDelay={1000} enterNextDelay={200} {...props} ref={ref} />;
 });
 
 Tooltip.displayName = 'Tooltip';


### PR DESCRIPTION
# Description
Fix footer layout issues.

- Should not see two scrollbars. Right panel should only have one scrollbar.
- Test expand icon in all tabs.
- Test in fullscreen and make sure no double scrollbar.. also when you switch back from fullscreen.
- Remove arrow in layers in left panel (in detail, datatable and guide).
- Show Stack icons when layer has items.

Fixes #2024 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

__Add the URL for your deploy!__
https://kaminderpal.github.io/geoview/raw-feature-info.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
