### PR TITLE
bug(WMS): error with empty style in HRDEM layers

### DIFF
--- a/packages/geoview-core/public/templates/layers/wms.html
+++ b/packages/geoview-core/public/templates/layers/wms.html
@@ -137,6 +137,18 @@
                       'layerName': { 'en': 'Test Spatiotemporel' }
                     }
                   ]
+                },
+                {
+                  'geoviewLayerId': 'HRDEM-dsm-hillshade',
+                  'geoviewLayerName': { 'en': 'DSM Hillshade' },
+                  'metadataAccessPath': { 'en': 'https://datacube.services.geo.ca/ows/elevation' },
+                  'geoviewLayerType': 'ogcWms',
+                  'listOfLayerEntryConfig': [
+                    {
+                      'layerId': 'dsm-hillshade',
+                      'layerName': { 'en': 'DSM-Hillshade' }
+                    }
+                  ]
                 }
               ]
             },

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -520,7 +520,7 @@ export class WMS extends AbstractGeoViewRaster {
 
         if (Array.isArray(layerConfig.source?.style)) {
           this.WMSStyles = layerConfig.source.style;
-        } else if ((layerCapabilities.Style.length as number) > 1) {
+        } else if (layerCapabilities.Style && (layerCapabilities.Style.length as number) > 1) {
           this.WMSStyles = [];
           for (let i = 0; i < (layerCapabilities.Style.length as number); i++) {
             this.WMSStyles.push(layerCapabilities.Style[i].Name as string);


### PR DESCRIPTION
Closes #1891

# Description

Fixes issue with missing style config causing errors in WMS layers

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added DSM Hillshade layer to first WMS map.
https://damonu2.github.io/geoview/wms.html#HLYR1

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2111)
<!-- Reviewable:end -->
