### PR TITLE
refactor(layer-sets) - Fourth spring-board PR focusing mainly on the LayerSets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,6 +40,15 @@
       "italic": false
     },
     {
+      "tag": "fixme",
+      "color": "#FF2D00",
+      "strikethrough": false,
+      "underline": false,
+      "backgroundColor": "transparent",
+      "bold": false,
+      "italic": false
+    },
+    {
       "tag": "todo",
       "color": "#FF8C00",
       "strikethrough": false,

--- a/packages/geoview-core/public/templates/demos/demo-function-event.html
+++ b/packages/geoview-core/public/templates/demos/demo-function-event.html
@@ -187,7 +187,7 @@
       // Add WMS Button======================================================================================================
       // find the button element by ID
       var addLayerButton = document.getElementById('Add-layer');
-      const config = 
+      const config =
         {
           'geoviewLayerId': 'wmsLYR1-msi',
           'geoviewLayerName': { 'en': 'MSI' },
@@ -356,7 +356,7 @@
       disableHoverButton.addEventListener('click', async () => {
         cgpv.api.maps.Map1.layer.hoverFeatureInfoLayerSet.disableHoverListener('esriFeatureLYR5/0')
       });
-      
+
       // Enable hover Button========================================================================================================
       // find the button element by ID
       var enableHoverButton = document.getElementById('Enable-hover');
@@ -374,7 +374,7 @@
       disableFeatureInfoButton.addEventListener('click', async () => {
         cgpv.api.maps.Map1.layer.featureInfoLayerSet.disableClickListener('esriFeatureLYR5/0')
       });
-      
+
       // Enable feature info Button========================================================================================================
       // find the button element by ID
       var enableFeatureInfoButton = document.getElementById('Enable-feature-info');

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/feature-info-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/feature-info-event-processor.ts
@@ -125,13 +125,12 @@ export class FeatureInfoEventProcessor extends AbstractEventProcessor {
     // The feature info state
     const featureInfoState = this.getFeatureInfoState(mapId);
 
+    // Create a details object for each layer which is then used to render layers in details panel.
+    const layerDataArray = [...featureInfoState.layerDataArray];
+    if (!layerDataArray.find((layerEntry) => layerEntry.layerPath === resultSetEntry.layerPath)) layerDataArray.push(resultSetEntry);
+
     // Depending on the event type
     if (eventType === 'click') {
-      /**
-       * Create a details object for each layer which is then used to render layers in details panel.
-       */
-      const layerDataArray = [...featureInfoState.layerDataArray];
-      if (!layerDataArray.find((layerEntry) => layerEntry.layerPath === resultSetEntry.layerPath)) layerDataArray.push(resultSetEntry);
       const atLeastOneFeature = layerDataArray.find((layerEntry) => !!layerEntry.features?.length) || false;
 
       // Update the layer data array in the store, all the time, for all statuses
@@ -149,6 +148,9 @@ export class FeatureInfoEventProcessor extends AbstractEventProcessor {
           UIEventProcessor.setActiveAppBarTab(mapId, 'AppbarPanelButtonDetails', 'details', true);
         }
       }
+    } else if (eventType === 'name') {
+      // Update the layer data array in the store, all the time, for all statuses
+      featureInfoState.setterActions.setLayerDataArray(layerDataArray);
     }
 
     // Nothing to do

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -8,12 +8,12 @@ import {
   isVectorLegend,
   isWmsLegend,
 } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
+import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
 import { ILayerState, TypeLegend, TypeLegendResultSetEntry } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { AbstractEventProcessor } from '@/api/event-processors/abstract-event-processor';
 
 import {
-  TypeLayerEntryConfig,
   TypeStyleGeometry,
   isClassBreakStyleConfig,
   isSimpleStyleConfig,
@@ -140,7 +140,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
     const { layerPath } = legendResultSetEntry;
     const layerPathNodes = layerPath.split('/');
 
-    const setLayerControls = (layerConfig: TypeLayerEntryConfig): TypeLayerControls => {
+    const setLayerControls = (layerConfig: ConfigBaseClass): TypeLayerControls => {
       const controls: TypeLayerControls = {
         highlight: layerConfig.initialSettings?.controls?.highlight !== undefined ? layerConfig.initialSettings?.controls?.highlight : true,
         hover: layerConfig.initialSettings?.controls?.hover !== undefined ? layerConfig.initialSettings?.controls?.hover : true,
@@ -156,6 +156,9 @@ export class LegendEventProcessor extends AbstractEventProcessor {
     };
 
     const createNewLegendEntries = (currentLevel: number, existingEntries: TypeLegendLayer[]): void => {
+      // If outside of range of layer paths, stop
+      if (layerPathNodes.length < currentLevel) return;
+
       const suffix = layerPathNodes.slice(0, currentLevel);
       const entryLayerPath = suffix.join('/');
       const layerConfig = MapEventProcessor.getMapViewerLayerAPI(mapId).getLayerEntryConfig(entryLayerPath);

--- a/packages/geoview-core/src/core/components/data-table/hooks/useFeatureFieldInfos.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useFeatureFieldInfos.tsx
@@ -5,7 +5,7 @@ import { logger } from '@/core/utils/logger';
 
 /**
  * Custom hook for caching the mapping of fieldInfos aka columns for data table.
- * @param {TypeLayerData[]} layerData data from the query
+ * @param {TypeAllFeatureInfoResultSetEntry[]} layerData data from the query
  * @returns {MappedLayerDataType[]} layerData with columns.
  */
 export function useFeatureFieldInfos(layerData: TypeAllFeatureInfoResultSetEntry[]): MappedLayerDataType[] {

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -77,7 +77,10 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   }, [layersData, layerDetails, selectedLayer]);
 
   const handleZoomTo = (): void => {
-    zoomToLayerExtent(layerDetails.layerPath);
+    zoomToLayerExtent(layerDetails.layerPath).catch((error) => {
+      // Log
+      logger.logPromiseFailed('in zoomToLayerExtent in layer-details.handleZoomTo', error);
+    });
   };
 
   const handleOpenTable = (): void => {

--- a/packages/geoview-core/src/core/components/legend/legend-layer.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer.tsx
@@ -84,7 +84,10 @@ export function LegendLayer(props: LegendLayerProps): JSX.Element {
    */
   const handleZoomTo = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
     e.stopPropagation();
-    zoomToLayerExtent(layer.layerPath);
+    zoomToLayerExtent(layer.layerPath).catch((error) => {
+      // Log
+      logger.logPromiseFailed('in zoomToLayerExtent in legend-layer.handleZoomTo', error);
+    });
   };
 
   const visibility = !getVisibilityFromOrderedLayerInfo(layer.layerPath);

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
@@ -2,7 +2,6 @@ import { useStore } from 'zustand';
 import { TypeSetStore, TypeGetStore } from '@/core/stores/geoview-store';
 import { useGeoViewStore } from '@/core/stores/stores-managers';
 import {
-  TypeLayerData,
   TypeFeatureInfoEntry,
   TypeResultSet,
   TypeResultSetEntry,
@@ -150,7 +149,13 @@ export function initFeatureInfoState(set: TypeSetStore, get: TypeGetStore): IFea
   } as IFeatureInfoState;
 }
 
-export type TypeFeatureInfoResultSetEntry = TypeResultSetEntry & TypeLayerData;
+export type TypeFeatureInfoSetEntry = {
+  eventListenerEnabled: boolean;
+  queryStatus: TypeQueryStatus;
+  features: TypeFeatureInfoEntry[] | undefined | null;
+};
+
+export type TypeFeatureInfoResultSetEntry = TypeResultSetEntry & TypeFeatureInfoSetEntry;
 
 export type TypeFeatureInfoResultSet = TypeResultSet<TypeFeatureInfoResultSetEntry>;
 
@@ -164,13 +169,13 @@ export type TypeHoverFeatureInfo =
   | undefined
   | null;
 
-export type TypeHoverLayerData = {
+export type TypeHoverSetEntry = {
   eventListenerEnabled: boolean;
   queryStatus: TypeQueryStatus;
   feature: TypeHoverFeatureInfo;
 };
 
-export type TypeHoverResultSetEntry = TypeResultSetEntry & TypeHoverLayerData;
+export type TypeHoverResultSetEntry = TypeResultSetEntry & TypeHoverSetEntry;
 
 export type TypeHoverResultSet = TypeResultSet<TypeHoverResultSetEntry>;
 

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/geochart-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/geochart-state.ts
@@ -1,6 +1,6 @@
 import { useStore } from 'zustand';
 import { GeoChartConfig } from '@/core/utils/config/reader/uuid-config-reader';
-import { TypeLayerData, TypeResultSet, TypeResultSetEntry } from '@/geo/map/map-schema-types';
+import { TypeQueryStatus, TypeResultSet, TypeResultSetEntry } from '@/geo/map/map-schema-types';
 
 import { useGeoViewStore } from '@/core/stores/stores-managers';
 import { TypeGetStore, TypeSetStore } from '@/core/stores/geoview-store';
@@ -125,11 +125,15 @@ export function initializeGeochartState(set: TypeSetStore, get: TypeGetStore): I
   return init;
 }
 
+export type GeoChartResultInfo = {
+  queryStatus: TypeQueryStatus;
+};
+
 export type GeoChartStoreByLayerPath = {
   [layerPath: string]: GeoChartConfig;
 };
 
-export type TypeGeochartResultSetEntry = TypeResultSetEntry & TypeLayerData;
+export type TypeGeochartResultSetEntry = TypeResultSetEntry & GeoChartResultInfo;
 
 export type TypeGeochartResultSet = TypeResultSet<TypeGeochartResultSetEntry>;
 
@@ -138,8 +142,9 @@ export type TypeGeochartResultSet = TypeResultSet<TypeGeochartResultSetEntry>;
 // **********************************************************
 export const useGeochartConfigs = (): GeoChartStoreByLayerPath =>
   useStore(useGeoViewStore(), (state) => state.geochartState.geochartChartsConfig);
-export const useGeochartLayerDataArray = (): TypeLayerData[] => useStore(useGeoViewStore(), (state) => state.geochartState.layerDataArray);
-export const useGeochartLayerDataArrayBatch = (): TypeLayerData[] =>
+export const useGeochartLayerDataArray = (): TypeGeochartResultSetEntry[] =>
+  useStore(useGeoViewStore(), (state) => state.geochartState.layerDataArray);
+export const useGeochartLayerDataArrayBatch = (): TypeGeochartResultSetEntry[] =>
   useStore(useGeoViewStore(), (state) => state.geochartState.layerDataArrayBatch);
 export const useGeochartSelectedLayerPath = (): string => useStore(useGeoViewStore(), (state) => state.geochartState.selectedLayerPath);
 

--- a/packages/geoview-core/src/core/utils/config/validation-classes/abstract-base-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/abstract-base-layer-entry-config.ts
@@ -2,7 +2,6 @@
 // ? we escape all private attribute in this file
 import {
   TypeBaseSourceVectorInitialConfig,
-  TypeLayerInitialSettings,
   TypeSourceImageEsriInitialConfig,
   TypeSourceImageInitialConfig,
   TypeSourceImageStaticInitialConfig,
@@ -12,7 +11,7 @@ import {
   TypeVectorTileSourceInitialConfig,
 } from '@/geo/map/map-schema-types';
 import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
-import { TypeJsonObject, TypeJsonValue } from '@/core/types/global-types';
+import { TypeJsonObject } from '@/core/types/global-types';
 import { FilterNodeArrayType } from '@/geo/utils/renderer/geoview-renderer-types';
 
 /** ******************************************************************************************************************************
@@ -30,12 +29,6 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
 
   /** Indicates if filter is on/off */
   legendFilterIsOff: boolean = false;
-
-  /**
-   * Initial settings to apply to the GeoView layer entry at creation time. Initial settings are inherited from the parent in the
-   * configuration tree.
-   */
-  initialSettings?: TypeLayerInitialSettings = {};
 
   /** Source settings to apply to the GeoView layer source at creation time. */
   source?:
@@ -81,9 +74,11 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
    * Overrides the serialization of the mother class
    * @returns {TypeJsonValue} The serialized TypeBaseLayerEntryConfig
    */
-  override onSerialize(): TypeJsonValue {
+  override onSerialize(): TypeJsonObject {
     // Call parent
-    const serialized = super.onSerialize() as unknown as AbstractBaseLayerEntryConfig;
+    // Can be any object so disable eslint
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const serialized = super.onSerialize() as any;
 
     // Copy values
     serialized.layerIdExtension = this.layerIdExtension;
@@ -91,6 +86,6 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
     serialized.initialSettings = this.initialSettings;
 
     // Return it
-    return serialized as unknown as TypeJsonValue;
+    return serialized;
   }
 }

--- a/packages/geoview-core/src/core/utils/config/validation-classes/group-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/group-layer-entry-config.ts
@@ -1,4 +1,4 @@
-import { CONST_LAYER_ENTRY_TYPES, TypeLayerEntryConfig, TypeLayerInitialSettings } from '@/geo/map/map-schema-types';
+import { CONST_LAYER_ENTRY_TYPES, TypeLayerEntryConfig } from '@/geo/map/map-schema-types';
 import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
 
 /** ******************************************************************************************************************************
@@ -13,12 +13,6 @@ export class GroupLayerEntryConfig extends ConfigBaseClass {
 
   /** The ending element of the layer configuration path is not used on groups. */
   declare layerIdExtension: never;
-
-  /**
-   * Initial settings to apply to the GeoView layer entry at creation time. Initial settings are inherited from the parent in the
-   * configuration tree.
-   */
-  initialSettings?: TypeLayerInitialSettings;
 
   /** Source settings to apply to the GeoView layer source at creation time is not used by groups. */
   declare source: never;

--- a/packages/geoview-core/src/geo/layer/layer-sets/abstract-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/abstract-layer-set.ts
@@ -43,6 +43,9 @@ export abstract class AbstractLayerSet {
   /** Indicates the default when registering a layer */
   #defaultRegisterLayerCheck = true;
 
+  // The registered layers
+  #registeredLayers: (AbstractGeoViewLayer | AbstractGVLayer)[] = [];
+
   // Keep all callback delegates references
   #onLayerSetUpdatedHandlers: LayerSetUpdatedDelegate[] = [];
 
@@ -162,6 +165,9 @@ export abstract class AbstractLayerSet {
   async registerLayer(layer: AbstractGeoViewLayer | AbstractGVLayer, layerPath: string): Promise<void> {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
 
+    // If the layer is already registered, skip it, we don't register twice
+    if (this.#registeredLayers.includes(layer)) return;
+
     // Wait a maximum of 20 seconds for the layer to get to loaded state so that it can get registered, otherwise another attempt will have to be made
     // This await is important when devs call this method directly to register ad-hoc layers.
     await whenThisThen(() => layer.getLayerConfig(layerPath)?.layerStatus === 'loaded', 20000);
@@ -216,6 +222,9 @@ export abstract class AbstractLayerSet {
       this.resultSet[layerPath].layerStatus = layer.getLayerStatus(layerPath);
       this.resultSet[layerPath].layerName = layerName;
     }
+
+    // Add to the registered layers array
+    this.#registeredLayers.push(layer);
 
     // Register the layer name changed handler
     layer.onLayerNameChanged(this.#boundHandleLayerNameChanged);

--- a/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
@@ -2,6 +2,8 @@ import { DataTableEventProcessor } from '@/api/event-processors/event-processor-
 import { QueryType } from '@/geo/map/map-schema-types';
 import { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { AbstractGVLayer } from '../gv-layers/abstract-gv-layer';
+import { WMS } from '../geoview-layers/raster/wms';
+import { GVWMS } from '../gv-layers/raster/gv-wms';
 import { AbstractLayerSet, PropagationType } from './abstract-layer-set';
 import {
   TypeAllFeatureInfoResultSet,
@@ -26,7 +28,12 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
   protected override onRegisterLayerCheck(layer: AbstractGeoViewLayer | AbstractGVLayer, layerPath: string): boolean {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
     // Return if the layer is of queryable type and source is queryable
-    return AbstractLayerSet.isQueryableType(layer) && AbstractLayerSet.isSourceQueryable(layer, layerPath);
+    return (
+      AbstractLayerSet.isQueryableType(layer) &&
+      !(layer instanceof WMS) &&
+      !(layer instanceof GVWMS) &&
+      AbstractLayerSet.isSourceQueryable(layer, layerPath)
+    );
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
@@ -1,19 +1,17 @@
 import { DataTableEventProcessor } from '@/api/event-processors/event-processor-children/data-table-event-processor';
-import { logger } from '@/core/utils/logger';
-import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
-import { QueryType, TypeLayerStatus } from '@/geo/map/map-schema-types';
-import { CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
-
-import { AbstractLayerSet } from './abstract-layer-set';
+import { QueryType } from '@/geo/map/map-schema-types';
+import { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
+import { AbstractGVLayer } from '../gv-layers/abstract-gv-layer';
+import { AbstractLayerSet, PropagationType } from './abstract-layer-set';
 import {
   TypeAllFeatureInfoResultSet,
   TypeAllFeatureInfoResultSetEntry,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 
 /**
- * A class containing a set of layers associated with a TypeAllFeatureInfoResultSet object, which will receive the result of a
- * "get  all feature info" request made on a specific layer of the map. The query is made for one layer at a time.
- *
+ * A Layer-set working with the LayerApi at handling a result set of registered layers and synchronizing
+ * events happening on them (in this case when the user queries for all records within a layer) with a store
+ * for UI updates.
  * @class AllFeatureInfoLayerSet
  */
 export class AllFeatureInfoLayerSet extends AbstractLayerSet {
@@ -21,109 +19,64 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
   declare resultSet: TypeAllFeatureInfoResultSet;
 
   /**
-   * Propagate to store
-   * @param {TypeAllFeatureInfoResultSetEntry} resultSetEntry - The result entry to propagate
-   * @private
-   */
-  #propagateToStore(resultSetEntry: TypeAllFeatureInfoResultSetEntry): void {
-    DataTableEventProcessor.propagateFeatureInfoToStore(this.getMapId(), resultSetEntry);
-  }
-
-  /**
-   * Overrides the behavior to apply when an all-feature-info-layer-set wants to check for condition to register a layer in its set.
-   * @param {ConfigBaseClass} layerConfig - The layer config
+   * Overrides the behavior to apply when a feature-info-layer-set wants to check for condition to register a layer in its set.
+   * @param {AbstractGeoViewLayer | AbstractGVLayer} layer - The layer
    * @returns {boolean} True when the layer should be registered to this all-feature-info-layer-set.
    */
-  protected override onRegisterLayerCheck(layerConfig: ConfigBaseClass): boolean {
-    // Log
-    logger.logTraceCore('ALL-FEATURE-INFO-LAYER-SET - onRegisterLayerCheck', layerConfig.layerPath);
-
-    // TODO: Make a util function for this check - this can be done prior to layer creation in config section
-    // for some layer type, we know there is no data-table
-    if (
-      layerConfig.schemaTag &&
-      [
-        CONST_LAYER_TYPES.ESRI_IMAGE,
-        CONST_LAYER_TYPES.IMAGE_STATIC,
-        CONST_LAYER_TYPES.XYZ_TILES,
-        CONST_LAYER_TYPES.VECTOR_TILES,
-        CONST_LAYER_TYPES.WMS,
-      ].includes(layerConfig.schemaTag)
-    )
-      return false;
-
-    // Default
-    return super.onRegisterLayerCheck(layerConfig);
+  protected override onRegisterLayerCheck(layer: AbstractGeoViewLayer | AbstractGVLayer, layerPath: string): boolean {
+    // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
+    // Return if the layer is of queryable type and source is queryable
+    return AbstractLayerSet.isQueryableType(layer) && AbstractLayerSet.isSourceQueryable(layer, layerPath);
   }
 
   /**
    * Overrides the behavior to apply when an all-feature-info-layer-set wants to register a layer in its set.
-   * @param {ConfigBaseClass} layerConfig - The layer config
+   * @param {AbstractGeoViewLayer | AbstractGVLayer} layer - The layer
    */
-  protected override onRegisterLayer(layerConfig: ConfigBaseClass): void {
-    // Log
-    logger.logTraceCore('ALL-FEATURE-INFO-LAYER-SET - onRegisterLayer', layerConfig.layerPath);
-
+  protected override onRegisterLayer(layer: AbstractGeoViewLayer | AbstractGVLayer, layerPath: string): void {
+    // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
     // Call parent
-    super.onRegisterLayer(layerConfig);
+    super.onRegisterLayer(layer, layerPath);
 
     // Update the resultSet data
-    this.resultSet[layerConfig.layerPath].eventListenerEnabled = true;
-    this.resultSet[layerConfig.layerPath].queryStatus = 'processed';
-    this.resultSet[layerConfig.layerPath].features = [];
+    this.resultSet[layerPath].eventListenerEnabled = true;
+    this.resultSet[layerPath].queryStatus = 'processed';
+    this.resultSet[layerPath].features = [];
 
-    // Propagate to store on registration
-    this.#propagateToStore(this.resultSet[layerConfig.layerPath]);
-    DataTableEventProcessor.setInitialSettings(this.getMapId(), layerConfig.layerPath);
+    // Extra initialization of settings
+    DataTableEventProcessor.setInitialSettings(this.getMapId(), layerPath);
   }
 
   /**
-   * Overrides the behavior to apply when unregistering a layer from the all-feature-info-layer-set.
-   * @param {ConfigBaseClass} layerConfig - The layer config
+   * Overrides the behavior to apply when propagating to the store
+   * @param {TypeAllFeatureInfoResultSetEntry} resultSetEntry - The result set entry to propagate
    */
-  protected override onUnregisterLayer(layerConfig: ConfigBaseClass): void {
-    // Log
-    logger.logTraceCore('ALL-FEATURE-INFO-LAYER-SET - onUnregisterLayer', layerConfig.layerPath);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected override onPropagateToStore(resultSetEntry: TypeAllFeatureInfoResultSetEntry, type: PropagationType): void {
+    // Redirect
+    this.#propagateToStore(resultSetEntry);
+  }
 
-    // Call parent
-    super.onUnregisterLayer(layerConfig);
+  /**
+   * Propagates the resultSetEntry to the store
+   * @param {TypeAllFeatureInfoResultSetEntry} resultSetEntry - The result set entry to propagate to the store
+   * @private
+   */
+  #propagateToStore(resultSetEntry: TypeAllFeatureInfoResultSetEntry): void {
+    // Only if the layerStatus is loaded
+    if (resultSetEntry.layerStatus === 'loaded') {
+      // Propagate
+      DataTableEventProcessor.propagateFeatureInfoToStore(this.getMapId(), resultSetEntry);
+    }
+  }
 
+  /**
+   * Overrides the behavior to apply when deleting from the store
+   * @param {string} layerPath - The layer path to delete from the store
+   */
+  protected override onDeleteFromStore(layerPath: string): void {
     // Remove it from data table info array
-    DataTableEventProcessor.deleteFeatureAllInfo(this.getMapId(), layerConfig.layerPath);
-  }
-
-  /**
-   * Overrides the behavior to apply when a layer status changed for a all-feature-info-layer-set.
-   * @param {ConfigBaseClass} layerConfig - The layer config
-   * @param {TypeLayerStatus} layerStatus - The new layer status
-   */
-  protected override onProcessLayerStatusChanged(layerConfig: ConfigBaseClass, layerStatus: TypeLayerStatus): void {
-    // Call parent. After this call, this.resultSet?.[layerPath]?.layerStatus may have changed!
-    super.onProcessLayerStatusChanged(layerConfig, layerStatus);
-
-    // Propagate to the store on layer status changed
-    this.#propagateToStore(this.resultSet[layerConfig.layerPath]);
-
-    // If the layer is in error
-    if (this.resultSet[layerConfig.layerPath].layerStatus === 'error') {
-      // Remove it from the store immediately
-      this.onUnregisterLayer(layerConfig);
-    }
-  }
-
-  /**
-   * Overrides behaviour when layer name is changed.
-   * @param {ConfigBaseClass} layerConfig - The layer path being affected
-   * @param {string} name - The new layer name
-   */
-  protected override onProcessNameChanged(layerConfig: ConfigBaseClass, name: string): void {
-    if (this.resultSet?.[layerConfig.layerPath]) {
-      // Call parent
-      super.onProcessNameChanged(layerConfig, name);
-
-      // Propagate to store
-      DataTableEventProcessor.propagateFeatureInfoToStore(this.getMapId(), this.resultSet[layerConfig.layerPath]);
-    }
+    DataTableEventProcessor.deleteFeatureAllInfo(this.getMapId(), layerPath);
   }
 
   /**
@@ -134,61 +87,53 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
    */
   // TODO: (futur development) The queryType is a door opened to allow the triggering using a bounding box or a polygon.
   async queryLayer(layerPath: string, queryType: QueryType = 'all'): Promise<TypeAllFeatureInfoResultSet | void> {
-    // TODO: REFACTOR - Watch out for code reentrancy between queries!
-    // TO.DOCONT: Consider using a LIFO pattern, per layer path, as the race condition resolution
+    // FIXME: Watch out for code reentrancy between queries!
+    // FIX.MECONT: Consider using a LIFO pattern, per layer path, as the race condition resolution
     // GV Each query should be distinct as far as the resultSet goes! The 'reinitialization' below isn't sufficient.
     // GV As it is (and was like this before events refactor), the this.resultSet is mutating between async calls.
 
-    // TODO: Refactor - Make this function throw an error instead of returning void as option of the promise (to have same behavior as feature-info-layer-set)
-
     // If valid layer path
-    if (this.layerApi.isLayerEntryConfigRegistered(layerPath) && this.resultSet[layerPath]) {
+    if (this.resultSet[layerPath]) {
+      // If event listener is disabled
+      if (!this.resultSet[layerPath].eventListenerEnabled) return Promise.resolve();
+
       // Get the layer config and layer associated with the layer path
       const layer = this.layerApi.getGeoviewLayerHybrid(layerPath);
-      const layerConfig = layer?.getLayerConfig(layerPath);
 
-      // If event listener disabled
-      if (!this.resultSet[layerPath].eventListenerEnabled) return Promise.resolve();
-      if (!AbstractLayerSet.isQueryable(layerConfig)) return Promise.resolve();
+      // If layer was found
+      if (layer) {
+        // If state is not queryable
+        if (!AbstractLayerSet.isStateQueryable(layer, layerPath)) return Promise.resolve();
 
-      // If layer is good
-      if (layer && layerConfig) {
-        // If layer is loaded
-        if (layerConfig.layerStatus === 'loaded') {
-          this.resultSet[layerPath].features = undefined;
-          this.resultSet[layerPath].queryStatus = 'processing';
-
-          // Propagate to the store
-          this.#propagateToStore(this.resultSet[layerConfig.layerPath]);
-
-          // Process query on results data
-          const promiseResult = AbstractLayerSet.queryLayerFeatures(this.resultSet[layerPath], layerConfig, layer, queryType, layerPath);
-
-          // Wait for promise to resolve
-          const arrayOfRecords = await promiseResult;
-
-          // Keep the features retrieved
-          this.resultSet[layerPath].features = arrayOfRecords;
-
-          // When property features is undefined, we are waiting for the query result.
-          // when Array.isArray(features) is true, the features property contains the query result.
-          // when property features is null, the query ended with an error.
-          this.resultSet[layerPath].queryStatus = arrayOfRecords ? 'processed' : 'error';
-        } else {
-          this.resultSet[layerPath].features = null;
-          this.resultSet[layerPath].queryStatus = 'error';
-        }
+        // Flag processing
+        this.resultSet[layerPath].queryStatus = 'processing';
 
         // Propagate to the store
-        this.#propagateToStore(this.resultSet[layerConfig.layerPath]);
+        this.#propagateToStore(this.resultSet[layerPath]);
+
+        // Process query on results data
+        const promiseResult = AbstractLayerSet.queryLayerFeatures(this.resultSet[layerPath], layer, queryType, layerPath);
+
+        // Wait for promise to resolve
+        const arrayOfRecords = await promiseResult;
+
+        // Keep the features retrieved
+        this.resultSet[layerPath].features = arrayOfRecords;
+
+        // When property features is undefined, we are waiting for the query result.
+        // when Array.isArray(features) is true, the features property contains the query result.
+        // when property features is null, the query ended with an error.
+        this.resultSet[layerPath].queryStatus = arrayOfRecords ? 'processed' : 'error';
+      } else {
+        this.resultSet[layerPath].features = null;
+        this.resultSet[layerPath].queryStatus = 'error';
       }
 
-      // Return the resultsSet
-      return this.resultSet;
+      // Propagate to the store
+      this.#propagateToStore(this.resultSet[layerPath]);
     }
 
-    // Log the error
-    logger.logError(`The queryLayer method cannot be used on an inexistant layer path (${layerPath})`);
-    return Promise.resolve();
+    // Return the resultsSet
+    return this.resultSet;
   }
 }

--- a/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
@@ -93,6 +93,7 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
   queryLayers(pixelCoordinate: Coordinate): void {
     // FIXME: Watch out for code reentrancy between queries!
     // FIX.MECONT: Consider using a LIFO pattern, per layer path, as the race condition resolution
+    // FIX.MECONT: For this one, because there is only one at the time, we should even query first layer in order of visible layer that is query able
     // Query types of what we're doing
     const queryType = 'at_pixel';
 

--- a/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
@@ -2,17 +2,19 @@ import debounce from 'lodash/debounce';
 
 import { Coordinate } from 'ol/coordinate';
 import { logger } from '@/core/utils/logger';
-import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
-import { CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
-import { AbstractLayerSet } from './abstract-layer-set';
+import { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
+import { AbstractGVLayer } from '../gv-layers/abstract-gv-layer';
+import { WMS } from '../geoview-layers/raster/wms';
+import { GVWMS } from '../gv-layers/raster/gv-wms';
+import { AbstractLayerSet, PropagationType } from './abstract-layer-set';
 import { LayerApi } from '@/geo/layer/layer';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
-import { TypeHoverResultSet } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
+import { TypeHoverResultSet, TypeHoverResultSetEntry } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 
 /**
- * A class containing a set of layers associated with a TypeHoverResultSetEntry object, which will receive the result of a
- * "get feature info" request made on the map layers when the user hovers over a position in a stationary way.
- *
+ * A Layer-set working with the LayerApi at handling a result set of registered layers and synchronizing
+ * events happening on them (in this case when the user hovers on the map) with a store
+ * for UI updates.
  * @class HoverFeatureInfoLayerSet
  */
 export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
@@ -37,35 +39,51 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
 
   /**
    * Overrides the behavior to apply when a hover-feature-info-layer-set wants to check for condition to register a layer in its set.
-   * @param {ConfigBaseClass} layerConfig - The layer config
+   * @param {AbstractGeoViewLayer | AbstractGVLayer} layer - The layer
    * @returns {boolean} True when the layer should be registered to this hover-feature-info-layer-set.
    */
-  protected override onRegisterLayerCheck(layerConfig: ConfigBaseClass): boolean {
-    // Log
-    logger.logTraceCore('HOVER-FEATURE-INFO-LAYER-SET - onRegisterLayerCheck', layerConfig.layerPath);
-
-    // For WMS, there's no hover, never
-    if (layerConfig.schemaTag === CONST_LAYER_TYPES.WMS) return false;
-
-    // Default
-    return super.onRegisterLayerCheck(layerConfig);
+  protected override onRegisterLayerCheck(layer: AbstractGeoViewLayer | AbstractGVLayer, layerPath: string): boolean {
+    // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
+    // Return if the layer is of queryable type and source is queryable
+    return (
+      AbstractLayerSet.isQueryableType(layer) &&
+      !(layer instanceof WMS) &&
+      !(layer instanceof GVWMS) &&
+      AbstractLayerSet.isSourceQueryable(layer, layerPath)
+    );
   }
 
   /**
    * Overrides the behavior to apply when a hover-feature-info-layer-set wants to register a layer in its set.
-   * @param {ConfigBaseClass} layerConfig - The layer config
+   * @param {AbstractGeoViewLayer | AbstractGVLayer} layer - The layer
    */
-  protected override onRegisterLayer(layerConfig: ConfigBaseClass): void {
-    // Log
-    logger.logTraceCore('HOVER-FEATURE-INFO-LAYER-SET - onRegisterLayer', layerConfig.layerPath);
-
+  protected override onRegisterLayer(layer: AbstractGeoViewLayer | AbstractGVLayer, layerPath: string): void {
+    // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
     // Call parent
-    super.onRegisterLayer(layerConfig);
+    super.onRegisterLayer(layer, layerPath);
 
     // Update the resultSet data
-    this.resultSet[layerConfig.layerPath].eventListenerEnabled = true;
-    this.resultSet[layerConfig.layerPath].queryStatus = 'processed';
-    this.resultSet[layerConfig.layerPath].feature = undefined;
+    this.resultSet[layerPath].eventListenerEnabled = true;
+    this.resultSet[layerPath].queryStatus = 'processed';
+    this.resultSet[layerPath].feature = undefined;
+  }
+
+  /**
+   * Overrides the behavior to apply when propagating to the store
+   * @param {TypeHoverResultSetEntry} resultSetEntry - The result set entry to propagate to the store
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected override onPropagateToStore(resultSetEntry: TypeHoverResultSetEntry, type: PropagationType): void {
+    // Nothing to do here, hover's store only needs updating when a query happens
+  }
+
+  /**
+   * Overrides the behavior to apply when deleting from the store
+   * @param {string} layerPath - The layer path to delete from the store
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected override onDeleteFromStore(layerPath: string): void {
+    // Nothing to do here, hover's store only needs updating when a query happens
   }
 
   /**
@@ -73,20 +91,26 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
    * @param {Coordinate} pixelCoordinate - The pixel coordinate where to query the features
    */
   queryLayers(pixelCoordinate: Coordinate): void {
+    // FIXME: Watch out for code reentrancy between queries!
+    // FIX.MECONT: Consider using a LIFO pattern, per layer path, as the race condition resolution
     // Query types of what we're doing
     const queryType = 'at_pixel';
 
     // Reinitialize the resultSet
     // Loop on each layer path in the resultSet
     Object.keys(this.resultSet).forEach((layerPath) => {
-      const layer = this.layerApi.getGeoviewLayerHybrid(layerPath);
-      const layerConfig = layer?.getLayerConfig(layerPath);
-
+      // If event listener is disabled
       if (!this.resultSet[layerPath].eventListenerEnabled) return;
-      if (!AbstractLayerSet.isQueryable(layerConfig)) return;
 
-      // If layer is loaded
-      if (layer && layerConfig?.layerStatus === 'loaded') {
+      // Get the layer config and layer associated with the layer path
+      const layer = this.layerApi.getGeoviewLayerHybrid(layerPath);
+
+      // If layer was found
+      if (layer) {
+        // If state is not queryable
+        if (!AbstractLayerSet.isStateQueryable(layer, layerPath)) return;
+
+        // Flag processing
         this.resultSet[layerPath].feature = undefined;
         this.resultSet[layerPath].queryStatus = 'init';
 
@@ -94,7 +118,7 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
         MapEventProcessor.setMapHoverFeatureInfo(this.getMapId(), this.resultSet[layerPath].feature);
 
         // Process query on results data
-        AbstractLayerSet.queryLayerFeatures(this.resultSet[layerPath], layerConfig, layer, queryType, pixelCoordinate)
+        AbstractLayerSet.queryLayerFeatures(this.resultSet[layerPath], layer, queryType, pixelCoordinate)
           .then((arrayOfRecords) => {
             if (arrayOfRecords === null) {
               this.resultSet[layerPath].queryStatus = 'error';
@@ -126,6 +150,9 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
       } else {
         this.resultSet[layerPath].feature = null;
         this.resultSet[layerPath].queryStatus = 'error';
+
+        // Propagate to the store
+        MapEventProcessor.setMapHoverFeatureInfo(this.getMapId(), this.resultSet[layerPath].feature);
       }
     });
   }

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -776,9 +776,10 @@ export class LayerApi {
 
   /**
    * Registers the layer in the LayerApi layer-sets to start managing it.
-   * @param {AbstractGeoViewLayer | AbstractGVLayer} layer - The layer to register
+   * This function may be used to start managing a layer in the UI when said layer has been created outside of the regular config->layer flow.
+   * @param {AbstractGVLayer} layer - The layer to register
    */
-  registerLayerInLayerSets(layer: AbstractGeoViewLayer | AbstractGVLayer, layerPath: string): void {
+  registerLayerInLayerSets(layer: AbstractGVLayer, layerPath: string): void {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
     // Tell the layer sets about it
     this.#allLayerSets.forEach((layerSet) => {

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -84,8 +84,6 @@ import { TypeLegendItem } from '@/core/components/layers/types';
 import { VectorLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-layer-entry-config';
 import { LegendEventProcessor } from '@/api/event-processors/event-processor-children/legend-event-processor';
 
-export type TypeRegisteredLayers = { [layerPath: string]: TypeLayerEntryConfig };
-
 export type GeoViewLayerAddedResult = {
   layer: AbstractGeoViewLayer;
   promiseLayer: Promise<void>;
@@ -126,7 +124,7 @@ export class LayerApi {
   #allLayerSets: AbstractLayerSet[];
 
   /** Layers with valid configuration for this map. */
-  #layerEntryConfigs: TypeRegisteredLayers = {};
+  #layerEntryConfigs: { [layerPath: string]: ConfigBaseClass } = {};
 
   // Dictionary holding all the old geoview layers
   #geoviewLayers: { [geoviewLayerId: string]: AbstractGeoViewLayer } = {};
@@ -146,10 +144,13 @@ export class LayerApi {
   // Keep all callback delegates references
   #onLayerAddedHandlers: LayerAddedDelegate[] = [];
 
+  // Keep all callback delegates references
   #onLayerRemovedHandlers: LayerRemovedDelegate[] = [];
 
+  // Keep all callback delegates references
   #onLayerVisibilityToggledHandlers: LayerVisibilityToggledDelegate[] = [];
 
+  // Keep all callback delegates references
   #onLayerItemVisibilityToggledHandlers: LayerVisibilityToggledDelegate[] = [];
 
   // Maximum time duration to wait when registering a layer for the time slider
@@ -343,23 +344,23 @@ export class LayerApi {
    * Gets the Layer Entry Configs
    * @returns {string[]} The GeoView Layer Entry Configs
    */
-  getLayerEntryConfigs(): TypeLayerEntryConfig[] {
+  getLayerEntryConfigs(): ConfigBaseClass[] {
     return Object.values(this.#layerEntryConfigs);
   }
 
   /**
    * Gets the layer configuration of the specified layer path.
    * @param {string} layerPath The layer path.
-   * @returns {TypeLayerEntryConfig | undefined} The layer configuration or undefined if not found.
+   * @returns {ConfigBaseClass | undefined} The layer configuration or undefined if not found.
    */
-  getLayerEntryConfig(layerPath: string): TypeLayerEntryConfig | undefined {
+  getLayerEntryConfig(layerPath: string): ConfigBaseClass | undefined {
     return this.#layerEntryConfigs?.[layerPath];
   }
 
   /**
    * Obsolete function to set the layer configuration in the registered layers.
    */
-  setLayerEntryConfigObsolete(layerConfig: TypeLayerEntryConfig): void {
+  setLayerEntryConfigObsolete(layerConfig: ConfigBaseClass): void {
     // FIXME: Obsolete function that should be deleted once the Layers refactoring is done
     // Keep it :( (get rid of this later)
     this.#layerEntryConfigs[layerConfig.layerPath] = layerConfig;
@@ -721,9 +722,9 @@ export class LayerApi {
 
   /**
    * Registers the layer identifier.
-   * @param {TypeLayerEntryConfig} layerConfig - The layer entry config to register
+   * @param {ConfigBaseClass} layerConfig - The layer entry config to register
    */
-  registerLayerConfigInit(layerConfig: TypeLayerEntryConfig): void {
+  registerLayerConfigInit(layerConfig: ConfigBaseClass): void {
     // Log (keep the commented line for now)
     // logger.logDebug('registerLayerConfigInit', layerConfig.layerPath, layerConfig.layerStatus);
 
@@ -733,15 +734,15 @@ export class LayerApi {
     // If not a group
     if (layerConfig.entryType !== CONST_LAYER_ENTRY_TYPES.GROUP) {
       // Register the layer entry config
-      this.registerLayerConfigUpdate(layerConfig as AbstractBaseLayerEntryConfig);
+      this.registerLayerConfigInLayerSets(layerConfig as AbstractBaseLayerEntryConfig);
     }
   }
 
   /**
-   * Registers the layer in the LayerApi to start managing it.
+   * Registers the layer config in the LayerApi to start managing it.
    * @param {AbstractBaseLayerEntryConfig} layerConfig - The layer entry config to register
    */
-  registerLayerConfigUpdate(layerConfig: AbstractBaseLayerEntryConfig): void {
+  registerLayerConfigInLayerSets(layerConfig: AbstractBaseLayerEntryConfig): void {
     // TODO: Refactor - Keeping this function separate from registerLayerConfigInit for now, because this registerLayerConfigUpdate was
     // TO.DOCONT: called in 'processListOfLayerEntryConfig' processes happening externally. I've since commented those calls to try
     // TO.DOCONT: things out. If things are stable, we can remove the dead code in the processListOfLayerEntryConfig and merge
@@ -765,12 +766,28 @@ export class LayerApi {
 
     // Tell the layer sets about it
     this.#allLayerSets.forEach((layerSet) => {
-      // Register or Unregister the layer
-      layerSet.registerOrUnregisterLayer(layerConfig, 'add');
+      // Register the config to the layer set
+      layerSet.registerLayerConfig(layerConfig);
     });
 
     // eslint-disable-next-line no-param-reassign
     layerConfig.layerStatus = 'registered';
+  }
+
+  /**
+   * Registers the layer in the LayerApi layer-sets to start managing it.
+   * @param {AbstractGeoViewLayer | AbstractGVLayer} layer - The layer to register
+   */
+  registerLayerInLayerSets(layer: AbstractGeoViewLayer | AbstractGVLayer, layerPath: string): void {
+    // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
+    // Tell the layer sets about it
+    this.#allLayerSets.forEach((layerSet) => {
+      // Register the layer to the layer set
+      layerSet.registerLayer(layer, layerPath).catch((error) => {
+        // Log
+        logger.logPromiseFailed('in registerLayer in registerLayerUpdate', error);
+      });
+    });
   }
 
   /**
@@ -987,16 +1004,9 @@ export class LayerApi {
 
   /**
    * Unregisters the layer in the LayerApi to stop managing it.
-   * @param {AbstractGeoViewLayer} geoviewLayer - The geoview layer associated with the layer entry config
-   * @param {TypeLayerEntryConfig} layerConfig - The layer entry config to unregister
+   * @param {ConfigBaseClass} layerConfig - The layer entry config to unregister
    */
-  unregisterLayer(layerConfig: TypeLayerEntryConfig): void {
-    // TODO: Fix - Reactivate and make this work
-    // // Register a handler on the layer config to track the status changed
-    // layerConfig.offLayerStatusChanged((config: ConfigBaseClass, layerStatusEvent: LayerStatusChangedEvent) => {
-    //   this.#handleLayerStatusChanged(config, layerStatusEvent);
-    // });
-
+  unregisterLayerConfig(layerConfig: ConfigBaseClass): void {
     // Unregister from ordered layer info
     this.#unregisterFromOrderedLayerInfo(layerConfig);
 
@@ -1011,47 +1021,47 @@ export class LayerApi {
 
     // Tell the layer sets about it
     this.#allLayerSets.forEach((layerSet) => {
-      // Register or Unregister the layer
-      layerSet.registerOrUnregisterLayer(layerConfig, 'remove');
+      // Unregister from the layer set
+      layerSet.unregister(layerConfig.layerPath);
     });
   }
 
   /**
    * Unregisters layer information from layer info store.
-   * @param {TypeLayerEntryConfig} layerConfig - The layer configuration to be unregistered.
+   * @param {ConfigBaseClass} layerConfig - The layer configuration to be unregistered.
    * @private
    */
-  #unregisterFromOrderedLayerInfo(layerConfig: TypeLayerEntryConfig): void {
+  #unregisterFromOrderedLayerInfo(layerConfig: ConfigBaseClass): void {
     // Remove from ordered layer info
     MapEventProcessor.removeOrderedLayerInfo(this.getMapId(), layerConfig.layerPath);
   }
 
   /**
    * Unregisters layer information from TimeSlider.
-   * @param {TypeLayerEntryConfig} layerConfig - The layer configuration to be unregistered.
+   * @param {ConfigBaseClass} layerConfig - The layer configuration to be unregistered.
    * @private
    */
-  #unregisterFromTimeSlider(layerConfig: TypeLayerEntryConfig): void {
+  #unregisterFromTimeSlider(layerConfig: ConfigBaseClass): void {
     // Remove from the TimeSlider
     TimeSliderEventProcessor.removeTimeSliderLayer(this.getMapId(), layerConfig.layerPath);
   }
 
   /**
    * Unregisters layer information from GeoChart.
-   * @param {TypeLayerEntryConfig} layerConfig - The layer configuration to be unregistered.
+   * @param {ConfigBaseClass} layerConfig - The layer configuration to be unregistered.
    * @private
    */
-  #unregisterFromGeoChart(layerConfig: TypeLayerEntryConfig): void {
+  #unregisterFromGeoChart(layerConfig: ConfigBaseClass): void {
     // Remove from the GeoChart Charts
     GeochartEventProcessor.removeGeochartChart(this.getMapId(), layerConfig.layerPath);
   }
 
   /**
    * Unregisters layer information from Swiper.
-   * @param {TypeLayerEntryConfig} layerConfig - The layer configuration to be unregistered.
+   * @param {ConfigBaseClass} layerConfig - The layer configuration to be unregistered.
    * @private
    */
-  #unregisterFromSwiper(layerConfig: TypeLayerEntryConfig): void {
+  #unregisterFromSwiper(layerConfig: ConfigBaseClass): void {
     // Remove it from the Swiper
     SwiperEventProcessor.removeLayerPath(this.getMapId(), layerConfig.layerPath);
   }
@@ -1084,18 +1094,18 @@ export class LayerApi {
   /**
    * Checks if the layer results sets are all ready using the resultSet from the FeatureInfo LayerSet
    */
-  checkFeatureInfoLayerResultSetsReady(callbackNotReady?: (layerEntryConfig: TypeLayerEntryConfig) => void): boolean {
+  checkFeatureInfoLayerResultSetsReady(callbackNotReady?: (layerEntryConfig: ConfigBaseClass) => void): boolean {
     // For each registered layer entry
     let allGood = true;
-    Object.entries(this.#layerEntryConfigs).forEach(([layerPath, registeredLayer]) => {
+    this.getLayerEntryConfigs().forEach((layerConfig) => {
       // If not queryable, don't expect a result set
-      if (!registeredLayer.source?.featureInfo?.queryable) return;
+      if (!(layerConfig as AbstractBaseLayerEntryConfig).source?.featureInfo?.queryable) return;
 
       const { resultSet } = this.featureInfoLayerSet;
-      const layerResultSetReady = Object.keys(resultSet).includes(layerPath);
+      const layerResultSetReady = Object.keys(resultSet).includes(layerConfig.layerPath);
       if (!layerResultSetReady) {
         // Callback about it
-        callbackNotReady?.(registeredLayer);
+        callbackNotReady?.(layerConfig);
         allGood = false;
       }
     });
@@ -1108,6 +1118,9 @@ export class LayerApi {
    * Removes all geoview layers from the map
    */
   removeAllGeoviewLayers(): void {
+    // FIXME: Layers refactoring. When working in LAYERS_HYBRID_MODE=true, the GVLayers aren't created until the layer config gets in 'processed' layer status.
+    // FIX.MECONT: Therefore, this can't remove the layers that failed due to for example bad metadataUrl.
+    // FIX.MECONT: To effectively remove all layers in the UI boxes, this removal process should be using the 'LayerConfigs' (and the layer paths). Not the 'Layer' classes.
     // For each Geoview layers
     this.getGeoviewLayersHybrid().forEach((geoviewLayer) => {
       // Remove it
@@ -1138,7 +1151,7 @@ export class LayerApi {
         // Remove ol layer
         if (this.getOLLayer(registeredLayerPath)) this.mapViewer.map.removeLayer(this.getOLLayer(registeredLayerPath) as BaseLayer);
         // Unregister layer
-        this.unregisterLayer(this.getLayerEntryConfig(registeredLayerPath)!);
+        this.unregisterLayerConfig(this.getLayerEntryConfig(registeredLayerPath)!);
         // Remove from registered layers
         delete this.#layerEntryConfigs[layerPath];
       }
@@ -1153,7 +1166,7 @@ export class LayerApi {
 
       // If it is a single layer, remove geoview layer
       if (layerPathNodes.length === 1 || (layerPathNodes.length === 2 && geoviewLayer.listOfLayerEntryConfig.length === 1)) {
-        geoviewLayer.olRootLayer!.dispose();
+        geoviewLayer.olRootLayer?.dispose();
         delete this.#geoviewLayers[layerPathNodes[0]];
         const { mapFeaturesConfig } = this.mapViewer;
 
@@ -1391,13 +1404,13 @@ export class LayerApi {
    * @param {string} name - The new name to use.
    */
   setLayerName(layerPath: string, name: string): void {
-    const layerConfig = this.#layerEntryConfigs[layerPath];
-    if (layerConfig) {
-      layerConfig.layerName = createLocalizedString(name);
-      this.#allLayerSets.forEach((layerSet) => {
-        // Process the layer status change
-        layerSet.processNameChanged(layerConfig, name);
-      });
+    // Get the layer
+    const layer = this.getGeoviewLayerHybrid(layerPath);
+
+    // If found
+    if (layer) {
+      // Set the layer name on the layer
+      layer.setLayerName(layerPath, createLocalizedString(name));
     } else {
       logger.logError(`Unable to find layer ${layerPath}`);
     }
@@ -1411,7 +1424,7 @@ export class LayerApi {
    * @param {'aliasFields' | 'outfields'} fields - The fields to change.
    */
   redefineFeatureFields(layerPath: string, fieldNames: string, fields: 'aliasFields' | 'outfields'): void {
-    const layerConfig = this.#layerEntryConfigs[layerPath];
+    const layerConfig = this.#layerEntryConfigs[layerPath] as AbstractBaseLayerEntryConfig;
     if (!layerConfig) logger.logError(`Unable to find layer ${layerPath}`);
     else if (layerConfig.source?.featureInfo && layerConfig.source?.featureInfo.queryable !== false)
       layerConfig.source.featureInfo[fields] = createLocalizedString(fieldNames);

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -208,6 +208,7 @@ export type TypeResultSet<T extends TypeResultSetEntry = TypeResultSetEntry> = {
   [layerPath: string]: T;
 };
 
+// TODO: Refactor - Check if this type is still used and replace it with something like TypeAllFeatureInfoResultSetEntry?
 export type TypeLayerData = {
   eventListenerEnabled: boolean;
   // When property features is undefined, we are waiting for the query result.

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -280,7 +280,7 @@ export class MapViewer {
     // initialize layers and load the layers passed in from map config if any
     this.layer = new LayerApi(this);
 
-    // TODO: Check - Maybe we want to await on this (for the Geocore layers that take longer to initialize) - to confirm
+    // Load the list of geoview layers in the config to add all layers on the map
     this.layer.loadListOfGeoviewLayer(this.mapFeaturesConfig.map.listOfGeoviewLayerConfig).catch((error) => {
       // Log
       logger.logPromiseFailed('loadListOfGeoviewLayer in initMap in MapViewer', error);
@@ -1380,8 +1380,8 @@ export class MapViewer {
    * @returns {Coordinate} The coordinate in the map projection
    */
   convertCoordinateFromProjToMapProj(coordinate: Coordinate, fromProj: ProjectionLike): Coordinate {
-    // TODO: In this function and equivalent 3 others below, make it so if the given projection is the same as the map projection
-    // TO.DOCONT: just skip and return the same geometry. It'd save many 'if' like 'if projA <> projB then call this' in the code base
+    // TODO: In this function and equivalent 3 others below, make it so that if the given projection is the same as the map projection
+    // TO.DOCONT: it just skips and returns the same geometry. It'd save many 'if' like 'if projA <> projB then call this' in the code base
     return Projection.transform(coordinate, fromProj, this.getProjection());
   }
 


### PR DESCRIPTION
# Description

Fourth spring-board PR focusing mainly on the LayerSets with a distinction between registering a layer-config and registering a layer.
- Changed a couple TypeLayerEntryConfig to ConfigBaseClass to better represent the actual object being used.
- Fixing the auto-switching to Details panel when we were changing a layer name via the event template
- Removed the layer config parameter in the create default style in the geoview-renderer class

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted, June 3rd: 16h45: https://alex-nrcan.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2201)
<!-- Reviewable:end -->
