### PR TITLE
Input and internal schema validation plus  default maxExtent issue

### DIFF
--- a/packages/geoview-core/src/api/config/types/config-constants.ts
+++ b/packages/geoview-core/src/api/config/types/config-constants.ts
@@ -1,25 +1,9 @@
 // TODO: When we are done with the config extraction, do a review of all the constants, types and utilities to
 // TODOCONT: remove code duplication.
 
-import { AbstractGeoviewLayerConfig } from '@config/types/classes/geoview-config/abstract-geoview-layer-config';
-import { LayerEntryTypesKey, LayerTypesKey, TypeGeoviewLayerType } from '@config/types/config-types';
-import {
-  TypeAppBarProps,
-  TypeBasemapId,
-  TypeBasemapOptions,
-  TypeDisplayTheme,
-  TypeExternalPackages,
-  TypeInteraction,
-  TypeLayerEntryType,
-  TypeListOfLocalizedLanguages,
-  TypeMapConfig,
-  TypeNavBarProps,
-  TypeOverviewMapProps,
-  TypeServiceUrls,
-  TypeValidMapProjectionCodes,
-  TypeValidVersions,
-  TypeViewSettings,
-} from '@config/types/map-schema-types';
+import { Cast, LayerEntryTypesKey, LayerTypesKey, TypeGeoviewLayerType } from '@config/types/config-types';
+import { TypeBasemapId, TypeLayerEntryType, TypeValidMapProjectionCodes } from '@config/types/map-schema-types';
+import { MapFeatureConfig } from '@config/types/classes/map-feature-config';
 
 /** The default geocore url */
 export const CV_CONFIG_GEOCORE_URL = 'https://geocore-stage.api.geo.ca';
@@ -136,9 +120,9 @@ export const CV_MAP_EXTENTS: Record<TypeValidMapProjectionCodes, number[]> = {
  *  Definition of the MapFeatureConfig default values. All the default values that applies to the map feature configuration are
  * defined here.
  */
-export const CV_DEFAULT_MAP_FEATURE_CONFIG = {
+export const CV_DEFAULT_MAP_FEATURE_CONFIG = Cast<MapFeatureConfig>({
   map: {
-    interaction: 'dynamic' as TypeInteraction,
+    interaction: 'dynamic',
     viewSettings: {
       initialView: {
         zoomAndCenter: [3.5, [-90, 60]],
@@ -149,29 +133,29 @@ export const CV_DEFAULT_MAP_FEATURE_CONFIG = {
       maxZoom: 50,
       maxExtent: [-125, 30, -60, 89],
       projection: 3978,
-    } as TypeViewSettings,
+    },
     basemapOptions: {
       basemapId: 'transport',
       shaded: true,
       labeled: true,
-    } as TypeBasemapOptions,
-    listOfGeoviewLayerConfig: [] as AbstractGeoviewLayerConfig[],
+    },
+    listOfGeoviewLayerConfig: [],
     extraOptions: {},
-  } as TypeMapConfig,
-  theme: 'geo.ca' as TypeDisplayTheme,
+  },
+  theme: 'geo.ca',
   components: ['north-arrow', 'overview-map'],
-  appBar: { tabs: { core: ['geolocator'] } } as TypeAppBarProps,
-  navBar: ['zoom', 'fullscreen', 'home'] as TypeNavBarProps,
+  appBar: { tabs: { core: ['geolocator'] } },
+  navBar: ['zoom', 'fullscreen', 'home'],
   corePackages: [],
-  overviewMap: undefined as TypeOverviewMapProps | undefined,
-  externalPackages: [] as TypeExternalPackages,
+  overviewMap: undefined,
+  externalPackages: [],
   serviceUrls: {
     geocoreUrl: CV_CONFIG_GEOCORE_URL,
     geolocator: CV_CONFIG_GEOLOCATOR_URL,
-  } as TypeServiceUrls,
-  supportedLanguages: ['en', 'fr'] as TypeListOfLocalizedLanguages,
-  schemaVersionUsed: '1.0' as TypeValidVersions,
-};
+  },
+  suportedLanguages: ['en', 'fr'],
+  schemaVersionUsed: '1.0',
+});
 
 /**
  *  Definition of the initial settings default values.

--- a/packages/geoview-core/src/api/config/types/config-validation-schema.json
+++ b/packages/geoview-core/src/api/config/types/config-validation-schema.json
@@ -746,19 +746,6 @@
           "type": "string",
           "description": "The id of the layer to display on the map."
         },
-        "layerName": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/TypeLocalizedString",
-              "description": "Used by the input schema."
-            },
-            {
-              "type": "string",
-              "description": "Used by the internal schema."
-            }
-          ],
-          "description": "The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
-        },
         "geometryType": {
           "$ref": "#/definitions/TypeGeometryType",
           "description": "The type of geometry used by the layer."
@@ -796,15 +783,34 @@
         },
         "style": {
           "$ref": "#/definitions/TypeStyleConfig"
+        }
+      },
+      "if": {
+        "properties": {
+          "entryType": {
+            "enum": ["vector"],
+            "description": "The entryType property is not defined by the user but by the viewer according to the geoview layer type. It is used as a flag indicating the type of schema used (input/internal)."
+          }
         },
-        "not": {
-          "listOfLayerEntryConfig": {
-            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
-            "description": "The list of layer entry configurations to use from the GeoView layer group."
+        "required": ["entryType"]
+      },
+      "then": {
+        "properties": {
+          "layerName": {
+            "type": "string",
+            "description": "Used by the internal schema."
           }
         }
       },
-      "required": ["entryType", "layerId"]
+      "else": {
+        "properties": {
+          "layerName": {
+              "$ref": "#/definitions/TypeLocalizedString",
+              "description": "Used by the input schema. The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
+          }
+        }
+      },
+    "required": ["layerId"]
     },
     "TypeVectorTileLayerEntryConfig": {
       "additionalProperties": false,
@@ -817,19 +823,6 @@
         "layerId": {
           "type": "string",
           "description": "The id of the layer to display on the map."
-        },
-        "layerName": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/TypeLocalizedString",
-              "description": "Used by the input schema."
-            },
-            {
-              "type": "string",
-              "description": "Used by the internal schema."
-            }
-          ],
-          "description": "The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
         },
         "geometryType": {
           "$ref": "#/definitions/TypeGeometryType",
@@ -869,15 +862,34 @@
         },
         "style": {
           "$ref": "#/definitions/TypeStyleConfig"
+        }
+      },
+      "if": {
+        "properties": {
+          "entryType": {
+            "enum": ["vector-tile"],
+            "description": "The entryType property is not defined by the user but by the viewer according to the geoview layer type. It is used as a flag indicating the type of schema used (input/internal)."
+          }
         },
-        "not": {
-          "listOfLayerEntryConfig": {
-            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
-            "description": "The list of layer entry configurations to use from the GeoView layer group."
+        "required": ["entryType"]
+      },
+      "then": {
+        "properties": {
+          "layerName": {
+            "type": "string",
+            "description": "Used by the internal schema."
           }
         }
       },
-      "required": ["entryType", "layerId"]
+      "else": {
+        "properties": {
+          "layerName": {
+              "$ref": "#/definitions/TypeLocalizedString",
+              "description": "Used by the input schema. The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
+          }
+        }
+      },
+    "required": ["layerId"]
     },
     "TypeVectorTileSourceInitialConfig": {
       "additionalProperties": false,
@@ -910,19 +922,6 @@
         "layerId": {
           "type": "string",
           "description": "The id of the layer to display on the map."
-        },
-        "layerName": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/TypeLocalizedString",
-              "description": "Used by the input schema."
-            },
-            {
-              "type": "string",
-              "description": "Used by the internal schema."
-            }
-          ],
-          "description": "The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
         },
         "attributions": {
           "type": "array",
@@ -957,15 +956,34 @@
         },
         "style": {
           "$ref": "#/definitions/TypeStyleConfig"
+        }
+      },
+      "if": {
+        "properties": {
+          "entryType": {
+            "enum": ["raster-image"],
+            "description": "The entryType property is not defined by the user but by the viewer according to the geoview layer type. It is used as a flag indicating the type of schema used (input/internal)."
+          }
         },
-        "not": {
-          "listOfLayerEntryConfig": {
-            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
-            "description": "The list of layer entry configurations to use from the GeoView layer group."
+        "required": ["entryType"]
+      },
+      "then": {
+        "properties": {
+          "layerName": {
+            "type": "string",
+            "description": "Used by the internal schema."
           }
         }
       },
-      "required": ["entryType", "layerId"]
+      "else": {
+        "properties": {
+          "layerName": {
+              "$ref": "#/definitions/TypeLocalizedString",
+              "description": "Used by the input schema. The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
+          }
+        }
+      },
+    "required": ["layerId"]
     },
     "TypeEsriDynamicLayerEntryConfig": {
       "additionalProperties": false,
@@ -1028,15 +1046,34 @@
         },
         "style": {
           "$ref": "#/definitions/TypeStyleConfig"
+        }
+      },
+      "if": {
+        "properties": {
+          "entryType": {
+            "enum": ["raster-image"],
+            "description": "The entryType property is not defined by the user but by the viewer according to the geoview layer type. It is used as a flag indicating the type of schema used (input/internal)."
+          }
         },
-        "not": {
-          "listOfLayerEntryConfig": {
-            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
-            "description": "The list of layer entry configurations to use from the GeoView layer group."
+        "required": ["entryType"]
+      },
+      "then": {
+        "properties": {
+          "layerName": {
+            "type": "string",
+            "description": "Used by the internal schema."
           }
         }
       },
-      "required": ["entryType", "layerId"]
+      "else": {
+        "properties": {
+          "layerName": {
+            "$ref": "#/definitions/TypeLocalizedString",
+            "description": "Used by the input schema. The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
+          }
+        }
+      },
+    "required": ["layerId"]
     },
     "TypeEsriImageLayerEntryConfig": {
       "additionalProperties": false,
@@ -1048,19 +1085,6 @@
         "layerId": {
           "type": "string",
           "description": "The id of the layer to display on the map."
-        },
-        "layerName": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/TypeLocalizedString",
-              "description": "Used by the input schema."
-            },
-            {
-              "type": "string",
-              "description": "Used by the internal schema."
-            }
-          ],
-          "description": "The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
         },
         "attributions": {
           "type": "array",
@@ -1095,15 +1119,34 @@
         },
         "style": {
           "$ref": "#/definitions/TypeStyleConfig"
+        }
+      },
+      "if": {
+        "properties": {
+          "entryType": {
+            "enum": ["raster-image"],
+            "description": "The entryType property is not defined by the user but by the viewer according to the geoview layer type. It is used as a flag indicating the type of schema used (input/internal)."
+          }
         },
-        "not": {
-          "listOfLayerEntryConfig": {
-            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
-            "description": "The list of layer entry configurations to use from the GeoView layer group."
+        "required": ["entryType"]
+      },
+      "then": {
+        "properties": {
+          "layerName": {
+            "type": "string",
+            "description": "Used by the internal schema."
           }
         }
       },
-      "required": ["entryType", "layerId"]
+      "else": {
+        "properties": {
+          "layerName": {
+              "$ref": "#/definitions/TypeLocalizedString",
+              "description": "Used by the input schema. The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
+          }
+        }
+      },
+    "required": ["layerId"]
     },
     "TypeImageStaticLayerEntryConfig": {
       "additionalProperties": false,
@@ -1115,19 +1158,6 @@
         "layerId": {
           "type": "string",
           "description": "The id of the layer to display on the map."
-        },
-        "layerName": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/TypeLocalizedString",
-              "description": "Used by the input schema."
-            },
-            {
-              "type": "string",
-              "description": "Used by the internal schema."
-            }
-          ],
-          "description": "The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
         },
         "attributions": {
           "type": "array",
@@ -1159,15 +1189,34 @@
         },
         "source": {
           "$ref": "#/definitions/TypeSourceImageStaticInitialConfig"
+        }
+      },
+      "if": {
+        "properties": {
+          "entryType": {
+            "enum": ["raster-image"],
+            "description": "The entryType property is not defined by the user but by the viewer according to the geoview layer type. It is used as a flag indicating the type of schema used (input/internal)."
+          }
         },
-        "not": {
-          "listOfLayerEntryConfig": {
-            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
-            "description": "The list of layer entry configurations to use from the GeoView layer group."
+        "required": ["entryType"]
+      },
+      "then": {
+        "properties": {
+          "layerName": {
+            "type": "string",
+            "description": "Used by the internal schema."
           }
         }
       },
-      "required": ["entryType", "layerId"]
+      "else": {
+        "properties": {
+          "layerName": {
+              "$ref": "#/definitions/TypeLocalizedString",
+              "description": "Used by the input schema. The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
+          }
+        }
+      },
+    "required": ["layerId"]
     },
     "TypeTileLayerEntryConfig": {
       "additionalProperties": false,
@@ -1179,19 +1228,6 @@
         "layerId": {
           "type": "string",
           "description": "The id of the layer to display on the map."
-        },
-        "layerName": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/TypeLocalizedString",
-              "description": "Used by the input schema."
-            },
-            {
-              "type": "string",
-              "description": "Used by the internal schema."
-            }
-          ],
-          "description": "The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
         },
         "attributions": {
           "type": "array",
@@ -1223,15 +1259,34 @@
         },
         "source": {
           "$ref": "#/definitions/TypeSourceTileInitialConfig"
+        }
+      },
+      "if": {
+        "properties": {
+          "entryType": {
+            "enum": ["raster-tile"],
+            "description": "The entryType property is not defined by the user but by the viewer according to the geoview layer type. It is used as a flag indicating the type of schema used (input/internal)."
+          }
         },
-        "not": {
-          "listOfLayerEntryConfig": {
-            "$ref": "#/definitions/TypeListOfLayerEntryConfig",
-            "description": "The list of layer entry configurations to use from the GeoView layer group."
+        "required": ["entryType"]
+      },
+      "then": {
+        "properties": {
+          "layerName": {
+            "type": "string",
+            "description": "Used by the internal schema."
           }
         }
       },
-      "required": ["entryType", "layerId"]
+      "else": {
+        "properties": {
+          "layerName": {
+              "$ref": "#/definitions/TypeLocalizedString",
+              "description": "Used by the input schema. The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
+          }
+        }
+      },
+    "required": ["layerId"]
     },
     "TypeLayerEntryType": {
       "enum": ["vector", "vector-tile", "raster-tile", "raster-image", "geoCore"],
@@ -1248,19 +1303,6 @@
         "layerId": {
           "type": "string",
           "description": "The id of the layer group to display on the map."
-        },
-        "layerName": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/TypeLocalizedString",
-              "description": "Used by the input schema."
-            },
-            {
-              "type": "string",
-              "description": "Used by the internal schema."
-            }
-          ],
-          "description": "The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
         },
         "bounds": {
           "type": "array",
@@ -1279,32 +1321,32 @@
           "description": "The list of layer entry configurations to use from the GeoView layer group."
         }
       },
-      "required": ["entryType", "layerId", "listOfLayerEntryConfig"]
-    },
-    "TypeLayerEntryConfig": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/TypeLayerGroupEntryConfig"
+      "if": {
+        "properties": {
+          "entryType": {
+            "enum": ["group"],
+            "description": "The entryType property is not defined by the user but by the viewer according to the geoview layer type. It is used as a flag indicating the type of schema used (input/internal)."
+          }
         },
-        {
-          "$ref": "#/definitions/TypeVectorTileLayerEntryConfig"
-        },
-        {
-          "$ref": "#/definitions/TypeVectorLayerEntryConfig"
-        },
-        {
-          "$ref": "#/definitions/TypeOgcWmsLayerEntryConfig"
-        },
-        {
-          "$ref": "#/definitions/TypeEsriDynamicLayerEntryConfig"
-        },
-        {
-          "$ref": "#/definitions/TypeEsriImageLayerEntryConfig"
-        },
-        {
-          "$ref": "#/definitions/TypeTileLayerEntryConfig"
+        "required": ["entryType"]
+      },
+      "then": {
+        "properties": {
+          "layerName": {
+            "type": "string",
+            "description": "Used by the internal schema."
+          }
         }
-      ]
+      },
+      "else": {
+        "properties": {
+          "layerName": {
+              "$ref": "#/definitions/TypeLocalizedString",
+              "description": "Used by the input schema. The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information."
+          }
+        }
+      },
+      "required": ["layerId", "listOfLayerEntryConfig"]
     },
     "TypeListOfLayerEntryConfig": {
       "type": "array",


### PR DESCRIPTION
# Description

This PR groups two issues:
- The creation and activation of two schemas (input/internal) that validate hte configuration provided by the user and the the structure of the internal representation of the map and layer instances.
- The correction of the default maxExtent according to the projection code used.

Fixes #2121, 2122

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using Chrome Devtools to trace and debug the code.

__Deploy URL__: https://ychoquet.github.io/GeoView/config-sandbox.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2124)
<!-- Reviewable:end -->
