### PR TITLE
refactor(layers) - Fifth spring-board PR focusing on the new layers, bounds calculation, layerStatus propagation and more

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -12,10 +12,10 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.17.0
-        version: 7.24.5
+        version: 7.24.7
       '@babel/eslint-parser':
         specifier: ^7.17.0
-        version: 7.24.5(@babel/core@7.24.5)(eslint@8.57.0)
+        version: 7.24.7(@babel/core@7.24.7)(eslint@8.57.0)
       '@typescript-eslint/eslint-plugin':
         specifier: ~7.8.0
         version: 7.8.0(@typescript-eslint/parser@7.8.0)(eslint@8.57.0)(typescript@4.9.5)
@@ -27,7 +27,7 @@ importers:
         version: 8.57.0
       eslint-config-airbnb:
         specifier: ^19.0.4
-        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.1)(eslint@8.57.0)
+        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.2)(eslint@8.57.0)
       eslint-config-prettier:
         specifier: ^8.3.0
         version: 8.10.0(eslint@8.57.0)
@@ -45,7 +45,7 @@ importers:
         version: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.57.0)(prettier@2.8.8)
       eslint-plugin-react:
         specifier: ^7.28.0
-        version: 7.34.1(eslint@8.57.0)
+        version: 7.34.2(eslint@8.57.0)
       eslint-plugin-react-hooks:
         specifier: ^4.3.0
         version: 4.6.2(eslint@8.57.0)
@@ -64,16 +64,16 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.17.0
-        version: 7.24.5
+        version: 7.24.7
       '@babel/eslint-parser':
         specifier: ^7.17.0
-        version: 7.24.5(@babel/core@7.24.5)(eslint@8.57.0)
+        version: 7.24.7(@babel/core@7.24.7)(eslint@8.57.0)
       '@babel/runtime':
         specifier: ^7.17.0
-        version: 7.24.5
+        version: 7.24.7
       '@types/react':
         specifier: ^18.2.0
-        version: 18.3.2
+        version: 18.3.3
       '@types/react-dom':
         specifier: ^18.2.0
         version: 18.3.0
@@ -88,7 +88,7 @@ importers:
         version: 8.57.0
       eslint-config-airbnb:
         specifier: ^19.0.4
-        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.1)(eslint@8.57.0)
+        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.2)(eslint@8.57.0)
       eslint-config-prettier:
         specifier: ^8.3.0
         version: 8.10.0(eslint@8.57.0)
@@ -106,7 +106,7 @@ importers:
         version: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.57.0)(prettier@2.8.8)
       eslint-plugin-react:
         specifier: ^7.28.0
-        version: 7.34.1(eslint@8.57.0)
+        version: 7.34.2(eslint@8.57.0)
       eslint-plugin-react-hooks:
         specifier: ^4.3.0
         version: 4.6.2(eslint@8.57.0)
@@ -127,34 +127,34 @@ importers:
     dependencies:
       '@emotion/react':
         specifier: ^11.11.0
-        version: 11.11.4(@types/react@18.3.2)(react@18.3.1)
+        version: 11.11.4(@types/react@18.3.3)(react@18.3.1)
       '@emotion/styled':
         specifier: ^11.11.0
-        version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.2)(react@18.3.1)
+        version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.3.1)
       '@fontsource/roboto':
         specifier: ^5.0.13
         version: 5.0.13
       '@mui/base':
         specifier: 5.0.0-beta.37
-        version: 5.0.0-beta.37(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+        version: 5.0.0-beta.37(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@mui/icons-material':
         specifier: ^5.15.11
-        version: 5.15.17(@mui/material@5.15.17)(@types/react@18.3.2)(react@18.3.1)
+        version: 5.15.20(@mui/material@5.15.20)(@types/react@18.3.3)(react@18.3.1)
       '@mui/lab':
         specifier: 5.0.0-alpha.168
-        version: 5.0.0-alpha.168(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/material@5.15.17)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+        version: 5.0.0-alpha.168(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/material@5.15.20)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@mui/material':
         specifier: ^5.15.11
-        version: 5.15.17(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+        version: 5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@mui/styles':
         specifier: ^5.15.11
-        version: 5.15.17(@types/react@18.3.2)(react@18.3.1)
+        version: 5.15.20(@types/react@18.3.3)(react@18.3.1)
       '@mui/system':
         specifier: ^5.15.11
-        version: 5.15.15(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react@18.3.1)
+        version: 5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react@18.3.1)
       '@mui/x-date-pickers':
         specifier: ^7.6.1
-        version: 7.6.2(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/material@5.15.17)(@types/react@18.3.2)(dayjs@1.11.11)(react-dom@18.3.1)(react@18.3.1)
+        version: 7.7.0(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/material@5.15.20)(@types/react@18.3.3)(dayjs@1.11.11)(react-dom@18.3.1)(react@18.3.1)
       '@nieuwlandgeo/sldreader':
         specifier: ^0.3.1
         version: 0.3.1(ol@9.1.0)
@@ -163,10 +163,10 @@ importers:
         version: 9.7.3(react-dom@18.3.1)(react@18.3.1)
       ajv:
         specifier: ^8.12.0
-        version: 8.13.0
+        version: 8.16.0
       axios:
         specifier: ^1.3.4
-        version: 1.6.8
+        version: 1.7.2
       dayjs:
         specifier: ^1.11.9
         version: 1.11.11
@@ -208,13 +208,13 @@ importers:
         version: 7.4.7(react@18.3.1)
       material-react-table:
         specifier: ^2.13.0
-        version: 2.13.0(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/icons-material@5.15.17)(@mui/material@5.15.17)(@mui/x-date-pickers@7.6.2)(react-dom@18.3.1)(react@18.3.1)
+        version: 2.13.0(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/icons-material@5.15.20)(@mui/material@5.15.20)(@mui/x-date-pickers@7.7.0)(react-dom@18.3.1)(react@18.3.1)
       ol:
-        specifier: ^9.0.0
+        specifier: 9.1.0
         version: 9.1.0
       ol-mapbox-style:
         specifier: ^12.2.1
-        version: 12.3.2(ol@9.1.0)
+        version: 12.3.3(ol@9.1.0)
       proj4:
         specifier: ^2.7.5
         version: 2.11.0
@@ -247,89 +247,89 @@ importers:
         version: 1.10.3
       yet-another-react-lightbox:
         specifier: ^3.11.3
-        version: 3.18.0(react-dom@18.3.1)(react@18.3.1)
+        version: 3.20.0(react-dom@18.3.1)(react@18.3.1)
       zustand:
         specifier: ~4.4.1
-        version: 4.4.7(@types/react@18.3.2)(react@18.3.1)
+        version: 4.4.7(@types/react@18.3.3)(react@18.3.1)
     devDependencies:
       '@babel/cli':
         specifier: ^7.17.0
-        version: 7.24.5(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/core':
         specifier: ^7.17.0
-        version: 7.24.5
+        version: 7.24.7
       '@babel/eslint-parser':
         specifier: ^7.17.0
-        version: 7.24.5(@babel/core@7.24.5)(eslint@8.57.0)
+        version: 7.24.7(@babel/core@7.24.7)(eslint@8.57.0)
       '@babel/plugin-proposal-decorators':
         specifier: ^7.17.0
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-proposal-do-expressions':
         specifier: ^7.16.7
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-proposal-export-default-from':
         specifier: ^7.16.7
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-proposal-function-bind':
         specifier: ^7.16.7
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-proposal-function-sent':
         specifier: ^7.16.7
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-proposal-pipeline-operator':
         specifier: ^7.16.7
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-proposal-throw-expressions':
         specifier: ^7.16.7
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-syntax-dynamic-import':
         specifier: ^7.8.3
-        version: 7.8.3(@babel/core@7.24.5)
+        version: 7.8.3(@babel/core@7.24.7)
       '@babel/plugin-syntax-import-meta':
         specifier: ^7.10.4
-        version: 7.10.4(@babel/core@7.24.5)
+        version: 7.10.4(@babel/core@7.24.7)
       '@babel/plugin-transform-class-properties':
         specifier: ^7.22.0
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-export-namespace-from':
         specifier: ^7.22.0
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-json-strings':
         specifier: ^7.22.0
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-logical-assignment-operators':
         specifier: ^7.22.0
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-nullish-coalescing-operator':
         specifier: ^7.22.0
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-numeric-separator':
         specifier: ^7.22.0
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-optional-chaining':
         specifier: ^7.22.0
-        version: 7.24.5(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-private-methods':
         specifier: ^7.22.0
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-runtime':
         specifier: ^7.17.0
-        version: 7.24.3(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/preset-env':
         specifier: ^7.16.11
-        version: 7.24.5(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/preset-react':
         specifier: ^7.16.7
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/preset-typescript':
         specifier: ^7.16.7
-        version: 7.24.1(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/runtime':
         specifier: ^7.17.0
-        version: 7.24.5
+        version: 7.24.7
       '@babel/runtime-corejs3':
         specifier: ^7.17.0
-        version: 7.24.5
+        version: 7.24.7
       '@types/create-react-class':
         specifier: ^15.6.3
         version: 15.6.8
@@ -344,7 +344,7 @@ importers:
         version: 27.5.2
       '@types/lodash':
         specifier: ^4.14.188
-        version: 4.17.1
+        version: 4.17.5
       '@types/lodash-webpack-plugin':
         specifier: ^0.11.6
         version: 0.11.9
@@ -353,7 +353,7 @@ importers:
         version: 2.5.5
       '@types/react':
         specifier: ^18.2.0
-        version: 18.3.2
+        version: 18.3.3
       '@types/react-dom':
         specifier: ^18.2.0
         version: 18.3.0
@@ -374,10 +374,10 @@ importers:
         version: 7.8.0(eslint@8.57.0)(typescript@4.9.5)
       babel-jest:
         specifier: ^27.4.6
-        version: 27.5.1(@babel/core@7.24.5)
+        version: 27.5.1(@babel/core@7.24.7)
       babel-loader:
         specifier: ^8.2.3
-        version: 8.3.0(@babel/core@7.24.5)(webpack@5.91.0)
+        version: 8.3.0(@babel/core@7.24.7)(webpack@5.92.0)
       babel-plugin-import:
         specifier: ^1.13.3
         version: 1.13.8
@@ -386,19 +386,19 @@ importers:
         version: 3.3.4
       compression-webpack-plugin:
         specifier: ^10.0.0
-        version: 10.0.0(webpack@5.91.0)
+        version: 10.0.0(webpack@5.92.0)
       copy-webpack-plugin:
         specifier: ^10.2.4
-        version: 10.2.4(webpack@5.91.0)
+        version: 10.2.4(webpack@5.92.0)
       css-loader:
         specifier: ^6.6.0
-        version: 6.11.0(webpack@5.91.0)
+        version: 6.11.0(webpack@5.92.0)
       eslint:
         specifier: ^8.8.0
         version: 8.57.0
       eslint-config-airbnb:
         specifier: ^19.0.4
-        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.1)(eslint@8.57.0)
+        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.2)(eslint@8.57.0)
       eslint-config-prettier:
         specifier: ^8.3.0
         version: 8.10.0(eslint@8.57.0)
@@ -416,13 +416,13 @@ importers:
         version: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.57.0)(prettier@2.8.8)
       eslint-plugin-react:
         specifier: ^7.28.0
-        version: 7.34.1(eslint@8.57.0)
+        version: 7.34.2(eslint@8.57.0)
       eslint-plugin-react-hooks:
         specifier: ^4.3.0
         version: 4.6.2(eslint@8.57.0)
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.91.0)
+        version: 6.2.0(webpack@5.92.0)
       gh-pages:
         specifier: ^3.2.3
         version: 3.2.3
@@ -431,37 +431,37 @@ importers:
         version: 7.2.3
       html-loader:
         specifier: ~5.0.0
-        version: 5.0.0(webpack@5.91.0)
+        version: 5.0.0(webpack@5.92.0)
       html-webpack-plugin:
         specifier: ^5.5.0
-        version: 5.6.0(webpack@5.91.0)
+        version: 5.6.0(webpack@5.92.0)
       jest:
         specifier: ^27.4.7
         version: 27.5.1
       lodash-webpack-plugin:
         specifier: ^0.11.6
-        version: 0.11.6(webpack@5.91.0)
+        version: 0.11.6(webpack@5.92.0)
       markdown-loader:
         specifier: ~8.0.0
-        version: 8.0.0(webpack@5.91.0)
+        version: 8.0.0(webpack@5.92.0)
       prettier:
         specifier: ^2.6.0
         version: 2.8.8
       sass:
         specifier: ^1.49.7
-        version: 1.77.1
+        version: 1.77.5
       sass-loader:
         specifier: ^12.4.0
-        version: 12.6.0(sass@1.77.1)(webpack@5.91.0)
+        version: 12.6.0(sass@1.77.5)(webpack@5.92.0)
       simple-zustand-devtools:
         specifier: ^1.1.0
-        version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)(zustand@4.4.7)
+        version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)(zustand@4.4.7)
       style-loader:
         specifier: ^3.3.1
-        version: 3.3.4(webpack@5.91.0)
+        version: 3.3.4(webpack@5.92.0)
       terser-webpack-plugin:
         specifier: ^5.3.1
-        version: 5.3.10(webpack@5.91.0)
+        version: 5.3.10(webpack@5.92.0)
       typedoc:
         specifier: ^0.23.14
         version: 0.23.28(typescript@4.9.5)
@@ -470,7 +470,7 @@ importers:
         version: 4.9.5
       webpack:
         specifier: ^5.68.0
-        version: 5.91.0(webpack-cli@4.10.0)
+        version: 5.92.0(webpack-cli@4.10.0)
       webpack-bundle-analyzer:
         specifier: ^4.5.0
         version: 4.10.2
@@ -479,10 +479,10 @@ importers:
         version: 3.1.0
       webpack-cli:
         specifier: ^4.9.2
-        version: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.91.0)
+        version: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.2(webpack-cli@4.10.0)(webpack@5.91.0)
+        version: 4.15.2(webpack-cli@4.10.0)(webpack@5.92.0)
       webpack-merge:
         specifier: ^5.8.0
         version: 5.10.0
@@ -491,10 +491,10 @@ importers:
     dependencies:
       '@mui/material':
         specifier: ^5.15.11
-        version: 5.15.17(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+        version: 5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       geochart:
         specifier: Canadian-Geospatial-Platform/geochart#develop
-        version: github.com/Canadian-Geospatial-Platform/geochart/a3f626faf274e58b2683f6ac9bcbe7387c27d89a(@types/react@18.3.2)
+        version: github.com/Canadian-Geospatial-Platform/geochart/a3f626faf274e58b2683f6ac9bcbe7387c27d89a(@types/react@18.3.3)
       geoview-core:
         specifier: workspace:~0.1.0
         version: link:../geoview-core
@@ -504,19 +504,19 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.17.0
-        version: 7.24.5
+        version: 7.24.7
       '@babel/eslint-parser':
         specifier: ^7.17.0
-        version: 7.24.5(@babel/core@7.24.5)(eslint@8.57.0)
+        version: 7.24.7(@babel/core@7.24.7)(eslint@8.57.0)
       '@babel/runtime':
         specifier: ^7.17.0
-        version: 7.24.5
+        version: 7.24.7
       '@types/lodash':
         specifier: ^4.14.188
-        version: 4.17.1
+        version: 4.17.5
       '@types/react':
         specifier: ^18.2.0
-        version: 18.3.2
+        version: 18.3.3
       '@types/react-dom':
         specifier: ^18.2.0
         version: 18.3.0
@@ -531,7 +531,7 @@ importers:
         version: 8.57.0
       eslint-config-airbnb:
         specifier: ^19.0.4
-        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.1)(eslint@8.57.0)
+        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.2)(eslint@8.57.0)
       eslint-config-prettier:
         specifier: ^8.3.0
         version: 8.10.0(eslint@8.57.0)
@@ -549,7 +549,7 @@ importers:
         version: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.57.0)(prettier@2.8.8)
       eslint-plugin-react:
         specifier: ^7.28.0
-        version: 7.34.1(eslint@8.57.0)
+        version: 7.34.2(eslint@8.57.0)
       eslint-plugin-react-hooks:
         specifier: ^4.3.0
         version: 4.6.2(eslint@8.57.0)
@@ -578,7 +578,7 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       ol:
-        specifier: ^9.0.0
+        specifier: 9.1.0
         version: 9.1.0
       react-draggable:
         specifier: ^4.4.5
@@ -586,16 +586,16 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.17.0
-        version: 7.24.5
+        version: 7.24.7
       '@babel/eslint-parser':
         specifier: ^7.17.0
-        version: 7.24.5(@babel/core@7.24.5)(eslint@8.57.0)
+        version: 7.24.7(@babel/core@7.24.7)(eslint@8.57.0)
       '@babel/runtime':
         specifier: ^7.17.0
-        version: 7.24.5
+        version: 7.24.7
       '@types/lodash':
         specifier: ^4.14.188
-        version: 4.17.1
+        version: 4.17.5
       '@typescript-eslint/eslint-plugin':
         specifier: ~7.8.0
         version: 7.8.0(@typescript-eslint/parser@7.8.0)(eslint@8.57.0)(typescript@4.9.5)
@@ -607,7 +607,7 @@ importers:
         version: 8.57.0
       eslint-config-airbnb:
         specifier: ^19.0.4
-        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.1)(eslint@8.57.0)
+        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.2)(eslint@8.57.0)
       eslint-config-prettier:
         specifier: ^8.3.0
         version: 8.10.0(eslint@8.57.0)
@@ -625,7 +625,7 @@ importers:
         version: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.57.0)(prettier@2.8.8)
       eslint-plugin-react:
         specifier: ^7.28.0
-        version: 7.34.1(eslint@8.57.0)
+        version: 7.34.2(eslint@8.57.0)
       eslint-plugin-react-hooks:
         specifier: ^4.3.0
         version: 4.6.2(eslint@8.57.0)
@@ -646,23 +646,23 @@ importers:
     dependencies:
       '@mui/material':
         specifier: ^5.15.11
-        version: 5.15.17(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
+        version: 5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       geoview-core:
         specifier: workspace:~0.1.0
         version: link:../geoview-core
     devDependencies:
       '@babel/core':
         specifier: ^7.17.0
-        version: 7.24.5
+        version: 7.24.7
       '@babel/eslint-parser':
         specifier: ^7.17.0
-        version: 7.24.5(@babel/core@7.24.5)(eslint@8.57.0)
+        version: 7.24.7(@babel/core@7.24.7)(eslint@8.57.0)
       '@babel/runtime':
         specifier: ^7.17.0
-        version: 7.24.5
+        version: 7.24.7
       '@types/react':
         specifier: ^18.2.0
-        version: 18.3.2
+        version: 18.3.3
       '@types/react-dom':
         specifier: ^18.2.0
         version: 18.3.0
@@ -677,7 +677,7 @@ importers:
         version: 8.57.0
       eslint-config-airbnb:
         specifier: ^19.0.4
-        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.1)(eslint@8.57.0)
+        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.2)(eslint@8.57.0)
       eslint-config-prettier:
         specifier: ^8.3.0
         version: 8.10.0(eslint@8.57.0)
@@ -695,7 +695,7 @@ importers:
         version: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.57.0)(prettier@2.8.8)
       eslint-plugin-react:
         specifier: ^7.28.0
-        version: 7.34.1(eslint@8.57.0)
+        version: 7.34.2(eslint@8.57.0)
       eslint-plugin-react-hooks:
         specifier: ^4.3.0
         version: 4.6.2(eslint@8.57.0)
@@ -725,16 +725,16 @@ packages:
       '@jridgewell/trace-mapping': 0.3.25
     dev: true
 
-  /@babel/cli@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-2qg1mYtJRsOOWF6IUwLP5jI42P8Cc0hQ5TmnjLrik/4DKouO8dFJN80HEz81VmVeUs97yuuf3vQ/9j7Elrcjlg==}
+  /@babel/cli@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-8dfPprJgV4O14WTx+AQyEA+opgUKPrsIXX/MdL50J1n06EQJ6m1T+CdsJe0qEC0B/Xl85i+Un5KVAxd/PACX9A==}
     engines: {node: '>=6.9.0'}
     hasBin: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
+      '@babel/core': 7.24.7
       '@jridgewell/trace-mapping': 0.3.25
-      commander: 4.1.1
+      commander: 6.2.1
       convert-source-map: 2.0.0
       fs-readdir-recursive: 1.1.0
       glob: 7.2.3
@@ -745,34 +745,34 @@ packages:
       chokidar: 3.6.0
     dev: true
 
-  /@babel/code-frame@7.24.2:
-    resolution: {integrity: sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==}
+  /@babel/code-frame@7.24.7:
+    resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.24.5
+      '@babel/highlight': 7.24.7
       picocolors: 1.0.1
 
-  /@babel/compat-data@7.24.4:
-    resolution: {integrity: sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==}
+  /@babel/compat-data@7.24.7:
+    resolution: {integrity: sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/core@7.24.5:
-    resolution: {integrity: sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==}
+  /@babel/core@7.24.7:
+    resolution: {integrity: sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.24.2
-      '@babel/generator': 7.24.5
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
-      '@babel/helpers': 7.24.5
-      '@babel/parser': 7.24.5
-      '@babel/template': 7.24.0
-      '@babel/traverse': 7.24.5
-      '@babel/types': 7.24.5
+      '@babel/code-frame': 7.24.7
+      '@babel/generator': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-module-transforms': 7.24.7(@babel/core@7.24.7)
+      '@babel/helpers': 7.24.7
+      '@babel/parser': 7.24.7
+      '@babel/template': 7.24.7
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.3.5
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -780,1448 +780,1506 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/eslint-parser@7.24.5(@babel/core@7.24.5)(eslint@8.57.0):
-    resolution: {integrity: sha512-gsUcqS/fPlgAw1kOtpss7uhY6E9SFFANQ6EFX5GTvzUwaV0+sGaZWk6xq22MOdeT9wfxyokW3ceCUvOiRtZciQ==}
+  /@babel/eslint-parser@7.24.7(@babel/core@7.24.7)(eslint@8.57.0):
+    resolution: {integrity: sha512-SO5E3bVxDuxyNxM5agFv480YA2HO6ohZbGxbazZdIk3KQOPOGVNw6q78I9/lbviIf95eq6tPozeYnJLbjnC8IA==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
     dependencies:
-      '@babel/core': 7.24.5
+      '@babel/core': 7.24.7
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 8.57.0
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
     dev: true
 
-  /@babel/generator@7.24.5:
-    resolution: {integrity: sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==}
+  /@babel/generator@7.24.7:
+    resolution: {integrity: sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.24.5
+      '@babel/types': 7.24.7
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
-    dev: true
 
-  /@babel/helper-annotate-as-pure@7.22.5:
-    resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
+  /@babel/helper-annotate-as-pure@7.24.7:
+    resolution: {integrity: sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.24.5
+      '@babel/types': 7.24.7
     dev: true
 
-  /@babel/helper-builder-binary-assignment-operator-visitor@7.22.15:
-    resolution: {integrity: sha512-QkBXwGgaoC2GtGZRoma6kv7Szfv06khvhFav67ZExau2RaXzy8MpHSMO2PNoP2XtmQphJQRHFfg77Bq731Yizw==}
+  /@babel/helper-builder-binary-assignment-operator-visitor@7.24.7:
+    resolution: {integrity: sha512-xZeCVVdwb4MsDBkkyZ64tReWYrLRHlMN72vP7Bdm3OUOuyFZExhsHUUnuWnm2/XOlAJzR0LfPpB56WXZn0X/lA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.24.5
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/helper-compilation-targets@7.23.6:
-    resolution: {integrity: sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==}
+  /@babel/helper-compilation-targets@7.24.7:
+    resolution: {integrity: sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/compat-data': 7.24.4
-      '@babel/helper-validator-option': 7.23.5
-      browserslist: 4.23.0
+      '@babel/compat-data': 7.24.7
+      '@babel/helper-validator-option': 7.24.7
+      browserslist: 4.23.1
       lru-cache: 5.1.1
       semver: 6.3.1
     dev: true
 
-  /@babel/helper-create-class-features-plugin@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-uRc4Cv8UQWnE4NXlYTIIdM7wfFkOqlFztcC/gVXDKohKoVB3OyonfelUBaJzSwpBntZ2KYGF/9S7asCHsXwW6g==}
+  /@babel/helper-create-class-features-plugin@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-kTkaDl7c9vO80zeX1rJxnuRpEsD5tA81yh11X1gQo+PhSti3JS+7qeZo9U4RHobKRiFPKaGK3svUAeb8D0Q7eg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-member-expression-to-functions': 7.24.5
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.5)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/helper-split-export-declaration': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-function-name': 7.24.7
+      '@babel/helper-member-expression-to-functions': 7.24.7
+      '@babel/helper-optimise-call-expression': 7.24.7
+      '@babel/helper-replace-supers': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+      '@babel/helper-split-export-declaration': 7.24.7
       semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.24.5):
-    resolution: {integrity: sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==}
+  /@babel/helper-create-regexp-features-plugin@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-03TCmXy2FtXJEZfbXDTSqq1fRJArk7lX9DOFC/47VthYcxyIOx+eXQmdo6DOQvrbpIix+KfXwvuXdFDZHxt+rA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
       regexpu-core: 5.3.2
       semver: 6.3.1
     dev: true
 
-  /@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.24.5):
+  /@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.24.7):
     resolution: {integrity: sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.24.5
-      debug: 4.3.4
+      '@babel/core': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      debug: 4.3.5
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-environment-visitor@7.22.20:
-    resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-function-name@7.23.0:
-    resolution: {integrity: sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==}
+  /@babel/helper-environment-visitor@7.24.7:
+    resolution: {integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.24.0
-      '@babel/types': 7.24.5
-    dev: true
+      '@babel/types': 7.24.7
 
-  /@babel/helper-hoist-variables@7.22.5:
-    resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
+  /@babel/helper-function-name@7.24.7:
+    resolution: {integrity: sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.24.5
-    dev: true
+      '@babel/template': 7.24.7
+      '@babel/types': 7.24.7
 
-  /@babel/helper-member-expression-to-functions@7.24.5:
-    resolution: {integrity: sha512-4owRteeihKWKamtqg4JmWSsEZU445xpFRXPEwp44HbgbxdWlUV1b4Agg4lkA806Lil5XM/e+FJyS0vj5T6vmcA==}
+  /@babel/helper-hoist-variables@7.24.7:
+    resolution: {integrity: sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.24.5
-    dev: true
+      '@babel/types': 7.24.7
 
-  /@babel/helper-module-imports@7.24.3:
-    resolution: {integrity: sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==}
+  /@babel/helper-member-expression-to-functions@7.24.7:
+    resolution: {integrity: sha512-LGeMaf5JN4hAT471eJdBs/GK1DoYIJ5GCtZN/EsL6KUiiDZOvO/eKE11AMZJa2zP4zk4qe9V2O/hxAmkRc8p6w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.24.5
-
-  /@babel/helper-module-transforms@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-module-imports': 7.24.3
-      '@babel/helper-simple-access': 7.24.5
-      '@babel/helper-split-export-declaration': 7.24.5
-      '@babel/helper-validator-identifier': 7.24.5
-    dev: true
-
-  /@babel/helper-optimise-call-expression@7.22.5:
-    resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.5
-    dev: true
-
-  /@babel/helper-plugin-utils@7.24.5:
-    resolution: {integrity: sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.24.5):
-    resolution: {integrity: sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-wrap-function': 7.24.5
-    dev: true
-
-  /@babel/helper-replace-supers@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-QCR1UqC9BzG5vZl8BMicmZ28RuUBnHhAMddD8yHFHDRH9lLTZ9uUPehX8ctVPT8l0TKblJidqcgUUKGVrePleQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-member-expression-to-functions': 7.24.5
-      '@babel/helper-optimise-call-expression': 7.22.5
-    dev: true
-
-  /@babel/helper-simple-access@7.24.5:
-    resolution: {integrity: sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.5
-    dev: true
-
-  /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
-    resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.5
-    dev: true
-
-  /@babel/helper-split-export-declaration@7.24.5:
-    resolution: {integrity: sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.5
-    dev: true
-
-  /@babel/helper-string-parser@7.24.1:
-    resolution: {integrity: sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==}
-    engines: {node: '>=6.9.0'}
-
-  /@babel/helper-validator-identifier@7.24.5:
-    resolution: {integrity: sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==}
-    engines: {node: '>=6.9.0'}
-
-  /@babel/helper-validator-option@7.23.5:
-    resolution: {integrity: sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/helper-wrap-function@7.24.5:
-    resolution: {integrity: sha512-/xxzuNvgRl4/HLNKvnFwdhdgN3cpLxgLROeLDl83Yx0AJ1SGvq1ak0OszTOjDfiB8Vx03eJbeDWh9r+jCCWttw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-function-name': 7.23.0
-      '@babel/template': 7.24.0
-      '@babel/types': 7.24.5
-    dev: true
-
-  /@babel/helpers@7.24.5:
-    resolution: {integrity: sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.24.0
-      '@babel/traverse': 7.24.5
-      '@babel/types': 7.24.5
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/highlight@7.24.5:
-    resolution: {integrity: sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==}
+  /@babel/helper-module-imports@7.24.7:
+    resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.24.5
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/helper-module-transforms@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-simple-access': 7.24.7
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@babel/helper-validator-identifier': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-optimise-call-expression@7.24.7:
+    resolution: {integrity: sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.7
+    dev: true
+
+  /@babel/helper-plugin-utils@7.24.7:
+    resolution: {integrity: sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-remap-async-to-generator@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-9pKLcTlZ92hNZMQfGCHImUpDOlAgkkpqalWEeftW5FBya75k8Li2ilerxkM/uBEj01iBZXcCIB/bwvDYgWyibA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-wrap-function': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-replace-supers@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-member-expression-to-functions': 7.24.7
+      '@babel/helper-optimise-call-expression': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-simple-access@7.24.7:
+    resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-skip-transparent-expression-wrappers@7.24.7:
+    resolution: {integrity: sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-split-export-declaration@7.24.7:
+    resolution: {integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.7
+
+  /@babel/helper-string-parser@7.24.7:
+    resolution: {integrity: sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-identifier@7.24.7:
+    resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-option@7.24.7:
+    resolution: {integrity: sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-wrap-function@7.24.7:
+    resolution: {integrity: sha512-N9JIYk3TD+1vq/wn77YnJOqMtfWhNewNE+DJV4puD2X7Ew9J4JvrzrFDfTfyv5EgEXVy9/Wt8QiOErzEmv5Ifw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-function-name': 7.24.7
+      '@babel/template': 7.24.7
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helpers@7.24.7:
+    resolution: {integrity: sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.24.7
+      '@babel/types': 7.24.7
+    dev: true
+
+  /@babel/highlight@7.24.7:
+    resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.0.1
 
-  /@babel/parser@7.24.5:
-    resolution: {integrity: sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==}
+  /@babel/parser@7.24.7:
+    resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-    dev: true
 
-  /@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-LdXRi1wEMTrHVR4Zc9F8OewC3vdm5h4QB6L71zy6StmYeqGi1b3ttIO8UC+BfZKcH9jdr4aI249rBkm+3+YvHw==}
+  /@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-TiT1ss81W80eQsN+722OaeQMY/G4yTb4G9JrqeiDADs3N8lbPMGldWi9x8tyqCW5NLx1Jh2AvkE6r6QvEltMMQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-y4HqEnkelJIOQGd+3g1bTeKsA5c6qM7eOn7VggGVbBc0y8MLSKHacwcIE2PplNlQSj0PqS9rrXL/nkPVK+kUNg==}
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-unaQgZ/iRu/By6tsjMZzpeBZjChYfLYry6HrEXPoz3KmfF0sVBQ1l8zKMQ4xRGLWVsjuvB8nQfjNP/DcfEOCsg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-Hj791Ii4ci8HqnaKHAlLNs+zaLXb0EzSDhiAWp5VNlyvCNymYfacs64pxTxbH1znW/NcArSmwpmG9IKE/TUVVQ==}
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-+izXIbke1T33mY4MSNnrqhPXDz01WYhEf3yF5NbnUtkiNnm+XBZJl3kNfoK6NKmYlz/D07+l2GWVK/QfDkNCuQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-transform-optional-chaining': 7.24.5(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-m9m/fXsXLiHfwdgydIFnpk+7jlVbnvlK5B2EKiPdLUb6WX654ZaaEWJUjk8TftRbZpK0XibovlLWX4KIZhV6jw==}
+  /@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-utA4HuR6F4Vvcr+o4DnjL8fCOlgRFGbeeBEGNg3ZTrLFw6VWG5XmUrvcQ0FjIYMU2ST4XcR2Wsp7t9qOAPnxMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-proposal-decorators@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-zPEvzFijn+hRvJuX2Vu3KbEBN39LN3f7tW3MQO2LsIs57B26KU+kUc82BdAktS1VCM6libzh45eKGI65lg0cpA==}
+  /@babel/plugin-proposal-decorators@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-RL9GR0pUG5Kc8BUWLNDm2T5OpYwSX15r98I0IkgmRQTXuELq/OynH8xtMTMvTJFjXbMWFVTKtYkTaYQsuAwQlQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-create-class-features-plugin': 7.24.5(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-decorators': 7.24.1(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-decorators': 7.24.7(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-proposal-do-expressions@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-tVYbJAE3Duz/T0lV5P27aAgpg2vTfUuV0dXN4NNbnoRk7G989IcgjYIA+1pMHUMMLij7Gun42CC15UN5jWm4LA==}
+  /@babel/plugin-proposal-do-expressions@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-M9pJwhoROof4rc4WzDdMoftv8JrtYfBVurvReacQ8lit+qUd0d71+1zUltb6/zCI7HBW4+KZbtBGmcudXw0GDQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-do-expressions': 7.24.1(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-do-expressions': 7.24.7(@babel/core@7.24.7)
     dev: true
 
-  /@babel/plugin-proposal-export-default-from@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-+0hrgGGV3xyYIjOrD/bUZk/iUwOIGuoANfRfVg1cPhYBxF+TIXSEcc42DqzBICmWsnAQ+SfKedY0bj8QD+LuMg==}
+  /@babel/plugin-proposal-export-default-from@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-CcmFwUJ3tKhLjPdt4NP+SHMshebytF8ZTYOv5ZDpkzq2sin80Wb5vJrGt8fhPrORQCfoSa0LAxC/DW+GAC5+Hw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-export-default-from': 7.24.1(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-export-default-from': 7.24.7(@babel/core@7.24.7)
     dev: true
 
-  /@babel/plugin-proposal-function-bind@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-GDz3lXY623E+SMhloR0HDKYfFjLnqYEHjxIHo3SvpJTV3SV89974Y3mADXSYnO1N+UP7bioAFKqpOmsD9aOnuw==}
+  /@babel/plugin-proposal-function-bind@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-cq2mwxcvNAWWL+IiqiSiVhCeqTQs532Ktl3N2FMuW0bQVF/N0W6QNyywO+KkM3Yr/jwYmjeSS+yKQQUh79VOxQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-function-bind': 7.24.1(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-function-bind': 7.24.7(@babel/core@7.24.7)
     dev: true
 
-  /@babel/plugin-proposal-function-sent@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-GxHpB7jATDZWYEuYkR5jv5aiHbwkmbvk3fJP5G2Dvl7va+kewfbYxpnU1BadIHd3kXlLPQj4CKbLKoWxX4nTtA==}
+  /@babel/plugin-proposal-function-sent@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-42Pq9d8fV5CrjygcVAA7aAEFpkAJluWWvlO7bvOMDEutxIS44COcFU61V92VBzUZvOkjIoQrPJNUtmY/d9XMgA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-wrap-function': 7.24.5
-      '@babel/plugin-syntax-function-sent': 7.24.1(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-wrap-function': 7.24.7
+      '@babel/plugin-syntax-function-sent': 7.24.7(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-proposal-pipeline-operator@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-JFqo+VsSosYxzo1PPfrbeoIi0IcAJnjGpDXeVABNl5bH6/Zvn84Kd8utGEA1eT3gLsynyt1+TfQ/opGXtb0Y/A==}
+  /@babel/plugin-proposal-pipeline-operator@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-cJOSXlieT6/Yul8yEkbBRzhyf/J4jeeqUREw8HCf8nxT4DTP5FCdC0EXf+b8+vBt34IMYYvTDiC8uC91KSSLpA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-pipeline-operator': 7.24.1(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-pipeline-operator': 7.24.7(@babel/core@7.24.7)
     dev: true
 
-  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.5):
+  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.7):
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
+      '@babel/core': 7.24.7
     dev: true
 
-  /@babel/plugin-proposal-throw-expressions@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-wiae/VkKNX1WuM+wXIeAZY1cvbVKJJIf92eA23s2ufpp4w+vOlp+/4T3yfxN6nzN+hIwT15AsdwujAelIqNW+w==}
+  /@babel/plugin-proposal-throw-expressions@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-Rh4WoHyWKgsxvdkEMqDEZtKuGnZw+JwicMCvcZaIjYaQ3fK+a8JZYLhgcac9dKcL47Xqf+SG3MopTx+8BACdrQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-throw-expressions': 7.24.1(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-throw-expressions': 7.24.7(@babel/core@7.24.7)
     dev: true
 
-  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.5):
+  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.7):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.24.5):
+  /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.24.7):
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.5):
+  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.7):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.5):
+  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.7):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-decorators@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-05RJdO/cCrtVWuAaSn1tS3bH8jbsJa/Y1uD186u6J4C/1mnHFxseeuWpsqr9anvo7TUulev7tm7GDwRV+VuhDw==}
+  /@babel/plugin-syntax-decorators@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-Ui4uLJJrRV1lb38zg1yYTmRKmiZLiftDEvZN2iq3kd9kUFU+PttmzTbAFC2ucRk/XJmtek6G23gPsuZbhrT8fQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-do-expressions@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-l5ZJA2DB2s/pM3SQzwf1ykWOiBaqN6Eb07EoZ/mH8dUR5RnaWlmPLoav6y4OT8A9Pkl615osBMZOedFbErdOOA==}
+  /@babel/plugin-syntax-do-expressions@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-lQee+garSbTjCvXdzfjXeSzPd03pyBXALfB2C4bW7SwORrZAs5CDt67toH8MRPuvQFYvWpkXYe07AhHDY3tWfQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.24.5):
+  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.24.7):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-export-default-from@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-cNXSxv9eTkGUtd0PsNMK8Yx5xeScxfpWOUAxE+ZPAXXEcAMOC3fk7LRdXq5fvpra2pLx2p1YtkAhpUbB2SwaRA==}
+  /@babel/plugin-syntax-export-default-from@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-bTPz4/635WQ9WhwsyPdxUJDVpsi/X9BMmy/8Rf/UAlOO4jSql4CxUCjWI5PiM+jG+c4LVPTScoTw80geFj9+Bw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.24.5):
+  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.24.7):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-function-bind@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-7K+uzNJ5ZuL6g4Ud/UhbIxghwN2FAj8NBrzEO+eM0g9YddjOv+BD81ar/N7Es5sH+G8z9tnTYcfCu6EaPrkSDw==}
+  /@babel/plugin-syntax-function-bind@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-dqm7VhgJ2sXCEc0WDJV+q8OI1Qzwn4OFbqsHTVtYoc4L7jJYtF6pEQYcbmlMMWBZjw0tJYuXeyiTQVboWIwAKg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-function-sent@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-aVwkxqagsGCI8vtuyMI+LnZ2SWtGP4+v9T/T88j2MwKRsGYzc9FAaEzsNMu1Htu6SsHPcfwQ7uZ7pYPGrVmG+g==}
+  /@babel/plugin-syntax-function-sent@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-me5EHEx4GXxAE8mnlZaWA+ARIyMSPOXcw6WlqWGIfTg36oeWm4FxR/Djs1DGPbmSIwJqMboiN7gK8eCyzyNK2A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-import-assertions@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-IuwnI5XnuF189t91XbxmXeCDz3qs6iDRO7GJ++wcfgeXNs/8FmIlKcpDSXNVyuLQxlwvskmI3Ct73wUODkJBlQ==}
+  /@babel/plugin-syntax-import-assertions@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-Ec3NRUMoi8gskrkBe3fNmEQfxDvY8bgfQpz6jlk/41kX9eUjvpyqWU7PBP/pLAvMaSQjbMNKJmvX57jP+M6bPg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-import-attributes@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-zhQTMH0X2nVLnb04tz+s7AMuasX8U0FnpE+nHTOhSOINjWMnopoZTxtIKsd45n4GQ/HIZLyfIpoul8e2m0DnRA==}
+  /@babel/plugin-syntax-import-attributes@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.5):
+  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.7):
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.5):
+  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.7):
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==}
+  /@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.5):
+  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.7):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.5):
+  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.7):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.5):
+  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.7):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.5):
+  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.7):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.5):
+  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.7):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.5):
+  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.7):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-pipeline-operator@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-UU7uLj95zh6oMQiREvkTmXAvWy9pJI9p76SFkNsXTesDwQ67YM1UU1Bkx576djA6ZDcPSbzM/MqTJNcYeQ0G2g==}
+  /@babel/plugin-syntax-pipeline-operator@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-PnW47ro0vPh4Raqabn3FM7opwdKbNQoFJKSNfCj7lmqcQlVMYFcJ6b+rhMyfB/g1SlWRwnodffVzLcee1FDHYQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.5):
+  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.7):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-throw-expressions@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-o4dN/9/hUAC6RuX1QZDlauBG2nmSmUMk0K7/IOIFxjM8V16FS1JTHHiBWqGkkIjK4myeHucJbBHurqjtWFAdsw==}
+  /@babel/plugin-syntax-throw-expressions@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-b1bdlAmUTy9VQ/g2cnBuJFwd7jeARNW2F65c9Gcn8qyNYGuVy/cYyqpiSL6SVmUAJTDbIYL2FzlZ8nH1qUCBXA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.5):
+  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.7):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==}
+  /@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.5):
+  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.7):
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-arrow-functions@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-ngT/3NkRhsaep9ck9uj2Xhv9+xB1zShY3tM3g6om4xxCELwCDN4g4Aq5dRn48+0hasAql7s2hdBOysCfNpr4fw==}
+  /@babel/plugin-transform-arrow-functions@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-Dt9LQs6iEY++gXUwY03DNFat5C2NbO48jj+j/bSAz6b3HgPs39qcPiYt77fDObIcFwj3/C2ICX9YMwGflUoSHQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-async-generator-functions@7.24.3(@babel/core@7.24.5):
-    resolution: {integrity: sha512-Qe26CMYVjpQxJ8zxM1340JFNjZaF+ISWpr1Kt/jGo+ZTUzKkfw/pphEWbRCb+lmSM6k/TOgfYLvmbHkUQ0asIg==}
+  /@babel/plugin-transform-async-generator-functions@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-o+iF77e3u7ZS4AoAuJvapz9Fm001PuD2V3Lp6OSE4FYQke+cSewYtnek+THqGRWyQloRCyvWL1OkyfNEl9vr/g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.24.5)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-remap-async-to-generator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-async-to-generator@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-AawPptitRXp1y0n4ilKcGbRYWfbbzFWz2NqNu7dacYDtFtz0CMjG64b3LQsb3KIgnf4/obcUL78hfaOS7iCUfw==}
+  /@babel/plugin-transform-async-to-generator@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-SQY01PcJfmQ+4Ash7NE+rpbLFbmqA2GPIgqzxfFTL4t1FKRq4zTms/7htKpoCUI9OcFYgzqfmCdH53s6/jn5fA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-module-imports': 7.24.3
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-remap-async-to-generator': 7.24.7(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-TWWC18OShZutrv9C6mye1xwtam+uNi2bnTOCBUd5sZxyHOiWbU6ztSROofIMrK84uweEZC219POICK/sTYwfgg==}
+  /@babel/plugin-transform-block-scoped-functions@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-block-scoping@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-sMfBc3OxghjC95BkYrYocHL3NaOplrcaunblzwXhGmlPwpmfsxr4vK+mBBt49r+S240vahmv+kUxkeKgs+haCw==}
+  /@babel/plugin-transform-block-scoping@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-Nd5CvgMbWc+oWzBsuaMcbwjJWAcp5qzrbg69SZdHSP7AMY0AbWFqFO0WTFCA1jxhMCwodRwvRec8k0QUbZk7RQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-class-properties@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-OMLCXi0NqvJfORTaPQBwqLXHhb93wkBKZ4aNwMl6WtehO7ar+cmp+89iPEQPqxAnxsOKTaMcs3POz3rKayJ72g==}
+  /@babel/plugin-transform-class-properties@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-create-class-features-plugin': 7.24.5(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-class-static-block@7.24.4(@babel/core@7.24.5):
-    resolution: {integrity: sha512-B8q7Pz870Hz/q9UgP8InNpY01CSLDSCyqX7zcRuv3FcPl87A2G17lASroHWaCtbdIcbYzOZ7kWmXFKbijMSmFg==}
+  /@babel/plugin-transform-class-static-block@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-HMXK3WbBPpZQufbMG4B46A90PkuuhN9vBCb5T8+VAHqvAqvcLi+2cKoukcpmUYkszLhScU3l1iudhrks3DggRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-create-class-features-plugin': 7.24.5(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-classes@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-gWkLP25DFj2dwe9Ck8uwMOpko4YsqyfZJrOmqqcegeDYEbp7rmn4U6UQZNj08UF6MaX39XenSpKRCvpDRBtZ7Q==}
+  /@babel/plugin-transform-classes@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-CFbbBigp8ln4FU6Bpy6g7sE8B/WmCmzvivzUC6xDAdWVsjYTXijpuuGJmYkAaoWAzcItGKT3IOAbxRItZ5HTjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.5)
-      '@babel/helper-split-export-declaration': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-function-name': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-replace-supers': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-split-export-declaration': 7.24.7
       globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-computed-properties@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-5pJGVIUfJpOS+pAqBQd+QMaTD2vCL/HcePooON6pDpHgRp4gNRmzyHTPIkXntwKsq3ayUFVfJaIKPw2pOkOcTw==}
+  /@babel/plugin-transform-computed-properties@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-25cS7v+707Gu6Ds2oY6tCkUwsJ9YIDbggd9+cu9jzzDgiNq7hR/8dkzxWfKWnTic26vsI3EsCXNd4iEB6e8esQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/template': 7.24.0
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/template': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-destructuring@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-SZuuLyfxvsm+Ah57I/i1HVjveBENYK9ue8MJ7qkc7ndoNjqquJiElzA7f5yaAXjyW2hKojosOTAQQRX50bPSVg==}
+  /@babel/plugin-transform-destructuring@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-19eJO/8kdCQ9zISOf+SEUJM/bAUIsvY3YDnXZTupUCQ8LgrWnsG/gFB9dvXqdXnRXMAM8fvt7b0CBKQHNGy1mw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-dotall-regex@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-p7uUxgSoZwZ2lPNMzUkqCts3xlp8n+o05ikjy7gbtFJSt9gdU88jAmtfmOxHM14noQXBxfgzf2yRWECiNVhTCw==}
+  /@babel/plugin-transform-dotall-regex@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-ZOA3W+1RRTSWvyqcMJDLqbchh7U4NRGqwRfFSVbOLS/ePIP4vHB5e8T8eXcuqyN1QkgKyj5wuW0lcS85v4CrSw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-duplicate-keys@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-msyzuUnvsjsaSaocV6L7ErfNsa5nDWL1XKNnDePLgmz+WdU4w/J8+AxBMrWfi9m4IxfL5sZQKUPQKDQeeAT6lA==}
+  /@babel/plugin-transform-duplicate-keys@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-JdYfXyCRihAe46jUIliuL2/s0x0wObgwwiGxw/UbgJBr20gQBThrokO4nYKgWkD7uBaqM7+9x5TU7NkExZJyzw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-dynamic-import@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-av2gdSTyXcJVdI+8aFZsCAtR29xJt0S5tas+Ef8NvBNmD1a+N/3ecMLeMBgfcK+xzsjdLDT6oHt+DFPyeqUbDA==}
+  /@babel/plugin-transform-dynamic-import@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-sc3X26PhZQDb3JhORmakcbvkeInvxz+A8oda99lj7J60QRuPZvNAk9wQlTBS1ZynelDrDmTU4pw1tyc5d5ZMUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.7)
     dev: true
 
-  /@babel/plugin-transform-exponentiation-operator@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-U1yX13dVBSwS23DEAqU+Z/PkwE9/m7QQy8Y9/+Tdb8UWYaGNDYwTLi19wqIAiROr8sXVum9A/rtiH5H0boUcTw==}
+  /@babel/plugin-transform-exponentiation-operator@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-Rqe/vSc9OYgDajNIK35u7ot+KeCoetqQYFXM4Epf7M7ez3lWlOjrDjrwMei6caCVhfdw+mIKD4cgdGNy5JQotQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-export-namespace-from@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-Ft38m/KFOyzKw2UaJFkWG9QnHPG/Q/2SkOrRk4pNBPg5IPZ+dOxcmkK5IyuBcxiNPyyYowPGUReyBvrvZs7IlQ==}
+  /@babel/plugin-transform-export-namespace-from@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-v0K9uNYsPL3oXZ/7F9NNIbAj2jv1whUEtyA6aujhekLs56R++JDQuzRcP2/z4WX5Vg/c5lE9uWZA0/iUoFhLTA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.7)
     dev: true
 
-  /@babel/plugin-transform-for-of@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-OxBdcnF04bpdQdR3i4giHZNZQn7cm8RQKcSwA17wAAqEELo1ZOwp5FFgeptWUQXFyT9kwHo10aqqauYkRZPCAg==}
+  /@babel/plugin-transform-for-of@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-wo9ogrDG1ITTTBsy46oGiN1dS9A7MROBTcYsfS8DtsImMkHk9JXJ3EWQM6X2SUw4x80uGPlwj0o00Uoc6nEE3g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-function-name@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-BXmDZpPlh7jwicKArQASrj8n22/w6iymRnvHYYd2zO30DbE277JO20/7yXJT3QxDPtiQiOxQBbZH4TpivNXIxA==}
+  /@babel/plugin-transform-function-name@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-U9FcnA821YoILngSmYkW6FjyQe2TyZD5pHt4EVIhmcTkrJw/3KqcrRSxuOo5tFZJi7TE19iDyI1u+weTI7bn2w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-function-name': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-json-strings@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-U7RMFmRvoasscrIFy5xA4gIp8iWnWubnKkKuUGJjsuOH7GfbMkB+XZzeslx2kLdEGdOJDamEmCqOks6e8nv8DQ==}
+  /@babel/plugin-transform-json-strings@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-2yFnBGDvRuxAaE/f0vfBKvtnvvqU8tGpMHqMNpTN2oWMKIR3NqFkjaAgGwawhqK/pIN2T3XdjGPdaG0vDhOBGw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.7)
     dev: true
 
-  /@babel/plugin-transform-literals@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-zn9pwz8U7nCqOYIiBaOxoQOtYmMODXTJnkxG4AtX8fPmnCRYWBOHD0qcpwS9e2VDSp1zNJYpdnFMIKb8jmwu6g==}
+  /@babel/plugin-transform-literals@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-vcwCbb4HDH+hWi8Pqenwnjy+UiklO4Kt1vfspcQYFhJdpthSnW8XvWGyDZWKNVrVbVViI/S7K9PDJZiUmP2fYQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-logical-assignment-operators@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-OhN6J4Bpz+hIBqItTeWJujDOfNP+unqv/NJgyhlpSqgBTPm37KkMmZV6SYcOj+pnDbdcl1qRGV/ZiIjX9Iy34w==}
+  /@babel/plugin-transform-logical-assignment-operators@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-4D2tpwlQ1odXmTEIFWy9ELJcZHqrStlzK/dAOWYyxX3zT0iXQB6banjgeOJQXzEc4S0E0a5A+hahxPaEFYftsw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.7)
     dev: true
 
-  /@babel/plugin-transform-member-expression-literals@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-4ojai0KysTWXzHseJKa1XPNXKRbuUrhkOPY4rEGeR+7ChlJVKxFa3H3Bz+7tWaGKgJAXUWKOGmltN+u9B3+CVg==}
+  /@babel/plugin-transform-member-expression-literals@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-T/hRC1uqrzXMKLQ6UCwMT85S3EvqaBXDGf0FaMf4446Qx9vKwlghvee0+uuZcDUCZU5RuNi4781UQ7R308zzBw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-modules-amd@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-lAxNHi4HVtjnHd5Rxg3D5t99Xm6H7b04hUS7EHIXcUl2EV4yl1gWdqZrNzXnSrHveL9qMdbODlLF55mvgjAfaQ==}
+  /@babel/plugin-transform-modules-amd@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-9+pB1qxV3vs/8Hdmz/CulFB8w2tuu6EB94JZFsjdqxQokwGa9Unap7Bo2gGBGIvPmDIVvQrom7r5m/TCDMURhg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-module-transforms': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-commonjs@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-szog8fFTUxBfw0b98gEWPaEqF42ZUD/T3bkynW/wtgx2p/XCP55WEsb+VosKceRSd6njipdZvNogqdtI4Q0chw==}
+  /@babel/plugin-transform-modules-commonjs@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-iFI8GDxtevHJ/Z22J5xQpVqFLlMNstcLXh994xifFwxxGslr2ZXXLWgtBeLctOD63UFDArdvN6Tg8RFw+aEmjQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-simple-access': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-module-transforms': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-simple-access': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-systemjs@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-mqQ3Zh9vFO1Tpmlt8QPnbwGHzNz3lpNEMxQb1kAemn/erstyqw1r9KeOlOfo3y6xAnFEcOv2tSyrXfmMk+/YZA==}
+  /@babel/plugin-transform-modules-systemjs@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-GYQE0tW7YoaN13qFh3O1NCY4MPkUiAH3fiF7UcV/I3ajmDKEdG3l+UOcbAm4zUE3gnvUU+Eni7XrVKo9eO9auw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-validator-identifier': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-hoist-variables': 7.24.7
+      '@babel/helper-module-transforms': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-validator-identifier': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-umd@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-tuA3lpPj+5ITfcCluy6nWonSL7RvaG0AOTeAuvXqEKS34lnLzXpDb0dcP6K8jD0zWZFNDVly90AGFJPnm4fOYg==}
+  /@babel/plugin-transform-modules-umd@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-3aytQvqJ/h9z4g8AsKPLvD4Zqi2qT+L3j7XoFFu1XBlZWEl2/1kWnhmAbxpLgPrHSY0M6UA02jyTiwUVtiKR6A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-module-transforms': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
+  /@babel/plugin-transform-named-capturing-groups-regex@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-/jr7h/EWeJtk1U/uz2jlsCioHkZk1JJZVcc8oQsJ1dUlaJD83f4/6Zeh2aHt9BIFokHIsSeDfhUmju0+1GPd6g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-new-target@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-/rurytBM34hYy0HKZQyA0nHbQgQNFm4Q/BOc9Hflxi2X3twRof7NaE5W46j4kQitm7SvACVRXsa6N/tSZxvPug==}
+  /@babel/plugin-transform-new-target@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-RNKwfRIXg4Ls/8mMTza5oPF5RkOW8Wy/WgMAp1/F1yZ8mMbtwXW+HDoJiOsagWrAhI5f57Vncrmr9XeT4CVapA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-nullish-coalescing-operator@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-iQ+caew8wRrhCikO5DrUYx0mrmdhkaELgFa+7baMcVuhxIkN7oxt06CZ51D65ugIb1UWRQ8oQe+HXAVM6qHFjw==}
+  /@babel/plugin-transform-nullish-coalescing-operator@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-Ts7xQVk1OEocqzm8rHMXHlxvsfZ0cEF2yomUqpKENHWMF4zKk175Y4q8H5knJes6PgYad50uuRmt3UJuhBw8pQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
     dev: true
 
-  /@babel/plugin-transform-numeric-separator@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-7GAsGlK4cNL2OExJH1DzmDeKnRv/LXq0eLUSvudrehVA5Rgg4bIrqEUW29FbKMBRT0ztSqisv7kjP+XIC4ZMNw==}
+  /@babel/plugin-transform-numeric-separator@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-e6q1TiVUzvH9KRvicuxdBTUj4AdKSRwzIyFFnfnezpCfP2/7Qmbb8qbU2j7GODbl4JMkblitCQjKYUaX/qkkwA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.7)
     dev: true
 
-  /@babel/plugin-transform-object-rest-spread@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-7EauQHszLGM3ay7a161tTQH7fj+3vVM/gThlz5HpFtnygTxjrlvoeq7MPVA1Vy9Q555OB8SnAOsMkLShNkkrHA==}
+  /@babel/plugin-transform-object-rest-spread@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-4QrHAr0aXQCEFni2q4DqKLD31n2DL+RxcwnNjDFkSG0eNQ/xCavnRkfCUjsyqGC2OviNJvZOF/mQqZBw7i2C5Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-transform-parameters': 7.24.5(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.7)
     dev: true
 
-  /@babel/plugin-transform-object-super@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-oKJqR3TeI5hSLRxudMjFQ9re9fBVUU0GICqM3J1mi8MqlhVr6hC/ZN4ttAyMuQR6EZZIY6h/exe5swqGNNIkWQ==}
+  /@babel/plugin-transform-object-super@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-A/vVLwN6lBrMFmMDmPPz0jnE6ZGx7Jq7d6sT/Ev4H65RER6pZ+kczlf1DthF5N0qaPHBsI7UXiE8Zy66nmAovg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-replace-supers': 7.24.7(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-optional-catch-binding@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-oBTH7oURV4Y+3EUrf6cWn1OHio3qG/PVwO5J03iSJmBg6m2EhKjkAu/xuaXaYwWW9miYtvbWv4LNf0AmR43LUA==}
+  /@babel/plugin-transform-optional-catch-binding@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-uLEndKqP5BfBbC/5jTwPxLh9kqPWWgzN/f8w6UwAIirAEqiIVJWWY312X72Eub09g5KF9+Zn7+hT7sDxmhRuKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.7)
     dev: true
 
-  /@babel/plugin-transform-optional-chaining@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-xWCkmwKT+ihmA6l7SSTpk8e4qQl/274iNbSKRRS8mpqFR32ksy36+a+LWY8OXCCEefF8WFlnOHVsaDI2231wBg==}
+  /@babel/plugin-transform-optional-chaining@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-tK+0N9yd4j+x/4hxF3F0e0fu/VdcxU18y5SevtyM/PCFlQvXbR0Zmlo2eBrKtVipGNFzpq56o8WsIIKcJFUCRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-parameters@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-9Co00MqZ2aoky+4j2jhofErthm6QVLKbpQrvz20c3CH9KQCLHyNB+t2ya4/UrRpQGR+Wrwjg9foopoeSdnHOkA==}
+  /@babel/plugin-transform-parameters@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-private-methods@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-tGvisebwBO5em4PaYNqt4fkw56K2VALsAbAakY0FjTYqJp7gfdrgr7YX76Or8/cpik0W6+tj3rZ0uHU9Oil4tw==}
+  /@babel/plugin-transform-private-methods@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-COTCOkG2hn4JKGEKBADkA8WNb35TGkkRbI5iT845dB+NyqgO8Hn+ajPbSnIQznneJTa3d30scb6iz/DhH8GsJQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-create-class-features-plugin': 7.24.5(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-private-property-in-object@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-JM4MHZqnWR04jPMujQDTBVRnqxpLLpx2tkn7iPn+Hmsc0Gnb79yvRWOkvqFOx3Z7P7VxiRIR22c4eGSNj87OBQ==}
+  /@babel/plugin-transform-private-property-in-object@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-9z76mxwnwFxMyxZWEgdgECQglF2Q7cFLm0kMf8pGwt+GSJsY0cONKj/UuO4bOH0w/uAel3ekS4ra5CEAyJRmDA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.24.5(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-property-literals@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-LetvD7CrHmEx0G442gOomRr66d7q8HzzGGr4PMHGr+5YIm6++Yke+jxj246rpvsbyhJwCLxcTn6zW1P1BSenqA==}
+  /@babel/plugin-transform-property-literals@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-react-display-name@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-mvoQg2f9p2qlpDQRBC7M3c3XTr0k7cp/0+kFKKO/7Gtu0LSw16eKB+Fabe2bDT/UpsyasTBBkAnbdsLrkD5XMw==}
+  /@babel/plugin-transform-react-display-name@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-H/Snz9PFxKsS1JLI4dJLtnJgCJRoo0AUm3chP6NYr+9En1JMKloheEiLIhlp5MDVznWo+H3AAC1Mc8lmUEpsgg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==}
+  /@babel/plugin-transform-react-jsx-development@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-QG9EnzoGn+Qar7rxuW+ZOsbWOt56FvvI93xInqsZDC5fsekx1AlIO4KIJ5M+D0p0SqSH156EpmZyXq630B8OlQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.5):
-    resolution: {integrity: sha512-5xOpoPguCZCRbo/JeHlloSkTA8Bld1J/E1/kLfD1nsuiW1m8tduTA1ERCgIZokDflX/IBzKcqR3l7VlRgiIfHA==}
+  /@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-module-imports': 7.24.3
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.24.5)
-      '@babel/types': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.7)
+      '@babel/types': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-react-pure-annotations@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-+pWEAaDJvSm9aFvJNpLiM2+ktl2Sn2U5DdyiWdZBxmLc6+xGt88dvFqsHiAiDS+8WqUwbDfkKz9jRxK3M0k+kA==}
+  /@babel/plugin-transform-react-pure-annotations@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-PLgBVk3fzbmEjBJ/u8kFzOqS9tUeDjiaWud/rRym/yjCo/M9cASPlnrd2ZmmZpQT40fOOrvR8jh+n8jikrOhNA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-regenerator@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-sJwZBCzIBE4t+5Q4IGLaaun5ExVMRY0lYwos/jNecjMrVCygCdph3IKv0tkP5Fc87e/1+bebAmEAGBfnRD+cnw==}
+  /@babel/plugin-transform-regenerator@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-lq3fvXPdimDrlg6LWBoqj+r/DEWgONuwjuOuQCSYgRroXDH/IdM1C0IZf59fL5cHLpjEH/O6opIRBbqv7ELnuA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
       regenerator-transform: 0.15.2
     dev: true
 
-  /@babel/plugin-transform-reserved-words@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-JAclqStUfIwKN15HrsQADFgeZt+wexNQ0uLhuqvqAUFoqPMjEcFCYZBhq0LUdz6dZK/mD+rErhW71fbx8RYElg==}
+  /@babel/plugin-transform-reserved-words@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-0DUq0pHcPKbjFZCfTss/pGkYMfy3vFWydkUBd9r0GHpIyfs2eCDENvqadMycRS9wZCXR41wucAfJHJmwA0UmoQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-runtime@7.24.3(@babel/core@7.24.5):
-    resolution: {integrity: sha512-J0BuRPNlNqlMTRJ72eVptpt9VcInbxO6iP3jaxr+1NPhC0UkKL+6oeX6VXMEYdADnuqmMmsBspt4d5w8Y/TCbQ==}
+  /@babel/plugin-transform-runtime@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-YqXjrk4C+a1kZjewqt+Mmu2UuV1s07y8kqcUf4qYLnoqemhR4gRQikhdAhSVJioMjVTu6Mo6pAbaypEA3jY6fw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-module-imports': 7.24.3
-      '@babel/helper-plugin-utils': 7.24.5
-      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.5)
-      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.5)
-      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.7)
+      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.7)
+      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.7)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-shorthand-properties@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-LyjVB1nsJ6gTTUKRjRWx9C1s9hE7dLfP/knKdrfeH9UPtAGjYGgxIbFfx7xyLIEWs7Xe1Gnf8EWiUqfjLhInZA==}
+  /@babel/plugin-transform-shorthand-properties@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-KsDsevZMDsigzbA09+vacnLpmPH4aWjcZjXdyFKGzpplxhbeB4wYtury3vglQkg6KM/xEPKt73eCjPPf1PgXBA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-spread@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-KjmcIM+fxgY+KxPVbjelJC6hrH1CgtPmTvdXAfn3/a9CnWGSTY7nH4zm5+cjmWJybdcPSsD0++QssDsjcpe47g==}
+  /@babel/plugin-transform-spread@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-x96oO0I09dgMDxJaANcRyD4ellXFLLiWhuwDxKZX5g2rWP1bTPkBSwCYv96VDXVT1bD9aPj8tppr5ITIh8hBng==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-sticky-regex@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-9v0f1bRXgPVcPrngOQvLXeGNNVLc8UjMVfebo9ka0WF3/7+aVUHmaJVT3sa0XCzEFioPfPHZiOcYG9qOsH63cw==}
+  /@babel/plugin-transform-sticky-regex@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-kHPSIJc9v24zEml5geKg9Mjx5ULpfncj0wRpYtxbvKyTtHCYDkVE3aHQ03FrpEo4gEe2vrJJS1Y9CJTaThA52g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-template-literals@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-WRkhROsNzriarqECASCNu/nojeXCDTE/F2HmRgOzi7NGvyfYGq1NEjKBK3ckLfRgGc6/lPAqP0vDOSw3YtG34g==}
+  /@babel/plugin-transform-template-literals@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-typeof-symbol@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-UTGnhYVZtTAjdwOTzT+sCyXmTn8AhaxOS/MjG9REclZ6ULHWF9KoCZur0HSGU7hk8PdBFKKbYe6+gqdXWz84Jg==}
+  /@babel/plugin-transform-typeof-symbol@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-VtR8hDy7YLB7+Pet9IarXjg/zgCMSF+1mNS/EQEiEaUPoFXCVsHG64SIxcaaI2zJgRiv+YmgaQESUfWAdbjzgg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-typescript@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-E0VWu/hk83BIFUWnsKZ4D81KXjN5L3MobvevOHErASk9IPwKHOkTgvqzvNo1yP/ePJWqqK2SpUR5z+KQbl6NVw==}
+  /@babel/plugin-transform-typescript@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-iLD3UNkgx2n/HrjBesVbYX6j0yqn/sJktvbtKKgcaLIQ4bTTQ8obAypc1VpyHPD2y4Phh9zHOaAt8e/L14wCpw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.24.5(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/plugin-transform-unicode-escapes@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-RlkVIcWT4TLI96zM660S877E7beKlQw7Ig+wqkKBiWfj0zH5Q4h50q6er4wzZKRNSYpfo6ILJ+hrJAGSX2qcNw==}
+  /@babel/plugin-transform-unicode-escapes@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-U3ap1gm5+4edc2Q/P+9VrBNhGkfnf+8ZqppY71Bo/pzZmXhhLdqgaUl6cuB07O1+AQJtCLfaOmswiNbSQ9ivhw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-unicode-property-regex@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-Ss4VvlfYV5huWApFsF8/Sq0oXnGO+jB+rijFEFugTd3cwSObUSnUi88djgR5528Csl0uKlrI331kRqe56Ov2Ng==}
+  /@babel/plugin-transform-unicode-property-regex@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-uH2O4OV5M9FZYQrwc7NdVmMxQJOCCzFeYudlZSzUAHRFeOujQefa92E74TQDVskNHCzOXoigEuoyzHDhaEaK5w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-unicode-regex@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-2A/94wgZgxfTsiLaQ2E36XAOdcZmGAaEEgVmxQWwZXWkGhvoHbaqXcKnU8zny4ycpu3vNqg0L/PcCiYtHtA13g==}
+  /@babel/plugin-transform-unicode-regex@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-hlQ96MBZSAXUq7ltkjtu3FJCCSMx/j629ns3hA3pXnBXjanNP0LHi+JpPeA81zaWgVK1VGH95Xuy7u0RyQ8kMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/plugin-transform-unicode-sets-regex@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-fqj4WuzzS+ukpgerpAoOnMfQXwUHFxXUZUE84oL2Kao2N8uSlvcpnAidKASgsNgzZHBsHWvcm8s9FPWUhAb8fA==}
+  /@babel/plugin-transform-unicode-sets-regex@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-2G8aAvF4wy1w/AGZkemprdGMRg5o6zPNhbHVImRz3lss55TYCBd6xStN19rt8XJHq20sqV0JbyWjOWwQRwV/wg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.5)
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-create-regexp-features-plugin': 7.24.7(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.7
     dev: true
 
-  /@babel/preset-env@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-UGK2ifKtcC8i5AI4cH+sbLLuLc2ktYSFJgBAXorKAsHUZmrQ1q6aQ6i3BvU24wWs2AAKqQB6kq3N9V9Gw1HiMQ==}
+  /@babel/preset-env@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-1YZNsc+y6cTvWlDHidMBsQZrZfEFjRIo/BZCT906PMdzOyXtSLTgqGdrpcuTDCXyd11Am5uQULtDIcCfnTc8fQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.24.4
-      '@babel/core': 7.24.5
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-validator-option': 7.23.5
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.5(@babel/core@7.24.5)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.5)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.5)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.5)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.5)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-import-assertions': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-syntax-import-attributes': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.5)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.5)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.5)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.5)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.5)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.5)
-      '@babel/plugin-transform-arrow-functions': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-async-generator-functions': 7.24.3(@babel/core@7.24.5)
-      '@babel/plugin-transform-async-to-generator': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-block-scoped-functions': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-block-scoping': 7.24.5(@babel/core@7.24.5)
-      '@babel/plugin-transform-class-properties': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-class-static-block': 7.24.4(@babel/core@7.24.5)
-      '@babel/plugin-transform-classes': 7.24.5(@babel/core@7.24.5)
-      '@babel/plugin-transform-computed-properties': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-destructuring': 7.24.5(@babel/core@7.24.5)
-      '@babel/plugin-transform-dotall-regex': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-duplicate-keys': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-dynamic-import': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-exponentiation-operator': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-export-namespace-from': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-for-of': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-function-name': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-json-strings': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-literals': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-logical-assignment-operators': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-member-expression-literals': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-modules-amd': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-modules-systemjs': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-modules-umd': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.24.5)
-      '@babel/plugin-transform-new-target': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-numeric-separator': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-object-rest-spread': 7.24.5(@babel/core@7.24.5)
-      '@babel/plugin-transform-object-super': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-optional-catch-binding': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-optional-chaining': 7.24.5(@babel/core@7.24.5)
-      '@babel/plugin-transform-parameters': 7.24.5(@babel/core@7.24.5)
-      '@babel/plugin-transform-private-methods': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-private-property-in-object': 7.24.5(@babel/core@7.24.5)
-      '@babel/plugin-transform-property-literals': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-regenerator': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-reserved-words': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-shorthand-properties': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-spread': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-sticky-regex': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-template-literals': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-typeof-symbol': 7.24.5(@babel/core@7.24.5)
-      '@babel/plugin-transform-unicode-escapes': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-unicode-property-regex': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-unicode-regex': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-unicode-sets-regex': 7.24.1(@babel/core@7.24.5)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.5)
-      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.5)
-      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.5)
-      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.5)
+      '@babel/compat-data': 7.24.7
+      '@babel/core': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-validator-option': 7.24.7
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.7)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.7)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.7)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.7)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-async-generator-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-class-static-block': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-classes': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-destructuring': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-dotall-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-duplicate-keys': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-dynamic-import': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-exponentiation-operator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-for-of': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-json-strings': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-logical-assignment-operators': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-member-expression-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-modules-amd': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-modules-systemjs': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-modules-umd': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-new-target': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-numeric-separator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-object-super': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-optional-chaining': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-private-property-in-object': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-property-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-regenerator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-reserved-words': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-typeof-symbol': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-escapes': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-property-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-sets-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.7)
+      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.7)
+      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.7)
+      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.7)
       core-js-compat: 3.37.1
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.24.5):
+  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.24.7):
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/types': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/types': 7.24.7
       esutils: 2.0.3
     dev: true
 
-  /@babel/preset-react@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-eFa8up2/8cZXLIpkafhaADTXSnl7IsUFCYenRWrARBz0/qZwcT0RBXpys0LJU4+WfPoF2ZG6ew6s2V6izMCwRA==}
+  /@babel/preset-react@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-AAH4lEkpmzFWrGVlHaxJB7RLH21uPQ9+He+eFLWHmF9IuFQVugz8eAsamaW0DXRrTfco5zj1wWtpdcXJUOfsag==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-validator-option': 7.23.5
-      '@babel/plugin-transform-react-display-name': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.5)
-      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.24.5)
-      '@babel/plugin-transform-react-pure-annotations': 7.24.1(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-validator-option': 7.24.7
+      '@babel/plugin-transform-react-display-name': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-jsx-development': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-pure-annotations': 7.24.7(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@babel/preset-typescript@7.24.1(@babel/core@7.24.5):
-    resolution: {integrity: sha512-1DBaMmRDpuYQBPWD8Pf/WEwCrtgRHxsZnP4mIy9G/X+hFfbI47Q2G4t1Paakld84+qsk2fSsUPMKg71jkoOOaQ==}
+  /@babel/preset-typescript@7.24.7(@babel/core@7.24.7):
+    resolution: {integrity: sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-plugin-utils': 7.24.5
-      '@babel/helper-validator-option': 7.23.5
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.5)
-      '@babel/plugin-transform-typescript': 7.24.5(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-validator-option': 7.24.7
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-modules-commonjs': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-typescript': 7.24.7(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@babel/regjsgen@0.8.0:
     resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
     dev: true
 
-  /@babel/runtime-corejs3@7.24.5:
-    resolution: {integrity: sha512-GWO0mgzNMLWaSYM4z4NVIuY0Cd1fl8cPnuetuddu5w/qGuvt5Y7oUi/kvvQGK9xgOkFJDQX2heIvTRn/OQ1XTg==}
+  /@babel/runtime-corejs3@7.24.7:
+    resolution: {integrity: sha512-eytSX6JLBY6PVAeQa2bFlDx/7Mmln/gaEpsit5a3WEvjGfiIytEsgAwuIXCPM0xvw0v0cJn3ilq0/TvXrW0kgA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       core-js-pure: 3.37.1
       regenerator-runtime: 0.14.1
     dev: true
 
-  /@babel/runtime@7.24.5:
-    resolution: {integrity: sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.14.1
-
   /@babel/runtime@7.24.7:
     resolution: {integrity: sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
-    dev: false
 
-  /@babel/template@7.24.0:
-    resolution: {integrity: sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==}
+  /@babel/template@7.24.7:
+    resolution: {integrity: sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.24.2
-      '@babel/parser': 7.24.5
-      '@babel/types': 7.24.5
-    dev: true
+      '@babel/code-frame': 7.24.7
+      '@babel/parser': 7.24.7
+      '@babel/types': 7.24.7
 
-  /@babel/traverse@7.24.5:
-    resolution: {integrity: sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==}
+  /@babel/traverse@7.24.7:
+    resolution: {integrity: sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.24.2
-      '@babel/generator': 7.24.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-split-export-declaration': 7.24.5
-      '@babel/parser': 7.24.5
-      '@babel/types': 7.24.5
-      debug: 4.3.4
+      '@babel/code-frame': 7.24.7
+      '@babel/generator': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-function-name': 7.24.7
+      '@babel/helper-hoist-variables': 7.24.7
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@babel/parser': 7.24.7
+      '@babel/types': 7.24.7
+      debug: 4.3.5
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
-  /@babel/types@7.24.5:
-    resolution: {integrity: sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==}
+  /@babel/types@7.24.7:
+    resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-string-parser': 7.24.1
-      '@babel/helper-validator-identifier': 7.24.5
+      '@babel/helper-string-parser': 7.24.7
+      '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
 
   /@bcoe/v8-coverage@0.2.3:
@@ -2236,8 +2294,8 @@ packages:
   /@emotion/babel-plugin@11.11.0:
     resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
     dependencies:
-      '@babel/helper-module-imports': 7.24.3
-      '@babel/runtime': 7.24.5
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/runtime': 7.24.7
       '@emotion/hash': 0.9.1
       '@emotion/memoize': 0.8.1
       '@emotion/serialize': 1.1.4
@@ -2247,6 +2305,8 @@ packages:
       find-root: 1.1.0
       source-map: 0.5.7
       stylis: 4.2.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@emotion/cache@11.11.0:
@@ -2273,7 +2333,7 @@ packages:
     resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
     dev: false
 
-  /@emotion/react@11.11.4(@types/react@18.3.2)(react@18.3.1):
+  /@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1):
     resolution: {integrity: sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==}
     peerDependencies:
       '@types/react': '*'
@@ -2282,16 +2342,18 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       '@emotion/babel-plugin': 11.11.0
       '@emotion/cache': 11.11.0
       '@emotion/serialize': 1.1.4
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.3.1)
       '@emotion/utils': 1.2.1
       '@emotion/weak-memoize': 0.3.1
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@emotion/serialize@1.1.4:
@@ -2308,7 +2370,7 @@ packages:
     resolution: {integrity: sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==}
     dev: false
 
-  /@emotion/styled@11.11.5(@emotion/react@11.11.4)(@types/react@18.3.2)(react@18.3.1):
+  /@emotion/styled@11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.3.1):
     resolution: {integrity: sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==}
     peerDependencies:
       '@emotion/react': ^11.0.0-rc.0
@@ -2318,15 +2380,17 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       '@emotion/babel-plugin': 11.11.0
       '@emotion/is-prop-valid': 1.2.2
-      '@emotion/react': 11.11.4(@types/react@18.3.2)(react@18.3.1)
+      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.3.1)
       '@emotion/serialize': 1.1.4
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.3.1)
       '@emotion/utils': 1.2.1
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       react: 18.3.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@emotion/unitless@0.8.1:
@@ -2359,8 +2423,8 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@eslint-community/regexpp@4.10.0:
-    resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
+  /@eslint-community/regexpp@4.10.1:
+    resolution: {integrity: sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
@@ -2369,7 +2433,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.5
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -2399,8 +2463,8 @@ packages:
       '@floating-ui/utils': 0.2.2
     dev: false
 
-  /@floating-ui/react-dom@2.0.9(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-q0umO0+LQK4+p6aGyvzASqKbKOJcAHJ7ycE9CuUvfx3s9zTHWmGJTPOIlM/hmSBfUfg/XfY5YhLBLR/LHwShQQ==}
+  /@floating-ui/react-dom@2.1.0(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -2421,9 +2485,10 @@ packages:
   /@humanwhocodes/config-array@0.11.14:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.4
+      debug: 4.3.5
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2436,6 +2501,7 @@ packages:
 
   /@humanwhocodes/object-schema@2.0.3:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
     dev: true
 
   /@istanbuljs/load-nyc-config@1.1.0:
@@ -2459,7 +2525,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -2480,7 +2546,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -2499,7 +2565,7 @@ packages:
       jest-util: 27.5.1
       jest-validate: 27.5.1
       jest-watcher: 27.5.1
-      micromatch: 4.0.5
+      micromatch: 4.0.7
       rimraf: 3.0.2
       slash: 3.0.0
       strip-ansi: 6.0.1
@@ -2517,7 +2583,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       jest-mock: 27.5.1
     dev: true
 
@@ -2527,7 +2593,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -2556,7 +2622,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -2615,7 +2681,7 @@ packages:
     resolution: {integrity: sha512-ipON6WtYgl/1329g5AIJVbUuEh0wZVbdpGwC99Jw4LwuoBNS95MVphU6zOeD9pDkon+LLbFL7lOQRapbB8SCHw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/core': 7.24.5
+      '@babel/core': 7.24.7
       '@jest/types': 27.5.1
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
@@ -2625,7 +2691,7 @@ packages:
       jest-haste-map: 27.5.1
       jest-regex-util: 27.5.1
       jest-util: 27.5.1
-      micromatch: 4.0.5
+      micromatch: 4.0.7
       pirates: 4.0.6
       slash: 3.0.0
       source-map: 0.6.1
@@ -2640,7 +2706,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       '@types/yargs': 16.0.9
       chalk: 4.1.2
     dev: true
@@ -2652,17 +2718,14 @@ packages:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.25
-    dev: true
 
   /@jridgewell/resolve-uri@3.1.2:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/set-array@1.2.1:
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/source-map@0.3.6:
     resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
@@ -2673,14 +2736,12 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.25:
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /@kurkle/color@0.3.2:
     resolution: {integrity: sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==}
@@ -2717,7 +2778,7 @@ packages:
     resolution: {integrity: sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==}
     dev: false
 
-  /@mui/base@5.0.0-beta.37(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
+  /@mui/base@5.0.0-beta.37(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-/o3anbb+DeCng8jNsd3704XtmmLDZju1Fo8R2o7ugrVtPQ/QpcqddwKNzKPZwa0J5T8YNW3ZVuHyQgbTnQLisQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -2728,19 +2789,19 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
-      '@floating-ui/react-dom': 2.0.9(react-dom@18.3.1)(react@18.3.1)
-      '@mui/types': 7.2.14(@types/react@18.3.2)
-      '@mui/utils': 5.15.14(@types/react@18.3.2)(react@18.3.1)
+      '@babel/runtime': 7.24.7
+      '@floating-ui/react-dom': 2.1.0(react-dom@18.3.1)(react@18.3.1)
+      '@mui/types': 7.2.14(@types/react@18.3.3)
+      '@mui/utils': 5.15.20(@types/react@18.3.3)(react@18.3.1)
       '@popperjs/core': 2.11.8
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
-  /@mui/base@5.0.0-beta.39(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
+  /@mui/base@5.0.0-beta.39(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-puyUptF7VJ+9/dMIRLF+DLR21cWfvejsA6OnatfJfqFp8aMhya7xQtvYLEfCch6ahvFZvNC9FFEGGR+qkgFjUg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -2751,19 +2812,19 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
-      '@floating-ui/react-dom': 2.0.9(react-dom@18.3.1)(react@18.3.1)
-      '@mui/types': 7.2.14(@types/react@18.3.2)
-      '@mui/utils': 5.15.14(@types/react@18.3.2)(react@18.3.1)
+      '@babel/runtime': 7.24.7
+      '@floating-ui/react-dom': 2.1.0(react-dom@18.3.1)(react@18.3.1)
+      '@mui/types': 7.2.14(@types/react@18.3.3)
+      '@mui/utils': 5.15.20(@types/react@18.3.3)(react@18.3.1)
       '@popperjs/core': 2.11.8
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
-  /@mui/base@5.0.0-beta.40(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
+  /@mui/base@5.0.0-beta.40(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -2774,24 +2835,24 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
-      '@floating-ui/react-dom': 2.0.9(react-dom@18.3.1)(react@18.3.1)
-      '@mui/types': 7.2.14(@types/react@18.3.2)
-      '@mui/utils': 5.15.14(@types/react@18.3.2)(react@18.3.1)
+      '@babel/runtime': 7.24.7
+      '@floating-ui/react-dom': 2.1.0(react-dom@18.3.1)(react@18.3.1)
+      '@mui/types': 7.2.14(@types/react@18.3.3)
+      '@mui/utils': 5.15.20(@types/react@18.3.3)(react@18.3.1)
       '@popperjs/core': 2.11.8
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
-  /@mui/core-downloads-tracker@5.15.17:
-    resolution: {integrity: sha512-DVAejDQkjNnIac7MfP8sLzuo7fyrBPxNdXe+6bYqOqg1z2OPTlfFAejSNzWe7UenRMuFu9/AyFXj/X2vN2w6dA==}
+  /@mui/core-downloads-tracker@5.15.20:
+    resolution: {integrity: sha512-DoL2ppgldL16utL8nNyj/P12f8mCNdx/Hb/AJnX9rLY4b52hCMIx1kH83pbXQ6uMy6n54M3StmEbvSGoj2OFuA==}
     dev: false
 
-  /@mui/icons-material@5.15.17(@mui/material@5.15.17)(@types/react@18.3.2)(react@18.3.1):
-    resolution: {integrity: sha512-xVzl2De7IY36s/keHX45YMiCpsIx3mNv2xwDgtBkRSnZQtVk+Gqufwj1ktUxEyjzEhBl0+PiNJqYC31C+n1n6A==}
+  /@mui/icons-material@5.15.20(@mui/material@5.15.20)(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-oGcKmCuHaYbAAoLN67WKSXtHmEgyWcJToT1uRtmPyxMj9N5uqwc/mRtEnst4Wj/eGr+zYH2FiZQ79v9k7kSk1Q==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@mui/material': ^5.0.0
@@ -2801,13 +2862,13 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
-      '@mui/material': 5.15.17(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
-      '@types/react': 18.3.2
+      '@babel/runtime': 7.24.7
+      '@mui/material': 5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@types/react': 18.3.3
       react: 18.3.1
     dev: false
 
-  /@mui/lab@5.0.0-alpha.168(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/material@5.15.17)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
+  /@mui/lab@5.0.0-alpha.168(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/material@5.15.20)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-VKLQP5J/SujylvW3/riMtQYTspTluUkKLW/eu48RwuKby583cFCg8p4fWl4PpC3drwq6g9AeJ7DG4w0K+zFbdA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -2825,23 +2886,23 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
-      '@emotion/react': 11.11.4(@types/react@18.3.2)(react@18.3.1)
-      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.2)(react@18.3.1)
-      '@mui/base': 5.0.0-beta.39(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
-      '@mui/material': 5.15.17(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
-      '@mui/system': 5.15.15(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react@18.3.1)
-      '@mui/types': 7.2.14(@types/react@18.3.2)
-      '@mui/utils': 5.15.14(@types/react@18.3.2)(react@18.3.1)
-      '@types/react': 18.3.2
+      '@babel/runtime': 7.24.7
+      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.3.1)
+      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.3.1)
+      '@mui/base': 5.0.0-beta.39(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@mui/material': 5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@mui/system': 5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react@18.3.1)
+      '@mui/types': 7.2.14(@types/react@18.3.3)
+      '@mui/utils': 5.15.20(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
-  /@mui/material@5.15.17(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-ru/MLvTkCh0AZXmqwIpqGTOoVBS/sX48zArXq/DvktxXZx4fskiRA2PEc7Rk5ZlFiZhKh4moL4an+l8zZwq49Q==}
+  /@mui/material@5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-tVq3l4qoXx/NxUgIx/x3lZiPn/5xDbdTE8VrLczNpfblLYZzlrbxA7kb9mI8NoBF6+w9WE9IrxWnKK5KlPI2bg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -2857,15 +2918,15 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
-      '@emotion/react': 11.11.4(@types/react@18.3.2)(react@18.3.1)
-      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.2)(react@18.3.1)
-      '@mui/base': 5.0.0-beta.40(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
-      '@mui/core-downloads-tracker': 5.15.17
-      '@mui/system': 5.15.15(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react@18.3.1)
-      '@mui/types': 7.2.14(@types/react@18.3.2)
-      '@mui/utils': 5.15.14(@types/react@18.3.2)(react@18.3.1)
-      '@types/react': 18.3.2
+      '@babel/runtime': 7.24.7
+      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.3.1)
+      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.3.1)
+      '@mui/base': 5.0.0-beta.40(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@mui/core-downloads-tracker': 5.15.20
+      '@mui/system': 5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react@18.3.1)
+      '@mui/types': 7.2.14(@types/react@18.3.3)
+      '@mui/utils': 5.15.20(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
       '@types/react-transition-group': 4.4.10
       clsx: 2.1.1
       csstype: 3.1.3
@@ -2876,8 +2937,8 @@ packages:
       react-transition-group: 4.4.5(react-dom@18.3.1)(react@18.3.1)
     dev: false
 
-  /@mui/private-theming@5.15.14(@types/react@18.3.2)(react@18.3.1):
-    resolution: {integrity: sha512-UH0EiZckOWcxiXLX3Jbb0K7rC8mxTr9L9l6QhOZxYc4r8FHUkefltV9VDGLrzCaWh30SQiJvAEd7djX3XXY6Xw==}
+  /@mui/private-theming@5.15.20(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-BK8F94AIqSrnaPYXf2KAOjGZJgWfvqAVQ2gVR3EryvQFtuBnG6RwodxrCvd3B48VuMy6Wsk897+lQMUxJyk+6g==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
@@ -2886,9 +2947,9 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
-      '@mui/utils': 5.15.14(@types/react@18.3.2)(react@18.3.1)
-      '@types/react': 18.3.2
+      '@babel/runtime': 7.24.7
+      '@mui/utils': 5.15.20(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
       prop-types: 15.8.1
       react: 18.3.1
     dev: false
@@ -2906,17 +2967,17 @@ packages:
       '@emotion/styled':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       '@emotion/cache': 11.11.0
-      '@emotion/react': 11.11.4(@types/react@18.3.2)(react@18.3.1)
-      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.2)(react@18.3.1)
+      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.3.1)
+      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.3.1)
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.3.1
     dev: false
 
-  /@mui/styles@5.15.17(@types/react@18.3.2)(react@18.3.1):
-    resolution: {integrity: sha512-PyZkFvUHDNcpCO+5Mr9t2g/De1JT7UAxjKgd5ojeoGmFiEhVQdZxbdHr6CZ1kBznqKU5nsWf1EmvI60iR3Nl+w==}
+  /@mui/styles@5.15.20(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-zpXYhNxQ9A4zxF3IRQRZRUg7fXYj6Wfa3nB+7yOLVecokhjCAr1zY2VC5Uznf5qs2cfgBRfmDkBYqvQjHWf2uA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
@@ -2925,12 +2986,12 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       '@emotion/hash': 0.9.1
-      '@mui/private-theming': 5.15.14(@types/react@18.3.2)(react@18.3.1)
-      '@mui/types': 7.2.14(@types/react@18.3.2)
-      '@mui/utils': 5.15.14(@types/react@18.3.2)(react@18.3.1)
-      '@types/react': 18.3.2
+      '@mui/private-theming': 5.15.20(@types/react@18.3.3)(react@18.3.1)
+      '@mui/types': 7.2.14(@types/react@18.3.3)
+      '@mui/utils': 5.15.20(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
       clsx: 2.1.1
       csstype: 3.1.3
       hoist-non-react-statics: 3.3.2
@@ -2946,8 +3007,8 @@ packages:
       react: 18.3.1
     dev: false
 
-  /@mui/system@5.15.15(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react@18.3.1):
-    resolution: {integrity: sha512-aulox6N1dnu5PABsfxVGOZffDVmlxPOVgj56HrUnJE8MCSh8lOvvkd47cebIVQQYAjpwieXQXiDPj5pwM40jTQ==}
+  /@mui/system@5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-LoMq4IlAAhxzL2VNUDBTQxAb4chnBe8JvRINVNDiMtHE2PiPOoHlhOPutSxEbaL5mkECPVWSv6p8JEV+uykwIA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -2962,21 +3023,21 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
-      '@emotion/react': 11.11.4(@types/react@18.3.2)(react@18.3.1)
-      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.2)(react@18.3.1)
-      '@mui/private-theming': 5.15.14(@types/react@18.3.2)(react@18.3.1)
+      '@babel/runtime': 7.24.7
+      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.3.1)
+      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.3.1)
+      '@mui/private-theming': 5.15.20(@types/react@18.3.3)(react@18.3.1)
       '@mui/styled-engine': 5.15.14(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(react@18.3.1)
-      '@mui/types': 7.2.14(@types/react@18.3.2)
-      '@mui/utils': 5.15.14(@types/react@18.3.2)(react@18.3.1)
-      '@types/react': 18.3.2
+      '@mui/types': 7.2.14(@types/react@18.3.3)
+      '@mui/utils': 5.15.20(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.3.1
     dev: false
 
-  /@mui/types@7.2.14(@types/react@18.3.2):
+  /@mui/types@7.2.14(@types/react@18.3.3):
     resolution: {integrity: sha512-MZsBZ4q4HfzBsywtXgM1Ksj6HDThtiwmOKUXH1pKYISI9gAVXCNHNpo7TlGoGrBaYWZTdNoirIN7JsQcQUjmQQ==}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
@@ -2984,11 +3045,11 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
     dev: false
 
-  /@mui/utils@5.15.14(@types/react@18.3.2)(react@18.3.1):
-    resolution: {integrity: sha512-0lF/7Hh/ezDv5X7Pry6enMsbYyGKjADzvHyo3Qrc/SSlTsQ1VkbDMbH0m2t3OR5iIVLwMoxwM7yGd+6FCMtTFA==}
+  /@mui/utils@5.15.20(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-mAbYx0sovrnpAu1zHc3MDIhPqL8RPVC5W5xcO1b7PiSCJPtckIZmBkp8hefamAvUiAV8gpfMOM6Zb+eSisbI2A==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
@@ -2997,16 +3058,16 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       '@types/prop-types': 15.7.12
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       prop-types: 15.8.1
       react: 18.3.1
       react-is: 18.3.1
     dev: false
 
-  /@mui/x-date-pickers@7.6.2(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/material@5.15.17)(@types/react@18.3.2)(dayjs@1.11.11)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-9e5qO76eLvjiEm7Yt4HNR1jqGFia7vnZYbhi4Tw/xQ32emMKYLUzXZLhQNtb1wa7SwHWxXcPJOkIEmvQgEvaqQ==}
+  /@mui/x-date-pickers@7.7.0(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/material@5.15.20)(@types/react@18.3.3)(dayjs@1.11.11)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-huyoA22Vi8iCkee6ro0sX7CcFIcPV/Fl7ZGWwaQC8PTAheXhz823DjMYAiwRU/imF+UFYfUInWQ4XZCIkM+2Dw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.9.0
@@ -3042,12 +3103,12 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.24.7
-      '@emotion/react': 11.11.4(@types/react@18.3.2)(react@18.3.1)
-      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.2)(react@18.3.1)
-      '@mui/base': 5.0.0-beta.40(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
-      '@mui/material': 5.15.17(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
-      '@mui/system': 5.15.15(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react@18.3.1)
-      '@mui/utils': 5.15.14(@types/react@18.3.2)(react@18.3.1)
+      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.3.1)
+      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.3.1)
+      '@mui/base': 5.0.0-beta.40(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@mui/material': 5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@mui/system': 5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react@18.3.1)
+      '@mui/utils': 5.15.20(@types/react@18.3.3)(react@18.3.1)
       '@types/react-transition-group': 4.4.10
       clsx: 2.1.1
       dayjs: 1.11.11
@@ -3219,67 +3280,67 @@ packages:
   /@types/babel__core@7.20.5:
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
     dependencies:
-      '@babel/parser': 7.24.5
-      '@babel/types': 7.24.5
+      '@babel/parser': 7.24.7
+      '@babel/types': 7.24.7
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.20.5
+      '@types/babel__traverse': 7.20.6
     dev: true
 
   /@types/babel__generator@7.6.8:
     resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
     dependencies:
-      '@babel/types': 7.24.5
+      '@babel/types': 7.24.7
     dev: true
 
   /@types/babel__template@7.4.4:
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
     dependencies:
-      '@babel/parser': 7.24.5
-      '@babel/types': 7.24.5
+      '@babel/parser': 7.24.7
+      '@babel/types': 7.24.7
     dev: true
 
-  /@types/babel__traverse@7.20.5:
-    resolution: {integrity: sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==}
+  /@types/babel__traverse@7.20.6:
+    resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
     dependencies:
-      '@babel/types': 7.24.5
+      '@babel/types': 7.24.7
     dev: true
 
   /@types/body-parser@1.19.5:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
     dev: true
 
   /@types/bonjour@3.5.13:
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
     dev: true
 
   /@types/connect-history-api-fallback@1.5.4:
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
     dependencies:
-      '@types/express-serve-static-core': 4.19.0
-      '@types/node': 20.12.12
+      '@types/express-serve-static-core': 4.19.3
+      '@types/node': 20.14.2
     dev: true
 
   /@types/connect@3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
     dev: true
 
   /@types/create-react-class@15.6.8:
     resolution: {integrity: sha512-s5HocgHXvN4Phoypsz8+4TLFreWRUrMcq9MHgwVleqNNR5EipSrFN49LCU/N7j8nIiQoRExY9n79LBrTDdsE1Q==}
     dependencies:
       '@types/prop-types': 15.7.12
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
     dev: true
 
-  /@types/emscripten@1.39.12:
-    resolution: {integrity: sha512-AQImDBgudQfMqUBfrjZYilRxoHDzTBp+ejh+g1fY67eSMalwIKtBXofjpyI0JBgNpHGzxeGAR2QDya0wxW9zbA==}
+  /@types/emscripten@1.39.13:
+    resolution: {integrity: sha512-cFq+fO/isvhvmuP/+Sl4K4jtU6E23DoivtbO4r50e3odaxAiVdbfSYRDdJ4gCdxx+3aRjhphS5ZMwIH4hFy/Cw==}
     dev: true
 
   /@types/eslint-scope@3.7.7:
@@ -3300,10 +3361,10 @@ packages:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
 
-  /@types/express-serve-static-core@4.19.0:
-    resolution: {integrity: sha512-bGyep3JqPCRry1wq+O5n7oiBgGWmeIJXPjXXCo8EK0u8duZGSYar7cGqd3ML2JUsLGeB7fmc06KYo9fLGWqPvQ==}
+  /@types/express-serve-static-core@4.19.3:
+    resolution: {integrity: sha512-KOzM7MhcBFlmnlr/fzISFF5vGWVSvN6fTd4T+ExOt08bA/dA5kpSzY52nMsI1KDFmUREpJelPYyuslLRSjjgCg==}
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -3313,7 +3374,7 @@ packages:
     resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
     dependencies:
       '@types/body-parser': 1.19.5
-      '@types/express-serve-static-core': 4.19.0
+      '@types/express-serve-static-core': 4.19.3
       '@types/qs': 6.9.15
       '@types/serve-static': 1.15.7
     dev: true
@@ -3326,20 +3387,20 @@ packages:
     resolution: {integrity: sha512-WRXN0kQPCnqxN0/PgNgc7WBF6c8rbSHsEep3/qBLpsQ824RONdOmTs0TV7XhIW2GDNRAHO2CqCgAFLR5PChosw==}
     dependencies:
       '@types/fbemitter': 2.0.35
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
     dev: true
 
   /@types/glob@7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
     dev: true
 
   /@types/graceful-fs@4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
     dev: true
 
   /@types/history@4.7.11:
@@ -3357,7 +3418,7 @@ packages:
   /@types/http-proxy@1.17.14:
     resolution: {integrity: sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==}
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.6:
@@ -3397,8 +3458,8 @@ packages:
       '@types/webpack': 4.41.38
     dev: true
 
-  /@types/lodash@4.17.1:
-    resolution: {integrity: sha512-X+2qazGS3jxLAIz5JDXDzglAF3KpijdhFxlf/V1+hEsOUc+HnWi81L/uv/EvGuV90WY+7mPGFCUDGfQC3Gj95Q==}
+  /@types/lodash@4.17.5:
+    resolution: {integrity: sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==}
     dev: true
 
   /@types/mime@1.3.5:
@@ -3412,11 +3473,11 @@ packages:
   /@types/node-forge@1.3.11:
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
     dev: true
 
-  /@types/node@20.12.12:
-    resolution: {integrity: sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==}
+  /@types/node@20.14.2:
+    resolution: {integrity: sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -3447,14 +3508,14 @@ packages:
   /@types/react-dom@18.3.0:
     resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
     dependencies:
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
     dev: true
 
   /@types/react-router-dom@5.3.3:
     resolution: {integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       '@types/react-router': 5.1.20
     dev: true
 
@@ -3462,17 +3523,17 @@ packages:
     resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
     dev: true
 
   /@types/react-transition-group@4.4.10:
     resolution: {integrity: sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==}
     dependencies:
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
     dev: false
 
-  /@types/react@18.3.2:
-    resolution: {integrity: sha512-Btgg89dAnqD4vV7R3hlwOxgqobUQKgx3MmrQRi0yYbs/P0ym8XozIAlkqVilPqHQwXs4e9Tf63rrCgl58BcO4w==}
+  /@types/react@18.3.3:
+    resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
     dependencies:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
@@ -3495,7 +3556,7 @@ packages:
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
     dev: true
 
   /@types/serve-index@1.9.4:
@@ -3508,14 +3569,14 @@ packages:
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       '@types/send': 0.17.4
     dev: true
 
   /@types/sockjs@0.3.36:
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
     dev: true
 
   /@types/source-list-map@0.1.6:
@@ -3525,8 +3586,8 @@ packages:
   /@types/sql.js@1.4.9:
     resolution: {integrity: sha512-ep8b36RKHlgWPqjNG9ToUrPiwkhwh0AEzy883mO5Xnd+cL6VBH1EvSjBAAuxLUFF2Vn/moE3Me6v9E1Lo+48GQ==}
     dependencies:
-      '@types/emscripten': 1.39.12
-      '@types/node': 20.12.12
+      '@types/emscripten': 1.39.13
+      '@types/node': 20.14.2
     dev: true
 
   /@types/stack-utils@2.0.3:
@@ -3546,7 +3607,7 @@ packages:
   /@types/webpack-sources@3.2.3:
     resolution: {integrity: sha512-4nZOdMwSPHZ4pTEZzSp0AsTM4K7Qmu40UKW4tJDiOVs20UzYF9l+qUe4s0ftfN0pin06n+5cWWDJXH+sbhAiDw==}
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       '@types/source-list-map': 0.1.6
       source-map: 0.7.4
     dev: true
@@ -3554,7 +3615,7 @@ packages:
   /@types/webpack@4.41.38:
     resolution: {integrity: sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==}
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       '@types/tapable': 1.0.12
       '@types/uglify-js': 3.17.5
       '@types/webpack-sources': 3.2.3
@@ -3565,7 +3626,7 @@ packages:
   /@types/ws@8.5.10:
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
     dev: true
 
   /@types/yargs-parser@21.0.3:
@@ -3589,13 +3650,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.10.0
+      '@eslint-community/regexpp': 4.10.1
       '@typescript-eslint/parser': 7.8.0(eslint@8.57.0)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 7.8.0
       '@typescript-eslint/type-utils': 7.8.0(eslint@8.57.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 7.8.0
-      debug: 4.3.4
+      debug: 4.3.5
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -3621,7 +3682,7 @@ packages:
       '@typescript-eslint/types': 7.8.0
       '@typescript-eslint/typescript-estree': 7.8.0(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 7.8.0
-      debug: 4.3.4
+      debug: 4.3.5
       eslint: 8.57.0
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -3656,7 +3717,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.8.0(typescript@4.9.5)
       '@typescript-eslint/utils': 7.8.0(eslint@8.57.0)(typescript@4.9.5)
-      debug: 4.3.4
+      debug: 4.3.5
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@4.9.5)
       typescript: 4.9.5
@@ -3685,7 +3746,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4
+      debug: 4.3.5
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.2
@@ -3706,7 +3767,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 7.8.0
       '@typescript-eslint/visitor-keys': 7.8.0
-      debug: 4.3.4
+      debug: 4.3.5
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -3882,14 +3943,14 @@ packages:
       '@xtuc/long': 4.2.2
     dev: true
 
-  /@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0)(webpack@5.91.0):
+  /@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0)(webpack@5.92.0):
     resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
     peerDependencies:
       webpack: 4.x.x || 5.x.x
       webpack-cli: 4.x.x
     dependencies:
-      webpack: 5.91.0(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.91.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
     dev: true
 
   /@webpack-cli/info@1.5.0(webpack-cli@4.10.0):
@@ -3898,7 +3959,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.13.0
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.91.0)
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
     dev: true
 
   /@webpack-cli/serve@1.7.0(webpack-cli@4.10.0)(webpack-dev-server@4.15.2):
@@ -3910,8 +3971,8 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.91.0)
-      webpack-dev-server: 4.15.2(webpack-cli@4.10.0)(webpack@5.91.0)
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
+      webpack-dev-server: 4.15.2(webpack-cli@4.10.0)(webpack@5.92.0)
     dev: true
 
   /@xtuc/ieee754@1.2.0:
@@ -3942,8 +4003,8 @@ packages:
       acorn-walk: 7.2.0
     dev: true
 
-  /acorn-import-assertions@1.9.0(acorn@8.11.3):
-    resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
+  /acorn-import-attributes@1.9.5(acorn@8.11.3):
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
       acorn: ^8
     dependencies:
@@ -3984,7 +4045,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3992,7 +4053,7 @@ packages:
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     dependencies:
-      ajv: 8.13.0
+      ajv: 8.16.0
 
   /ajv-keywords@3.5.2(ajv@6.12.6):
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -4002,12 +4063,12 @@ packages:
       ajv: 6.12.6
     dev: true
 
-  /ajv-keywords@5.1.0(ajv@8.13.0):
+  /ajv-keywords@5.1.0(ajv@8.16.0):
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
       ajv: ^8.8.2
     dependencies:
-      ajv: 8.13.0
+      ajv: 8.16.0
       fast-deep-equal: 3.1.3
     dev: true
 
@@ -4020,8 +4081,8 @@ packages:
       uri-js: 4.4.1
     dev: true
 
-  /ajv@8.13.0:
-    resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
+  /ajv@8.16.0:
+    resolution: {integrity: sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==}
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -4191,8 +4252,9 @@ packages:
       es-shim-unscopables: 1.0.2
     dev: true
 
-  /array.prototype.tosorted@1.1.3:
-    resolution: {integrity: sha512-/DdH4TiTmOKzyQbp/eadcCVexiCb36xJg7HshYOYJnNZFDj33GEv0P7GxsynpShhq4OLYJzbGcBDkLsDt7MnNg==}
+  /array.prototype.tosorted@1.1.4:
+    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
+    engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
@@ -4245,8 +4307,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /axios@1.6.8:
-    resolution: {integrity: sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==}
+  /axios@1.7.2:
+    resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
     dependencies:
       follow-redirects: 1.15.6
       form-data: 4.0.0
@@ -4261,18 +4323,18 @@ packages:
       dequal: 2.0.3
     dev: true
 
-  /babel-jest@27.5.1(@babel/core@7.24.5):
+  /babel-jest@27.5.1(@babel/core@7.24.7):
     resolution: {integrity: sha512-cdQ5dXjGRd0IBRATiQ4mZGlGlRE8kJpjPOixdNRdT+m3UcNqmYWN6rK6nvtXYfY3D76cb8s/O1Ss8ea24PIwcg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
-      '@babel/core': 7.24.5
+      '@babel/core': 7.24.7
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 27.5.1(@babel/core@7.24.5)
+      babel-preset-jest: 27.5.1(@babel/core@7.24.7)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -4280,32 +4342,34 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader@8.3.0(@babel/core@7.24.5)(webpack@5.91.0):
+  /babel-loader@8.3.0(@babel/core@7.24.7)(webpack@5.92.0):
     resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
     engines: {node: '>= 8.9'}
     peerDependencies:
       '@babel/core': ^7.0.0
       webpack: '>=2'
     dependencies:
-      '@babel/core': 7.24.5
+      '@babel/core': 7.24.7
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
     dev: true
 
   /babel-plugin-import@1.13.8:
     resolution: {integrity: sha512-36babpjra5m3gca44V6tSTomeBlPA7cHUynrE2WiQIm3rEGD9xy28MKsx5IdO45EbnpJY7Jrgd00C6Dwt/l/2Q==}
     dependencies:
-      '@babel/helper-module-imports': 7.24.3
+      '@babel/helper-module-imports': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /babel-plugin-istanbul@6.1.1:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/helper-plugin-utils': 7.24.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.2.1
@@ -4318,96 +4382,98 @@ packages:
     resolution: {integrity: sha512-50wCwD5EMNW4aRpOwtqzyZHIewTYNxLA4nhB+09d8BIssfNfzBRhkBIHiaPv1Si226TQSvp8gxAJm2iY2qs2hQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/template': 7.24.0
-      '@babel/types': 7.24.5
+      '@babel/template': 7.24.7
+      '@babel/types': 7.24.7
       '@types/babel__core': 7.20.5
-      '@types/babel__traverse': 7.20.5
+      '@types/babel__traverse': 7.20.6
     dev: true
 
   /babel-plugin-lodash@3.3.4:
     resolution: {integrity: sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==}
     dependencies:
-      '@babel/helper-module-imports': 7.24.3
-      '@babel/types': 7.24.5
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/types': 7.24.7
       glob: 7.2.3
       lodash: 4.17.21
       require-package-name: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       cosmiconfig: 7.1.0
       resolve: 1.22.8
     dev: false
 
-  /babel-plugin-polyfill-corejs2@0.4.11(@babel/core@7.24.5):
+  /babel-plugin-polyfill-corejs2@0.4.11(@babel/core@7.24.7):
     resolution: {integrity: sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/compat-data': 7.24.4
-      '@babel/core': 7.24.5
-      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.24.5)
+      '@babel/compat-data': 7.24.7
+      '@babel/core': 7.24.7
+      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.24.7)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-corejs3@0.10.4(@babel/core@7.24.5):
+  /babel-plugin-polyfill-corejs3@0.10.4(@babel/core@7.24.7):
     resolution: {integrity: sha512-25J6I8NGfa5YkCDogHRID3fVCadIR8/pGl1/spvCkzb6lVn6SR3ojpx9nOn9iEBcUsjY24AmdKm5khcfKdylcg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.24.7)
       core-js-compat: 3.37.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-regenerator@0.6.2(@babel/core@7.24.5):
+  /babel-plugin-polyfill-regenerator@0.6.2(@babel/core@7.24.7):
     resolution: {integrity: sha512-2R25rQZWP63nGwaAswvDazbPXfrM3HwVoBXK6HcqeKrSrL/JqcC/rDcf95l4r7LXLyxDXc8uQDa064GubtCABg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.24.7)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-preset-current-node-syntax@1.0.1(@babel/core@7.24.5):
+  /babel-preset-current-node-syntax@1.0.1(@babel/core@7.24.7):
     resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.5)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.5)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.5)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.5)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.5)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.5)
+      '@babel/core': 7.24.7
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.7)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.7)
     dev: true
 
-  /babel-preset-jest@27.5.1(@babel/core@7.24.5):
+  /babel-preset-jest@27.5.1(@babel/core@7.24.7):
     resolution: {integrity: sha512-Nptf2FzlPCWYuJg41HBqXVT8ym6bXOevuCTbhxlUpjwtysGaIWFvDEjp4y+G7fl13FgOdjs7P/DmErqH7da0Ag==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.5
+      '@babel/core': 7.24.7
       babel-plugin-jest-hoist: 27.5.1
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.5)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.7)
     dev: true
 
   /balanced-match@1.0.2:
@@ -4470,26 +4536,26 @@ packages:
       balanced-match: 1.0.2
     dev: true
 
-  /braces@3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+  /braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
     dependencies:
-      fill-range: 7.0.1
+      fill-range: 7.1.1
     dev: true
 
   /browser-process-hrtime@1.0.0:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
     dev: true
 
-  /browserslist@4.23.0:
-    resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
+  /browserslist@4.23.1:
+    resolution: {integrity: sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001618
-      electron-to-chromium: 1.4.770
+      caniuse-lite: 1.0.30001633
+      electron-to-chromium: 1.4.802
       node-releases: 2.0.14
-      update-browserslist-db: 1.0.16(browserslist@4.23.0)
+      update-browserslist-db: 1.0.16(browserslist@4.23.1)
     dev: true
 
   /bser@2.1.1:
@@ -4531,7 +4597,7 @@ packages:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.6.2
+      tslib: 2.6.3
     dev: true
 
   /camelcase@5.3.1:
@@ -4544,8 +4610,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite@1.0.30001618:
-    resolution: {integrity: sha512-p407+D1tIkDvsEAPS22lJxLQQaG8OTBEqo0KhzfABGk0TU4juBNDSfH0hyAp/HRyx+M8L17z/ltyhxh27FTfQg==}
+  /caniuse-lite@1.0.30001633:
+    resolution: {integrity: sha512-6sT0yf/z5jqf8tISAgpJDrmwOpLsrpnyCdD/lOZKvKkkJK4Dn0X5i7KF7THEZhOq+30bmhwBlNEaqPUiHiKtZg==}
     dev: true
 
   /chalk@2.4.2:
@@ -4569,20 +4635,20 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /chart.js@4.4.2:
-    resolution: {integrity: sha512-6GD7iKwFpP5kbSD4MeRRRlTnQvxfQREy36uEtm1hzHzcOqwWx0YEHuspuoNlslu+nciLIB7fjjsHkUv/FzFcOg==}
+  /chart.js@4.4.3:
+    resolution: {integrity: sha512-qK1gkGSRYcJzqrrzdR6a+I0vQ4/R+SoODXyAjscQ/4mzuNzySaMCd+hyVxitSY1+L2fjPD1Gbn+ibNqRmwQeLw==}
     engines: {pnpm: '>=8'}
     dependencies:
       '@kurkle/color': 0.3.2
     dev: false
 
-  /chartjs-adapter-moment@1.0.1(chart.js@4.4.2)(moment@2.30.1):
+  /chartjs-adapter-moment@1.0.1(chart.js@4.4.3)(moment@2.30.1):
     resolution: {integrity: sha512-Uz+nTX/GxocuqXpGylxK19YG4R3OSVf8326D+HwSTsNw1LgzyIGRo+Qujwro1wy6X+soNSnfj5t2vZ+r6EaDmA==}
     peerDependencies:
       chart.js: '>=3.0.0'
       moment: ^2.10.2
     dependencies:
-      chart.js: 4.4.2
+      chart.js: 4.4.3
       moment: 2.30.1
     dev: false
 
@@ -4591,7 +4657,7 @@ packages:
     engines: {node: '>= 8.10.0'}
     dependencies:
       anymatch: 3.1.3
-      braces: 3.0.2
+      braces: 3.0.3
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3
@@ -4601,8 +4667,8 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /chrome-trace-event@1.0.3:
-    resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
+  /chrome-trace-event@1.0.4:
+    resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
     dev: true
 
@@ -4718,8 +4784,8 @@ packages:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
 
-  /commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+  /commander@6.2.1:
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
     dev: true
 
@@ -4744,7 +4810,7 @@ packages:
       mime-db: 1.52.0
     dev: true
 
-  /compression-webpack-plugin@10.0.0(webpack@5.91.0):
+  /compression-webpack-plugin@10.0.0(webpack@5.92.0):
     resolution: {integrity: sha512-wLXLIBwpul/ALcm7Aj+69X0pYT3BYt6DdPn3qrgBIh9YejV9Bju9ShhlAsjujLyWMo6SAweFIWaUoFmXZNuNrg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -4752,7 +4818,7 @@ packages:
     dependencies:
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
     dev: true
 
   /compression@1.7.4:
@@ -4809,7 +4875,7 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /copy-webpack-plugin@10.2.4(webpack@5.91.0):
+  /copy-webpack-plugin@10.2.4(webpack@5.92.0):
     resolution: {integrity: sha512-xFVltahqlsRcyyJqQbDY6EYTtyQZF9rf+JPjwHObLdPFMEISqkFkr7mFoVOC6BfYS/dNThyoQKvziugm+OnwBg==}
     engines: {node: '>= 12.20.0'}
     peerDependencies:
@@ -4821,13 +4887,13 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
     dev: true
 
   /core-js-compat@3.37.1:
     resolution: {integrity: sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==}
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.1
     dev: true
 
   /core-js-pure@3.37.1:
@@ -4867,7 +4933,7 @@ packages:
       which: 2.0.2
     dev: true
 
-  /css-loader@6.11.0(webpack@5.91.0):
+  /css-loader@6.11.0(webpack@5.92.0):
     resolution: {integrity: sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -4887,7 +4953,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
       semver: 7.6.2
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
     dev: true
 
   /css-select@4.3.0:
@@ -4903,7 +4969,7 @@ packages:
   /css-vendor@2.0.8:
     resolution: {integrity: sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       is-in-browser: 1.1.3
     dev: false
 
@@ -5000,8 +5066,8 @@ packages:
       ms: 2.1.3
     dev: true
 
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+  /debug@4.3.5:
+    resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -5010,7 +5076,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
@@ -5138,7 +5203,7 @@ packages:
   /dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       csstype: 3.1.3
     dev: false
 
@@ -5197,7 +5262,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.6.3
     dev: true
 
   /duplexer@0.1.2:
@@ -5212,8 +5277,8 @@ packages:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
     dev: true
 
-  /electron-to-chromium@1.4.770:
-    resolution: {integrity: sha512-ONwOsDiVvV07CMsyH4+dEaZ9L79HMH/ODHnDS3GkIhgNqdDHJN2C18kFb0fBj0RXpQywsPJl6k2Pqg1IY4r1ig==}
+  /electron-to-chromium@1.4.802:
+    resolution: {integrity: sha512-TnTMUATbgNdPXVSHsxvNVSG0uEd6cSZsANjm8c9HbvflZVVn1yTRcmVXYT1Ma95/ssB/Dcd30AHweH2TE+dNpA==}
     dev: true
 
   /email-addresses@3.1.0:
@@ -5243,8 +5308,8 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /enhanced-resolve@5.16.1:
-    resolution: {integrity: sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==}
+  /enhanced-resolve@5.17.0:
+    resolution: {integrity: sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==}
     engines: {node: '>=10.13.0'}
     dependencies:
       graceful-fs: 4.2.11
@@ -5358,8 +5423,8 @@ packages:
       safe-array-concat: 1.1.2
     dev: true
 
-  /es-module-lexer@1.5.2:
-    resolution: {integrity: sha512-l60ETUTmLqbVbVHv1J4/qj+M8nq7AwMzEcg3kmJDt9dCNrTk+yHcYFf/Kw75pMDwd9mPcIGCG5LcS20SxYRzFA==}
+  /es-module-lexer@1.5.3:
+    resolution: {integrity: sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==}
     dev: true
 
   /es-object-atoms@1.0.0:
@@ -5442,7 +5507,7 @@ packages:
       semver: 6.3.1
     dev: true
 
-  /eslint-config-airbnb@19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.1)(eslint@8.57.0):
+  /eslint-config-airbnb@19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.8.0)(eslint-plugin-react-hooks@4.6.2)(eslint-plugin-react@7.34.2)(eslint@8.57.0):
     resolution: {integrity: sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==}
     engines: {node: ^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5456,7 +5521,7 @@ packages:
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-import: 2.29.1(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
-      eslint-plugin-react: 7.34.1(eslint@8.57.0)
+      eslint-plugin-react: 7.34.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
       object.assign: 4.1.5
       object.entries: 1.1.8
@@ -5546,7 +5611,7 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       aria-query: 5.3.0
       array-includes: 3.1.8
       array.prototype.flatmap: 1.3.2
@@ -5591,8 +5656,8 @@ packages:
       eslint: 8.57.0
     dev: true
 
-  /eslint-plugin-react@7.34.1(eslint@8.57.0):
-    resolution: {integrity: sha512-N97CxlouPT1AHt8Jn0mhhN2RrADlUAsk1/atcT2KyA/l9Q/E6ll7OIGwNumFmWfZ9skV3XXccYS19h80rHtgkw==}
+  /eslint-plugin-react@7.34.2(eslint@8.57.0):
+    resolution: {integrity: sha512-2HCmrU+/JNigDN6tg55cRDKCQWicYAPB38JGSFDQt95jDm8rrvSUo7YPkOIm5l6ts1j1zCvysNcasvfTMQzUOw==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
@@ -5601,7 +5666,7 @@ packages:
       array.prototype.findlast: 1.2.5
       array.prototype.flatmap: 1.3.2
       array.prototype.toreversed: 1.1.2
-      array.prototype.tosorted: 1.1.3
+      array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.0.19
       eslint: 8.57.0
@@ -5650,7 +5715,7 @@ packages:
     hasBin: true
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      '@eslint-community/regexpp': 4.10.0
+      '@eslint-community/regexpp': 4.10.1
       '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.57.0
       '@humanwhocodes/config-array': 0.11.14
@@ -5660,7 +5725,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.5
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -5835,7 +5900,7 @@ packages:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.5
+      micromatch: 4.0.7
     dev: true
 
   /fast-json-stable-stringify@2.1.0:
@@ -5877,7 +5942,7 @@ packages:
       flat-cache: 3.2.0
     dev: true
 
-  /file-loader@6.2.0(webpack@5.91.0):
+  /file-loader@6.2.0(webpack@5.92.0):
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -5885,14 +5950,14 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
     dev: true
 
   /file-selector@0.6.0:
     resolution: {integrity: sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==}
     engines: {node: '>= 12'}
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.3
     dev: false
 
   /filename-reserved-regex@2.0.0:
@@ -5914,8 +5979,8 @@ packages:
     engines: {node: '>= 0.4.0'}
     dev: true
 
-  /fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+  /fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
     requiresBuild: true
     dependencies:
@@ -6110,7 +6175,7 @@ packages:
       parse-headers: 2.0.5
       quick-lru: 6.1.2
       web-worker: 1.3.0
-      xml-utils: 1.8.0
+      xml-utils: 1.10.1
       zstddec: 0.1.0
     dev: false
 
@@ -6183,6 +6248,7 @@ packages:
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -6195,7 +6261,6 @@ packages:
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
-    dev: true
 
   /globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -6361,7 +6426,7 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
-  /html-loader@5.0.0(webpack@5.91.0):
+  /html-loader@5.0.0(webpack@5.92.0):
     resolution: {integrity: sha512-puaGKdjdVVIFRtgIC2n5dt5bt0N5j6heXlAQZ4Do1MLjHmOT1gCE1Ogg7XZNeJlnOVHHsrZKGs5dfh+XwZ3XPw==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
@@ -6369,7 +6434,7 @@ packages:
     dependencies:
       html-minifier-terser: 7.2.0
       parse5: 7.1.2
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
     dev: true
 
   /html-minifier-terser@6.1.0:
@@ -6383,7 +6448,7 @@ packages:
       he: 1.2.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.31.0
+      terser: 5.31.1
     dev: true
 
   /html-minifier-terser@7.2.0:
@@ -6397,7 +6462,7 @@ packages:
       entities: 4.5.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.31.0
+      terser: 5.31.1
     dev: true
 
   /html-parse-stringify@3.0.1:
@@ -6422,7 +6487,7 @@ packages:
     resolution: {integrity: sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==}
     dev: false
 
-  /html-webpack-plugin@5.6.0(webpack@5.91.0):
+  /html-webpack-plugin@5.6.0(webpack@5.92.0):
     resolution: {integrity: sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -6439,7 +6504,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
     dev: true
 
   /htmlparser2@6.1.0:
@@ -6503,7 +6568,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6522,7 +6587,7 @@ packages:
       http-proxy: 1.18.1
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
-      micromatch: 4.0.5
+      micromatch: 4.0.7
     transitivePeerDependencies:
       - debug
     dev: true
@@ -6543,7 +6608,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6572,13 +6637,13 @@ packages:
   /i18next@22.5.1:
     resolution: {integrity: sha512-8TGPgM3pAD+VRsMtUMNknRz3kzqwp/gPALrWMsDnmC1mKqJwpWyooQRLMcbTwq8z8YwSmuj+ZYvc+xCuEpkssA==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
     dev: false
 
-  /i18next@23.11.4:
-    resolution: {integrity: sha512-CCUjtd5TfaCl+mLUzAA0uPSN+AVn4fP/kWCYt/hocPUwusTpMVczdrRyOBUwk6N05iH40qiKx6q1DoNJtBIwdg==}
+  /i18next@23.11.5:
+    resolution: {integrity: sha512-41pvpVbW9rhZPk5xjCX2TPJi2861LEig/YRhUkY+1FQ2IQPS0bKUDYnEqY8XPPbB48h1uIwLnP9iiEfuSl20CA==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
     dev: false
 
   /iconv-lite@0.4.24:
@@ -6632,6 +6697,7 @@ packages:
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
@@ -6933,8 +6999,8 @@ packages:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/parser': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/parser': 7.24.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -6955,7 +7021,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.5
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -6996,7 +7062,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -7055,10 +7121,10 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.24.5
+      '@babel/core': 7.24.7
       '@jest/test-sequencer': 27.5.1
       '@jest/types': 27.5.1
-      babel-jest: 27.5.1(@babel/core@7.24.5)
+      babel-jest: 27.5.1(@babel/core@7.24.7)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -7074,7 +7140,7 @@ packages:
       jest-runner: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
-      micromatch: 4.0.5
+      micromatch: 4.0.7
       parse-json: 5.2.0
       pretty-format: 27.5.1
       slash: 3.0.0
@@ -7121,7 +7187,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -7139,7 +7205,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -7155,7 +7221,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -7163,7 +7229,7 @@ packages:
       jest-serializer: 27.5.1
       jest-util: 27.5.1
       jest-worker: 27.5.1
-      micromatch: 4.0.5
+      micromatch: 4.0.7
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -7177,7 +7243,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -7216,12 +7282,12 @@ packages:
     resolution: {integrity: sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/code-frame': 7.24.2
+      '@babel/code-frame': 7.24.7
       '@jest/types': 27.5.1
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      micromatch: 4.0.5
+      micromatch: 4.0.7
       pretty-format: 27.5.1
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -7232,7 +7298,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
     dev: true
 
   /jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
@@ -7288,7 +7354,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -7345,7 +7411,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       graceful-fs: 4.2.11
     dev: true
 
@@ -7353,16 +7419,16 @@ packages:
     resolution: {integrity: sha512-yYykXI5a0I31xX67mgeLw1DZ0bJB+gpq5IpSuCAoyDi0+BhgU/RIrL+RTzDmkNTchvDFWKP8lp+w/42Z3us5sA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/generator': 7.24.5
-      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.24.5)
-      '@babel/traverse': 7.24.5
-      '@babel/types': 7.24.5
+      '@babel/core': 7.24.7
+      '@babel/generator': 7.24.7
+      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.24.7)
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/babel__traverse': 7.20.5
+      '@types/babel__traverse': 7.20.6
       '@types/prettier': 2.7.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.5)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.7)
       chalk: 4.1.2
       expect: 27.5.1
       graceful-fs: 4.2.11
@@ -7384,7 +7450,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -7409,7 +7475,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -7420,7 +7486,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -7515,7 +7581,6 @@ packages:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -7565,7 +7630,7 @@ packages:
   /jss-plugin-camel-case@10.10.0:
     resolution: {integrity: sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       hyphenate-style-name: 1.0.5
       jss: 10.10.0
     dev: false
@@ -7573,21 +7638,21 @@ packages:
   /jss-plugin-default-unit@10.10.0:
     resolution: {integrity: sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       jss: 10.10.0
     dev: false
 
   /jss-plugin-global@10.10.0:
     resolution: {integrity: sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       jss: 10.10.0
     dev: false
 
   /jss-plugin-nested@10.10.0:
     resolution: {integrity: sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       jss: 10.10.0
       tiny-warning: 1.0.3
     dev: false
@@ -7595,14 +7660,14 @@ packages:
   /jss-plugin-props-sort@10.10.0:
     resolution: {integrity: sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       jss: 10.10.0
     dev: false
 
   /jss-plugin-rule-value-function@10.10.0:
     resolution: {integrity: sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       jss: 10.10.0
       tiny-warning: 1.0.3
     dev: false
@@ -7610,7 +7675,7 @@ packages:
   /jss-plugin-vendor-prefixer@10.10.0:
     resolution: {integrity: sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       css-vendor: 2.0.8
       jss: 10.10.0
     dev: false
@@ -7618,7 +7683,7 @@ packages:
   /jss@10.10.0:
     resolution: {integrity: sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       csstype: 3.1.3
       is-in-browser: 1.1.3
       tiny-warning: 1.0.3
@@ -7655,15 +7720,15 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /language-subtag-registry@0.3.22:
-    resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
+  /language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
     dev: true
 
   /language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
     dependencies:
-      language-subtag-registry: 0.3.22
+      language-subtag-registry: 0.3.23
     dev: true
 
   /launch-editor@2.6.1:
@@ -7733,13 +7798,13 @@ packages:
       p-locate: 5.0.0
     dev: true
 
-  /lodash-webpack-plugin@0.11.6(webpack@5.91.0):
+  /lodash-webpack-plugin@0.11.6(webpack@5.92.0):
     resolution: {integrity: sha512-nsHN/+IxZK/C425vGC8pAxkKJ8KQH2+NJnhDul14zYNWr6HJcA95w+oRR7Cp0oZpOdMplDZXmjVROp8prPk7ig==}
     peerDependencies:
       webpack: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.1.0
     dependencies:
       lodash: 4.17.21
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
     dev: true
 
   /lodash.debounce@4.0.8:
@@ -7762,7 +7827,7 @@ packages:
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.3
     dev: true
 
   /lru-cache@5.1.1:
@@ -7807,14 +7872,14 @@ packages:
     resolution: {integrity: sha512-X1dtuTuH2D1MRMuductMZCLV/fy9EoIgqW/lmu8vQSAhEatx/tdFebkYT3TVhdTwqFDHbLEgQBD3IKA4KI7aoQ==}
     dev: false
 
-  /markdown-loader@8.0.0(webpack@5.91.0):
+  /markdown-loader@8.0.0(webpack@5.92.0):
     resolution: {integrity: sha512-dxrR3WhK/hERbStPFb/yeNdEeWCKa2qUDdXiq3VTruBUWufOtERX04X0K44K4dnlN2i9pjSEzYIQJ3LjH0xkEw==}
     engines: {node: '>=12.22.9'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
       marked: 4.3.0
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
     dev: true
 
   /markdown-to-jsx@7.4.7(react@18.3.1):
@@ -7831,7 +7896,7 @@ packages:
     hasBin: true
     dev: true
 
-  /material-react-table@2.13.0(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/icons-material@5.15.17)(@mui/material@5.15.17)(@mui/x-date-pickers@7.6.2)(react-dom@18.3.1)(react@18.3.1):
+  /material-react-table@2.13.0(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/icons-material@5.15.20)(@mui/material@5.15.20)(@mui/x-date-pickers@7.7.0)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-ds4/cupDsXvoz8K8OpM3UqUyqKoAMkVdvmvP/+ovuWA23fPcjYvFFkUpBxtnZq5GKWM0+SZWzr14KQ1DgKCaFQ==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -7843,11 +7908,11 @@ packages:
       react: '>=17.0'
       react-dom: '>=17.0'
     dependencies:
-      '@emotion/react': 11.11.4(@types/react@18.3.2)(react@18.3.1)
-      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.2)(react@18.3.1)
-      '@mui/icons-material': 5.15.17(@mui/material@5.15.17)(@types/react@18.3.2)(react@18.3.1)
-      '@mui/material': 5.15.17(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
-      '@mui/x-date-pickers': 7.6.2(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/material@5.15.17)(@types/react@18.3.2)(dayjs@1.11.11)(react-dom@18.3.1)(react@18.3.1)
+      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.3.1)
+      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.3.1)
+      '@mui/icons-material': 5.15.20(@mui/material@5.15.20)(@types/react@18.3.3)(react@18.3.1)
+      '@mui/material': 5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@mui/x-date-pickers': 7.7.0(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@mui/material@5.15.20)(@types/react@18.3.3)(dayjs@1.11.11)(react-dom@18.3.1)(react@18.3.1)
       '@tanstack/match-sorter-utils': 8.15.1
       '@tanstack/react-table': 8.16.0(react-dom@18.3.1)(react@18.3.1)
       '@tanstack/react-virtual': 3.3.0(react-dom@18.3.1)(react@18.3.1)
@@ -7890,11 +7955,11 @@ packages:
     resolution: {integrity: sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==}
     dev: false
 
-  /micromatch@4.0.5:
-    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+  /micromatch@4.0.7:
+    resolution: {integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==}
     engines: {node: '>=8.6'}
     dependencies:
-      braces: 3.0.2
+      braces: 3.0.3
       picomatch: 2.3.1
     dev: true
 
@@ -7961,7 +8026,6 @@ packages:
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -7997,7 +8061,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.6.2
+      tslib: 2.6.3
     dev: true
 
   /node-fetch@2.6.7:
@@ -8120,8 +8184,8 @@ packages:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
     dev: true
 
-  /ol-mapbox-style@12.3.2(ol@9.1.0):
-    resolution: {integrity: sha512-Qw9I6+WHz9zBsLNm8zWWb707Y/hXrQP1fcwK86pxcX/FklwyDxAhfJAdTkINHncZ331CBEWcqvi2tzoN23dgwg==}
+  /ol-mapbox-style@12.3.3(ol@9.1.0):
+    resolution: {integrity: sha512-Wyb1vSxTl/c09S9yC/Dcr7XWQf5u19/9BriqOiDJRgbjLTAbrWXW8l+5N9E/I0fV2gcTQDE+7iFtvVOvXcTmMA==}
     peerDependencies:
       ol: '*'
     dependencies:
@@ -8241,7 +8305,7 @@ packages:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.6.3
     dev: true
 
   /parent-module@1.0.1:
@@ -8258,7 +8322,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.24.2
+      '@babel/code-frame': 7.24.7
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -8286,7 +8350,7 @@ packages:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.6.3
     dev: true
 
   /path-exists@4.0.0:
@@ -8387,7 +8451,7 @@ packages:
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
-      postcss-selector-parser: 6.0.16
+      postcss-selector-parser: 6.1.0
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -8398,7 +8462,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       postcss: 8.4.38
-      postcss-selector-parser: 6.0.16
+      postcss-selector-parser: 6.1.0
     dev: true
 
   /postcss-modules-values@4.0.0(postcss@8.4.38):
@@ -8411,8 +8475,8 @@ packages:
       postcss: 8.4.38
     dev: true
 
-  /postcss-selector-parser@6.0.16:
-    resolution: {integrity: sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==}
+  /postcss-selector-parser@6.1.0:
+    resolution: {integrity: sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==}
     engines: {node: '>=4'}
     dependencies:
       cssesc: 3.0.0
@@ -8576,13 +8640,13 @@ packages:
       quickselect: 2.0.0
     dev: false
 
-  /react-chartjs-2@5.2.0(chart.js@4.4.2)(react@18.3.1):
+  /react-chartjs-2@5.2.0(chart.js@4.4.3)(react@18.3.1):
     resolution: {integrity: sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==}
     peerDependencies:
       chart.js: ^4.1.1
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      chart.js: 4.4.2
+      chart.js: 4.4.3
       react: 18.3.1
     dev: false
 
@@ -8632,14 +8696,14 @@ packages:
       react-native:
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       html-parse-stringify: 3.0.1
       i18next: 22.5.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
-  /react-i18next@13.5.0(i18next@23.11.4)(react-dom@18.3.1)(react@18.3.1):
+  /react-i18next@13.5.0(i18next@23.11.5)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==}
     peerDependencies:
       i18next: '>= 23.2.3'
@@ -8652,9 +8716,9 @@ packages:
       react-native:
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       html-parse-stringify: 3.0.1
-      i18next: 23.11.4
+      i18next: 23.11.5
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     dev: false
@@ -8701,7 +8765,7 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -8781,7 +8845,7 @@ packages:
   /regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.24.7
     dev: true
 
   /regexp.prototype.flags@1.5.2:
@@ -8905,6 +8969,7 @@ packages:
 
   /rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
     dependencies:
       glob: 7.2.3
@@ -8962,7 +9027,7 @@ packages:
       postcss: 8.4.38
     dev: false
 
-  /sass-loader@12.6.0(sass@1.77.1)(webpack@5.91.0):
+  /sass-loader@12.6.0(sass@1.77.5)(webpack@5.92.0):
     resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -8983,12 +9048,12 @@ packages:
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
-      sass: 1.77.1
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      sass: 1.77.5
+      webpack: 5.92.0(webpack-cli@4.10.0)
     dev: true
 
-  /sass@1.77.1:
-    resolution: {integrity: sha512-OMEyfirt9XEfyvocduUIOlUSkWOXS/LAt6oblR/ISXCTukyavjex+zQNm51pPCOiFKY1QpWvEH1EeCkgyV3I6w==}
+  /sass@1.77.5:
+    resolution: {integrity: sha512-oDfX1mukIlxacPdQqNb6mV2tVCrnE+P3nVYioy72V5tlk56CPNcO4TCuFcaCRKKfJ1M3lH95CleRS+dVKL2qMg==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
@@ -9032,9 +9097,9 @@ packages:
     engines: {node: '>= 12.13.0'}
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.13.0
+      ajv: 8.16.0
       ajv-formats: 2.1.1
-      ajv-keywords: 5.1.0(ajv@8.13.0)
+      ajv-keywords: 5.1.0(ajv@8.16.0)
     dev: true
 
   /select-hose@2.0.0:
@@ -9189,7 +9254,7 @@ packages:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
 
-  /simple-zustand-devtools@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)(zustand@4.4.7):
+  /simple-zustand-devtools@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)(zustand@4.4.7):
     resolution: {integrity: sha512-Axfcfr9L3YL3kto7aschCQLY2VUlXXMnIVtaTe9Y0qWbNmPsX/y7KsNprmxBZoB0pww5ZGs1u/ohcrvQ3tE6jA==}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -9198,11 +9263,11 @@ packages:
       react-dom: '>=18.0.0'
       zustand: '>=1.0.2'
     dependencies:
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      zustand: 4.4.7(@types/react@18.3.2)(react@18.3.1)
+      zustand: 4.4.7(@types/react@18.3.3)(react@18.3.1)
     dev: true
 
   /sirv@2.0.4:
@@ -9288,7 +9353,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.5
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -9302,7 +9367,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.5
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -9454,13 +9519,13 @@ packages:
       escape-string-regexp: 1.0.5
     dev: true
 
-  /style-loader@3.3.4(webpack@5.91.0):
+  /style-loader@3.3.4(webpack@5.92.0):
     resolution: {integrity: sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
     dev: true
 
   /style-to-js@1.1.1:
@@ -9532,7 +9597,7 @@ packages:
       supports-hyperlinks: 2.3.0
     dev: true
 
-  /terser-webpack-plugin@5.3.10(webpack@5.91.0):
+  /terser-webpack-plugin@5.3.10(webpack@5.92.0):
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -9552,12 +9617,12 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
-      terser: 5.31.0
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      terser: 5.31.1
+      webpack: 5.92.0(webpack-cli@4.10.0)
     dev: true
 
-  /terser@5.31.0:
-    resolution: {integrity: sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==}
+  /terser@5.31.1:
+    resolution: {integrity: sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -9668,8 +9733,8 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tslib@2.6.2:
-    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+  /tslib@2.6.3:
+    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
   /tsutils@3.21.0(typescript@4.9.5):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -9832,13 +9897,13 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /update-browserslist-db@1.0.16(browserslist@4.23.0):
+  /update-browserslist-db@1.0.16(browserslist@4.23.1):
     resolution: {integrity: sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.1
       escalade: 3.1.2
       picocolors: 1.0.1
     dev: true
@@ -9990,7 +10055,7 @@ packages:
       humanize: 0.0.9
     dev: true
 
-  /webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.91.0):
+  /webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0):
     resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -10011,7 +10076,7 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0)(webpack@5.91.0)
+      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0)(webpack@5.92.0)
       '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0)
       '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0)(webpack-dev-server@4.15.2)
       colorette: 2.0.20
@@ -10021,13 +10086,13 @@ packages:
       import-local: 3.1.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 4.15.2(webpack-cli@4.10.0)(webpack@5.91.0)
+      webpack-dev-server: 4.15.2(webpack-cli@4.10.0)(webpack@5.92.0)
       webpack-merge: 5.10.0
     dev: true
 
-  /webpack-dev-middleware@5.3.4(webpack@5.91.0):
+  /webpack-dev-middleware@5.3.4(webpack@5.92.0):
     resolution: {integrity: sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -10038,10 +10103,10 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.91.0(webpack-cli@4.10.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
     dev: true
 
-  /webpack-dev-server@4.15.2(webpack-cli@4.10.0)(webpack@5.91.0):
+  /webpack-dev-server@4.15.2(webpack-cli@4.10.0)(webpack@5.92.0):
     resolution: {integrity: sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==}
     engines: {node: '>= 12.13.0'}
     hasBin: true
@@ -10082,9 +10147,9 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.91.0(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.91.0)
-      webpack-dev-middleware: 5.3.4(webpack@5.91.0)
+      webpack: 5.92.0(webpack-cli@4.10.0)
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
+      webpack-dev-middleware: 5.3.4(webpack@5.92.0)
       ws: 8.17.0
     transitivePeerDependencies:
       - bufferutil
@@ -10107,8 +10172,8 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
-  /webpack@5.91.0(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==}
+  /webpack@5.92.0(webpack-cli@4.10.0):
+    resolution: {integrity: sha512-Bsw2X39MYIgxouNATyVpCNVWBCuUwDgWtN78g6lSdPJRLaQ/PUVm/oXcaRAyY/sMFoKFQrsPeqvTizWtq7QPCA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -10123,11 +10188,11 @@ packages:
       '@webassemblyjs/wasm-edit': 1.12.1
       '@webassemblyjs/wasm-parser': 1.12.1
       acorn: 8.11.3
-      acorn-import-assertions: 1.9.0(acorn@8.11.3)
-      browserslist: 4.23.0
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.16.1
-      es-module-lexer: 1.5.2
+      acorn-import-attributes: 1.9.5(acorn@8.11.3)
+      browserslist: 4.23.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.17.0
+      es-module-lexer: 1.5.3
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -10138,9 +10203,9 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.91.0)
+      terser-webpack-plugin: 5.3.10(webpack@5.92.0)
       watchpack: 2.4.1
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.91.0)
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.0)
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -10310,8 +10375,8 @@ packages:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
     dev: true
 
-  /xml-utils@1.8.0:
-    resolution: {integrity: sha512-1TY5yLw8DApowZAUsWCniNr8HH6Ebt6O7UQvmIwziGKwUNsQx6e+4NkfOvCfnqmYIcPjCeoI6dh1JenPJ9a1hQ==}
+  /xml-utils@1.10.1:
+    resolution: {integrity: sha512-Dn6vJ1Z9v1tepSjvnCpwk5QqwIPcEFKdgnjqfYOABv1ngSofuAhtlugcUC3ehS1OHdgDWSG6C5mvj+Qm15udTQ==}
     dev: false
 
   /xmlchars@2.2.0:
@@ -10350,8 +10415,8 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /yet-another-react-lightbox@3.18.0(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-Zf3Stgp+gSAZe5Uy45OJDDxxXoE+fENZjJnAa7HD+yb/5xAhBQqqz8K7u4kAuj12lexEOASks2wHeYaZ+yUVnQ==}
+  /yet-another-react-lightbox@3.20.0(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-Ty0yrqfVJ5XVq0gr1EmN31Ng5gkjC79RePrtzqGi/Xn+erwiuzEDTmKqbO9pDqrfb05xfow2NwWcp3auk4RVuQ==}
     engines: {node: '>=14'}
     peerDependencies:
       react: '>=16.8.0'
@@ -10370,7 +10435,7 @@ packages:
     resolution: {integrity: sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==}
     dev: false
 
-  /zustand@4.4.7(@types/react@18.3.2)(react@18.3.1):
+  /zustand@4.4.7(@types/react@18.3.3)(react@18.3.1):
     resolution: {integrity: sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
@@ -10385,31 +10450,32 @@ packages:
       react:
         optional: true
     dependencies:
-      '@types/react': 18.3.2
+      '@types/react': 18.3.3
       react: 18.3.1
       use-sync-external-store: 1.2.0(react@18.3.1)
 
-  github.com/Canadian-Geospatial-Platform/geochart/a3f626faf274e58b2683f6ac9bcbe7387c27d89a(@types/react@18.3.2):
+  github.com/Canadian-Geospatial-Platform/geochart/a3f626faf274e58b2683f6ac9bcbe7387c27d89a(@types/react@18.3.3):
     resolution: {tarball: https://codeload.github.com/Canadian-Geospatial-Platform/geochart/tar.gz/a3f626faf274e58b2683f6ac9bcbe7387c27d89a}
     id: github.com/Canadian-Geospatial-Platform/geochart/a3f626faf274e58b2683f6ac9bcbe7387c27d89a
     name: geoview-geochart
     version: 0.1.0
     dependencies:
-      '@emotion/react': 11.11.4(@types/react@18.3.2)(react@18.3.1)
-      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.2)(react@18.3.1)
-      '@mui/icons-material': 5.15.17(@mui/material@5.15.17)(@types/react@18.3.2)(react@18.3.1)
-      '@mui/material': 5.15.17(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)
-      ajv: 8.13.0
+      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.3.1)
+      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.3.1)
+      '@mui/icons-material': 5.15.20(@mui/material@5.15.20)(@types/react@18.3.3)(react@18.3.1)
+      '@mui/material': 5.15.20(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      ajv: 8.16.0
       ajv-formats: 2.1.1
-      chart.js: 4.4.2
-      chartjs-adapter-moment: 1.0.1(chart.js@4.4.2)(moment@2.30.1)
-      i18next: 23.11.4
+      chart.js: 4.4.3
+      chartjs-adapter-moment: 1.0.1(chart.js@4.4.3)(moment@2.30.1)
+      i18next: 23.11.5
       moment: 2.30.1
       react: 18.3.1
-      react-chartjs-2: 5.2.0(chart.js@4.4.2)(react@18.3.1)
+      react-chartjs-2: 5.2.0(chart.js@4.4.3)(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
-      react-i18next: 13.5.0(i18next@23.11.4)(react-dom@18.3.1)(react@18.3.1)
+      react-i18next: 13.5.0(i18next@23.11.5)(react-dom@18.3.1)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
       - react-native
+      - supports-color
     dev: false

--- a/packages/geoview-core/package.json
+++ b/packages/geoview-core/package.json
@@ -71,7 +71,7 @@
     "linkifyjs": "^4.1.0",
     "lodash": "^4.17.21",
     "material-react-table": "^2.13.0",
-    "ol": "^9.0.0",
+    "ol": "9.1.0",
     "ol-mapbox-style": "^12.2.1",
     "proj4": "^2.7.5",
     "prop-types": "^15.8.1",

--- a/packages/geoview-core/public/templates/demos/demo-function-event.html
+++ b/packages/geoview-core/public/templates/demos/demo-function-event.html
@@ -216,7 +216,7 @@
         });
 
         // listen to layer filter applied event
-        cgpv.api.maps.Map1.layer.getGeoviewLayer('uniqueValueId/1').onLayerFilterApplied((sender, payload) => {
+        cgpv.api.maps.Map1.layer.getGeoviewLayerHybrid('uniqueValueId/1').onLayerFilterApplied((sender, payload) => {
           cgpv.api.maps.Map1.notifications.addNotificationSuccess(`Filter ${payload.filter} applied to ${payload.layerPath}`);
         });
 

--- a/packages/geoview-core/public/templates/layers/layerlib.js
+++ b/packages/geoview-core/public/templates/layers/layerlib.js
@@ -206,7 +206,7 @@ const createTableOfFilter = (mapId) => {
     cgpv.api.maps[mapId].layer.getLayerEntryConfigIds().forEach((layerPath) => {
       if (layerPath.startsWith(geoviewLayer.getGeoviewLayerId())) {
         const layerConfig = cgpv.api.maps[mapId].layer.getLayerEntryConfig(layerPath);
-        cgpv.api.utilities.geo.getLegendStylesFromConfig(layerConfig).then((legendStyle) => {
+        cgpv.api.utilities.geo.getLegendStylesFromConfig(layerConfig.style).then((legendStyle) => {
           mapButtonsDiv = document.createElement('td');
           // mapButtonsDiv.style.width = '16.66%';
           mapButtonsDiv.border = '1px solid black';

--- a/packages/geoview-core/public/templates/layers/wms.html
+++ b/packages/geoview-core/public/templates/layers/wms.html
@@ -581,7 +581,7 @@
                   // TO.DOCONT: Johann: This was to select a style for a WMS on the fly.... I think it is not use anymore. But I think it may be good to have this
                   // TO.DOCONT: and this mean we need the config section who extract and get the style and layers who apply the style form config or from function call.
                   cgpv.api.maps.LYR3.layer
-                    .getGeoviewLayer('wmsLYR3-Root')
+                    .getGeoviewLayerHybrid('wmsLYR3-Root')
                     .setStyle(dropDownContent.value, 'wmsLYR3-Root/landcover_2015_19classes');
                 });
               }

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -265,10 +265,13 @@ export class LegendEventProcessor extends AbstractEventProcessor {
         // eslint-disable-next-line no-param-reassign
         else existingEntries[entryIndex] = newLegendLayer;
 
-        // TODO: Refactor - Layers refactoring. There needs to be a calculateBounds somewhere (new layers, new config?) to complete the full layers migration.
-        const myLayer = MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayer(layerPathNodes[0])!;
         // TODO: calculateBounds issue will be tackle ASAP in a next PR
-        newLegendLayer.bounds = myLayer.allLayerStatusAreGreaterThanOrEqualTo('loaded') ? myLayer.calculateBounds(layerPath) : undefined;
+        // If all layer status are loaded
+        if (
+          MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayer(layerPathNodes[0])?.allLayerStatusAreGreaterThanOrEqualTo('loaded')
+        ) {
+          newLegendLayer.bounds = MapEventProcessor.getMapViewerLayerAPI(mapId).calculateBounds(layerPath);
+        }
       }
     };
 

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -1,4 +1,4 @@
-import { TypeLayerControls } from '@config/types/map-schema-types';
+import { AbstractBaseLayerEntryConfig, TypeLayerControls } from '@config/types/map-schema-types';
 import { TypeLegendLayer, TypeLegendLayerItem, TypeLegendItem } from '@/core/components/layers/types';
 import {
   CONST_LAYER_TYPES,
@@ -235,7 +235,10 @@ export class LegendEventProcessor extends AbstractEventProcessor {
           controls,
           layerId: layerPathNodes[currentLevel],
           layerPath: entryLayerPath,
-          layerAttribution: MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayer(layerPathNodes[0])!.attributions,
+          layerAttribution:
+            MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayerHybrid(entryLayerPath)?.getAttributions() ||
+            (MapEventProcessor.getMapViewerLayerAPI(mapId).getLayerEntryConfig(entryLayerPath) as AbstractBaseLayerEntryConfig | undefined)
+              ?.attributions,
           layerName:
             legendResultSetEntry.layerName ||
             getLocalizedValue(layerConfig.layerName, AppEventProcessor.getDisplayLanguage(mapId)) ||
@@ -262,6 +265,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
         // eslint-disable-next-line no-param-reassign
         else existingEntries[entryIndex] = newLegendLayer;
 
+        // TODO: Refactor - Layers refactoring. There needs to be a calculateBounds somewhere (new layers, new config?) to complete the full layers migration.
         const myLayer = MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayer(layerPathNodes[0])!;
         // TODO: calculateBounds issue will be tackle ASAP in a next PR
         newLegendLayer.bounds = myLayer.allLayerStatusAreGreaterThanOrEqualTo('loaded') ? myLayer.calculateBounds(layerPath) : undefined;

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -519,7 +519,9 @@ export class MapEventProcessor extends AbstractEventProcessor {
 
     // Redirect to layer to highlight
     MapEventProcessor.getMapViewerLayerAPI(mapId).highlightLayer(layerPath);
+
     // Get bounds and highlight a bounding box for the layer
+    // TODO: Refactor - Layers refactoring. There needs to be a calculateBounds somewhere (new layers, new config?) to complete the full layers migration.
     const bounds = MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayer(layerPath)?.calculateBounds(layerPath);
     if (bounds && bounds[0] !== Infinity) this.getMapStateProtected(mapId).actions.highlightBBox(bounds, true);
 
@@ -852,8 +854,10 @@ export class MapEventProcessor extends AbstractEventProcessor {
    * @return {Extent | undefined}
    */
   static getLayerBounds(mapId: string, layerPath: string): Extent | undefined {
+    // TODO: Refactor - Layers refactoring. There needs to be a calculateBounds somewhere (new layers, new config?) to complete the full layers migration.
     const layer = MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayer(layerPath);
     if (layer) {
+      // TODO: Check - Do we really want to calculate the bounds again? How many times are we calculating them!?
       const bounds = layer.calculateBounds(layerPath);
       if (bounds) return bounds;
     }

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -521,8 +521,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
     MapEventProcessor.getMapViewerLayerAPI(mapId).highlightLayer(layerPath);
 
     // Get bounds and highlight a bounding box for the layer
-    // TODO: Refactor - Layers refactoring. There needs to be a calculateBounds somewhere (new layers, new config?) to complete the full layers migration.
-    const bounds = MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayer(layerPath)?.calculateBounds(layerPath);
+    const bounds = MapEventProcessor.getMapViewerLayerAPI(mapId).calculateBounds(layerPath);
     if (bounds && bounds[0] !== Infinity) this.getMapStateProtected(mapId).actions.highlightBBox(bounds, true);
 
     return layerPath;
@@ -854,14 +853,8 @@ export class MapEventProcessor extends AbstractEventProcessor {
    * @return {Extent | undefined}
    */
   static getLayerBounds(mapId: string, layerPath: string): Extent | undefined {
-    // TODO: Refactor - Layers refactoring. There needs to be a calculateBounds somewhere (new layers, new config?) to complete the full layers migration.
-    const layer = MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayer(layerPath);
-    if (layer) {
-      // TODO: Check - Do we really want to calculate the bounds again? How many times are we calculating them!?
-      const bounds = layer.calculateBounds(layerPath);
-      if (bounds) return bounds;
-    }
-    return undefined;
+    // Redirect to layer api calculate bounds
+    return MapEventProcessor.getMapViewerLayerAPI(mapId).calculateBounds(layerPath);
   }
 
   // #endregion

--- a/packages/geoview-core/src/api/events/event-helper.ts
+++ b/packages/geoview-core/src/api/events/event-helper.ts
@@ -7,30 +7,30 @@ export default class EventHelper {
   /**
    * Emits an event to all handlers.
    * @param {T} sender - The object emitting the event
-   * @param {EventDelegateBase<T, U>[]} handlersList - The list of handlers to be called with the event
+   * @param {EventDelegateBase<T, U, Z>[]} handlersList - The list of handlers to be called with the event
    * @param {U} event - The event to emit
    */
-  public static emitEvent<T, U>(sender: T, handlersList: EventDelegateBase<T, U>[], event: U): void {
+  public static emitEvent<T, U, Z>(sender: T, handlersList: EventDelegateBase<T, U, Z>[], event: U): Z[] {
     // Trigger all the handlers in the array
-    handlersList.forEach((handler) => handler(sender, event));
+    return handlersList.map((handler) => handler(sender, event));
   }
 
   /**
    * Adds an event handler callback in the provided handlersList.
-   * @param {EventDelegateBase<T, U>[]} handlersList - The list of handlers to be called with the event
-   * @param {EventDelegateBase<T, U>} callback - The callback to be executed whenever the event is raised
+   * @param {EventDelegateBase<T, U, Z>[]} handlersList - The list of handlers to be called with the event
+   * @param {EventDelegateBase<T, U, Z>} callback - The callback to be executed whenever the event is raised
    */
-  public static onEvent<T, U>(handlersList: EventDelegateBase<T, U>[], callback: EventDelegateBase<T, U>): void {
+  public static onEvent<T, U, Z>(handlersList: EventDelegateBase<T, U, Z>[], callback: EventDelegateBase<T, U, Z>): void {
     // Push a new callback handler to the list of handlers
     handlersList.push(callback);
   }
 
   /**
    * Removes an event handler callback from the provided handlersList.
-   * @param {EventDelegateBase<T, U>[]} handlersList - The list of handlers on which to check to remove the handler
-   * @param {EventDelegateBase<T, U>} callback - The callback to stop being called whenever the event is emitted
+   * @param {EventDelegateBase<T, U, Z>[]} handlersList - The list of handlers on which to check to remove the handler
+   * @param {EventDelegateBase<T, U, Z>} callback - The callback to stop being called whenever the event is emitted
    */
-  public static offEvent<T, U>(handlersList: EventDelegateBase<T, U>[], callback: EventDelegateBase<T, U>): void {
+  public static offEvent<T, U, Z>(handlersList: EventDelegateBase<T, U, Z>[], callback: EventDelegateBase<T, U, Z>): void {
     // Find the callback and remove it
     const index = handlersList.indexOf(callback);
     if (index !== -1) {
@@ -39,4 +39,4 @@ export default class EventHelper {
   }
 }
 
-export type EventDelegateBase<T, U> = (sender: T, event: U) => void;
+export type EventDelegateBase<T, U, Z> = (sender: T, event: U) => Z;

--- a/packages/geoview-core/src/core/components/app-bar/app-bar-api.ts
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar-api.ts
@@ -238,7 +238,7 @@ export type AppBarCreatedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type AppBarCreatedDelegate = EventDelegateBase<AppBarApi, AppBarCreatedEvent>;
+type AppBarCreatedDelegate = EventDelegateBase<AppBarApi, AppBarCreatedEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -251,4 +251,4 @@ export type AppBarRemovedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type AppBarRemovedDelegate = EventDelegateBase<AppBarApi, AppBarRemovedEvent>;
+type AppBarRemovedDelegate = EventDelegateBase<AppBarApi, AppBarRemovedEvent, void>;

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar-api.ts
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar-api.ts
@@ -151,7 +151,7 @@ export type FooterTabCreatedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type FooterTabCreatedDelegate = EventDelegateBase<FooterBarApi, FooterTabCreatedEvent>;
+type FooterTabCreatedDelegate = EventDelegateBase<FooterBarApi, FooterTabCreatedEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -163,4 +163,4 @@ export type FooterTabRemovedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type FooterTabRemovedDelegate = EventDelegateBase<FooterBarApi, FooterTabRemovedEvent>;
+type FooterTabRemovedDelegate = EventDelegateBase<FooterBarApi, FooterTabRemovedEvent, void>;

--- a/packages/geoview-core/src/core/components/layers/hooks/helpers.ts
+++ b/packages/geoview-core/src/core/components/layers/hooks/helpers.ts
@@ -198,7 +198,7 @@ export function useLegendHelpers(): unknown {
         bounds: undefined,
         layerId: `layer${i}`,
         layerPath: `test_${generateId()}`,
-        layerName: `TEST---${setData.data?.layerName?.en ?? 'Unknown Layer name'}`,
+        layerName: `TEST---Unknown Layer name`,
         type: setData.data?.type ?? CONST_LAYER_TYPES.IMAGE_STATIC,
         layerStatus: setData.layerStatus,
         legendQueryStatus: 'queried',

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -155,8 +155,8 @@ export function SingleLayer({
   };
 
   const handleLayerClick = (): void => {
-    // TODO: backend set layerStatus of parent groups to 'loaded' when all children are loaded. Then we will remove 'newInstance' from the condition.
-    if (!['processed', 'loaded', 'newInstance'].includes(layer.layerStatus!)) {
+    // Only clickable if the layer status is processed or loaded
+    if (!['processed', 'loaded'].includes(layer.layerStatus!)) {
       return;
     }
 

--- a/packages/geoview-core/src/core/components/nav-bar/nav-bar-api.ts
+++ b/packages/geoview-core/src/core/components/nav-bar/nav-bar-api.ts
@@ -222,7 +222,7 @@ export type NavBarCreatedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type NavBarCreatedDelegate = EventDelegateBase<NavBarApi, NavBarCreatedEvent>;
+type NavBarCreatedDelegate = EventDelegateBase<NavBarApi, NavBarCreatedEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -235,4 +235,4 @@ export type NavBarRemovedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type NavBarRemovedDelegate = EventDelegateBase<NavBarApi, NavBarRemovedEvent>;
+type NavBarRemovedDelegate = EventDelegateBase<NavBarApi, NavBarRemovedEvent, void>;

--- a/packages/geoview-core/src/core/stores/state-api.ts
+++ b/packages/geoview-core/src/core/stores/state-api.ts
@@ -164,7 +164,7 @@ export class StateApi {
 /**
  * Define a delegate for the event handler function signature
  */
-type LayersReorderedDelegate = EventDelegateBase<StateApi, LayersReorderedEvent>;
+type LayersReorderedDelegate = EventDelegateBase<StateApi, LayersReorderedEvent, void>;
 
 /**
  * Define an event for the delegate

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -84,9 +84,9 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
         return LegendEventProcessor.findLayerByPath(curLayers, layerPath);
       },
       getLayerBounds: (layerPath: string) => {
+        // TODO: Refactor - Layers refactoring. There needs to be a calculateBounds somewhere (new layers, new config?) to complete the full layers migration.
         const layer = MapEventProcessor.getMapViewerLayerAPI(get().mapId).getGeoviewLayer(layerPath);
         if (layer) {
-          // TODO: Refactor - Layers refactoring. There needs to be a calculateBounds somewhere (new layers, new config?) to complete the full layers migration.
           const bounds = layer.calculateBounds(layerPath);
           if (bounds) return bounds;
         }
@@ -172,6 +172,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
         const options: FitOptions = { padding: OL_ZOOM_PADDING, duration: OL_ZOOM_DURATION };
 
         // Get the layer and always calculate the bounds. This will prevent bounds undefined error
+        // TODO: Refactor - Layers refactoring. There needs to be a calculateBounds somewhere (new layers, new config?) to complete the full layers migration.
         const myLayer = MapEventProcessor.getMapViewerLayerAPI(get().mapId).getGeoviewLayer(layerPath.split('/')[0])!;
         const bounds = myLayer.calculateBounds(layerPath);
         if (bounds) return MapEventProcessor.zoomToExtent(get().mapId, bounds, options);

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -10,7 +10,6 @@ import { TypeGetStore, TypeSetStore } from '@/core/stores/geoview-store';
 import { TypeResultSet, TypeResultSetEntry, TypeStyleConfig } from '@/geo/map/map-schema-types';
 import { OL_ZOOM_DURATION, OL_ZOOM_PADDING } from '@/core/utils/constant';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
-import { TypeLocalizedString } from '@/api/config/types/map-schema-types';
 import { TypeGeoviewLayerType, TypeVectorLayerStyles } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { LegendEventProcessor } from '@/api/event-processors/event-processor-children/legend-event-processor';
 
@@ -262,7 +261,6 @@ export type TypeLegendResultInfo = {
 export type LegendQueryStatus = 'init' | 'querying' | 'queried';
 
 export type TypeLegend = {
-  layerName?: TypeLocalizedString;
   type: TypeGeoviewLayerType;
   styleConfig?: TypeStyleConfig | null;
   // Layers other than vector layers use the HTMLCanvasElement type for their legend.

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -85,6 +85,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
         return LegendEventProcessor.findLayerByPath(curLayers, layerPath);
       },
 
+      // TODO: Refactor - This 'get' shouldn't be an 'action'. This function should be removed and a state getter be created to access the bounds state from the store directly (for the UI to use)
       getLayerBounds: (layerPath: string): Extent | undefined => {
         // TODO: Check - There is a calculateBounds() call here in a state action which should probably just get the layer bounds from the store/state? not recalculate again?
         // Redirect to processor.

--- a/packages/geoview-core/src/core/utils/config/config-validation.ts
+++ b/packages/geoview-core/src/core/utils/config/config-validation.ts
@@ -48,7 +48,6 @@ import { ImageStaticLayerEntryConfig } from './validation-classes/raster-validat
 import { EsriDynamicLayerEntryConfig } from './validation-classes/raster-validation-classes/esri-dynamic-layer-entry-config';
 import { EsriImageLayerEntryConfig } from './validation-classes/raster-validation-classes/esri-image-layer-entry-config';
 import { GroupLayerEntryConfig } from './validation-classes/group-layer-entry-config';
-import { ConfigBaseClass } from './validation-classes/config-base-class';
 import { api } from '@/app';
 
 // ******************************************************************************************************************************
@@ -126,7 +125,7 @@ export class ConfigValidation {
     const groupSchemaPath = `https://cgpv/schema#/definitions/TypeLayerGroupEntryConfig`;
 
     for (let i = 0; i < listOfLayerEntryConfig.length; i++) {
-      const schemaPath = layerEntryIsGroupLayer(listOfLayerEntryConfig[i] as ConfigBaseClass) ? groupSchemaPath : layerSchemaPath;
+      const schemaPath = layerEntryIsGroupLayer(listOfLayerEntryConfig[i]) ? groupSchemaPath : layerSchemaPath;
       const validate = validator.getSchema(schemaPath);
 
       if (!validate) {
@@ -150,7 +149,7 @@ export class ConfigValidation {
 
     for (let i = 0; i < listOfLayerEntryConfig.length; i++) {
       if (
-        layerEntryIsGroupLayer(listOfLayerEntryConfig[i] as ConfigBaseClass) &&
+        layerEntryIsGroupLayer(listOfLayerEntryConfig[i]) &&
         !this.#isValidTypeListOfLayerEntryConfig(geoviewLayerType, listOfLayerEntryConfig[i].listOfLayerEntryConfig!, validator)
       )
         return false;
@@ -294,7 +293,7 @@ export class ConfigValidation {
         layerConfig.parentLayerConfig?.initialSettings || layerConfig.geoviewLayerConfig?.initialSettings
       );
 
-      if (layerEntryIsGroupLayer(layerConfig as ConfigBaseClass)) {
+      if (layerEntryIsGroupLayer(layerConfig)) {
         // We must set the parents of all elements in the group.
         ConfigValidation.#recursivelySetChildParent(geoviewLayerConfig, [layerConfig], parentLayerConfig);
         const parent = new GroupLayerEntryConfig(layerConfig as GroupLayerEntryConfig);

--- a/packages/geoview-core/src/core/utils/config/validation-classes/abstract-base-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/abstract-base-layer-entry-config.ts
@@ -7,6 +7,9 @@ import {
   TypeSourceImageStaticInitialConfig,
   TypeSourceImageWmsInitialConfig,
   TypeSourceTileInitialConfig,
+  TypeStyleConfig,
+  TypeStyleGeometry,
+  TypeStyleSettings,
   TypeVectorSourceInitialConfig,
   TypeVectorTileSourceInitialConfig,
 } from '@/geo/map/map-schema-types';
@@ -41,6 +44,9 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
     | TypeSourceImageEsriInitialConfig
     | TypeSourceImageStaticInitialConfig;
 
+  /** Style to apply to the vector layer. */
+  style?: TypeStyleConfig;
+
   /** The listOfLayerEntryConfig attribute is not used by child of AbstractBaseLayerEntryConfig. */
   declare listOfLayerEntryConfig: never;
 
@@ -50,6 +56,8 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
    */
   protected constructor(layerConfig: AbstractBaseLayerEntryConfig) {
     super(layerConfig);
+    // Attribute 'style' must exist in layerConfig even if it is undefined
+    if (!('style' in this)) this.style = undefined;
     Object.assign(this, layerConfig);
   }
 
@@ -68,6 +76,31 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
   setMetadata(layerMetadata: TypeJsonObject): void {
     // TODO: Refactor - Layers refactoring. Reminder: turn this function private eventually?
     this.#metadata = layerMetadata;
+  }
+
+  /**
+   * The TypeStyleGeometries associated with the style as could be read from the layer config metadata.
+   * @returns {TypeStyleGeometry[]} The array of TypeStyleGeometry
+   */
+  getTypeGeometries(): TypeStyleGeometry[] {
+    return Object.keys(this.style || {}) as TypeStyleGeometry[];
+  }
+
+  /**
+   * The first TypeStyleSetting associated with the TypeStyleGeometry associated with the style as could be read from the layer config metadata.
+   * @returns {TypeStyleSettings[]} The array of TypeStyleSettings
+   */
+  getFirstStyleSettings(): TypeStyleSettings | undefined {
+    // Get the type geometries
+    const styles = this.getTypeGeometries();
+
+    // If at least one, get the first one
+    if (styles.length > 0) {
+      return this.style![styles[0]];
+    }
+
+    // None
+    return undefined;
   }
 
   /**

--- a/packages/geoview-core/src/core/utils/config/validation-classes/config-base-class.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/config-base-class.ts
@@ -150,13 +150,21 @@ export abstract class ConfigBaseClass {
     }
     if (newLayerStatus === 'processed' && this.#waitForProcessedBeforeSendingLoaded) this.layerStatus = 'loaded';
 
-    if (
-      // eslint-disable-next-line no-underscore-dangle
-      this._layerStatus === 'loaded' &&
-      this.parentLayerConfig &&
-      ConfigBaseClass.allLayerStatusAreGreaterThanOrEqualTo('loaded', [this.parentLayerConfig as GroupLayerEntryConfig])
-    )
-      this.parentLayerConfig.layerStatus = 'loaded';
+    // TODO: Cleanup - Commenting this and leaving it here for now.. It turns out that the parentLayerConfig property can't be trusted
+    // GV due to a bug with different instances of entryconfigs stored in the objects and depending how you navigate the objects, you get
+    // GV different instances. Example below (where 'parentLayerConfig.listOfLayerEntryConfig[0]' is indeed going back to 'uniqueValueId/uniqueValueId/4')
+    // GV This: cgpv.api.maps['sandboxMap'].layer.getLayerEntryConfig('uniqueValueId/uniqueValueId/4').layerStatus
+    // GV Isn't the same as this: cgpv.api.maps['sandboxMap'].layer.getLayerEntryConfig('uniqueValueId/uniqueValueId/4').parentLayerConfig.listOfLayerEntryConfig[0].layerStatus
+    // Commenting this out until a fix is found..
+
+    // // eslint-disable-next-line no-underscore-dangle
+    // if (this._layerStatus === 'loaded' && this.parentLayerConfig) {
+    //   // If all children of the parent are loaded, set the parent as loaded
+    //   if (ConfigBaseClass.allLayerStatusAreGreaterThanOrEqualTo('loaded', this.parentLayerConfig.listOfLayerEntryConfig)) {
+    //     // Set the parent as loaded
+    //     this.parentLayerConfig.layerStatus = 'loaded';
+    //   }
+    // }
   }
 
   /**

--- a/packages/geoview-core/src/core/utils/config/validation-classes/config-base-class.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/config-base-class.ts
@@ -3,7 +3,6 @@ import EventHelper, { EventDelegateBase } from '@/api/events/event-helper';
 import { TypeGeoviewLayerType } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import {
   TypeGeoviewLayerConfig,
-  TypeLayerEntryConfig,
   TypeLayerEntryType,
   TypeLayerInitialSettings,
   TypeLayerStatus,
@@ -218,14 +217,13 @@ export abstract class ConfigBaseClass {
    * Recursively checks the list of layer entries to see if all of them are greater than or equal to the provided layer status.
    *
    * @param {TypeLayerStatus} layerStatus - The layer status to compare with the internal value of the config.
-   * @param {TypeLayerEntryConfig[]} listOfLayerEntryConfig - The list of layer's configuration
-   *                                                            (default: this.listOfLayerEntryConfig).
+   * @param {ConfigBaseClass[]} listOfLayerEntryConfig - The list of layer's configuration (default: this.listOfLayerEntryConfig).
    *
    * @returns {boolean} true when all layers are greater than or equal to the layerStatus parameter.
    */
-  static allLayerStatusAreGreaterThanOrEqualTo(layerStatus: TypeLayerStatus, listOfLayerEntryConfig: TypeLayerEntryConfig[]): boolean {
+  static allLayerStatusAreGreaterThanOrEqualTo(layerStatus: TypeLayerStatus, listOfLayerEntryConfig: ConfigBaseClass[]): boolean {
     // Try to find a layer that is not greater than or equal to the layerStatus parameter. If you can, return false
-    return !listOfLayerEntryConfig.find((layerConfig: TypeLayerEntryConfig) => {
+    return !listOfLayerEntryConfig.find((layerConfig) => {
       if (layerEntryIsGroupLayer(layerConfig))
         return !this.allLayerStatusAreGreaterThanOrEqualTo(layerStatus, layerConfig.listOfLayerEntryConfig);
       return !layerConfig.isGreaterThanOrEqualTo(layerStatus || 'newInstance');

--- a/packages/geoview-core/src/core/utils/config/validation-classes/raster-validation-classes/esri-dynamic-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/raster-validation-classes/esri-dynamic-layer-entry-config.ts
@@ -1,11 +1,5 @@
 import { CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
-import {
-  CONST_LAYER_ENTRY_TYPES,
-  TypeSourceImageEsriInitialConfig,
-  TypeStyleConfig,
-  TypeStyleGeometry,
-  TypeStyleSettings,
-} from '@/geo/map/map-schema-types';
+import { CONST_LAYER_ENTRY_TYPES, TypeSourceImageEsriInitialConfig } from '@/geo/map/map-schema-types';
 import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
 
 /** ******************************************************************************************************************************
@@ -24,9 +18,6 @@ export class EsriDynamicLayerEntryConfig extends AbstractBaseLayerEntryConfig {
   /** Source settings to apply to the GeoView image layer source at creation time. */
   declare source: TypeSourceImageEsriInitialConfig;
 
-  /** Style to apply to the raster layer. */
-  style?: TypeStyleConfig;
-
   /**
    * The class constructor.
    * @param {EsriDynamicLayerEntryConfig} layerConfig - The layer configuration we want to instanciate.
@@ -37,21 +28,5 @@ export class EsriDynamicLayerEntryConfig extends AbstractBaseLayerEntryConfig {
     // if layerConfig.source.dataAccessPath is undefined, we assign the metadataAccessPath of the GeoView layer to it.
     if (!this.source) this.source = {};
     if (!this.source.dataAccessPath) this.source.dataAccessPath = { ...this.geoviewLayerConfig.metadataAccessPath! };
-  }
-
-  /**
-   * Guesses the TypeStyleGeometry associated with the style as could be read from the layer config metadata.
-   * @returns {TypeStyleGeometry} The guessed TypeStyleGeometry
-   */
-  getTypeGeometry(): TypeStyleGeometry {
-    return Object.keys(this.style!)[0] as TypeStyleGeometry;
-  }
-
-  /**
-   * Guesses the TypeStyleSettings associated with the style as could be read from the layer config metadata.
-   * @returns {TypeStyleSettings} The guessed TypeStyleSettings
-   */
-  getStyleSettings(): TypeStyleSettings | undefined {
-    return this.style?.[this.getTypeGeometry()];
   }
 }

--- a/packages/geoview-core/src/core/utils/config/validation-classes/raster-validation-classes/esri-image-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/raster-validation-classes/esri-image-layer-entry-config.ts
@@ -1,5 +1,5 @@
 import { CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
-import { CONST_LAYER_ENTRY_TYPES, TypeSourceImageEsriInitialConfig, TypeStyleConfig } from '@/geo/map/map-schema-types';
+import { CONST_LAYER_ENTRY_TYPES, TypeSourceImageEsriInitialConfig } from '@/geo/map/map-schema-types';
 import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
 
 /** ******************************************************************************************************************************
@@ -17,9 +17,6 @@ export class EsriImageLayerEntryConfig extends AbstractBaseLayerEntryConfig {
 
   /** Source settings to apply to the GeoView image layer source at creation time. */
   declare source: TypeSourceImageEsriInitialConfig;
-
-  /** Style to apply to the raster layer. */
-  style?: TypeStyleConfig;
 
   /**
    * The class constructor.

--- a/packages/geoview-core/src/core/utils/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
@@ -1,5 +1,5 @@
 import { CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
-import { CONST_LAYER_ENTRY_TYPES, TypeSourceImageWmsInitialConfig, TypeStyleConfig } from '@/geo/map/map-schema-types';
+import { CONST_LAYER_ENTRY_TYPES, TypeSourceImageWmsInitialConfig } from '@/geo/map/map-schema-types';
 import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
 import { createLocalizedString } from '@/core/utils/utilities';
 
@@ -18,9 +18,6 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
 
   /** Source settings to apply to the GeoView image layer source at creation time. */
   declare source: TypeSourceImageWmsInitialConfig;
-
-  /** Style to apply to the raster layer. */
-  style?: TypeStyleConfig;
 
   /**
    * The class constructor.

--- a/packages/geoview-core/src/core/utils/config/validation-classes/raster-validation-classes/vector-tiles-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/raster-validation-classes/vector-tiles-layer-entry-config.ts
@@ -1,12 +1,9 @@
 import { TypeSourceVectorTilesInitialConfig } from '@/geo/layer/geoview-layers/raster/vector-tiles';
-import { TypeStyleConfig, TypeTileGrid } from '@/geo/map/map-schema-types';
+import { TypeTileGrid } from '@/geo/map/map-schema-types';
 import { TileLayerEntryConfig } from '@/core/utils/config/validation-classes/tile-layer-entry-config';
 
 export class VectorTilesLayerEntryConfig extends TileLayerEntryConfig {
   declare source: TypeSourceVectorTilesInitialConfig;
-
-  /** Style to apply to the vector layer. */
-  style?: TypeStyleConfig;
 
   tileGrid!: TypeTileGrid;
 

--- a/packages/geoview-core/src/core/utils/config/validation-classes/vector-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/vector-layer-entry-config.ts
@@ -1,4 +1,4 @@
-import { CONST_LAYER_ENTRY_TYPES, TypeStyleConfig, TypeVectorSourceInitialConfig } from '@/geo/map/map-schema-types';
+import { CONST_LAYER_ENTRY_TYPES, TypeVectorSourceInitialConfig } from '@/geo/map/map-schema-types';
 import { AbstractBaseLayerEntryConfig } from './abstract-base-layer-entry-config';
 
 /** ******************************************************************************************************************************
@@ -13,9 +13,6 @@ export abstract class VectorLayerEntryConfig extends AbstractBaseLayerEntryConfi
 
   /** Initial settings to apply to the GeoView vector layer source at creation time. */
   declare source?: TypeVectorSourceInitialConfig;
-
-  /** Style to apply to the vector layer. */
-  style?: TypeStyleConfig;
 
   /**
    * The class constructor.

--- a/packages/geoview-core/src/core/utils/config/validation-classes/vector-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/vector-layer-entry-config.ts
@@ -4,6 +4,7 @@ import { AbstractBaseLayerEntryConfig } from './abstract-base-layer-entry-config
 /** ******************************************************************************************************************************
  * Type used to define a GeoView vector layer to display on the map.
  */
+// TODO: Refactor - This class should be named 'AbstractVectorLayerEntryConfig' to align with others
 export abstract class VectorLayerEntryConfig extends AbstractBaseLayerEntryConfig {
   /** Layer entry data type. */
   override entryType = CONST_LAYER_ENTRY_TYPES.VECTOR;

--- a/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/csv-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/csv-layer-entry-config.ts
@@ -24,8 +24,6 @@ export class CsvLayerEntryConfig extends VectorLayerEntryConfig {
     }
     // Default value for this.entryType is vector
     if (this.entryType === undefined) this.entryType = CONST_LAYER_ENTRY_TYPES.VECTOR;
-    // Attribute 'style' must exist in layerConfig even if it is undefined
-    if (!('style' in this)) this.style = undefined;
     // if this.source.dataAccessPath is undefined, we assign the metadataAccessPath of the CSV layer to it
     // and place the layerId at the end of it.
     // Value for this.source.format can only be CSV.

--- a/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/esri-feature-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/esri-feature-layer-entry-config.ts
@@ -15,8 +15,6 @@ export class EsriFeatureLayerEntryConfig extends VectorLayerEntryConfig {
     if (Number.isNaN(this.layerId)) {
       throw new Error(`The layer entry with layerId equal to ${this.layerPath} must be an integer string`);
     }
-    // Attribute 'style' must exist in layerConfig even if it is undefined
-    if (!('style' in this)) this.style = undefined;
     // if this.source.dataAccessPath is undefined, we assign the metadataAccessPath of the GeoView layer to it
     // and place the layerId at the end of it.
     // Value for this.source.format can only be EsriJSON.

--- a/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/geojson-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/geojson-layer-entry-config.ts
@@ -21,8 +21,6 @@ export class GeoJSONLayerEntryConfig extends VectorLayerEntryConfig {
     }
     // Default value for this.entryType is vector
     if (this.entryType === undefined) this.entryType = CONST_LAYER_ENTRY_TYPES.VECTOR;
-    // Attribute 'style' must exist in layerConfig even if it is undefined
-    if (!('style' in this)) this.style = undefined;
     // Value for this.source.format can only be GeoJSON.
     if (!this.source) this.source = { format: 'GeoJSON' };
     if (!this.source.format) this.source.format = 'GeoJSON';

--- a/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/geopackage-layer-config-entry.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/geopackage-layer-config-entry.ts
@@ -16,8 +16,6 @@ export class GeoPackageLayerEntryConfig extends VectorLayerEntryConfig {
 
     // Default value for this.entryType is vector
     if (this.entryType === undefined) this.entryType = CONST_LAYER_ENTRY_TYPES.VECTOR;
-    // Attribute 'style' must exist in layerConfig even if it is undefined
-    if (!('style' in this)) this.style = undefined;
     // if this.source.dataAccessPath is undefined, we assign the metadataAccessPath of the GeoView layer to it.
     // Value for this.source.format can only be GeoPackage.
     if (!this.source) this.source = { format: 'GeoPackage' };

--- a/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/ogc-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/ogc-layer-entry-config.ts
@@ -13,8 +13,6 @@ export class OgcFeatureLayerEntryConfig extends VectorLayerEntryConfig {
     super(layerConfig);
     Object.assign(this, layerConfig);
 
-    // Attribute 'style' must exist in layerConfig even if it is undefined
-    if (!('style' in this)) this.style = undefined;
     // if this.source.dataAccessPath is undefined, we assign the metadataAccessPath of the GeoView layer to it.
     // Value for this.source.format can only be featureAPI.
     if (!this.source) this.source = { format: 'featureAPI' };

--- a/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/wfs-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/wfs-layer-entry-config.ts
@@ -13,8 +13,6 @@ export class WfsLayerEntryConfig extends VectorLayerEntryConfig {
     super(layerConfig);
     Object.assign(this, layerConfig);
 
-    // Attribute 'style' must exist in layerConfig even if it is undefined
-    if (!('style' in this)) this.style = undefined;
     // if this.source.dataAccessPath is undefined, we assign the metadataAccessPath of the GeoView layer to it.
     // Value for this.source.format can only be WFS.
     if (!this.source) this.source = { format: 'WFS' };

--- a/packages/geoview-core/src/core/utils/notifications.ts
+++ b/packages/geoview-core/src/core/utils/notifications.ts
@@ -225,7 +225,7 @@ export class Notifications {
 /**
  * Define a delegate for the event handler function signature
  */
-type SnackBarOpenDelegate = EventDelegateBase<Notifications, SnackBarOpenEvent>;
+type SnackBarOpenDelegate = EventDelegateBase<Notifications, SnackBarOpenEvent, void>;
 
 /**
  * Define an event for the delegate

--- a/packages/geoview-core/src/geo/interaction/draw.ts
+++ b/packages/geoview-core/src/geo/interaction/draw.ts
@@ -171,4 +171,4 @@ export class Draw extends Interaction {
 /**
  * Define a delegate for the event handler function signature
  */
-type DrawDelegate = EventDelegateBase<Draw, OLDrawEvent>;
+type DrawDelegate = EventDelegateBase<Draw, OLDrawEvent, void>;

--- a/packages/geoview-core/src/geo/interaction/extent.ts
+++ b/packages/geoview-core/src/geo/interaction/extent.ts
@@ -98,4 +98,4 @@ export class Extent extends Interaction {
 /**
  * Define a delegate for the event handler function signature
  */
-type ExtentDelegate = EventDelegateBase<Extent, OLExtentEvent>;
+type ExtentDelegate = EventDelegateBase<Extent, OLExtentEvent, void>;

--- a/packages/geoview-core/src/geo/interaction/modify.ts
+++ b/packages/geoview-core/src/geo/interaction/modify.ts
@@ -143,4 +143,4 @@ export class Modify extends Interaction {
 /**
  * Define a delegate for the event handler function signature
  */
-type ModifyDelegate = EventDelegateBase<Modify, OLModifyEvent>;
+type ModifyDelegate = EventDelegateBase<Modify, OLModifyEvent, void>;

--- a/packages/geoview-core/src/geo/interaction/select.ts
+++ b/packages/geoview-core/src/geo/interaction/select.ts
@@ -110,4 +110,4 @@ export class Select extends Interaction {
 /**
  * Define a delegate for the event handler function signature
  */
-type SelectChangedDelegate = EventDelegateBase<Select, OLSelectEvent>;
+type SelectChangedDelegate = EventDelegateBase<Select, OLSelectEvent, void>;

--- a/packages/geoview-core/src/geo/interaction/translate.ts
+++ b/packages/geoview-core/src/geo/interaction/translate.ts
@@ -129,4 +129,4 @@ export class Translate extends Interaction {
 /**
  * Define a delegate for the event handler function signature
  */
-type TranslateDelegate = EventDelegateBase<Translate, OLTranslateEvent>;
+type TranslateDelegate = EventDelegateBase<Translate, OLTranslateEvent, void>;

--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -595,4 +595,4 @@ export type BasemapChangedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type BasemapChangedDelegate = EventDelegateBase<Basemap, BasemapChangedEvent>;
+type BasemapChangedDelegate = EventDelegateBase<Basemap, BasemapChangedEvent, void>;

--- a/packages/geoview-core/src/geo/layer/geometry/geometry.ts
+++ b/packages/geoview-core/src/geo/layer/geometry/geometry.ts
@@ -678,7 +678,7 @@ export class GeometryApi {
 /**
  * Define a delegate for the event handler function signature
  */
-type GeometryAddedDelegate = EventDelegateBase<GeometryApi, GeometryAddedEvent>;
+type GeometryAddedDelegate = EventDelegateBase<GeometryApi, GeometryAddedEvent, void>;
 
 /**
  * Event interface for GeometryAdded

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -1407,48 +1407,10 @@ export abstract class AbstractGeoViewLayer {
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
    * @returns {Extent} The new layer bounding box.
    */
-  protected abstract getBounds(layerPath: string, bounds?: Extent): Extent | undefined;
-
-  /** ***************************************************************************************************************************
-   * Compute the layer bounds or undefined if the result can not be obtained from the feature extents that compose the layer. If
-   * projectionCode is defined, returns the bounds in the specified projection otherwise use the map projection. The bounds are
-   * different from the extent. They are mainly used for display purposes to show the bounding box in which the data resides and
-   * to zoom in on the entire layer data. It is not used by openlayer to limit the display of data on the map.
-   *
-   * @param {string} layerPath The Layer path to the layer's configuration.
-   * @param {string | number | undefined} projectionCode Optional projection code to use for the returned bounds. Default to
-   * current projection.
-   *
-   * @returns {Extent | undefined} The layer bounding box.
-   */
-  calculateBounds(layerPath: string): Extent | undefined {
-    try {
-      let bounds: Extent | undefined;
-      const processGroupLayerBounds = (listOfLayerEntryConfig: ConfigBaseClass[]): void => {
-        listOfLayerEntryConfig.forEach((layerConfig) => {
-          if (layerEntryIsGroupLayer(layerConfig)) processGroupLayerBounds(layerConfig.listOfLayerEntryConfig);
-          else {
-            bounds = this.getBounds(layerConfig.layerPath, bounds);
-          }
-        });
-      };
-
-      const initialLayerConfig = this.getLayerConfig(layerPath);
-      if (initialLayerConfig) {
-        processGroupLayerBounds([initialLayerConfig]);
-      }
-
-      return bounds;
-    } catch (error) {
-      // Log
-      logger.logError(`Couldn't calculate bounds on layer ${layerPath}`, error);
-      return undefined;
-    }
-  }
+  abstract getBounds(layerPath: string): Extent | undefined;
 
   /** ***************************************************************************************************************************
    * Set the layerStatus code of all layers in the listOfLayerEntryConfig.

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -30,6 +30,7 @@ import {
   TypeGeoviewLayerConfig,
   TypeLayerEntryConfig,
   layerEntryIsGroupLayer,
+  TypeStyleConfig,
   TypeLayerInitialSettings,
   TypeLayerStatus,
   TypeStyleGeometry,
@@ -40,7 +41,6 @@ import {
   rangeDomainType,
   TypeLocation,
   QueryType,
-  TypeStyleConfig,
 } from '@/geo/map/map-schema-types';
 import { GeoViewLayerCreatedTwiceError } from '@/geo/layer/exceptions/layer-exceptions';
 import { Projection } from '@/geo/utils/projection';
@@ -538,7 +538,8 @@ export abstract class AbstractGeoViewLayer {
           // When we get here, we know that the metadata (if the service provide some) are processed.
 
           //
-          // TODO: Refactor - Layers refactoring. Make a super clear function when moving config information in the layer for real
+          // TODO: Refactor - Layers refactoring. Make it a super clear function when moving config information in the layer for real.
+          // TO.DOCONT: After this point(?) the layerConfig should be full static and the system should rely on the Layer class to do stuff.
           //
           // Save the style in the layer as we're done processing style found in metadata
           if (layerConfig instanceof AbstractBaseLayerEntryConfig) this.setStyle(layerConfig.layerPath, layerConfig.style!);
@@ -568,7 +569,8 @@ export abstract class AbstractGeoViewLayer {
    */
   async #processMetadataGroupLayer(layerConfig: GroupLayerEntryConfig): Promise<GroupLayerEntryConfig> {
     try {
-      // TODO: Check - Does this call makes sense for a metadata group layer? I'm not sure the "TypeScript" works here? Wrong type? Commenting line.. 2024-06-05
+      // TODO: Check - Does this call makes sense for a metadata group layer? I'm not sure the "TypeScript" works here?
+      // TO.DOCONT: Seems to be wrong type? I'm commenting line to see.. 2024-06-05
       // await this.processLayerMetadata(layerConfig);
       await this.processListOfLayerEntryMetadata(layerConfig.listOfLayerEntryConfig!);
       layerConfig.layerStatus = 'processed';

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -8,6 +8,7 @@ import { Pixel } from 'ol/pixel';
 import { Extent } from 'ol/extent';
 import LayerGroup, { Options as LayerGroupOptions } from 'ol/layer/Group';
 import Feature from 'ol/Feature';
+import Source from 'ol/source/Source';
 
 import { TypeLocalizedString } from '@config/types/map-schema-types';
 
@@ -29,7 +30,6 @@ import {
   TypeGeoviewLayerConfig,
   TypeLayerEntryConfig,
   layerEntryIsGroupLayer,
-  TypeStyleConfig,
   TypeLayerInitialSettings,
   TypeLayerStatus,
   TypeStyleGeometry,
@@ -40,6 +40,7 @@ import {
   rangeDomainType,
   TypeLocation,
   QueryType,
+  TypeStyleConfig,
 } from '@/geo/map/map-schema-types';
 import { GeoViewLayerCreatedTwiceError } from '@/geo/layer/exceptions/layer-exceptions';
 import { Projection } from '@/geo/utils/projection';
@@ -129,6 +130,9 @@ export abstract class AbstractGeoViewLayer {
   /** Layer temporal dimension indexed by layerPath. */
   #layerTemporalDimension: Record<string, TimeDimension> = {};
 
+  /** Style to apply to the layer. */
+  #style: Record<string, TypeStyleConfig> = {};
+
   /** Attribution used in the OpenLayer source. */
   attributions: string[] = [];
 
@@ -137,6 +141,12 @@ export abstract class AbstractGeoViewLayer {
 
   /** Date format object used to translate internal UTC ISO format to the external format, the one used by the user */
   externalFragmentsOrder: TypeDateFragments;
+
+  // Keep all callback delegates references
+  #onLayerNameChangedHandlers: LayerNameChangedDelegate[] = [];
+
+  // Keep all callback delegates references
+  #onLayerStyleChangedHandlers: LayerStyleChangedDelegate[] = [];
 
   // Keep all callback delegate references
   #onLegendQueryingHandlers: LegendQueryingDelegate[] = [];
@@ -151,13 +161,13 @@ export abstract class AbstractGeoViewLayer {
   #onLayerEntryProcessedHandlers: LayerEntryProcessedDelegate[] = [];
 
   // Keep all callback delegate references
+  #onLayerRequestingHandlers: LayerRequestingDelegate[] = [];
+
+  // Keep all callback delegate references
   #onLayerCreationHandlers: LayerCreationDelegate[] = [];
 
   // Keep all callback delegate references
   #onLayerFilterAppliedHandlers: LayerFilterAppliedDelegate[] = [];
-
-  // Keep all callback delegates references
-  #onLayerNameChangedHandlers: LayerNameChangedDelegate[] = [];
 
   // Keep all callback delegate references
   #onLayerOpacityChangedHandlers: LayerOpacityChangedDelegate[] = [];
@@ -295,6 +305,23 @@ export abstract class AbstractGeoViewLayer {
   setLayerName(layerPath: string, name: TypeLocalizedString | undefined): void {
     this.#layerName[layerPath] = name;
     this.#emitLayerNameChanged({ layerPath, layerName: name });
+  }
+
+  /**
+   * Gets the layer style
+   * @returns The layer style
+   */
+  getStyle(layerPath: string): TypeStyleConfig | undefined {
+    return this.#style[layerPath];
+  }
+
+  /**
+   * Sets the layer style
+   * @param {TypeStyleConfig | undefined} style - The layer style
+   */
+  setStyle(layerPath: string, style: TypeStyleConfig): void {
+    this.#style[layerPath] = style;
+    this.#emitLayerStyleChanged({ style, layerPath });
   }
 
   /** ***************************************************************************************************************************
@@ -458,27 +485,27 @@ export abstract class AbstractGeoViewLayer {
    * This method recursively validates the configuration of the layer entries to ensure that each layer is correctly defined. If
    * necessary, additional code can be executed in the child method to complete the layer configuration.
    *
-   * @param {TypeLayerEntryConfig[]} listOfLayerEntryConfig The list of layer entries configuration to validate.
+   * @param {ConfigBaseClass[]} listOfLayerEntryConfig The list of layer entries configuration to validate.
    */
-  protected abstract validateListOfLayerEntryConfig(listOfLayerEntryConfig: TypeLayerEntryConfig[]): void;
+  protected abstract validateListOfLayerEntryConfig(listOfLayerEntryConfig: ConfigBaseClass[]): void;
 
   /** ***************************************************************************************************************************
    * This method processes recursively the metadata of each layer in the "layer list" configuration.
    *
-   * @param {TypeLayerEntryConfig[]} listOfLayerEntryConfig The list of layers to process.
+   * @param {ConfigBaseClass[]} listOfLayerEntryConfig The list of layers to process.
    *
    * @returns {Promise<void>} A promise that the execution is completed.
    */
-  protected async processListOfLayerEntryMetadata(listOfLayerEntryConfig: TypeLayerEntryConfig[]): Promise<void> {
+  protected async processListOfLayerEntryMetadata(listOfLayerEntryConfig: ConfigBaseClass[]): Promise<void> {
     try {
-      const promisedAllLayerDone: Promise<TypeLayerEntryConfig>[] = [];
+      const promisedAllLayerDone: Promise<ConfigBaseClass>[] = [];
       for (let i = 0; i < listOfLayerEntryConfig.length; i++) {
-        const layerConfig: TypeLayerEntryConfig = listOfLayerEntryConfig[i];
+        const layerConfig = listOfLayerEntryConfig[i];
         if (layerEntryIsGroupLayer(layerConfig))
           if (layerConfig.isMetadataLayerGroup) promisedAllLayerDone.push(this.#processMetadataGroupLayer(layerConfig));
           // eslint-disable-next-line no-await-in-loop
           else await this.processListOfLayerEntryMetadata(layerConfig.listOfLayerEntryConfig);
-        else promisedAllLayerDone.push(this.processLayerMetadata(layerConfig));
+        else promisedAllLayerDone.push(this.processLayerMetadata(layerConfig as AbstractBaseLayerEntryConfig));
       }
       const arrayOfLayerConfigs = await Promise.all(promisedAllLayerDone);
       arrayOfLayerConfigs.forEach((layerConfig) => {
@@ -488,6 +515,13 @@ export abstract class AbstractGeoViewLayer {
           throw new Error(message);
         } else {
           // When we get here, we know that the metadata (if the service provide some) are processed.
+
+          //
+          // TODO: Refactor - Layers refactoring. Make a super clear function when moving config information in the layer for real
+          //
+          // Save the style in the layer as we're done processing style found in metadata
+          if (layerConfig instanceof AbstractBaseLayerEntryConfig) this.setStyle(layerConfig.layerPath, layerConfig.style!);
+
           // We need to signal to the layer sets that the 'processed' phase is done.
           // GV TODO: For the moment, be aware that the layerStatus setter is doing a lot of things behind the scene.
           // GV       The layerStatus setter contains a lot of code and we will change it in favor of a method.
@@ -513,7 +547,8 @@ export abstract class AbstractGeoViewLayer {
    */
   async #processMetadataGroupLayer(layerConfig: GroupLayerEntryConfig): Promise<GroupLayerEntryConfig> {
     try {
-      await this.processLayerMetadata(layerConfig);
+      // TODO: Check - Does this call makes sense for a metadata group layer? I'm not sure the "TypeScript" works here? Wrong type? Commenting line.. 2024-06-05
+      // await this.processLayerMetadata(layerConfig);
       await this.processListOfLayerEntryMetadata(layerConfig.listOfLayerEntryConfig!);
       layerConfig.layerStatus = 'processed';
       this.#emitLayerEntryProcessed({ config: layerConfig });
@@ -529,13 +564,13 @@ export abstract class AbstractGeoViewLayer {
    * This method is used to process the layer's metadata. It will fill the empty outfields and aliasFields properties of the
    * layer's configuration when applicable.
    *
-   * @param {TypeLayerEntryConfig} layerConfig The layer entry configuration to process.
+   * @param {AbstractBaseLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
-   * @returns {Promise<TypeLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
+   * @returns {Promise<AbstractBaseLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
    */
   // Added eslint-disable here, because we do want to override this method in children and keep 'this'.
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  protected processLayerMetadata(layerConfig: TypeLayerEntryConfig): Promise<TypeLayerEntryConfig> {
+  protected processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<AbstractBaseLayerEntryConfig> {
     if (!layerConfig.source) layerConfig.source = {};
     if (!layerConfig.source.featureInfo) layerConfig.source.featureInfo = { queryable: false };
 
@@ -895,7 +930,7 @@ export abstract class AbstractGeoViewLayer {
     const layerGroup = new LayerGroup(layerGroupOptions);
 
     // Emit about it
-    this.#emitLayerCreation({ layer: layerGroup, config: layerConfig });
+    this.emitLayerCreation({ config: layerConfig, layer: layerGroup });
 
     // Return it
     return layerGroup;
@@ -1118,37 +1153,11 @@ export abstract class AbstractGeoViewLayer {
    */
   async getLegend(layerPath: string): Promise<TypeLegend | null> {
     try {
-      const layerConfig = this.getLayerConfig(layerPath) as
-        | (AbstractBaseLayerEntryConfig & {
-            style: TypeStyleConfig;
-          })
-        | undefined;
-
-      if (!layerConfig) {
-        const legend: TypeLegend = {
-          type: this.type,
-          layerName: { en: 'config not found', fr: 'config inexistante' } as TypeLocalizedString,
-          styleConfig: null,
-          legend: null,
-        };
-        return legend;
-      }
-
-      if (!layerConfig.style) {
-        const legend: TypeLegend = {
-          type: this.type,
-          layerName: layerConfig.layerName!,
-          styleConfig: layerConfig.style,
-          legend: null,
-        };
-        return legend;
-      }
-
+      // Get the legend using the layer information and layer styling
       const legend: TypeLegend = {
         type: this.type,
-        layerName: layerConfig?.layerName,
-        styleConfig: layerConfig?.style,
-        legend: await getLegendStyles(layerConfig),
+        styleConfig: this.getStyle(layerPath),
+        legend: await getLegendStyles(this.getStyle(layerPath)),
       };
       return legend;
     } catch (error) {
@@ -1239,7 +1248,13 @@ export abstract class AbstractGeoViewLayer {
       features.forEach((featureNeedingItsCanvas) => {
         promisedAllCanvasFound.push(
           new Promise((resolveCanvas) => {
-            getFeatureCanvas(featureNeedingItsCanvas, layerConfig, callbackToFetchDataUrl)
+            getFeatureCanvas(
+              featureNeedingItsCanvas,
+              this.getStyle(layerConfig.layerPath)!,
+              layerConfig.filterEquation,
+              layerConfig.legendFilterIsOff,
+              callbackToFetchDataUrl
+            )
               .then((canvas) => {
                 resolveCanvas({ feature: featureNeedingItsCanvas, canvas });
               })
@@ -1490,29 +1505,29 @@ export abstract class AbstractGeoViewLayer {
     if (!olLayer) throw new Error(`An OpenLayer must be provided to register listeners. Layer path ${layerConfig.layerPath}`);
     if (!listenerType) throw new Error(`A listenerType must be provided to register listeners. Layer path ${layerConfig.layerPath}`);
 
-    // Group layers have no listener
-    if (layerConfig.entryType !== CONST_LAYER_ENTRY_TYPES.GROUP) {
-      let loadErrorListener: () => void;
+    // If in old LAYERS_HYBRID_MODE (in the new LAYERS_HYBRID_MODE we want the new classes to handle that)
+    if (!LayerApi.LAYERS_HYBRID_MODE) {
+      // Group layers have no listener
+      if (layerConfig.entryType !== CONST_LAYER_ENTRY_TYPES.GROUP) {
+        let loadErrorListener: () => void;
 
-      // Definition of the load end listener functions
-      const loadEndListener = (): void => {
-        // Call the overridable loaded function
-        this.onLoaded(layerConfig);
+        // Definition of the load end listener functions
+        const loadEndListener = (): void => {
+          // Call the overridable loaded function
+          this.onLoaded(layerConfig);
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (olLayer! as any).get('source').un(`${listenerType}loaderror`, loadErrorListener);
-      };
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (olLayer! as any).get('source').un(`${listenerType}loaderror`, loadErrorListener);
+        };
 
-      loadErrorListener = (): void => {
-        // Call the overridable error function
-        this.onError(layerConfig);
+        loadErrorListener = (): void => {
+          // Call the overridable error function
+          this.onError(layerConfig);
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (olLayer! as any).get('source').un(`${listenerType}loadend`, loadEndListener);
-      };
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (olLayer! as any).get('source').un(`${listenerType}loadend`, loadEndListener);
+        };
 
-      // If not LAYERS_HYBRID_MODE MODE (in LAYERS_HYBRID_MODE we want the new classes to handle that)
-      if (!LayerApi.LAYERS_HYBRID_MODE) {
         // Activation of the load end listeners
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (olLayer! as any).get('source').once(`${listenerType}loaderror`, loadErrorListener);
@@ -1522,7 +1537,7 @@ export abstract class AbstractGeoViewLayer {
     }
 
     // Emit about the layer creation so we can do something about it (part of the major layer refactor)
-    this.#emitLayerCreation({ layer: olLayer!, config: layerConfig });
+    this.emitLayerCreation({ config: layerConfig, layer: olLayer });
   }
 
   /**
@@ -1560,6 +1575,34 @@ export abstract class AbstractGeoViewLayer {
   }
 
   // #region EVENTS
+
+  /**
+   * Emits an event to all handlers.
+   * @param {LayerNameChangedEvent} event - The event to emit
+   * @private
+   */
+  #emitLayerNameChanged(event: LayerNameChangedEvent): void {
+    // Emit the event for all handlers
+    EventHelper.emitEvent(this, this.#onLayerNameChangedHandlers, event);
+  }
+
+  /**
+   * Registers a layer name changed event handler.
+   * @param {LayerNameChangedDelegate} callback - The callback to be executed whenever the event is emitted
+   */
+  onLayerNameChanged(callback: LayerNameChangedDelegate): void {
+    // Register the event handler
+    EventHelper.onEvent(this.#onLayerNameChangedHandlers, callback);
+  }
+
+  /**
+   * Unregisters a layer name changed event handler.
+   * @param {LayerNameChangedDelegate} callback - The callback to stop being called whenever the event is emitted
+   */
+  offLayerNameChanged(callback: LayerNameChangedDelegate): void {
+    // Unregister the event handler
+    EventHelper.offEvent(this.#onLayerNameChangedHandlers, callback);
+  }
 
   /**
    * Emits an event to all handlers.
@@ -1675,10 +1718,38 @@ export abstract class AbstractGeoViewLayer {
 
   /**
    * Emits an event to all handlers.
+   * @param {LayerRequestingEvent} event The event to emit
+   * @private
+   */
+  protected emitLayerRequesting(event: LayerRequestingEvent): (BaseLayer | undefined)[] {
+    // Emit the event for all handlers
+    return EventHelper.emitEvent(this, this.#onLayerRequestingHandlers, event);
+  }
+
+  /**
+   * Registers a layer creation event handler.
+   * @param {LayerRequestingDelegate} callback The callback to be executed whenever the event is emitted
+   */
+  onLayerRequesting(callback: LayerRequestingDelegate): void {
+    // Register the event handler
+    EventHelper.onEvent(this.#onLayerRequestingHandlers, callback);
+  }
+
+  /**
+   * Unregisters a layer creation event handler.
+   * @param {LayerRequestingDelegate} callback The callback to stop being called whenever the event is emitted
+   */
+  offLayerRequesting(callback: LayerRequestingDelegate): void {
+    // Unregister the event handler
+    EventHelper.offEvent(this.#onLayerRequestingHandlers, callback);
+  }
+
+  /**
+   * Emits an event to all handlers.
    * @param {LayerCreationEvent} event The event to emit
    * @private
    */
-  #emitLayerCreation(event: LayerCreationEvent): void {
+  protected emitLayerCreation(event: LayerCreationEvent): void {
     // Emit the event for all handlers
     EventHelper.emitEvent(this, this.#onLayerCreationHandlers, event);
   }
@@ -1731,30 +1802,29 @@ export abstract class AbstractGeoViewLayer {
 
   /**
    * Emits an event to all handlers.
-   * @param {LayerNameChangedEvent} event - The event to emit
-   * @private
+   * @param {LayerStyleChangedEvent} event - The event to emit
    */
-  #emitLayerNameChanged(event: LayerNameChangedEvent): void {
+  #emitLayerStyleChanged(event: LayerStyleChangedEvent): void {
     // Emit the event for all handlers
-    EventHelper.emitEvent(this, this.#onLayerNameChangedHandlers, event);
+    EventHelper.emitEvent(this, this.#onLayerStyleChangedHandlers, event);
   }
 
   /**
-   * Registers a layer name changed event handler.
-   * @param {LayerNameChangedDelegate} callback - The callback to be executed whenever the event is emitted
+   * Registers a layer style changed event handler.
+   * @param {LayerStyleChangedDelegate} callback - The callback to be executed whenever the event is emitted
    */
-  onLayerNameChanged(callback: LayerNameChangedDelegate): void {
+  onLayerStyleChanged(callback: LayerStyleChangedDelegate): void {
     // Register the event handler
-    EventHelper.onEvent(this.#onLayerNameChangedHandlers, callback);
+    EventHelper.onEvent(this.#onLayerStyleChangedHandlers, callback);
   }
 
   /**
-   * Unregisters a layer name changed event handler.
-   * @param {LayerNameChangedDelegate} callback - The callback to stop being called whenever the event is emitted
+   * Unregisters a layer style changed event handler.
+   * @param {LayerStyleChangedDelegate} callback - The callback to stop being called whenever the event is emitted
    */
-  offLayerNameChanged(callback: LayerNameChangedDelegate): void {
+  offLayerStyleChanged(callback: LayerStyleChangedDelegate): void {
     // Unregister the event handler
-    EventHelper.offEvent(this.#onLayerNameChangedHandlers, callback);
+    EventHelper.offEvent(this.#onLayerStyleChangedHandlers, callback);
   }
 
   /**
@@ -1798,7 +1868,7 @@ export type LegendQueryingEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type LegendQueryingDelegate = EventDelegateBase<AbstractGeoViewLayer, LegendQueryingEvent>;
+type LegendQueryingDelegate = EventDelegateBase<AbstractGeoViewLayer, LegendQueryingEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1811,7 +1881,7 @@ export type LegendQueriedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type LegendQueriedDelegate = EventDelegateBase<AbstractGeoViewLayer, LegendQueriedEvent>;
+type LegendQueriedDelegate = EventDelegateBase<AbstractGeoViewLayer, LegendQueriedEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1823,32 +1893,51 @@ export type VisibleChangedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type VisibleChangedDelegate = EventDelegateBase<AbstractGeoViewLayer, VisibleChangedEvent>;
+type VisibleChangedDelegate = EventDelegateBase<AbstractGeoViewLayer, VisibleChangedEvent, void>;
 
 /**
  * Define an event for the delegate
  */
 export type LayerEntryProcessedEvent = {
-  config: TypeLayerEntryConfig;
-};
-
-/**
- * Define a delegate for the event handler function signature
- */
-type LayerEntryProcessedDelegate = EventDelegateBase<AbstractGeoViewLayer, LayerEntryProcessedEvent>;
-
-/**
- * Define an event for the delegate
- */
-export type LayerCreationEvent = {
-  layer: BaseLayer;
   config: ConfigBaseClass;
 };
 
 /**
  * Define a delegate for the event handler function signature
  */
-type LayerCreationDelegate = EventDelegateBase<AbstractGeoViewLayer, LayerCreationEvent>;
+type LayerEntryProcessedDelegate = EventDelegateBase<AbstractGeoViewLayer, LayerEntryProcessedEvent, void>;
+
+/**
+ * Define an event for the delegate
+ */
+export type LayerRequestingEvent = {
+  // The configuration associated with the layer to be created
+  config: ConfigBaseClass;
+  // The OpenLayers source associated with the layer to be created
+  source: Source;
+  // Extra configuration can be anything (for simplicity)
+  extraConfig?: unknown;
+};
+
+/**
+ * Define a delegate for the event handler function signature
+ */
+type LayerRequestingDelegate = EventDelegateBase<AbstractGeoViewLayer, LayerRequestingEvent, BaseLayer | undefined>;
+
+/**
+ * Define an event for the delegate
+ */
+export type LayerCreationEvent = {
+  // The configuration associated with the created layer
+  config: ConfigBaseClass;
+  // The created layer
+  layer: BaseLayer;
+};
+
+/**
+ * Define a delegate for the event handler function signature
+ */
+type LayerCreationDelegate = EventDelegateBase<AbstractGeoViewLayer, LayerCreationEvent, void>;
 
 export interface TypeWmsLegendStyle {
   name: string;
@@ -1858,7 +1947,7 @@ export interface TypeWmsLegendStyle {
 /**
  * Define a delegate for the event handler function signature
  */
-type LayerFilterAppliedDelegate = EventDelegateBase<AbstractGeoViewLayer, LayerFilterAppliedEvent>;
+type LayerFilterAppliedDelegate = EventDelegateBase<AbstractGeoViewLayer, LayerFilterAppliedEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1873,7 +1962,7 @@ export type LayerFilterAppliedEvent = {
 /**
  * Define a delegate for the event handler function signature.
  */
-type LayerNameChangedDelegate = EventDelegateBase<AbstractGeoViewLayer, LayerNameChangedEvent>;
+type LayerNameChangedDelegate = EventDelegateBase<AbstractGeoViewLayer, LayerNameChangedEvent, void>;
 
 /**
  * Define an event for the delegate.
@@ -1889,7 +1978,7 @@ export type LayerNameChangedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type LayerOpacityChangedDelegate = EventDelegateBase<AbstractGeoViewLayer, LayerOpacityChangedEvent>;
+type LayerOpacityChangedDelegate = EventDelegateBase<AbstractGeoViewLayer, LayerOpacityChangedEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1899,6 +1988,22 @@ export type LayerOpacityChangedEvent = {
   layerPath: string;
   // The filter
   opacity: number;
+};
+
+/**
+ * Define a delegate for the event handler function signature
+ */
+type LayerStyleChangedDelegate = EventDelegateBase<AbstractGeoViewLayer, LayerStyleChangedEvent, void>;
+
+/**
+ * Define an event for the delegate
+ */
+export type LayerStyleChangedEvent = {
+  // The style
+  style: TypeStyleConfig;
+
+  // TODO: Refactor - After layers refactoring, remove the layerPath parameter here
+  layerPath: string;
 };
 
 export interface TypeWmsLegend extends Omit<TypeLegend, 'styleConfig'> {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -51,8 +51,13 @@ export async function commonfetchServiceMetadata(layer: EsriDynamic | EsriFeatur
       else {
         layer.metadata = JSON.parse(metadataString) as TypeJsonObject;
         if ('error' in layer.metadata) throw new Error(`Error code = ${layer.metadata.error.code}, ${layer.metadata.error.message}`);
-        const { copyrightText } = layer.metadata;
-        if (copyrightText && !layer.attributions.includes(copyrightText as string)) layer.attributions.push(copyrightText as string);
+        const copyrightText = layer.metadata.copyrightText as string;
+        const attributions = layer.getAttributions();
+        if (copyrightText && !attributions.includes(copyrightText)) {
+          // Add it
+          attributions.push(copyrightText);
+          layer.setAttributions(attributions);
+        }
       }
     } catch (error) {
       logger.logInfo('Unable to read metadata', error);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -375,10 +375,9 @@ export function commonProcessInitialSettings(
  *
  * @returns {Promise<TypeLayerEntryConfig>} A promise that the layer configuration has its metadata processed.
  */
-export async function commonProcessLayerMetadata(
-  layer: EsriDynamic | EsriFeature | EsriImage,
-  layerConfig: TypeLayerEntryConfig
-): Promise<TypeLayerEntryConfig> {
+export async function commonProcessLayerMetadata<
+  T extends EsriDynamicLayerEntryConfig | EsriFeatureLayerEntryConfig | EsriImageLayerEntryConfig
+>(layer: EsriDynamic | EsriFeature | EsriImage, layerConfig: T): Promise<T> {
   // User-defined groups do not have metadata provided by the service endpoint.
   if (layerEntryIsGroupLayer(layerConfig) && !layerConfig.isMetadataLayerGroup) return layerConfig;
   const { layerPath } = layerConfig;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -169,7 +169,8 @@ export function commonValidateListOfLayerEntryConfig(
         newListOfLayerEntryConfig.push(subLayerEntryConfig);
 
         // FIXME: Temporary patch to keep the behavior until those layer classes don't exist
-        MapEventProcessor.getMapViewerLayerAPI(layer.mapId).registerLayerConfigInit(subLayerEntryConfig);
+        // TODO: Refactor: Do not do this on the fly here anymore with the new configs (quite unpredictable)... (standardizing this call with the other one above for now)
+        MapEventProcessor.getMapViewerLayerAPI(layer.mapId).setLayerEntryConfigObsolete(subLayerEntryConfig);
       });
 
       layer.validateListOfLayerEntryConfig(newListOfLayerEntryConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -5,8 +5,6 @@ import { Extent } from 'ol/extent';
 
 import cloneDeep from 'lodash/cloneDeep';
 
-// import { layerEntryIsGroupLayer } from '@config/types/type-guards';
-
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
 import { Cast, TypeJsonArray, TypeJsonObject } from '@/core/types/global-types';
 import { getLocalizedValue, getXMLHttpRequest } from '@/core/utils/utilities';
@@ -355,7 +353,7 @@ export function commonProcessInitialSettings(
   // GV if (layerConfig.initialSettings?.minZoom === undefined && minScale !== 0) layerConfig.initialSettings.minZoom = minScale;
   // GV if (layerConfig.initialSettings?.maxZoom === undefined && maxScale !== 0) layerConfig.initialSettings.maxZoom = maxScale;
 
-  // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration and handle it later?
+  // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration and handle it later?
 
   if (layerConfig.initialSettings?.extent)
     layerConfig.initialSettings.extent = Projection.transformExtent(

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -353,6 +353,9 @@ export function commonProcessInitialSettings(
   // GV TODO: The solution implemented in the following two lines is not right. scale and zoom are not the same things.
   // GV if (layerConfig.initialSettings?.minZoom === undefined && minScale !== 0) layerConfig.initialSettings.minZoom = minScale;
   // GV if (layerConfig.initialSettings?.maxZoom === undefined && maxScale !== 0) layerConfig.initialSettings.maxZoom = maxScale;
+
+  // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration and handle it later?
+
   if (layerConfig.initialSettings?.extent)
     layerConfig.initialSettings.extent = Projection.transformExtent(
       layerConfig.initialSettings.extent,
@@ -360,6 +363,7 @@ export function commonProcessInitialSettings(
       `EPSG:${MapEventProcessor.getMapState(layer.mapId).currentProjection}`
     );
 
+  // TODO: Check - Here, we're *not* converting in the map projection in the pre-processing, but for some other layers we are (ogc-feature, wfs, ..?). Should be standardized.
   if (!layerConfig.initialSettings?.bounds) {
     const layerExtent = [
       layerMetadata.extent.xmin,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/abstract-geoview-raster.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/abstract-geoview-raster.ts
@@ -1,5 +1,7 @@
 import BaseLayer from 'ol/layer/Base';
 import LayerGroup from 'ol/layer/Group';
+import { Extent } from 'ol/extent';
+import { Projection, get as projectionGet } from 'ol/proj';
 
 import { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 
@@ -29,4 +31,29 @@ export type TypeBaseRasterLayer = BaseLayer | TypeRasterLayerGroup | TypeRasterL
  */
 // ******************************************************************************************************************************
 // GV Layers Refactoring - Obsolete (in layers)
-export abstract class AbstractGeoViewRaster extends AbstractGeoViewLayer {}
+export abstract class AbstractGeoViewRaster extends AbstractGeoViewLayer {
+  getSourceProjection(layerPath: string): Projection | undefined {
+    // Return the projection as read from the source or as ready from the metadata as second chance
+    return (
+      // Using any temporarily until layers migration is done and this is officially obsolete
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (super.getOLLayer(layerPath) as any).getSource()?.getProjection() || undefined
+    );
+  }
+
+  getMetadataProjection(): Projection | undefined {
+    return projectionGet(`EPSG:${this.metadata?.fullExtent?.spatialReference?.wkid}`) || undefined;
+  }
+
+  getMetadataExtent(): Extent | undefined {
+    if (this.metadata?.fullExtent) {
+      return [
+        this.metadata?.fullExtent.xmin as number,
+        this.metadata?.fullExtent.ymin as number,
+        this.metadata?.fullExtent.xmax as number,
+        this.metadata?.fullExtent.ymax as number,
+      ] as Extent;
+    }
+    return undefined;
+  }
+}

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/abstract-geoview-raster.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/abstract-geoview-raster.ts
@@ -1,9 +1,10 @@
 import BaseLayer from 'ol/layer/Base';
 import LayerGroup from 'ol/layer/Group';
 import { Extent } from 'ol/extent';
-import { Projection, get as projectionGet } from 'ol/proj';
+import { Projection as OLProjection } from 'ol/proj';
 
 import { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
+import { Projection } from '@/geo/utils/projection';
 
 /** *****************************************************************************************************************************
  * AbstractGeoViewRaster types
@@ -32,7 +33,12 @@ export type TypeBaseRasterLayer = BaseLayer | TypeRasterLayerGroup | TypeRasterL
 // ******************************************************************************************************************************
 // GV Layers Refactoring - Obsolete (in layers)
 export abstract class AbstractGeoViewRaster extends AbstractGeoViewLayer {
-  getSourceProjection(layerPath: string): Projection | undefined {
+  /**
+   * Gets the source projection
+   * @param {string} layerPath - The layer path to get the source for
+   * @returns {OLProjection | undefined} The OpenLayer projection
+   */
+  getSourceProjection(layerPath: string): OLProjection | undefined {
     // Return the projection as read from the source or as ready from the metadata as second chance
     return (
       // Using any temporarily until layers migration is done and this is officially obsolete
@@ -41,10 +47,18 @@ export abstract class AbstractGeoViewRaster extends AbstractGeoViewLayer {
     );
   }
 
-  getMetadataProjection(): Projection | undefined {
-    return projectionGet(`EPSG:${this.metadata?.fullExtent?.spatialReference?.wkid}`) || undefined;
+  /**
+   * Gets the metadata extent projection, if any.
+   * @returns {OLProjection | undefined} The OpenLayer projection
+   */
+  getMetadataProjection(): OLProjection | undefined {
+    return Projection.getProjection(`EPSG:${this.metadata?.fullExtent?.spatialReference?.wkid}`) || undefined;
   }
 
+  /**
+   * Gets the metadata extent, if any.
+   * @returns {Extent | undefined} The OpenLayer projection
+   */
   getMetadataExtent(): Extent | undefined {
     if (this.metadata?.fullExtent) {
       return [

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -289,7 +289,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
 
     // If no olLayer was obtained
     if (!olLayer) {
-      // Working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
+      // We're working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
       const imageLayerOptions: ImageOptions<ImageArcGISRest> = {
         source,
         properties: { layerConfig },
@@ -707,7 +707,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
         const fieldOfTheSameValue = EsriDynamic.#countFieldOfTheSameValue(styleSettings);
         const fieldOrder = EsriDynamic.#sortFieldOfTheSameValue(styleSettings, fieldOfTheSameValue);
         const queryTree = EsriDynamic.#getQueryTree(styleSettings, fieldOfTheSameValue, fieldOrder);
-        // TODO: Refactor - Layers refactoring. Use the source.featureInfo from the layer, not the layerConfig anymore, here and below
+        // TODO: Refactor - Layers refactoring. We should use the source.featureInfo from the layer, not the layerConfig anymore, here and below
         const query = this.#buildQuery(queryTree, 0, fieldOrder, styleSettings, layerConfig.source.featureInfo!);
         return `${query}${layerFilter ? ` and (${layerFilter})` : ''}`;
       }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -249,7 +249,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
   protected override processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<AbstractBaseLayerEntryConfig> {
     // Instance check
     if (!(layerConfig instanceof EsriDynamicLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
-    return commonProcessLayerMetadata(this, layerConfig as EsriDynamicLayerEntryConfig);
+    return commonProcessLayerMetadata(this, layerConfig);
   }
 
   /** ****************************************************************************************************************************
@@ -337,6 +337,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
       const layerConfig = this.getLayerConfig(layerPath)! as EsriDynamicLayerEntryConfig;
 
       // Guess the geometry type by taking the first style key
+      // TODO: Refactor - Layers migration. Johann: This will be modified with new schema, there is no more geometry on style
       const [geometryType] = layerConfig.getTypeGeometries();
 
       // Fetch the features

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -3,6 +3,7 @@
 import { ImageArcGISRest } from 'ol/source';
 import { Options as SourceOptions } from 'ol/source/ImageArcGISRest';
 import { Options as ImageOptions } from 'ol/layer/BaseImage';
+import BaseLayer from 'ol/layer/Base';
 import { Image as ImageLayer } from 'ol/layer';
 import { Coordinate } from 'ol/coordinate';
 import { Pixel } from 'ol/pixel';
@@ -14,7 +15,7 @@ import Geometry from 'ol/geom/Geometry';
 import { GeometryApi } from '@/geo/layer/geometry/geometry';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
-import { AbstractGeoViewRaster, TypeBaseRasterLayer } from '@/geo/layer/geoview-layers/raster/abstract-geoview-raster';
+import { AbstractGeoViewRaster } from '@/geo/layer/geoview-layers/raster/abstract-geoview-raster';
 import { Projection } from '@/geo/utils/projection';
 import { TypeJsonObject } from '@/core/types/global-types';
 import { logger } from '@/core/utils/logger';
@@ -240,27 +241,33 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * This method is used to process the layer's metadata. It will fill the empty fields of the layer's configuration (renderer,
    * initial settings, fields and aliases).
    *
-   * @param {EsriDynamicLayerEntryConfig} layerConfig The layer entry configuration to process.
+   * @param {AbstractBaseLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
-   * @returns {Promise<EsriDynamicLayerEntryConfig>} A promise that the layer configuration has its metadata processed.
+   * @returns {Promise<AbstractBaseLayerEntryConfig>} A promise that the layer configuration has its metadata processed.
    */
   // GV Layers Refactoring - Obsolete (in config?)
-  protected override processLayerMetadata(layerConfig: EsriDynamicLayerEntryConfig): Promise<EsriDynamicLayerEntryConfig> {
-    return commonProcessLayerMetadata(this, layerConfig);
+  protected override processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<AbstractBaseLayerEntryConfig> {
+    // Instance check
+    if (!(layerConfig instanceof EsriDynamicLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
+    return commonProcessLayerMetadata(this, layerConfig as EsriDynamicLayerEntryConfig);
   }
 
   /** ****************************************************************************************************************************
    * This method creates a GeoView EsriDynamic layer using the definition provided in the layerConfig parameter.
    *
-   * @param {EsriDynamicLayerEntryConfig} layerConfig Information needed to create the GeoView layer.
+   * @param {AbstractBaseLayerEntryConfig} layerConfig Information needed to create the GeoView layer.
    *
-   * @returns {Promise<TypeBaseRasterLayer | undefined>} The GeoView raster layer that has been created.
+   * @returns {Promise<BaseLayer | undefined>} The GeoView raster layer that has been created.
    */
   // GV Layers Refactoring - Obsolete (in config?, in layers?)
-  protected override async processOneLayerEntry(layerConfig: EsriDynamicLayerEntryConfig): Promise<TypeBaseRasterLayer | undefined> {
+  protected override async processOneLayerEntry(layerConfig: AbstractBaseLayerEntryConfig): Promise<BaseLayer | undefined> {
     // GV IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
     // GV            layerStatus values is correctly sequenced.
     await super.processOneLayerEntry(layerConfig);
+
+    // Instance check
+    if (!(layerConfig instanceof EsriDynamicLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
+
     const sourceOptions: SourceOptions = {};
     sourceOptions.attributions = [(this.metadata?.copyrightText ? this.metadata?.copyrightText : '') as string];
     sourceOptions.url = getLocalizedValue(layerConfig.source.dataAccessPath!, AppEventProcessor.getDisplayLanguage(this.mapId));

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -16,7 +16,7 @@ import { getLocalizedValue } from '@/core/utils/utilities';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { AbstractGeoViewRaster, TypeBaseRasterLayer } from '@/geo/layer/geoview-layers/raster/abstract-geoview-raster';
 import { Projection } from '@/geo/utils/projection';
-import { getMinOrMaxExtents } from '@/geo/utils/utilities';
+import { getExtentIntersection, getExtentUnionMaybe } from '@/geo/utils/utilities';
 import { TypeJsonObject } from '@/core/types/global-types';
 import { logger } from '@/core/utils/logger';
 import { DateMgt } from '@/core/utils/date-mgt';
@@ -263,7 +263,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
     // GV            layerStatus values is correctly sequenced.
     await super.processOneLayerEntry(layerConfig);
     const sourceOptions: SourceOptions = {};
-    sourceOptions.attributions = [(this.metadata!.copyrightText ? this.metadata!.copyrightText : '') as string];
+    sourceOptions.attributions = [(this.metadata?.copyrightText ? this.metadata?.copyrightText : '') as string];
     sourceOptions.url = getLocalizedValue(layerConfig.source.dataAccessPath!, AppEventProcessor.getDisplayLanguage(this.mapId));
     sourceOptions.params = { LAYERS: `show:${layerConfig.layerId}` };
     if (layerConfig.source.transparent) Object.defineProperty(sourceOptions.params, 'transparent', layerConfig.source.transparent!);
@@ -290,6 +290,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
 
     // If no olLayer was obtained
     if (!olLayer) {
+      // Working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
       const imageLayerOptions: ImageOptions<ImageArcGISRest> = {
         source,
         properties: { layerConfig },
@@ -307,10 +308,13 @@ export class EsriDynamic extends AbstractGeoViewRaster {
 
       // Create the OpenLayer layer
       olLayer = new ImageLayer(imageLayerOptions);
+
+      // Hook the loaded event
+      this.setLayerAndLoadEndListeners(layerConfig, olLayer, 'image');
     }
 
-    // TODO: Refactor - Wire it up
-    this.setLayerAndLoadEndListeners(layerConfig, olLayer, 'image');
+    // GV Time to emit about the layer creation!
+    this.emitLayerCreation({ config: layerConfig, layer: olLayer });
 
     return Promise.resolve(olLayer);
   }
@@ -900,29 +904,34 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @returns {Extent | undefined} The new layer bounding box.
    */
   // GV Layers Refactoring - Obsolete (in layers)
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+  protected override getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+    // Get the layer config
     const layerConfig = this.getLayerConfig(layerPath);
-    const layerBounds = layerConfig?.initialSettings?.bounds || [];
-    const projection =
-      this.metadata?.fullExtent?.spatialReference?.wkid || this.getMapViewer().getProjection().getCode().replace('EPSG:', '');
 
-    if (this.metadata?.fullExtent) {
-      layerBounds[0] = this.metadata?.fullExtent.xmin as number;
-      layerBounds[1] = this.metadata?.fullExtent.ymin as number;
-      layerBounds[2] = this.metadata?.fullExtent.xmax as number;
-      layerBounds[3] = this.metadata?.fullExtent.ymax as number;
+    // Get the layer config bounds
+    let layerConfigBounds = layerConfig?.initialSettings?.bounds;
+
+    // If layer bounds were found, project
+    if (layerConfigBounds) {
+      // Make sure we're in the map projection. Always EPSG:4326 when coming from our configuration.
+      layerConfigBounds = this.getMapViewer().convertExtentFromProjToMapProj(layerConfigBounds, 'EPSG:4326');
     }
 
-    if (layerBounds) {
-      let transformedBounds = layerBounds;
-      if (this.metadata?.fullExtent?.spatialReference?.wkid !== this.getMapViewer().getProjection().getCode().replace('EPSG:', '')) {
-        transformedBounds = this.getMapViewer().convertExtentFromProjToMapProj(layerBounds, `EPSG:${projection}`);
-      }
+    // Get the metadata extent
+    const metadataExtent = this.getMetadataExtent();
 
-      if (!bounds) bounds = [transformedBounds[0], transformedBounds[1], transformedBounds[2], transformedBounds[3]];
-      else bounds = getMinOrMaxExtents(bounds, transformedBounds);
+    // If found
+    let layerBounds;
+    if (metadataExtent) {
+      // Get the metadata projection
+      const metadataProjection = this.getMetadataProjection();
+      layerBounds = this.getMapViewer().convertExtentFromProjToMapProj(metadataExtent, metadataProjection);
     }
 
-    return bounds;
+    // If both layer config had bounds and layer has real bounds, take the intersection between them
+    if (layerConfigBounds && layerBounds) layerBounds = getExtentIntersection(layerBounds, layerConfigBounds);
+
+    // Return the layer bounds possibly unioned with 'bounds' received as param
+    return getExtentUnionMaybe(layerBounds, bounds);
   }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -16,7 +16,6 @@ import { getLocalizedValue } from '@/core/utils/utilities';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { AbstractGeoViewRaster, TypeBaseRasterLayer } from '@/geo/layer/geoview-layers/raster/abstract-geoview-raster';
 import { Projection } from '@/geo/utils/projection';
-import { getExtentIntersection, getExtentUnionMaybe } from '@/geo/utils/utilities';
 import { TypeJsonObject } from '@/core/types/global-types';
 import { logger } from '@/core/utils/logger';
 import { DateMgt } from '@/core/utils/date-mgt';
@@ -899,24 +898,12 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
    * @returns {Extent | undefined} The new layer bounding box.
    */
   // GV Layers Refactoring - Obsolete (in layers)
-  protected override getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
-    // Get the layer config
-    const layerConfig = this.getLayerConfig(layerPath);
-
-    // Get the layer config bounds
-    let layerConfigBounds = layerConfig?.initialSettings?.bounds;
-
-    // If layer bounds were found, project
-    if (layerConfigBounds) {
-      // Make sure we're in the map projection. Always EPSG:4326 when coming from our configuration.
-      layerConfigBounds = this.getMapViewer().convertExtentFromProjToMapProj(layerConfigBounds, 'EPSG:4326');
-    }
-
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override getBounds(layerPath: string): Extent | undefined {
     // Get the metadata extent
     const metadataExtent = this.getMetadataExtent();
 
@@ -928,10 +915,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
       layerBounds = this.getMapViewer().convertExtentFromProjToMapProj(metadataExtent, metadataProjection);
     }
 
-    // If both layer config had bounds and layer has real bounds, take the intersection between them
-    if (layerConfigBounds && layerBounds) layerBounds = getExtentIntersection(layerBounds, layerConfigBounds);
-
-    // Return the layer bounds possibly unioned with 'bounds' received as param
-    return getExtentUnionMaybe(layerBounds, bounds);
+    // Return the calculated layer bounds
+    return layerBounds;
   }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
@@ -5,7 +5,6 @@ import { Image as ImageLayer } from 'ol/layer';
 import { Extent } from 'ol/extent';
 
 import { getLocalizedValue } from '@/core/utils/utilities';
-import { getExtentIntersection, getExtentUnionMaybe } from '@/geo/utils/utilities';
 import { DateMgt } from '@/core/utils/date-mgt';
 import { TypeJsonObject } from '@/core/types/global-types';
 import { logger } from '@/core/utils/logger';
@@ -436,24 +435,12 @@ export class EsriImage extends AbstractGeoViewRaster {
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
    * @returns {Extent | undefined} The new layer bounding box.
    */
   // GV Layers Refactoring - Obsolete (in layers)
-  protected override getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
-    // Get the layer config
-    const layerConfig = this.getLayerConfig(layerPath);
-
-    // Get the layer config bounds
-    let layerConfigBounds = layerConfig?.initialSettings?.bounds;
-
-    // If layer bounds were found, project
-    if (layerConfigBounds) {
-      // Make sure we're in the map projection. Always EPSG:4326 when coming from our configuration.
-      layerConfigBounds = this.getMapViewer().convertExtentFromProjToMapProj(layerConfigBounds, 'EPSG:4326');
-    }
-
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override getBounds(layerPath: string): Extent | undefined {
     // Get the metadata extent
     const metadataExtent = this.getMetadataExtent();
 
@@ -465,10 +452,7 @@ export class EsriImage extends AbstractGeoViewRaster {
       layerBounds = this.getMapViewer().convertExtentFromProjToMapProj(metadataExtent, metadataProjection);
     }
 
-    // If both layer config had bounds and layer has real bounds, take the intersection between them
-    if (layerConfigBounds && layerBounds) layerBounds = getExtentIntersection(layerBounds, layerConfigBounds);
-
-    // Return the layer bounds possibly unioned with 'bounds' received as param
-    return getExtentUnionMaybe(layerBounds, bounds);
+    // Return the calculated layer bounds
+    return layerBounds;
   }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
@@ -294,7 +294,7 @@ export class EsriImage extends AbstractGeoViewRaster {
   protected override processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<AbstractBaseLayerEntryConfig> {
     // Instance check
     if (!(layerConfig instanceof EsriImageLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
-    return commonProcessLayerMetadata(this, layerConfig as EsriImageLayerEntryConfig);
+    return commonProcessLayerMetadata(this, layerConfig);
   }
 
   /** ****************************************************************************************************************************

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
@@ -1,5 +1,6 @@
 import { ImageArcGISRest } from 'ol/source';
 import { Options as SourceOptions } from 'ol/source/ImageArcGISRest';
+import BaseLayer from 'ol/layer/Base';
 import { Options as ImageOptions } from 'ol/layer/BaseImage';
 import { Image as ImageLayer } from 'ol/layer';
 import { Extent } from 'ol/extent';
@@ -11,7 +12,7 @@ import { logger } from '@/core/utils/logger';
 import { EsriImageLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/esri-image-layer-entry-config';
 import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
-import { AbstractGeoViewRaster, TypeBaseRasterLayer } from '@/geo/layer/geoview-layers/raster/abstract-geoview-raster';
+import { AbstractGeoViewRaster } from '@/geo/layer/geoview-layers/raster/abstract-geoview-raster';
 import {
   TypeLayerEntryConfig,
   TypeGeoviewLayerConfig,
@@ -285,27 +286,33 @@ export class EsriImage extends AbstractGeoViewRaster {
    * This method is used to process the layer's metadata. It will fill the empty fields of the layer's configuration (renderer,
    * initial settings, fields and aliases).
    *
-   * @param {EsriImageLayerEntryConfig} layerConfig The layer entry configuration to process.
+   * @param {AbstractBaseLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
-   * @returns {Promise<EsriImageLayerEntryConfig>} A promise that the layer configuration has its metadata processed.
+   * @returns {Promise<AbstractBaseLayerEntryConfig>} A promise that the layer configuration has its metadata processed.
    */
   // GV Layers Refactoring - Obsolete (in config?)
-  protected override processLayerMetadata(layerConfig: EsriImageLayerEntryConfig): Promise<EsriImageLayerEntryConfig> {
-    return commonProcessLayerMetadata(this, layerConfig);
+  protected override processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<AbstractBaseLayerEntryConfig> {
+    // Instance check
+    if (!(layerConfig instanceof EsriImageLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
+    return commonProcessLayerMetadata(this, layerConfig as EsriImageLayerEntryConfig);
   }
 
   /** ****************************************************************************************************************************
    * This method creates a GeoView Esri Image layer using the definition provided in the layerConfig parameter.
    *
-   * @param {EsriImageLayerEntryConfig} layerConfig Information needed to create the GeoView layer.
+   * @param {AbstractBaseLayerEntryConfig} layerConfig Information needed to create the GeoView layer.
    *
-   * @returns { Promise<TypeBaseRasterLayer | undefined>} The GeoView raster layer that has been created.
+   * @returns { Promise<BaseLayer | undefined>} The GeoView raster layer that has been created.
    */
   // GV Layers Refactoring - Obsolete (in config?, in layers?)
-  protected override async processOneLayerEntry(layerConfig: EsriImageLayerEntryConfig): Promise<TypeBaseRasterLayer | undefined> {
+  protected override async processOneLayerEntry(layerConfig: AbstractBaseLayerEntryConfig): Promise<BaseLayer | undefined> {
     // GV IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
     // GV            layerStatus values is correctly sequenced.
     await super.processOneLayerEntry(layerConfig);
+
+    // Instance check
+    if (!(layerConfig instanceof EsriImageLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
+
     const sourceOptions: SourceOptions = {};
     sourceOptions.attributions = [(this.metadata!.copyrightText ? this.metadata!.copyrightText : '') as string];
     sourceOptions.url = getLocalizedValue(layerConfig.source.dataAccessPath!, AppEventProcessor.getDisplayLanguage(this.mapId));

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
@@ -182,7 +182,7 @@ export class EsriImage extends AbstractGeoViewRaster {
 
       // TODO: Refactor - Find a better place to set the style than in a getter or rename this function like another TODO suggests
       // TO.DOCONT: This setter is also dangerous, because it triggers a style changed event which is listened by the legends-layer-set.
-      // TO.DOCONT: Fortunately, we have a loop check barrier, but setting a style during a legend fetch could lead to be more problematic.
+      // TO.DOCONT: Fortunately, we have a loop check barrier, but setting a style during a legend fetch getter could lead to be more problematic.
       this.setStyle(layerPath, styleConfig);
 
       const legend: TypeLegend = {
@@ -334,7 +334,7 @@ export class EsriImage extends AbstractGeoViewRaster {
 
     // If no olLayer was obtained
     if (!olLayer) {
-      // Working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
+      // We're working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
       const imageLayerOptions: ImageOptions<ImageArcGISRest> = {
         source,
         properties: { layerConfig },

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
@@ -10,7 +10,6 @@ import { AbstractGeoViewLayer, CONST_LAYER_TYPES } from '@/geo/layer/geoview-lay
 import { AbstractGeoViewRaster, TypeBaseRasterLayer } from '@/geo/layer/geoview-layers/raster/abstract-geoview-raster';
 import { TypeLayerEntryConfig, TypeGeoviewLayerConfig, layerEntryIsGroupLayer } from '@/geo/map/map-schema-types';
 import { getLocalizedValue } from '@/core/utils/utilities';
-import { getExtentUnionMaybe } from '@/geo/utils/utilities';
 import { logger } from '@/core/utils/logger';
 import { ImageStaticLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/image-static-layer-entry-config';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
@@ -306,12 +305,11 @@ export class ImageStatic extends AbstractGeoViewRaster {
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
-   * @returns {Extent} The new layer bounding box.
+   * @returns {Extent | undefined} The new layer bounding box.
    */
   // GV Layers Refactoring - Obsolete (in layers)
-  protected override getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+  override getBounds(layerPath: string): Extent | undefined {
     // Get the layer
     const layer = this.getOLLayer(layerPath) as ImageLayer<Static> | undefined;
 
@@ -325,7 +323,7 @@ export class ImageStatic extends AbstractGeoViewRaster {
       sourceExtent = this.getMapViewer().convertExtentFromProjToMapProj(sourceExtent, sourceProjection);
     }
 
-    // Return the layer bounds possibly unioned with 'bounds' received as param
-    return getExtentUnionMaybe(sourceExtent, bounds);
+    // Return the calculated layer bounds
+    return sourceExtent;
   }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
@@ -277,7 +277,7 @@ export class ImageStatic extends AbstractGeoViewRaster {
 
     // If no olLayer was obtained
     if (!olLayer) {
-      // Working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
+      // We're working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
       const staticImageOptions: ImageOptions<Static> = { source };
       // layerConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
       if (layerConfig.initialSettings?.extent !== undefined) staticImageOptions.extent = layerConfig.initialSettings.extent;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
@@ -1,13 +1,14 @@
 import axios from 'axios';
 
-import ImageLayer from 'ol/layer/Image';
 import Static, { Options as SourceOptions } from 'ol/source/ImageStatic';
+import BaseLayer from 'ol/layer/Base';
 import { Options as ImageOptions } from 'ol/layer/BaseImage';
+import ImageLayer from 'ol/layer/Image';
 import { Extent } from 'ol/extent';
 
 import { Cast, TypeJsonObject } from '@/core/types/global-types';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
-import { AbstractGeoViewRaster, TypeBaseRasterLayer } from '@/geo/layer/geoview-layers/raster/abstract-geoview-raster';
+import { AbstractGeoViewRaster } from '@/geo/layer/geoview-layers/raster/abstract-geoview-raster';
 import { TypeLayerEntryConfig, TypeGeoviewLayerConfig, layerEntryIsGroupLayer } from '@/geo/map/map-schema-types';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { logger } from '@/core/utils/logger';
@@ -15,6 +16,7 @@ import { ImageStaticLayerEntryConfig } from '@/core/utils/config/validation-clas
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 import { loadImage } from '@/geo/utils/renderer/geoview-renderer';
 import { TypeLegend } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
 
 export interface TypeImageStaticLayerConfig extends Omit<TypeGeoviewLayerConfig, 'listOfLayerEntryConfig'> {
   geoviewLayerType: typeof CONST_LAYER_TYPES.IMAGE_STATIC;
@@ -238,13 +240,16 @@ export class ImageStatic extends AbstractGeoViewRaster {
   /** ****************************************************************************************************************************
    * This method creates a GeoView Image Static layer using the definition provided in the layerConfig parameter.
    *
-   * @param {ImageStaticLayerEntryConfig} layerConfig Information needed to create the GeoView layer.
+   * @param {AbstractBaseLayerEntryConfig} layerConfig Information needed to create the GeoView layer.
    *
-   * @returns {Promise<TypeBaseRasterLayer | undefined>} The GeoView raster layer that has been created.
+   * @returns {Promise<BaseLayer | undefined>} The GeoView raster layer that has been created.
    */
   // GV Layers Refactoring - Obsolete (in config?, in layers?)
-  protected override async processOneLayerEntry(layerConfig: ImageStaticLayerEntryConfig): Promise<TypeBaseRasterLayer | undefined> {
+  protected override async processOneLayerEntry(layerConfig: AbstractBaseLayerEntryConfig): Promise<BaseLayer | undefined> {
     await super.processOneLayerEntry(layerConfig);
+
+    // Instance check
+    if (!(layerConfig instanceof ImageStaticLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
 
     if (!layerConfig?.source?.extent) throw new Error('Parameter extent is not defined in source element of layerConfig.');
     const sourceOptions: SourceOptions = {
@@ -313,7 +318,7 @@ export class ImageStatic extends AbstractGeoViewRaster {
     // Get the layer
     const layer = this.getOLLayer(layerPath) as ImageLayer<Static> | undefined;
 
-    // Get the source projection code
+    // Get the source projection
     const sourceProjection = this.getSourceProjection(layerPath);
 
     // Get the layer bounds

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
@@ -220,7 +220,7 @@ export class VectorTiles extends AbstractGeoViewRaster {
 
     // If no olLayer was obtained
     if (!olLayer) {
-      // Working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
+      // We're working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
       const tileLayerOptions: TileOptions<VectorTileSource> = { source };
       // layerConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
       if (layerConfig.initialSettings?.className !== undefined) tileLayerOptions.className = layerConfig.initialSettings.className;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
@@ -21,7 +21,6 @@ import {
   TypeTileGrid,
   layerEntryIsGroupLayer,
 } from '@/geo/map/map-schema-types';
-import { getExtentUnionMaybe } from '@/geo/utils/utilities';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { Cast, TypeJsonObject } from '@/core/types/global-types';
 import { api } from '@/app';
@@ -286,8 +285,7 @@ export class VectorTiles extends AbstractGeoViewRaster {
       layerConfig.source!.tileGrid = newTileGrid;
 
       if (layerConfig.initialSettings?.extent)
-        // TODO: Check - Why are we converting to the map projection in the processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
-        // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice?
+        // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration and handle it later?
         // eslint-disable-next-line no-param-reassign
         layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
     }
@@ -298,12 +296,11 @@ export class VectorTiles extends AbstractGeoViewRaster {
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
    * @returns {Extent | undefined} The new layer bounding box.
    */
   // GV Layers Refactoring - Obsolete (in layers)
-  protected override getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+  override getBounds(layerPath: string): Extent | undefined {
     // Get the layer
     const layer = this.getOLLayer(layerPath) as TileLayer<VectorTileSource> | undefined;
 
@@ -317,8 +314,8 @@ export class VectorTiles extends AbstractGeoViewRaster {
       sourceExtent = this.getMapViewer().convertExtentFromProjToMapProj(sourceExtent, sourceProjection);
     }
 
-    // Return the layer bounds possibly unioned with 'bounds' received as param
-    return getExtentUnionMaybe(sourceExtent, bounds);
+    // Return the calculated layer bounds
+    return sourceExtent;
   }
 
   // TODO: This section needs documentation (a header at least). Also, is it normal to have things hardcoded like that?

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
@@ -293,7 +293,7 @@ export class VectorTiles extends AbstractGeoViewRaster {
       layerConfig.source!.tileGrid = newTileGrid;
 
       if (layerConfig.initialSettings?.extent)
-        // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration and handle it later?
+        // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration and handle it later?
         // eslint-disable-next-line no-param-reassign
         layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
     }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -569,7 +569,7 @@ export class WMS extends AbstractGeoViewRaster {
 
         // If no olLayer was obtained
         if (!olLayer) {
-          // Working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
+          // We're working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
           const imageLayerOptions: ImageOptions<ImageWMS> = {
             source,
             properties: { layerCapabilities, layerConfig },

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -219,7 +219,7 @@ export class XYZTiles extends AbstractGeoViewRaster {
 
     // If no olLayer was obtained
     if (!olLayer) {
-      // Working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
+      // We're working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
       const tileLayerOptions: TileOptions<XYZ> = { source };
       // layerConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
       if (layerConfig.initialSettings?.className !== undefined) tileLayerOptions.className = layerConfig.initialSettings.className;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -272,7 +272,7 @@ export class XYZTiles extends AbstractGeoViewRaster {
       layerConfig.initialSettings = defaultsDeep(layerConfig.initialSettings, metadataLayerConfigFound!.initialSettings);
 
       if (layerConfig.initialSettings?.extent)
-        // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration and handle it later?
+        // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration and handle it later?
         // eslint-disable-next-line no-param-reassign
         layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
     }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -17,7 +17,6 @@ import {
   TypeGeoviewLayerConfig,
   layerEntryIsGroupLayer,
 } from '@/geo/map/map-schema-types';
-import { getExtentUnionMaybe } from '@/geo/utils/utilities';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { Cast, toJsonObject } from '@/core/types/global-types';
 import { XYZTilesLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/xyz-layer-entry-config';
@@ -266,8 +265,7 @@ export class XYZTiles extends AbstractGeoViewRaster {
       layerConfig.initialSettings = defaultsDeep(layerConfig.initialSettings, metadataLayerConfigFound!.initialSettings);
 
       if (layerConfig.initialSettings?.extent)
-        // TODO: Check - Why are we converting to the map projection in the processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
-        // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice?
+        // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration and handle it later?
         // eslint-disable-next-line no-param-reassign
         layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
     }
@@ -278,12 +276,11 @@ export class XYZTiles extends AbstractGeoViewRaster {
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
    * @returns {Extent | undefined} The new layer bounding box.
    */
   // GV Layers Refactoring - Obsolete (in layers)
-  protected override getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+  override getBounds(layerPath: string): Extent | undefined {
     // Get the layer
     const layer = this.getOLLayer(layerPath) as TileLayer<XYZ> | undefined;
 
@@ -297,7 +294,7 @@ export class XYZTiles extends AbstractGeoViewRaster {
       sourceExtent = this.getMapViewer().convertExtentFromProjToMapProj(sourceExtent, sourceProjection);
     }
 
-    // Return the layer bounds possibly unioned with 'bounds' received as param
-    return getExtentUnionMaybe(sourceExtent, bounds);
+    // Return the calculated layer bounds
+    return sourceExtent;
   }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -114,6 +114,10 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
     // GV IMPORTANT: The processOneLayerEntry method must call the corresponding method of its parent to ensure that the flow of
     // GV            layerStatus values is correctly sequenced.
     await super.processOneLayerEntry(layerConfig);
+
+    // Instance check
+    if (!(layerConfig instanceof VectorLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
+
     const vectorSource = this.createVectorSource(layerConfig);
     const vectorLayer = this.createVectorLayer(layerConfig as VectorLayerEntryConfig, vectorSource);
     return Promise.resolve(vectorLayer);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -476,6 +476,9 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * @returns {Feature[]} The array of features.
    */
   static convertCsv(mapId: string, csvData: string, layerConfig: VectorLayerEntryConfig): Feature[] | null {
+    // GV: This function and the below private static ones used to be in the CSV class directly, but something wasn't working with a 'Private element not accessible' error.
+    // GV: After moving the code to the mother class, it worked. It'll remain here for now until the config refactoring can take care of it in its re-writing
+
     const inProjection: ProjectionLike = layerConfig.source!.dataProjection || Projection.PROJECTION_NAMES.LNGLAT;
     const outProjection: ProjectionLike = MapEventProcessor.getMapViewer(mapId).getProjection().getCode();
     const latList = ['latitude', 'lat', 'y', 'ycoord', 'latitude/latitude', 'latitude / latitude'];

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -22,7 +22,6 @@ import { AbstractGeoViewLayer, CONST_LAYER_TYPES } from '@/geo/layer/geoview-lay
 import { TypeBaseSourceVectorInitialConfig, TypeFeatureInfoEntry, TypeLayerEntryConfig } from '@/geo/map/map-schema-types';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { DateMgt } from '@/core/utils/date-mgt';
-import { getExtentUnionMaybe } from '@/geo/utils/utilities';
 import { NodeType } from '@/geo/utils/renderer/geoview-renderer-types';
 import { VECTOR_LAYER } from '@/core/utils/constant';
 import { logger } from '@/core/utils/logger';
@@ -382,17 +381,16 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * Get the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds
    *
    * @param {string} layerPath The Layer path to the layer's configuration.
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
    *
    * @returns {Extent | undefined} The new layer bounding box.
    */
   // GV Layers Refactoring - Obsolete (in layers)
-  protected override getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+  override getBounds(layerPath: string): Extent | undefined {
     const layer = this.getOLLayer(layerPath) as VectorLayer<VectorSource> | undefined;
     const layerBounds = layer?.getSource()?.getExtent();
 
-    // Return the layer bounds possibly unioned with 'bounds' received as param
-    return getExtentUnionMaybe(layerBounds, bounds);
+    // Return the calculated layer bounds
+    return layerBounds;
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -249,7 +249,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
 
     // If no olLayer was obtained
     if (!olLayer) {
-      // Working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
+      // We're working in old LAYERS_HYBRID_MODE (in the new mode the code below is handled in the new classes)
       // Create the vector layer options.
       const layerOptions: VectorLayerOptions<VectorSource> = {
         properties: { layerConfig },

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/csv.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/csv.ts
@@ -6,15 +6,11 @@ import { ReadOptions } from 'ol/format/Feature';
 import { Vector as VectorSource } from 'ol/source';
 import Feature from 'ol/Feature';
 
-import { Point } from 'ol/geom';
-import { ProjectionLike } from 'ol/proj';
-
 // import { layerEntryIsGroupLayer } from '@config/types/type-guards';
 
 import { Cast, TypeJsonObject } from '@config/types/config-types';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { AbstractGeoViewVector } from '@/geo/layer/geoview-layers/vector/abstract-geoview-vector';
-import { Projection } from '@/geo/utils/projection';
 import {
   TypeLayerEntryConfig,
   TypeVectorSourceInitialConfig,
@@ -22,8 +18,6 @@ import {
   TypeBaseSourceVectorInitialConfig,
   layerEntryIsGroupLayer,
 } from '@/geo/map/map-schema-types';
-import { api } from '@/app';
-import { logger } from '@/core/utils/logger';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { CsvLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-validation-classes/csv-layer-entry-config';
 import { VectorLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-layer-entry-config';
@@ -159,143 +153,6 @@ export class CSV extends AbstractGeoViewVector {
     // process the feature info configuration and attach the config to the instance for access by parent class
     this.setLayerMetadata(layerConfig.layerPath, Cast<TypeJsonObject>(layerConfig));
     return Promise.resolve(layerConfig);
-  }
-
-  /** ***************************************************************************************************************************
-   * Converts csv to array of rows of separated values.
-   *
-   * @param {string} csvData The raw csv text.
-   * @param {string} separator The character used to separate the values.
-   *
-   * @returns {string[][]} An array of the rows of the csv, split by separator.
-   * @private
-   */
-  static #csvStringToArray(csvData: string, separator: string): string[][] {
-    const regex = new RegExp(`(\\${separator}|\\r?\\n|\\r|^)(?:"([^"]*(?:""[^"]*)*)"|([^\\${separator}\\r\\n]*))`, 'gi');
-    let matches;
-    const parsedData: string[][] = [[]];
-    // eslint-disable-next-line no-cond-assign
-    while ((matches = regex.exec(csvData))) {
-      if (matches[1].length && matches[1] !== separator) parsedData.push([]);
-      parsedData[parsedData.length - 1].push(matches[2] !== undefined ? matches[2].replace(/""/g, '"') : matches[3]);
-    }
-    return parsedData;
-  }
-
-  /** ***************************************************************************************************************************
-   * This method sets the outfields and aliasFields of the source feature info.
-   *
-   * @param {string[]} headers An array of field names.
-   * @param {string[]} firstRow The first row of data.
-   * @param {number[]} lonLatIndices The index of lon and lat in the array.
-   * @param {VectorLayerEntryConfig} layerConfig The vector layer entry to configure.
-   * @private
-   */
-  static #processFeatureInfoConfig(
-    headers: string[],
-    firstRow: string[],
-    lonLatIndices: number[],
-    layerConfig: VectorLayerEntryConfig
-  ): void {
-    if (!layerConfig.source) layerConfig.source = {};
-    if (!layerConfig.source.featureInfo) layerConfig.source.featureInfo = { queryable: true };
-    // Process undefined outfields or aliasFields ('' = false and !'' = true). Also, if en is undefined, then fr is also undefined.
-    // when en and fr are undefined, we set both en and fr to the same value.
-    if (!layerConfig.source.featureInfo.outfields?.en || !layerConfig.source.featureInfo.aliasFields?.en) {
-      const processOutField = !layerConfig.source.featureInfo.outfields?.en;
-      const processAliasFields = !layerConfig.source.featureInfo.aliasFields?.en;
-      if (processOutField) {
-        layerConfig.source.featureInfo.outfields = { en: '' };
-        layerConfig.source.featureInfo.fieldTypes = '';
-      }
-      if (processAliasFields) layerConfig.source.featureInfo.aliasFields = { en: '' };
-      headers.forEach((header) => {
-        const index = headers.indexOf(header);
-        if (index !== lonLatIndices[0] && index !== lonLatIndices[1]) {
-          let type = 'string';
-          if (firstRow[index] && firstRow[index] !== '' && Number(firstRow[index])) type = 'number';
-          if (processOutField) {
-            layerConfig.source!.featureInfo!.outfields!.en = `${layerConfig.source!.featureInfo!.outfields!.en}${header},`;
-            layerConfig.source!.featureInfo!.fieldTypes = `${layerConfig.source!.featureInfo!.fieldTypes}${type},`;
-          }
-          layerConfig.source!.featureInfo!.aliasFields!.en = `${layerConfig.source!.featureInfo!.outfields!.en}${header},`;
-        }
-      });
-      // Remove commas from end of strings
-      layerConfig.source.featureInfo!.outfields!.en = layerConfig.source.featureInfo!.outfields?.en?.slice(0, -1);
-      layerConfig.source.featureInfo!.fieldTypes = layerConfig.source.featureInfo!.fieldTypes?.slice(0, -1);
-      layerConfig.source.featureInfo!.aliasFields!.en = layerConfig.source.featureInfo!.aliasFields?.en?.slice(0, -1);
-      layerConfig.source!.featureInfo!.outfields!.fr = layerConfig.source!.featureInfo!.outfields?.en;
-      layerConfig.source!.featureInfo!.aliasFields!.fr = layerConfig.source!.featureInfo!.aliasFields?.en;
-    }
-    if (!layerConfig.source.featureInfo.nameField) {
-      const en =
-        layerConfig.source.featureInfo!.outfields!.en?.split(',')[0] || layerConfig.source.featureInfo!.outfields!.fr?.split(',')[0];
-      const fr = en;
-      if (en) layerConfig.source.featureInfo.nameField = { en, fr };
-    }
-  }
-
-  /** ***************************************************************************************************************************
-   * Converts csv text to feature array.
-   *
-   * @param {string} csvData The data from the .csv file.
-   * @param {VectorLayerEntryConfig} layerConfig The config of the layer.
-   *
-   * @returns {Feature[]} The array of features.
-   */
-  convertCsv(csvData: string, layerConfig: VectorLayerEntryConfig): Feature[] | null {
-    const inProjection: ProjectionLike = layerConfig.source!.dataProjection || Projection.PROJECTION_NAMES.LNGLAT;
-    const outProjection: ProjectionLike = this.getMapViewer().getProjection().getCode();
-    const latList = ['latitude', 'lat', 'y', 'ycoord', 'latitude/latitude', 'latitude / latitude'];
-    const lonList = ['longitude', 'lon', 'x', 'xcoord', 'longitude/longitude', 'longitude / longitude'];
-
-    const features: Feature[] = [];
-    let latIndex: number | undefined;
-    let lonIndex: number | undefined;
-    const csvRows = CSV.#csvStringToArray(csvData, layerConfig.source!.separator || ',');
-    const headers: string[] = csvRows[0];
-    for (let i = 0; i < headers.length; i++) {
-      if (latList.includes(headers[i].toLowerCase())) latIndex = i;
-      if (lonList.includes(headers[i].toLowerCase())) lonIndex = i;
-    }
-
-    if (latIndex === undefined || lonIndex === undefined) {
-      logger.logError(
-        `Could not find geographic data for ${getLocalizedValue(this.geoviewLayerName, AppEventProcessor.getDisplayLanguage(this.mapId))}`
-      );
-      // TODO: find a more centralized way to trap error and display message
-      api.maps[this.mapId].notifications.showError(
-        `Could not find geographic data for ${getLocalizedValue(this.geoviewLayerName, AppEventProcessor.getDisplayLanguage(this.mapId))}`
-      );
-      layerConfig.layerStatus = 'error';
-      return null;
-    }
-
-    CSV.#processFeatureInfoConfig(headers, csvRows[1], [latIndex, lonIndex], layerConfig);
-
-    for (let i = 1; i < csvRows.length; i++) {
-      const currentRow = csvRows[i];
-      const properties: { [key: string]: string | number } = {};
-      for (let j = 0; j < headers.length; j++) {
-        if (j !== latIndex && j !== lonIndex && currentRow[j]) {
-          properties[headers[j]] = currentRow[j] !== '' && Number(currentRow[j]) ? Number(currentRow[j]) : currentRow[j];
-        }
-      }
-
-      const lon = currentRow[lonIndex] ? Number(currentRow[lonIndex]) : Infinity;
-      const lat = currentRow[latIndex] ? Number(currentRow[latIndex]) : Infinity;
-      if (Number.isFinite(lon) && Number.isFinite(lat)) {
-        const coordinates = inProjection !== outProjection ? Projection.transform([lon, lat], inProjection, outProjection) : [lon, lat];
-        const feature = new Feature({
-          geometry: new Point(coordinates),
-          ...properties,
-        });
-        features.push(feature);
-      }
-    }
-
-    return features;
   }
 
   /** ***************************************************************************************************************************

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/csv.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/csv.ts
@@ -153,9 +153,9 @@ export class CSV extends AbstractGeoViewVector {
    *
    * @param {VectorLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
-   * @returns {Promise<TypeLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
+   * @returns {Promise<VectorLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
    */
-  protected override processLayerMetadata(layerConfig: VectorLayerEntryConfig): Promise<TypeLayerEntryConfig> {
+  protected override processLayerMetadata(layerConfig: VectorLayerEntryConfig): Promise<VectorLayerEntryConfig> {
     // process the feature info configuration and attach the config to the instance for access by parent class
     this.setLayerMetadata(layerConfig.layerPath, Cast<TypeJsonObject>(layerConfig));
     return Promise.resolve(layerConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/csv.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/csv.ts
@@ -145,11 +145,14 @@ export class CSV extends AbstractGeoViewVector {
   /** ***************************************************************************************************************************
    * Metadata is processed when parsing the file.
    *
-   * @param {VectorLayerEntryConfig} layerConfig The layer entry configuration to process.
+   * @param {AbstractBaseLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
-   * @returns {Promise<VectorLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
+   * @returns {Promise<AbstractBaseLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
    */
-  protected override processLayerMetadata(layerConfig: VectorLayerEntryConfig): Promise<VectorLayerEntryConfig> {
+  protected override processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<AbstractBaseLayerEntryConfig> {
+    // Instance check
+    if (!(layerConfig instanceof VectorLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
+
     // process the feature info configuration and attach the config to the instance for access by parent class
     this.setLayerMetadata(layerConfig.layerPath, Cast<TypeJsonObject>(layerConfig));
     return Promise.resolve(layerConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -203,13 +203,15 @@ export class EsriFeature extends AbstractGeoViewVector {
    * This method is used to process the layer's metadata. It will fill the empty fields of the layer's configuration (renderer,
    * initial settings, fields and aliases).
    *
-   * @param {EsriFeatureLayerEntryConfig} layerConfig The layer entry configuration to process.
+   * @param {AbstractBaseLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
-   * @returns {Promise<EsriFeatureLayerEntryConfig>} A promise that the layer configuration has its metadata processed.
+   * @returns {Promise<AbstractBaseLayerEntryConfig>} A promise that the layer configuration has its metadata processed.
    */
   // GV Layers Refactoring - Obsolete (in config?)
-  protected override processLayerMetadata(layerConfig: EsriFeatureLayerEntryConfig): Promise<EsriFeatureLayerEntryConfig> {
-    return commonProcessLayerMetadata(this, layerConfig);
+  protected override processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<AbstractBaseLayerEntryConfig> {
+    // Instance check
+    if (!(layerConfig instanceof EsriFeatureLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
+    return commonProcessLayerMetadata(this, layerConfig as EsriFeatureLayerEntryConfig);
   }
 
   /** ***************************************************************************************************************************

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -211,7 +211,7 @@ export class EsriFeature extends AbstractGeoViewVector {
   protected override processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<AbstractBaseLayerEntryConfig> {
     // Instance check
     if (!(layerConfig instanceof EsriFeatureLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
-    return commonProcessLayerMetadata(this, layerConfig as EsriFeatureLayerEntryConfig);
+    return commonProcessLayerMetadata(this, layerConfig);
   }
 
   /** ***************************************************************************************************************************

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -203,12 +203,12 @@ export class EsriFeature extends AbstractGeoViewVector {
    * This method is used to process the layer's metadata. It will fill the empty fields of the layer's configuration (renderer,
    * initial settings, fields and aliases).
    *
-   * @param {TypeLayerEntryConfig} layerConfig The layer entry configuration to process.
+   * @param {EsriFeatureLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
-   * @returns {Promise<TypeLayerEntryConfig>} A promise that the layer configuration has its metadata processed.
+   * @returns {Promise<EsriFeatureLayerEntryConfig>} A promise that the layer configuration has its metadata processed.
    */
   // GV Layers Refactoring - Obsolete (in config?)
-  protected override processLayerMetadata(layerConfig: TypeLayerEntryConfig): Promise<TypeLayerEntryConfig> {
+  protected override processLayerMetadata(layerConfig: EsriFeatureLayerEntryConfig): Promise<EsriFeatureLayerEntryConfig> {
     return commonProcessLayerMetadata(this, layerConfig);
   }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -154,10 +154,10 @@ export class GeoJSON extends AbstractGeoViewVector {
    *
    * @param {VectorLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
-   * @returns {Promise<TypeLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
+   * @returns {Promise<VectorLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
    */
   // GV Layers Refactoring - Obsolete (in config?)
-  protected override processLayerMetadata(layerConfig: VectorLayerEntryConfig): Promise<TypeLayerEntryConfig> {
+  protected override processLayerMetadata(layerConfig: VectorLayerEntryConfig): Promise<VectorLayerEntryConfig> {
     if (this.metadata) {
       const metadataLayerList = Cast<VectorLayerEntryConfig[]>(this.metadata?.listOfLayerEntryConfig);
       const layerMetadataFound = metadataLayerList.find(

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -198,6 +198,8 @@ export class GeoJSON extends AbstractGeoViewVector {
       }
 
       if (layerConfig.initialSettings?.extent)
+        // TODO: Check - Why are we converting to the map projection in the processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
+        // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice?
         layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
     }
     return Promise.resolve(layerConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -201,7 +201,7 @@ export class GeoJSON extends AbstractGeoViewVector {
       }
 
       if (layerConfig.initialSettings?.extent)
-        // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration and handle it later?
+        // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration and handle it later?
         layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
     }
     return Promise.resolve(layerConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -152,12 +152,15 @@ export class GeoJSON extends AbstractGeoViewVector {
    * This method is used to process the layer's metadata. It will fill the empty fields of the layer's configuration (renderer,
    * initial settings, fields and aliases).
    *
-   * @param {VectorLayerEntryConfig} layerConfig The layer entry configuration to process.
+   * @param {AbstractBaseLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
-   * @returns {Promise<VectorLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
+   * @returns {Promise<AbstractBaseLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
    */
   // GV Layers Refactoring - Obsolete (in config?)
-  protected override processLayerMetadata(layerConfig: VectorLayerEntryConfig): Promise<VectorLayerEntryConfig> {
+  protected override processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<AbstractBaseLayerEntryConfig> {
+    // Instance check
+    if (!(layerConfig instanceof VectorLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
+
     if (this.metadata) {
       const metadataLayerList = Cast<VectorLayerEntryConfig[]>(this.metadata?.listOfLayerEntryConfig);
       const layerMetadataFound = metadataLayerList.find(

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -198,8 +198,7 @@ export class GeoJSON extends AbstractGeoViewVector {
       }
 
       if (layerConfig.initialSettings?.extent)
-        // TODO: Check - Why are we converting to the map projection in the processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
-        // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice?
+        // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration and handle it later?
         layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
     }
     return Promise.resolve(layerConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
@@ -13,8 +13,6 @@ import * as SLDReader from '@nieuwlandgeo/sldreader';
 
 import { cloneDeep } from 'lodash';
 
-// import { layerEntryIsGroupLayer } from '@config/types/type-guards';
-
 import { Cast, TypeJsonObject } from '@/core/types/global-types';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { AbstractGeoViewVector } from './abstract-geoview-vector';
@@ -606,7 +604,9 @@ export class GeoPackage extends AbstractGeoViewVector {
             (layerConfig as TypeLayerEntryConfig).listOfLayerEntryConfig = [];
             const newLayerGroup = this.createLayerGroup(layerConfig, layerConfig.initialSettings!);
             for (let i = 0; i < layers.length; i++) {
-              const newLayerEntryConfig = cloneDeep(layerConfig) as AbstractBaseLayerEntryConfig;
+              // FIXME: This attempts to clone an object instead of a type. This should be changed to clone an actual object instead.
+              // FIX.MECONT: Otherwise, we're losing the methods on the class instance and it causes a "Private element is not present on this object" error
+              const newLayerEntryConfig = cloneDeep(layerConfig);
               newLayerEntryConfig.layerId = layers[i].name;
               newLayerEntryConfig.layerName = createLocalizedString(layers[i].name);
               newLayerEntryConfig.entryType = CONST_LAYER_ENTRY_TYPES.VECTOR;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geopackage.ts
@@ -282,7 +282,8 @@ export class GeoPackage extends AbstractGeoViewVector {
   ): Promise<[LayerData[], SldsInterface]> {
     const promisedGeopackageData = new Promise<[LayerData[], SldsInterface]>((resolve) => {
       const url = getLocalizedValue(layerConfig.source!.dataAccessPath!, AppEventProcessor.getDisplayLanguage(this.mapId));
-      if (this.attributions.length !== 0) sourceOptions.attributions = this.attributions;
+      const attributions = this.getAttributions();
+      if (attributions.length > 0) sourceOptions.attributions = attributions;
       const layersInfo: LayerData[] = [];
       const styleSlds: SldsInterface = {};
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
@@ -218,10 +218,10 @@ export class OgcFeature extends AbstractGeoViewVector {
    *
    * @param {VectorLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
-   * @returns {Promise<TypeLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
+   * @returns {Promise<VectorLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
    */
   // GV Layers Refactoring - Obsolete (in config?)
-  protected override async processLayerMetadata(layerConfig: VectorLayerEntryConfig): Promise<TypeLayerEntryConfig> {
+  protected override async processLayerMetadata(layerConfig: VectorLayerEntryConfig): Promise<VectorLayerEntryConfig> {
     try {
       const metadataUrl = getLocalizedValue(this.metadataAccessPath, AppEventProcessor.getDisplayLanguage(this.mapId));
       if (metadataUrl) {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
@@ -196,6 +196,8 @@ export class OgcFeature extends AbstractGeoViewVector {
           };
 
         if (layerConfig.initialSettings?.extent)
+          // TODO: Check - Why are we converting to the map projection in the processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
+          // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice?
           layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
 
         if (!layerConfig.initialSettings?.bounds && foundCollection.extent?.spatial?.bbox && foundCollection.extent?.spatial?.crs) {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
@@ -196,11 +196,11 @@ export class OgcFeature extends AbstractGeoViewVector {
           };
 
         if (layerConfig.initialSettings?.extent)
-          // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration and handle it later?
+          // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration and handle it later?
           layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
 
         if (!layerConfig.initialSettings?.bounds && foundCollection.extent?.spatial?.bbox && foundCollection.extent?.spatial?.crs) {
-          // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
+          // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration?
           // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice? Should be standardized so that the
           // TO.DOCONT: layer.getBounds() are coherent between children classes. And should probably *not* reproject in the map projection during layer metadata pre-processing if we want to
           // TO.DOCONT: be able to, possibly, fetch metadata information in a standalone manner, outside of a map.

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
@@ -196,11 +196,14 @@ export class OgcFeature extends AbstractGeoViewVector {
           };
 
         if (layerConfig.initialSettings?.extent)
-          // TODO: Check - Why are we converting to the map projection in the processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
-          // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice?
+          // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration and handle it later?
           layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
 
         if (!layerConfig.initialSettings?.bounds && foundCollection.extent?.spatial?.bbox && foundCollection.extent?.spatial?.crs) {
+          // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
+          // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice? Should be standardized so that the
+          // TO.DOCONT: layer.getBounds() are coherent between children classes. And should probably *not* reproject in the map projection during layer metadata pre-processing if we want to
+          // TO.DOCONT: be able to, possibly, fetch metadata information in a standalone manner, outside of a map.
           // layerConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
           layerConfig.initialSettings!.bounds = this.getMapViewer().convertExtentFromProjToMapProj(
             foundCollection.extent.spatial.bbox[0] as number[],

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
@@ -221,12 +221,15 @@ export class OgcFeature extends AbstractGeoViewVector {
    * This method is used to process the layer's metadata. It will fill the empty outfields and aliasFields properties of the
    * layer's configuration.
    *
-   * @param {VectorLayerEntryConfig} layerConfig The layer entry configuration to process.
+   * @param {AbstractBaseLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
-   * @returns {Promise<VectorLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
+   * @returns {Promise<AbstractBaseLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
    */
   // GV Layers Refactoring - Obsolete (in config?)
-  protected override async processLayerMetadata(layerConfig: VectorLayerEntryConfig): Promise<VectorLayerEntryConfig> {
+  protected override async processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<AbstractBaseLayerEntryConfig> {
+    // Instance check
+    if (!(layerConfig instanceof VectorLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
+
     try {
       const metadataUrl = getLocalizedValue(this.metadataAccessPath, AppEventProcessor.getDisplayLanguage(this.mapId));
       if (metadataUrl) {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -208,12 +208,18 @@ export class WFS extends AbstractGeoViewVector {
         }
 
         if (layerConfig.initialSettings?.extent)
+          // TODO: Check - Why are we converting to the map projection in the processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
+          // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice?
           layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
 
         if (!layerConfig.initialSettings?.bounds && foundMetadata['ows:WGS84BoundingBox']) {
+          // TODO: Check - This additional processing seem valid, but is it at the right place? A bit confusing with the rest of the codebase.
+          // TODO: Refactor - Layers refactoring. This code should probably be moved to be more compatible with the layers migration. This code here could have easily been forgotten.
           const lowerCorner = (foundMetadata['ows:WGS84BoundingBox']['ows:LowerCorner']['#text'] as string).split(' ');
           const upperCorner = (foundMetadata['ows:WGS84BoundingBox']['ows:UpperCorner']['#text'] as string).split(' ');
           const bounds = [Number(lowerCorner[0]), Number(lowerCorner[1]), Number(upperCorner[0]), Number(upperCorner[1])];
+          // TODO: Check - Why are we converting to the map projection in the processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
+          // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice?
           // layerConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
           layerConfig.initialSettings!.bounds = this.getMapViewer().convertExtentLngLatToMapProj(bounds);
         }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -208,18 +208,20 @@ export class WFS extends AbstractGeoViewVector {
         }
 
         if (layerConfig.initialSettings?.extent)
-          // TODO: Check - Why are we converting to the map projection in the processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
-          // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice?
+          // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration and handle it later?
           layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
 
         if (!layerConfig.initialSettings?.bounds && foundMetadata['ows:WGS84BoundingBox']) {
           // TODO: Check - This additional processing seem valid, but is it at the right place? A bit confusing with the rest of the codebase.
-          // TODO: Refactor - Layers refactoring. This code should probably be moved to be more compatible with the layers migration. This code here could have easily been forgotten.
+          // TODO: Refactor - Layers refactoring. Validate if this code is still being executed after the layers migration. This code may easily have been forgotten.
           const lowerCorner = (foundMetadata['ows:WGS84BoundingBox']['ows:LowerCorner']['#text'] as string).split(' ');
           const upperCorner = (foundMetadata['ows:WGS84BoundingBox']['ows:UpperCorner']['#text'] as string).split(' ');
           const bounds = [Number(lowerCorner[0]), Number(lowerCorner[1]), Number(upperCorner[0]), Number(upperCorner[1])];
-          // TODO: Check - Why are we converting to the map projection in the processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
-          // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice?
+
+          // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
+          // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice? Should be standardized so that the
+          // TO.DOCONT: layer.getBounds() are coherent between children classes. And should probably *not* reproject in the map projection during layer metadata pre-processing if we want to
+          // TO.DOCONT: be able to, possibly, fetch metadata information in a standalone manner, outside of a map.
           // layerConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
           layerConfig.initialSettings!.bounds = this.getMapViewer().convertExtentLngLatToMapProj(bounds);
         }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -208,7 +208,7 @@ export class WFS extends AbstractGeoViewVector {
         }
 
         if (layerConfig.initialSettings?.extent)
-          // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration and handle it later?
+          // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration and handle it later?
           layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
 
         if (!layerConfig.initialSettings?.bounds && foundMetadata['ows:WGS84BoundingBox']) {
@@ -218,7 +218,7 @@ export class WFS extends AbstractGeoViewVector {
           const upperCorner = (foundMetadata['ows:WGS84BoundingBox']['ows:UpperCorner']['#text'] as string).split(' ');
           const bounds = [Number(lowerCorner[0]), Number(lowerCorner[1]), Number(upperCorner[0]), Number(upperCorner[1])];
 
-          // TODO: Check - Why are we converting to the map projection in the pre-processing? Wouldn't it be best to leave it untouched, as it's part of the initial configuration?
+          // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration?
           // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice? Should be standardized so that the
           // TO.DOCONT: layer.getBounds() are coherent between children classes. And should probably *not* reproject in the map projection during layer metadata pre-processing if we want to
           // TO.DOCONT: be able to, possibly, fetch metadata information in a standalone manner, outside of a map.

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -227,10 +227,10 @@ export class WFS extends AbstractGeoViewVector {
    *
    * @param {VectorLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
-   * @returns {Promise<TypeLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
+   * @returns {Promise<VectorLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
    */
   // GV Layers Refactoring - Obsolete (in config?)
-  protected override async processLayerMetadata(layerConfig: VectorLayerEntryConfig): Promise<TypeLayerEntryConfig> {
+  protected override async processLayerMetadata(layerConfig: VectorLayerEntryConfig): Promise<VectorLayerEntryConfig> {
     try {
       let queryUrl = getLocalizedValue(layerConfig.source!.dataAccessPath, AppEventProcessor.getDisplayLanguage(this.mapId));
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -233,12 +233,15 @@ export class WFS extends AbstractGeoViewVector {
    * This method is used to process the layer's metadata. It will fill the empty outfields and aliasFields properties of the
    * layer's configuration.
    *
-   * @param {VectorLayerEntryConfig} layerConfig The layer entry configuration to process.
+   * @param {AbstractBaseLayerEntryConfig} layerConfig The layer entry configuration to process.
    *
-   * @returns {Promise<VectorLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
+   * @returns {Promise<AbstractBaseLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
    */
   // GV Layers Refactoring - Obsolete (in config?)
-  protected override async processLayerMetadata(layerConfig: VectorLayerEntryConfig): Promise<VectorLayerEntryConfig> {
+  protected override async processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<AbstractBaseLayerEntryConfig> {
+    // Instance check
+    if (!(layerConfig instanceof VectorLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
+
     try {
       let queryUrl = getLocalizedValue(layerConfig.source!.dataAccessPath, AppEventProcessor.getDisplayLanguage(this.mapId));
 

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -155,9 +155,9 @@ export abstract class AbstractGVLayer {
     } else {
       // Activation of the load end listeners
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (this.#olSource as any).once(`${listenerName}loaderror`, this.onLoaded.bind(this));
+      (this.#olSource as any).once(`${listenerName}loadend`, this.onLoaded.bind(this));
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (this.#olSource as any).once(`${listenerName}loadend`, this.onError.bind(this));
+      (this.#olSource as any).once(`${listenerName}loaderror`, this.onError.bind(this));
     }
   }
 

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -277,6 +277,20 @@ export abstract class AbstractGVLayer {
   }
 
   /**
+   * Gets the layer attributions
+   * @returns {string[]} The layer attributions
+   */
+  getAttributions(): string[] {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const attributionsAsRead = this.getOLSource().getAttributions()?.({} as any); // This looks very weird, but it's as documented in OpenLayers..
+
+    // Depending on the internal formatting
+    if (!attributionsAsRead) return [];
+    if (typeof attributionsAsRead === 'string') return [attributionsAsRead];
+    return attributionsAsRead;
+  }
+
+  /**
    * Gets the temporal dimension that is associated to the layer.
    * @returns {TimeDimension | undefined} The temporal dimension associated to the layer or undefined.
    */

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -118,6 +118,13 @@ export abstract class AbstractGVLayer {
   }
 
   /**
+   * Gets the bounds of the layer represented in the layerConfig pointed to by the layerPath, returns updated bounds.
+   * @returns {Extent} The layer bounding box.
+   */
+  // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
+  abstract getBounds(layerPath: string): Extent | undefined;
+
+  /**
    * Initializes the GVLayer. This function checks if the source is ready and if so it calls onLoaded() to pursue initialization of the layer.
    * If the source isn't ready, it registers to the source ready event to pursue initialization of the layer once its source is ready.
    */

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -627,17 +627,6 @@ export abstract class AbstractGVLayer {
   async getLegend(): Promise<TypeLegend | null> {
     // TODO: Refactor - Layers refactoring. Rename this function to onFetchLegend() once the layers refactoring is done
     try {
-      // TODO: Check - Remove this dead code? 2024-06-04
-      // if (!layerConfig.style) {
-      //   const legend: TypeLegend = {
-      //     type: layerConfig.geoviewLayerConfig.geoviewLayerType,
-      //     layerName: layerConfig.layerName!,
-      //     styleConfig: layerConfig.style,
-      //     legend: null,
-      //   };
-      //   return legend;
-      // }
-
       const legend: TypeLegend = {
         type: this.getLayerConfig().geoviewLayerConfig.geoviewLayerType,
         styleConfig: this.getStyle(this.getLayerPath()),

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/abstract-gv-raster.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/abstract-gv-raster.ts
@@ -1,9 +1,10 @@
 import BaseImageLayer from 'ol/layer/BaseImage';
 import ImageSource from 'ol/source/Image';
 import LayerRenderer from 'ol/renderer/Layer';
-import { Projection, get as projectionGet } from 'ol/proj';
 import { Extent } from 'ol/extent';
+import { Projection as OLProjection } from 'ol/proj';
 
+import { Projection } from '@/geo/utils/projection';
 import { AbstractGVLayer } from '../abstract-gv-layer';
 
 /**
@@ -23,10 +24,18 @@ export abstract class AbstractGVRaster extends AbstractGVLayer {
     return super.getOLLayer() as BaseImageLayer<ImageSource, LayerRenderer<any>>;
   }
 
-  getMetadataProjection(): Projection | undefined {
-    return projectionGet(`EPSG:${this.getLayerConfig().getMetadata()?.fullExtent?.spatialReference?.wkid}`) || undefined;
+  /**
+   * Gets the metadata extent projection, if any.
+   * @returns {OLProjection | undefined} The OpenLayer projection
+   */
+  getMetadataProjection(): OLProjection | undefined {
+    return Projection.getProjection(`EPSG:${this.getLayerConfig().getMetadata()?.fullExtent?.spatialReference?.wkid}`) || undefined;
   }
 
+  /**
+   * Gets the metadata extent, if any.
+   * @returns {Extent | undefined} The OpenLayer projection
+   */
   getMetadataExtent(): Extent | undefined {
     const metadata = this.getLayerConfig().getMetadata();
     if (metadata?.fullExtent) {

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/abstract-gv-raster.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/abstract-gv-raster.ts
@@ -37,6 +37,7 @@ export abstract class AbstractGVRaster extends AbstractGVLayer {
    * @returns {Extent | undefined} The OpenLayer projection
    */
   getMetadataExtent(): Extent | undefined {
+    // TODO: Layers refactoring. Johann: This should be converted to geoview schema in config
     const metadata = this.getLayerConfig().getMetadata();
     if (metadata?.fullExtent) {
       return [

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/abstract-gv-raster.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/abstract-gv-raster.ts
@@ -1,6 +1,8 @@
 import BaseImageLayer from 'ol/layer/BaseImage';
 import ImageSource from 'ol/source/Image';
 import LayerRenderer from 'ol/renderer/Layer';
+import { Projection, get as projectionGet } from 'ol/proj';
+import { Extent } from 'ol/extent';
 
 import { AbstractGVLayer } from '../abstract-gv-layer';
 
@@ -19,5 +21,22 @@ export abstract class AbstractGVRaster extends AbstractGVLayer {
     // Disabling 'any', because that's how it is in OpenLayers
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return super.getOLLayer() as BaseImageLayer<ImageSource, LayerRenderer<any>>;
+  }
+
+  getMetadataProjection(): Projection | undefined {
+    return projectionGet(`EPSG:${this.getLayerConfig().getMetadata()?.fullExtent?.spatialReference?.wkid}`) || undefined;
+  }
+
+  getMetadataExtent(): Extent | undefined {
+    const metadata = this.getLayerConfig().getMetadata();
+    if (metadata?.fullExtent) {
+      return [
+        metadata?.fullExtent.xmin as number,
+        metadata?.fullExtent.ymin as number,
+        metadata?.fullExtent.xmax as number,
+        metadata?.fullExtent.ymax as number,
+      ] as Extent;
+    }
+    return undefined;
   }
 }

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -124,6 +124,7 @@ export class GVEsriDynamic extends AbstractGVRaster {
       const layerConfig = this.getLayerConfig();
 
       // Guess the geometry type by taking the first style key
+      // TODO: Refactor - Layers migration. Johann: This will be modified with new schema, there is no more geometry on style
       const [geometryType] = layerConfig.getTypeGeometries();
 
       // Fetch the features

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -10,7 +10,6 @@ import Geometry from 'ol/geom/Geometry';
 
 import { GeometryApi } from '@/geo/layer/geometry/geometry';
 import { getLocalizedValue } from '@/core/utils/utilities';
-import { getExtentIntersection, getExtentUnionMaybe } from '@/geo/utils/utilities';
 import { Projection } from '@/geo/utils/projection';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 import { logger } from '@/core/utils/logger';
@@ -649,23 +648,12 @@ export class GVEsriDynamic extends AbstractGVRaster {
   }
 
   /**
-   * Gets the bounds of the layer and returns updated bounds
-   * @param {Extent | undefined} bounds - The current bounding box to be adjusted.
-   * @returns {Extent | undefined} The new layer bounding box.
+   * Gets the bounds of the layer and returns updated bounds.
+   * @returns {Extent | undefined} The layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override getBounds(layerPath: string): Extent | undefined {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
-    const layerConfig = this.getLayerConfig();
-
-    // Get the layer config bounds
-    let layerConfigBounds = layerConfig?.initialSettings?.bounds;
-
-    // If layer bounds were found, project
-    if (layerConfigBounds) {
-      // Make sure we're in the map projection. Always EPSG:4326 when coming from our configuration.
-      layerConfigBounds = this.getMapViewer().convertExtentFromProjToMapProj(layerConfigBounds, 'EPSG:4326');
-    }
-
     // Get the metadata extent
     const metadataExtent = this.getMetadataExtent();
 
@@ -677,10 +665,7 @@ export class GVEsriDynamic extends AbstractGVRaster {
       layerBounds = this.getMapViewer().convertExtentFromProjToMapProj(metadataExtent, metadataProjection);
     }
 
-    // If both layer config had bounds and layer has real bounds, take the intersection between them
-    if (layerConfigBounds && layerBounds) layerBounds = getExtentIntersection(layerBounds, layerConfigBounds);
-
-    // Return the layer bounds possibly unioned with 'bounds' received as param
-    return getExtentUnionMaybe(layerBounds, bounds);
+    // Return the calculated layer bounds
+    return layerBounds;
   }
 }

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
@@ -4,7 +4,7 @@ import { Image as ImageLayer } from 'ol/layer';
 import { Extent } from 'ol/extent';
 
 import { getLocalizedValue } from '@/core/utils/utilities';
-import { getMinOrMaxExtents } from '@/geo/utils/utilities';
+import { getExtentIntersection, getExtentUnionMaybe } from '@/geo/utils/utilities';
 import { DateMgt } from '@/core/utils/date-mgt';
 import { logger } from '@/core/utils/logger';
 import { EsriImageLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/esri-image-layer-entry-config';
@@ -241,33 +241,32 @@ export class GVEsriImage extends AbstractGVRaster {
   protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
     const layerConfig = this.getLayerConfig();
-    const layerBounds = layerConfig?.initialSettings?.bounds || [];
 
-    const projection =
-      layerConfig.getMetadata()?.fullExtent?.spatialReference?.wkid || this.getMapViewer().getProjection().getCode().replace('EPSG:', '');
+    // Get the layer config bounds
+    let layerConfigBounds = layerConfig?.initialSettings?.bounds;
 
-    if (layerConfig.getMetadata()?.fullExtent) {
-      layerBounds[0] = layerConfig.getMetadata()?.fullExtent.xmin as number;
-      layerBounds[1] = layerConfig.getMetadata()?.fullExtent.ymin as number;
-      layerBounds[2] = layerConfig.getMetadata()?.fullExtent.xmax as number;
-      layerBounds[3] = layerConfig.getMetadata()?.fullExtent.ymax as number;
+    // If layer bounds were found, project
+    if (layerConfigBounds) {
+      // Make sure we're in the map projection. Always EPSG:4326 when coming from our configuration.
+      layerConfigBounds = this.getMapViewer().convertExtentFromProjToMapProj(layerConfigBounds, 'EPSG:4326');
     }
 
-    if (layerBounds) {
-      let transformedBounds = layerBounds;
-      if (
-        layerConfig.getMetadata()?.fullExtent?.spatialReference?.wkid !== this.getMapViewer().getProjection().getCode().replace('EPSG:', '')
-      ) {
-        transformedBounds = this.getMapViewer().convertExtentFromProjToMapProj(layerBounds, `EPSG:${projection}`);
-      }
+    // Get the metadata extent
+    const metadataExtent = this.getMetadataExtent();
 
-      // eslint-disable-next-line no-param-reassign
-      if (!bounds) bounds = [transformedBounds[0], transformedBounds[1], transformedBounds[2], transformedBounds[3]];
-      // eslint-disable-next-line no-param-reassign
-      else bounds = getMinOrMaxExtents(bounds, transformedBounds);
+    // If found
+    let layerBounds;
+    if (metadataExtent) {
+      // Get the metadata projection
+      const metadataProjection = this.getMetadataProjection();
+      layerBounds = this.getMapViewer().convertExtentFromProjToMapProj(metadataExtent, metadataProjection);
     }
 
-    return bounds;
+    // If both layer config had bounds and layer has real bounds, take the intersection between them
+    if (layerConfigBounds && layerBounds) layerBounds = getExtentIntersection(layerBounds, layerConfigBounds);
+
+    // Return the layer bounds possibly unioned with 'bounds' received as param
+    return getExtentUnionMaybe(layerBounds, bounds);
   }
 }
 

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
@@ -4,7 +4,6 @@ import { Image as ImageLayer } from 'ol/layer';
 import { Extent } from 'ol/extent';
 
 import { getLocalizedValue } from '@/core/utils/utilities';
-import { getExtentIntersection, getExtentUnionMaybe } from '@/geo/utils/utilities';
 import { DateMgt } from '@/core/utils/date-mgt';
 import { logger } from '@/core/utils/logger';
 import { EsriImageLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/esri-image-layer-entry-config';
@@ -234,23 +233,12 @@ export class GVEsriImage extends AbstractGVRaster {
   }
 
   /**
-   * Gets the bounds of the layer and returns updated bounds
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
-   * @returns {Extent | undefined} The new layer bounding box.
+   * Gets the bounds of the layer and returns updated bounds.
+   * @returns {Extent | undefined} The layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override getBounds(layerPath: string): Extent | undefined {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
-    const layerConfig = this.getLayerConfig();
-
-    // Get the layer config bounds
-    let layerConfigBounds = layerConfig?.initialSettings?.bounds;
-
-    // If layer bounds were found, project
-    if (layerConfigBounds) {
-      // Make sure we're in the map projection. Always EPSG:4326 when coming from our configuration.
-      layerConfigBounds = this.getMapViewer().convertExtentFromProjToMapProj(layerConfigBounds, 'EPSG:4326');
-    }
-
     // Get the metadata extent
     const metadataExtent = this.getMetadataExtent();
 
@@ -262,11 +250,8 @@ export class GVEsriImage extends AbstractGVRaster {
       layerBounds = this.getMapViewer().convertExtentFromProjToMapProj(metadataExtent, metadataProjection);
     }
 
-    // If both layer config had bounds and layer has real bounds, take the intersection between them
-    if (layerConfigBounds && layerBounds) layerBounds = getExtentIntersection(layerBounds, layerConfigBounds);
-
-    // Return the layer bounds possibly unioned with 'bounds' received as param
-    return getExtentUnionMaybe(layerBounds, bounds);
+    // Return the calculated layer bounds
+    return layerBounds;
   }
 }
 

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-image-static.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-image-static.ts
@@ -149,7 +149,7 @@ export class GVImageStatic extends AbstractGVRaster {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   override getBounds(layerPath: string): Extent | undefined {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
-    // Get the source projection code
+    // Get the source projection
     const sourceProjection = this.getOLSource().getProjection() || undefined;
 
     // Get the layer bounds

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-image-static.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-image-static.ts
@@ -1,5 +1,6 @@
 import ImageLayer from 'ol/layer/Image';
 import Static from 'ol/source/ImageStatic';
+import { Options as ImageOptions } from 'ol/layer/BaseImage';
 import { Extent } from 'ol/extent';
 import axios from 'axios';
 
@@ -24,11 +25,20 @@ export class GVImageStatic extends AbstractGVRaster {
   /**
    * Constructs a GVImageStatic layer to manage an OpenLayer layer.
    * @param {string} mapId - The map id
-   * @param {ImageLayer<Static>} olLayer - The OpenLayer layer.
+   * @param {Static} olSource - The OpenLayer source.
    * @param {ImageStaticLayerEntryConfig} layerConfig - The layer configuration.
    */
-  public constructor(mapId: string, olLayer: ImageLayer<Static>, layerConfig: ImageStaticLayerEntryConfig) {
-    super(mapId, olLayer, layerConfig);
+  public constructor(mapId: string, olSource: Static, layerConfig: ImageStaticLayerEntryConfig) {
+    super(mapId, olSource, layerConfig);
+
+    // Create the image layer options.
+    const staticImageOptions: ImageOptions<Static> = { source: olSource };
+
+    // Init the layer options with initial settings
+    AbstractGVRaster.initOptionsWithInitialSettings(staticImageOptions, layerConfig);
+
+    // Create and set the OpenLayer layer
+    this.olLayer = new ImageLayer(staticImageOptions);
   }
 
   /**
@@ -44,9 +54,9 @@ export class GVImageStatic extends AbstractGVRaster {
    * Overrides the get of the OpenLayers Layer Source
    * @returns {Static} The OpenLayers Layer Source
    */
-  override getOLSource(): Static | undefined {
+  override getOLSource(): Static {
     // Get source from OL
-    return this.getOLLayer().getSource() || undefined;
+    return super.getOLSource() as Static;
   }
 
   /**
@@ -105,7 +115,6 @@ export class GVImageStatic extends AbstractGVRaster {
       if (!legendImage) {
         const legend: TypeLegend = {
           type: CONST_LAYER_TYPES.IMAGE_STATIC,
-          layerName: layerConfig!.layerName,
           legend: null,
         };
         return legend;
@@ -119,14 +128,12 @@ export class GVImageStatic extends AbstractGVRaster {
         drawingContext.drawImage(image, 0, 0);
         const legend: TypeLegend = {
           type: CONST_LAYER_TYPES.IMAGE_STATIC,
-          layerName: layerConfig!.layerName,
           legend: drawingCanvas,
         };
         return legend;
       }
       const legend: TypeLegend = {
         type: CONST_LAYER_TYPES.IMAGE_STATIC,
-        layerName: layerConfig!.layerName,
         legend: null,
       };
       return legend;

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-image-static.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-image-static.ts
@@ -7,7 +7,6 @@ import axios from 'axios';
 import { Cast, TypeJsonObject } from '@/core/types/global-types';
 import { CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { getLocalizedValue } from '@/core/utils/utilities';
-import { getExtentUnionMaybe } from '@/geo/utils/utilities';
 import { logger } from '@/core/utils/logger';
 import { ImageStaticLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/image-static-layer-entry-config';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
@@ -144,13 +143,12 @@ export class GVImageStatic extends AbstractGVRaster {
   }
 
   /**
-   * Gets the bounds of the layer and returns updated bounds
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
-   * @returns {Extent} The new layer bounding box.
+   * Gets the bounds of the layer and returns updated bounds.
+   * @returns {Extent | undefined} The layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override getBounds(layerPath: string): Extent | undefined {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
-
     // Get the source projection code
     const sourceProjection = this.getOLSource().getProjection() || undefined;
 
@@ -161,7 +159,7 @@ export class GVImageStatic extends AbstractGVRaster {
       sourceExtent = this.getMapViewer().convertExtentFromProjToMapProj(sourceExtent, sourceProjection);
     }
 
-    // Return the layer bounds possibly unioned with 'bounds' received as param
-    return getExtentUnionMaybe(sourceExtent, bounds);
+    // Return the calculated layer bounds
+    return sourceExtent;
   }
 }

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -12,7 +12,7 @@ import { Cast, toJsonObject, TypeJsonArray, TypeJsonObject } from '@/core/types/
 import { CONST_LAYER_TYPES, TypeWmsLegend, TypeWmsLegendStyle } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { xmlToJson, getLocalizedValue } from '@/core/utils/utilities';
 import { DateMgt } from '@/core/utils/date-mgt';
-import { getExtentIntersection, getExtentUnionMaybe } from '@/geo/utils/utilities';
+import { getExtentIntersection } from '@/geo/utils/utilities';
 import { logger } from '@/core/utils/logger';
 import { OgcWmsLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config';
 import { TypeFeatureInfoEntry } from '@/geo/map/map-schema-types';
@@ -565,11 +565,11 @@ export class GVWMS extends AbstractGVRaster {
   }
 
   /**
-   * Gets the bounds of the layer and returns updated bounds
-   * @param {Extent | undefined} bounds - The current bounding box to be adjusted.
-   * @returns {Extent | undefined} The new layer bounding box.
+   * Gets the bounds of the layer and returns updated bounds.
+   * @returns {Extent | undefined} The layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override getBounds(layerPath: string): Extent | undefined {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
     const layerConfig = this.getLayerConfig();
 
@@ -598,8 +598,8 @@ export class GVWMS extends AbstractGVRaster {
     // If both layer config had bounds and layer has real bounds, take the intersection between them
     if (layerConfigBounds && layerBounds) layerBounds = getExtentIntersection(layerBounds, layerConfigBounds);
 
-    // Return the layer bounds possibly unioned with 'bounds' received as param
-    return getExtentUnionMaybe(layerBounds, bounds);
+    // Return the calculated bounds
+    return layerBounds;
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/tile/gv-xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/tile/gv-xyz-tiles.ts
@@ -3,7 +3,7 @@ import { Options as TileOptions } from 'ol/layer/BaseTile';
 import XYZ from 'ol/source/XYZ';
 import { Extent } from 'ol/extent';
 
-import { getMinOrMaxExtents } from '@/geo/utils/utilities';
+import { getExtentUnionMaybe } from '@/geo/utils/utilities';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 import { XYZTilesLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/xyz-layer-entry-config';
 import { AbstractGVTile } from './abstract-gv-tile';
@@ -79,24 +79,20 @@ export class GVXYZTiles extends AbstractGVTile {
    */
   protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
-    const layerConfig = this.getLayerConfig();
-    const projection = this.getOLSource()?.getProjection()?.getCode() || this.getMapViewer().getProjection().getCode();
+    // Get the layer
+    const layer = this.getOLLayer() as TileLayer<XYZ> | undefined;
 
-    const layerBounds = this.getOLSource()?.getTileGrid()?.getExtent();
-    if (layerBounds) {
-      let transformedBounds = layerBounds;
-      if (
-        layerConfig.getMetadata()?.fullExtent?.spatialReference?.wkid !== this.getMapViewer().getProjection().getCode().replace('EPSG:', '')
-      ) {
-        transformedBounds = this.getMapViewer().convertExtentFromProjToMapProj(layerBounds, projection);
-      }
+    // Get the source projection code
+    const sourceProjection = this.getOLSource()?.getProjection() || undefined;
 
-      // eslint-disable-next-line no-param-reassign
-      if (!bounds) bounds = [transformedBounds[0], transformedBounds[1], transformedBounds[2], transformedBounds[3]];
-      // eslint-disable-next-line no-param-reassign
-      else bounds = getMinOrMaxExtents(bounds, transformedBounds);
+    // Get the layer bounds
+    let sourceExtent = layer?.getSource()?.getTileGrid()?.getExtent();
+    if (sourceExtent) {
+      // Make sure we're in the map projection
+      sourceExtent = this.getMapViewer().convertExtentFromProjToMapProj(sourceExtent, sourceProjection);
     }
 
-    return bounds;
+    // Return the layer bounds possibly unioned with 'bounds' received as param
+    return getExtentUnionMaybe(sourceExtent, bounds);
   }
 }

--- a/packages/geoview-core/src/geo/layer/gv-layers/tile/gv-xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/tile/gv-xyz-tiles.ts
@@ -3,7 +3,6 @@ import { Options as TileOptions } from 'ol/layer/BaseTile';
 import XYZ from 'ol/source/XYZ';
 import { Extent } from 'ol/extent';
 
-import { getExtentUnionMaybe } from '@/geo/utils/utilities';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 import { XYZTilesLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/xyz-layer-entry-config';
 import { AbstractGVTile } from './abstract-gv-tile';
@@ -73,11 +72,11 @@ export class GVXYZTiles extends AbstractGVTile {
   }
 
   /**
-   * Gets the bounds of the layer and returns updated bounds
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
-   * @returns {Extent | undefined} The new layer bounding box.
+   * Gets the bounds of the layer and returns updated bounds.
+   * @returns {Extent | undefined} The layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override getBounds(layerPath: string): Extent | undefined {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
     // Get the layer
     const layer = this.getOLLayer() as TileLayer<XYZ> | undefined;
@@ -92,7 +91,7 @@ export class GVXYZTiles extends AbstractGVTile {
       sourceExtent = this.getMapViewer().convertExtentFromProjToMapProj(sourceExtent, sourceProjection);
     }
 
-    // Return the layer bounds possibly unioned with 'bounds' received as param
-    return getExtentUnionMaybe(sourceExtent, bounds);
+    // Return the calculated layer bounds
+    return sourceExtent;
   }
 }

--- a/packages/geoview-core/src/geo/layer/gv-layers/tile/gv-xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/tile/gv-xyz-tiles.ts
@@ -1,4 +1,5 @@
 import TileLayer from 'ol/layer/Tile';
+import { Options as TileOptions } from 'ol/layer/BaseTile';
 import XYZ from 'ol/source/XYZ';
 import { Extent } from 'ol/extent';
 
@@ -18,11 +19,20 @@ export class GVXYZTiles extends AbstractGVTile {
   /**
    * Constructs a GVXYZTiles layer to manage an OpenLayer layer.
    * @param {string} mapId - The map id
-   * @param {TileLayer<XYZ>} olLayer - The OpenLayer layer.
+   * @param {XYZ} olSource - The OpenLayer source.
    * @param {XYZTilesLayerEntryConfig} layerConfig - The layer configuration.
    */
-  public constructor(mapId: string, olLayer: TileLayer<XYZ>, layerConfig: XYZTilesLayerEntryConfig) {
-    super(mapId, olLayer, layerConfig);
+  public constructor(mapId: string, olSource: XYZ, layerConfig: XYZTilesLayerEntryConfig) {
+    super(mapId, olSource, layerConfig);
+
+    // Create the tile layer options.
+    const tileLayerOptions: TileOptions<XYZ> = { source: olSource };
+
+    // Init the layer options with initial settings
+    AbstractGVTile.initOptionsWithInitialSettings(tileLayerOptions, layerConfig);
+
+    // Create and set the OpenLayer layer
+    this.olLayer = new TileLayer(tileLayerOptions);
   }
 
   /**
@@ -38,9 +48,9 @@ export class GVXYZTiles extends AbstractGVTile {
    * Overrides the get of the OpenLayers Layer Source
    * @returns {XYZ} The OpenLayers Layer Source
    */
-  override getOLSource(): XYZ | undefined {
+  override getOLSource(): XYZ {
     // Get source from OL
-    return this.getOLLayer().getSource() || undefined;
+    return super.getOLSource() as XYZ;
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/tile/gv-xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/tile/gv-xyz-tiles.ts
@@ -81,7 +81,7 @@ export class GVXYZTiles extends AbstractGVTile {
     // Get the layer
     const layer = this.getOLLayer() as TileLayer<XYZ> | undefined;
 
-    // Get the source projection code
+    // Get the source projection
     const sourceProjection = this.getOLSource()?.getProjection() || undefined;
 
     // Get the layer bounds

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector-tile.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector-tile.ts
@@ -1,7 +1,9 @@
 import VectorTile from 'ol/source/VectorTile';
 import BaseVectorLayer from 'ol/layer/BaseVector';
+import { Extent } from 'ol/extent';
 
 import { AbstractGVLayer } from '../abstract-gv-layer';
+import { getExtentUnionMaybe } from '@/geo/utils/utilities';
 
 /**
  * Abstract Geoview Layer managing an OpenLayer vector tile type layer.
@@ -18,5 +20,36 @@ export abstract class AbstractGVVectorTile extends AbstractGVLayer {
     // Disabling 'any', because too many renderer types in OpenLayers
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return super.getOLLayer() as BaseVectorLayer<VectorTile, any>;
+  }
+
+  /**
+   * Overrides the get of the OpenLayers Layer
+   * @returns {VectorTile} The OpenLayers Layer
+   */
+  override getOLSource(): VectorTile {
+    // Get source from OL
+    return super.getOLSource() as VectorTile;
+  }
+
+  /**
+   * Gets the bounds of the layer and returns updated bounds
+   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
+   * @returns {Extent | undefined} The new layer bounding box.
+   */
+  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+    // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
+
+    // Get the source projection
+    const sourceProjection = this.getOLSource().getProjection() || undefined;
+
+    // Get the layer bounds
+    let sourceExtent = this.getOLSource().getTileGrid()?.getExtent();
+    if (sourceExtent) {
+      // Make sure we're in the map projection
+      sourceExtent = this.getMapViewer().convertExtentFromProjToMapProj(sourceExtent, sourceProjection);
+    }
+
+    // Return the layer bounds possibly unioned with 'bounds' received as param
+    return getExtentUnionMaybe(sourceExtent, bounds);
   }
 }

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector-tile.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector-tile.ts
@@ -3,7 +3,6 @@ import BaseVectorLayer from 'ol/layer/BaseVector';
 import { Extent } from 'ol/extent';
 
 import { AbstractGVLayer } from '../abstract-gv-layer';
-import { getExtentUnionMaybe } from '@/geo/utils/utilities';
 
 /**
  * Abstract Geoview Layer managing an OpenLayer vector tile type layer.
@@ -32,13 +31,12 @@ export abstract class AbstractGVVectorTile extends AbstractGVLayer {
   }
 
   /**
-   * Gets the bounds of the layer and returns updated bounds
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
-   * @returns {Extent | undefined} The new layer bounding box.
+   * Gets the bounds of the layer and returns updated bounds.
+   * @returns {Extent | undefined} The layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override getBounds(layerPath: string): Extent | undefined {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
-
     // Get the source projection
     const sourceProjection = this.getOLSource().getProjection() || undefined;
 
@@ -49,7 +47,7 @@ export abstract class AbstractGVVectorTile extends AbstractGVLayer {
       sourceExtent = this.getMapViewer().convertExtentFromProjToMapProj(sourceExtent, sourceProjection);
     }
 
-    // Return the layer bounds possibly unioned with 'bounds' received as param
-    return getExtentUnionMaybe(sourceExtent, bounds);
+    // Return the calculated layer bounds
+    return sourceExtent;
   }
 }

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
@@ -10,7 +10,7 @@ import { Pixel } from 'ol/pixel';
 import Feature, { FeatureLike } from 'ol/Feature';
 
 import { DateMgt } from '@/core/utils/date-mgt';
-import { getMinOrMaxExtents } from '@/geo/utils/utilities';
+import { getExtentUnion } from '@/geo/utils/utilities';
 import { FilterNodeArrayType, NodeType } from '@/geo/utils/renderer/geoview-renderer-types';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 import { logger } from '@/core/utils/logger';
@@ -249,16 +249,10 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
    */
   protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
-    const layerBounds = this.getOLSource()?.getExtent();
+    const sourceExtent = this.getOLSource().getExtent();
 
-    if (layerBounds) {
-      // eslint-disable-next-line no-param-reassign
-      if (!bounds) bounds = [layerBounds[0], layerBounds[1], layerBounds[2], layerBounds[3]];
-      // eslint-disable-next-line no-param-reassign
-      else bounds = getMinOrMaxExtents(bounds, layerBounds);
-    }
-
-    return bounds;
+    // Return the bounds possibly unioned with 'bounds' received as param
+    return getExtentUnion(sourceExtent, bounds);
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
@@ -10,7 +10,6 @@ import { Pixel } from 'ol/pixel';
 import Feature, { FeatureLike } from 'ol/Feature';
 
 import { DateMgt } from '@/core/utils/date-mgt';
-import { getExtentUnion } from '@/geo/utils/utilities';
 import { FilterNodeArrayType, NodeType } from '@/geo/utils/renderer/geoview-renderer-types';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 import { logger } from '@/core/utils/logger';
@@ -243,16 +242,16 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
   }
 
   /**
-   * Gets the bounds of the layer and returns updated bounds
-   * @param {Extent | undefined} bounds - The current bounding box to be adjusted.
-   * @returns {Extent | undefined} The new layer bounding box.
+   * Gets the bounds of the layer and returns updated bounds.
+   * @returns {Extent | undefined} The layer bounding box.
    */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override getBounds(layerPath: string): Extent | undefined {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
     const sourceExtent = this.getOLSource().getExtent();
 
-    // Return the bounds possibly unioned with 'bounds' received as param
-    return getExtentUnion(sourceExtent, bounds);
+    // Return the calculated layer bounds
+    return sourceExtent;
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-csv.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-csv.ts
@@ -1,0 +1,21 @@
+import { Vector as VectorSource } from 'ol/source';
+import { CsvLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-validation-classes/csv-layer-entry-config';
+import { AbstractGVVector } from './abstract-gv-vector';
+
+/**
+ * Manages a CSV Feature layer.
+ *
+ * @exports
+ * @class GVCSV
+ */
+export class GVCSV extends AbstractGVVector {
+  /**
+   * Constructs a GVCSV layer to manage an OpenLayer layer.
+   * @param {string} mapId - The map id
+   * @param {VectorSource} olSource - The OpenLayer source.
+   * @param {CsvLayerEntryConfig} layerConfig - The layer configuration.
+   */
+  public constructor(mapId: string, olSource: VectorSource, layerConfig: CsvLayerEntryConfig) {
+    super(mapId, olSource, layerConfig);
+  }
+}

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-esri-feature.ts
@@ -16,11 +16,11 @@ export class GVEsriFeature extends AbstractGVVector {
   /**
    * Constructs a GVEsriFeature layer to manage an OpenLayer layer.
    * @param {string} mapId - The map id
-   * @param {VectorImage<VectorSource>} olLayer - The OpenLayer layer.
+   * @param {VectorSource} olSource - The OpenLayer source.
    * @param {EsriFeatureLayerEntryConfig} layerConfig - The layer configuration.
    */
-  public constructor(mapId: string, olLayer: VectorImage<VectorSource>, layerConfig: EsriFeatureLayerEntryConfig) {
-    super(mapId, olLayer, layerConfig);
+  public constructor(mapId: string, olSource: VectorSource, layerConfig: EsriFeatureLayerEntryConfig) {
+    super(mapId, olSource, layerConfig);
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-geojson.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-geojson.ts
@@ -1,4 +1,3 @@
-import BaseVectorLayer from 'ol/layer/BaseVector';
 import VectorSource from 'ol/source/Vector';
 import { GeoJSONLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-validation-classes/geojson-layer-entry-config';
 import { AbstractGVVector } from './abstract-gv-vector';
@@ -13,13 +12,13 @@ export class GVGeoJSON extends AbstractGVVector {
   /**
    * Constructs a GVGeoJSON layer to manage an OpenLayer layer.
    * @param {string} mapId - The map id
-   * @param {BaseVectorLayer<VectorSource, any>} olLayer - The OpenLayer layer.
+   * @param {VectorSource} olSource - The OpenLayer source.
    * @param {GeoJSONLayerEntryConfig} layerConfig - The layer configuration.
    */
   // Disabling 'any', because that's how it is in OpenLayers
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public constructor(mapId: string, olLayer: BaseVectorLayer<VectorSource, any>, layerConfig: GeoJSONLayerEntryConfig) {
-    super(mapId, olLayer, layerConfig);
+  public constructor(mapId: string, olSource: VectorSource, layerConfig: GeoJSONLayerEntryConfig) {
+    super(mapId, olSource, layerConfig);
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-ogc-feature.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-ogc-feature.ts
@@ -1,4 +1,3 @@
-import BaseVectorLayer from 'ol/layer/BaseVector';
 import VectorSource from 'ol/source/Vector';
 import { AbstractGVVector } from './abstract-gv-vector';
 import { OgcFeatureLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-validation-classes/ogc-layer-entry-config';
@@ -13,13 +12,13 @@ export class GVOGCFeature extends AbstractGVVector {
   /**
    * Constructs a GVOGCFeature layer to manage an OpenLayer layer.
    * @param {string} mapId - The map id
-   * @param {BaseVectorLayer<VectorSource, any>} olLayer - The OpenLayer layer.
+   * @param {VectorSource} olSource - The OpenLayer source.
    * @param {OgcFeatureLayerEntryConfig} layerConfig - The layer configuration.
    */
   // Disabling 'any', because that's how it is in OpenLayers
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public constructor(mapId: string, olLayer: BaseVectorLayer<VectorSource, any>, layerConfig: OgcFeatureLayerEntryConfig) {
-    super(mapId, olLayer, layerConfig);
+  public constructor(mapId: string, olSource: VectorSource, layerConfig: OgcFeatureLayerEntryConfig) {
+    super(mapId, olSource, layerConfig);
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-vector-tiles.ts
@@ -1,4 +1,5 @@
 import VectorTileLayer from 'ol/layer/VectorTile';
+import { Options as TileOptions } from 'ol/layer/BaseTile';
 import { VectorTile } from 'ol/source';
 import { Extent } from 'ol/extent';
 
@@ -14,16 +15,24 @@ import { AbstractGVVectorTile } from './abstract-gv-vector-tile';
  * @exports
  * @class GVVectorTiles
  */
-// ******************************************************************************************************************************
 export class GVVectorTiles extends AbstractGVVectorTile {
   /**
    * Constructs a GVVectorTiles layer to manage an OpenLayer layer.
    * @param {string} mapId - The map id
-   * @param {VectorTileLayer} olLayer - The OpenLayer layer.
+   * @param {VectorTile} olSource - The OpenLayer source.
    * @param {VectorTilesLayerEntryConfig} layerConfig - The layer configuration.
    */
-  public constructor(mapId: string, olLayer: VectorTileLayer, layerConfig: VectorTilesLayerEntryConfig) {
-    super(mapId, olLayer, layerConfig);
+  public constructor(mapId: string, olSource: VectorTile, layerConfig: VectorTilesLayerEntryConfig) {
+    super(mapId, olSource, layerConfig);
+
+    // Create the tile layer options.
+    const tileLayerOptions: TileOptions<VectorTile> = { source: olSource };
+
+    // Init the layer options with initial settings
+    AbstractGVVectorTile.initOptionsWithInitialSettings(tileLayerOptions, layerConfig);
+
+    // Create and set the OpenLayer layer
+    this.olLayer = new VectorTileLayer({ ...tileLayerOptions });
   }
 
   /**
@@ -39,9 +48,9 @@ export class GVVectorTiles extends AbstractGVVectorTile {
    * Overrides the get of the OpenLayers Layer
    * @returns {VectorTile} The OpenLayers Layer
    */
-  override getOLSource(): VectorTile | undefined {
+  override getOLSource(): VectorTile {
     // Get source from OL
-    return this.getOLLayer().getSource() || undefined;
+    return super.getOLSource() as VectorTile;
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-vector-tiles.ts
@@ -1,9 +1,7 @@
 import VectorTileLayer from 'ol/layer/VectorTile';
 import { Options as TileOptions } from 'ol/layer/BaseTile';
 import { VectorTile } from 'ol/source';
-import { Extent } from 'ol/extent';
 
-import { getMinOrMaxExtents } from '@/geo/utils/utilities';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 import { VectorTilesLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/vector-tiles-layer-entry-config';
 import { featureInfoGetFieldType } from '../utils';
@@ -45,15 +43,6 @@ export class GVVectorTiles extends AbstractGVVectorTile {
   }
 
   /**
-   * Overrides the get of the OpenLayers Layer
-   * @returns {VectorTile} The OpenLayers Layer
-   */
-  override getOLSource(): VectorTile {
-    // Get source from OL
-    return super.getOLSource() as VectorTile;
-  }
-
-  /**
    * Overrides the get of the layer configuration associated with the layer.
    * @returns {VectorTilesLayerEntryConfig} The layer configuration or undefined if not found.
    */
@@ -70,33 +59,5 @@ export class GVVectorTiles extends AbstractGVVectorTile {
   protected override getFieldType(fieldName: string): 'string' | 'date' | 'number' {
     // Redirect
     return featureInfoGetFieldType(this.getLayerConfig(), fieldName, AppEventProcessor.getDisplayLanguage(this.getMapId()));
-  }
-
-  /**
-   * Gets the bounds of the layer and returns updated bounds
-   * @param {Extent | undefined} bounds The current bounding box to be adjusted.
-   * @returns {Extent | undefined} The new layer bounding box.
-   */
-  protected getBounds(layerPath: string, bounds?: Extent): Extent | undefined {
-    // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
-    const layerConfig = this.getLayerConfig();
-    const projection = this.getOLSource()?.getProjection()?.getCode() || this.getMapViewer().getProjection().getCode();
-
-    const layerBounds = this.getOLSource()?.getTileGrid()?.getExtent();
-    if (layerBounds) {
-      let transformedBounds = layerBounds;
-      if (
-        layerConfig.getMetadata()?.fullExtent?.spatialReference?.wkid !== this.getMapViewer().getProjection().getCode().replace('EPSG:', '')
-      ) {
-        transformedBounds = this.getMapViewer().convertExtentFromProjToMapProj(layerBounds, projection);
-      }
-
-      // eslint-disable-next-line no-param-reassign
-      if (!bounds) bounds = [transformedBounds[0], transformedBounds[1], transformedBounds[2], transformedBounds[3]];
-      // eslint-disable-next-line no-param-reassign
-      else bounds = getMinOrMaxExtents(bounds, transformedBounds);
-    }
-
-    return bounds;
   }
 }

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-wfs.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/gv-wfs.ts
@@ -1,0 +1,48 @@
+import { Vector as VectorSource } from 'ol/source';
+import { TypeJsonArray } from '@/core/types/global-types';
+import { AbstractGVVector } from './abstract-gv-vector';
+import { WfsLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-validation-classes/wfs-layer-entry-config';
+
+/**
+ * Manages a WFS layer.
+ *
+ * @exports
+ * @class GVWFS
+ */
+export class GVWFS extends AbstractGVVector {
+  /**
+   * Constructs a GVWFS layer to manage an OpenLayer layer.
+   * @param {string} mapId - The map id
+   * @param {VectorSource} olSource - The OpenLayer source.
+   * @param {WfsLayerEntryConfig} layerConfig - The layer configuration.
+   */
+  // Disabling 'any', because that's how it is in OpenLayers
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public constructor(mapId: string, olSource: VectorSource, layerConfig: WfsLayerEntryConfig) {
+    super(mapId, olSource, layerConfig);
+  }
+
+  /**
+   * Overrides the get of the layer configuration associated with the layer.
+   * @returns {WfsLayerEntryConfig} The layer configuration or undefined if not found.
+   */
+  override getLayerConfig(): WfsLayerEntryConfig {
+    // Call parent and cast
+    return super.getLayerConfig() as WfsLayerEntryConfig;
+  }
+
+  /**
+   * Overrides the return of the field type from the metadata. If the type can not be found, return 'string'.
+   * @param {string} fieldName - The field name for which we want to get the type.
+   * @returns {'string' | 'date' | 'number'} The type of the field.
+   */
+  protected override getFieldType(fieldName: string): 'string' | 'date' | 'number' {
+    const fieldDefinitions = this.getLayerConfig().getMetadata() as TypeJsonArray;
+    const fieldDefinition = fieldDefinitions.find((metadataEntry) => metadataEntry.name === fieldName);
+    if (!fieldDefinition) return 'string';
+    const fieldEntryType = (fieldDefinition.type as string).split(':').slice(-1)[0] as string;
+    if (fieldEntryType === 'date') return 'date';
+    if (['int', 'number'].includes(fieldEntryType)) return 'number';
+    return 'string';
+  }
+}

--- a/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
@@ -29,6 +29,7 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
     // Return if the layer is of queryable type and source is queryable
     return (
+      super.onRegisterLayerCheck(layer, layerPath) &&
       AbstractLayerSet.isQueryableType(layer) &&
       !(layer instanceof WMS) &&
       !(layer instanceof GVWMS) &&

--- a/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
@@ -51,7 +51,11 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
 
     // Return if the layer is of queryable type and source is queryable
-    return AbstractLayerSet.isQueryableType(layer) && AbstractLayerSet.isSourceQueryable(layer, layerPath);
+    return (
+      super.onRegisterLayerCheck(layer, layerPath) &&
+      AbstractLayerSet.isQueryableType(layer) &&
+      AbstractLayerSet.isSourceQueryable(layer, layerPath)
+    );
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
@@ -49,6 +49,7 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
    */
   protected override onRegisterLayerCheck(layer: AbstractGeoViewLayer | AbstractGVLayer, layerPath: string): boolean {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
+
     // Return if the layer is of queryable type and source is queryable
     return AbstractLayerSet.isQueryableType(layer) && AbstractLayerSet.isSourceQueryable(layer, layerPath);
   }
@@ -59,6 +60,7 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
    */
   protected override onRegisterLayer(layer: AbstractGeoViewLayer | AbstractGVLayer, layerPath: string): void {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
+
     // Call parent
     super.onRegisterLayer(layer, layerPath);
 
@@ -268,7 +270,7 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
 /**
  * Define a delegate for the event handler function signature
  */
-type QueryEndedDelegate = EventDelegateBase<FeatureInfoLayerSet, QueryEndedEvent>;
+type QueryEndedDelegate = EventDelegateBase<FeatureInfoLayerSet, QueryEndedEvent, void>;
 
 /**
  * Define an event for the delegate

--- a/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
@@ -46,6 +46,7 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
     // TODO: Refactor - Layers refactoring. Remove the layerPath parameter once hybrid work is done
     // Return if the layer is of queryable type and source is queryable
     return (
+      super.onRegisterLayerCheck(layer, layerPath) &&
       AbstractLayerSet.isQueryableType(layer) &&
       !(layer instanceof WMS) &&
       !(layer instanceof GVWMS) &&

--- a/packages/geoview-core/src/geo/layer/layer-sets/legends-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/legends-layer-set.ts
@@ -33,11 +33,23 @@ export class LegendsLayerSet extends AbstractLayerSet {
   /**
    * Overrides the behavior to apply when an all-feature-info-layer-set wants to check for condition to register a layer in its set.
    * @param {ConfigBaseClass} layerConfig - The layer config
-   * @returns {boolean} True when the layer should be registered to this all-feature-info-layer-set.
+   * @returns {boolean} True when the layer should be registered to this legends-layer-set
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected override onRegisterLayerConfigCheck(layerConfig: ConfigBaseClass): boolean {
     // Always register layer configs for the legends-layer-set, because we want 'the box' in the UI to show the layer status progression
+    return true;
+  }
+
+  /**
+   * Overrides the behavior to apply when an all-feature-info-layer-set wants to check for condition to register a layer in its set.
+   * @param {AbstractGeoViewLayer | AbstractGVLayer} layer - The layer
+   * @param {string} layerPath - The layer path
+   * @returns {boolean} True when the layer should be registered to this legends-layer-set
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected override onRegisterLayerCheck(layer: AbstractGeoViewLayer | AbstractGVLayer, layerPath: string): boolean {
+    // Always register layers for the legends-layer-set, because we want 'the box' in the UI to show the layer status progression
     return true;
   }
 

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -1,12 +1,9 @@
 import BaseLayer from 'ol/layer/Base';
 import { Extent } from 'ol/extent';
 import Collection from 'ol/Collection';
-import { Source } from 'ol/source';
-import VectorImageLayer from 'ol/layer/VectorImage';
-import ImageLayer from 'ol/layer/Image';
-import VectorTileLayer from 'ol/layer/VectorTile';
-import BaseVectorLayer from 'ol/layer/BaseVector';
-import TileLayer from 'ol/layer/Tile';
+import { ImageArcGISRest, ImageWMS, Source, VectorTile, XYZ } from 'ol/source';
+import Static from 'ol/source/ImageStatic';
+import VectorSource from 'ol/source/Vector';
 
 import { GeoCore } from '@/geo/layer/other/geocore';
 import { GeometryApi } from '@/geo/layer/geometry/geometry';
@@ -18,14 +15,13 @@ import { ConfigValidation } from '@/core/utils/config/config-validation';
 import { createLocalizedString, generateId, whenThisThen } from '@/core/utils/utilities';
 import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
 import { logger } from '@/core/utils/logger';
-import { AbstractGeoViewLayer, LayerCreationEvent } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
+import { AbstractGeoViewLayer, LayerCreationEvent, LayerRequestingEvent } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import {
   MapConfigLayerEntry,
   TypeGeoviewLayerConfig,
   TypeLayerEntryConfig,
   mapConfigLayerEntryIsGeoCore,
   layerEntryIsGroupLayer,
-  CONST_LAYER_ENTRY_TYPES,
   TypeLayerStatus,
   TypeClassBreakStyleConfig,
   TypeUniqueValueStyleConfig,
@@ -69,6 +65,7 @@ import { GVEsriFeature } from './gv-layers/vector/gv-esri-feature';
 import { GVGeoJSON } from './gv-layers/vector/gv-geojson';
 import { GVOGCFeature } from './gv-layers/vector/gv-ogc-feature';
 import { GVVectorTiles } from './gv-layers/vector/gv-vector-tiles';
+import { GVWFS } from './gv-layers/vector/gv-wfs';
 import { EsriFeatureLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-validation-classes/esri-feature-layer-entry-config';
 import { EsriDynamicLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/esri-dynamic-layer-entry-config';
 import { GeoJSONLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-validation-classes/geojson-layer-entry-config';
@@ -78,10 +75,10 @@ import { EsriImageLayerEntryConfig } from '@/core/utils/config/validation-classe
 import { ImageStaticLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/image-static-layer-entry-config';
 import { VectorTilesLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/vector-tiles-layer-entry-config';
 import { XYZTilesLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/xyz-layer-entry-config';
+import { WfsLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-validation-classes/wfs-layer-entry-config';
 // import { LayerMockup } from './layer-mockup';
 import { FeatureInfoEventProcessor } from '@/api/event-processors/event-processor-children/feature-info-event-processor';
 import { TypeLegendItem } from '@/core/components/layers/types';
-import { VectorLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-layer-entry-config';
 import { LegendEventProcessor } from '@/api/event-processors/event-processor-children/legend-event-processor';
 
 export type GeoViewLayerAddedResult = {
@@ -681,19 +678,27 @@ export class LayerApi {
         // this.registerLayerConfigInit(layerConfig);
       });
 
+      layerBeingAdded.onLayerRequesting((geoviewLayer: AbstractGeoViewLayer, event: LayerRequestingEvent): BaseLayer | undefined => {
+        // Log
+        logger.logDebug(`Requesting layer for ${event.config.layerPath} on map ${this.getMapId()}`, event.config);
+
+        // If new layers mode, create the corresponding GVLayer
+        if (LayerApi.LAYERS_HYBRID_MODE) {
+          const gvLayer = this.#createGVLayer(this.getMapId(), geoviewLayer, event.source, event.config, event.extraConfig);
+          if (gvLayer) return gvLayer.getOLLayer();
+        }
+
+        // Don't provie any layer, working in old mode
+        return undefined;
+      });
+
       // Register when OpenLayer layer has been created
       layerBeingAdded.onLayerCreation((geoviewLayer: AbstractGeoViewLayer, event: LayerCreationEvent) => {
         // Log
         logger.logDebug(`OpenLayer created for ${event.config.layerPath} on map ${this.getMapId()}`, event.config);
 
-        // Keep a reference
+        // Keep a reference (this is tempting to put in the onLayerRequesting handler, but this one here also traps the LayerGroups - so more a catch all)
         this.#olLayers[event.config.layerPath] = event.layer;
-
-        // If new layers mode, create the corresponding GVLayer
-        if (LayerApi.LAYERS_HYBRID_MODE) {
-          // Create the right type of GVLayer
-          this.#createGVLayer(this.getMapId(), geoviewLayer, event.layer, event.config);
-        }
       });
 
       // Create a promise about the layer will be on the map
@@ -736,38 +741,28 @@ export class LayerApi {
     // Keep it
     this.#layerEntryConfigs[layerConfig.layerPath] = layerConfig;
 
-    // If not a group
-    if (layerConfig.entryType !== CONST_LAYER_ENTRY_TYPES.GROUP) {
-      // Register the layer entry config
-      this.registerLayerConfigInLayerSets(layerConfig as AbstractBaseLayerEntryConfig);
-    }
+    // Register the layer entry config
+    this.registerLayerConfigInLayerSets(layerConfig);
   }
 
   /**
    * Registers the layer config in the LayerApi to start managing it.
    * @param {AbstractBaseLayerEntryConfig} layerConfig - The layer entry config to register
    */
-  registerLayerConfigInLayerSets(layerConfig: AbstractBaseLayerEntryConfig): void {
+  registerLayerConfigInLayerSets(layerConfig: ConfigBaseClass): void {
     // TODO: Refactor - Keeping this function separate from registerLayerConfigInit for now, because this registerLayerConfigUpdate was
     // TO.DOCONT: called in 'processListOfLayerEntryConfig' processes happening externally. I've since commented those calls to try
     // TO.DOCONT: things out. If things are stable, we can remove the dead code in the processListOfLayerEntryConfig and merge
     // TO.DOCONT: registerLayerConfigInit with registerLayerConfigUpdate
 
     // Register for ordered layer information
-    this.#registerForOrderedLayerInfo(layerConfig);
+    this.#registerForOrderedLayerInfo(layerConfig as TypeLayerEntryConfig);
 
     // Register for TimeSlider
-    this.#registerForTimeSlider(layerConfig).catch((error) => {
+    this.#registerForTimeSlider(layerConfig as TypeLayerEntryConfig).catch((error) => {
       // Log
       logger.logPromiseFailed('in registration of layer for the time slider', error);
     });
-
-    // TODO: Uncomment this when visibility logic handle within orchestrator rather than too close to the store
-    // Register an event on the layer visible changed
-    // geoviewLayer.onVisibleChanged((layer, event) => {
-    //   // Propagate in the store
-    //   MapEventProcessor.setOrToggleMapLayerVisibility(this.getMapId(), registrationEvent.layerPath, event.visible);
-    // });
 
     // Tell the layer sets about it
     this.#allLayerSets.forEach((layerSet) => {
@@ -807,16 +802,20 @@ export class LayerApi {
   #createGVLayer(
     mapId: string,
     geoviewLayer: AbstractGeoViewLayer,
-    olLayer: BaseLayer,
-    config: ConfigBaseClass
+    olSource: Source,
+    config: ConfigBaseClass,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    extraConfig?: any
   ): AbstractGVLayer | undefined {
     // If new mode
     let metadata;
     let timeDimension;
+    let style;
     if (LayerApi.LAYERS_HYBRID_MODE) {
       // Get the metadata and the time dimension information as processed
       metadata = geoviewLayer.getLayerMetadata(config.layerPath);
       timeDimension = geoviewLayer.getTemporalDimension(config.layerPath);
+      style = geoviewLayer.getStyle(config.layerPath);
 
       // HACK: INJECT CONFIGURATION STUFF PRETENDNG THEY WERE PROCESSED
       // GV Keep this code commented in the source base for now
@@ -857,28 +856,33 @@ export class LayerApi {
       //   timeDimension = LayerMockup.configMSITemporalDimension();
       // }
 
-      // If any metadata
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-param-reassign
-      if (metadata && config instanceof AbstractBaseLayerEntryConfig) config.setMetadata(metadata);
+      // If good config
+      if (config instanceof AbstractBaseLayerEntryConfig) {
+        // If any metadata
+        if (metadata) config.setMetadata(metadata);
+      }
     }
 
     // Create the right GV Layer based on the OLLayer and config type
     let gvLayer;
-    if (olLayer instanceof ImageLayer && config instanceof EsriDynamicLayerEntryConfig) gvLayer = new GVEsriDynamic(mapId, olLayer, config);
-    else if (olLayer instanceof ImageLayer && config instanceof EsriImageLayerEntryConfig)
-      gvLayer = new GVEsriImage(mapId, olLayer, config);
-    else if (olLayer instanceof ImageLayer && config instanceof ImageStaticLayerEntryConfig)
-      gvLayer = new GVImageStatic(mapId, olLayer, config);
-    else if (olLayer instanceof ImageLayer && config instanceof OgcWmsLayerEntryConfig) gvLayer = new GVWMS(mapId, olLayer, config);
-    else if (olLayer instanceof TileLayer && config instanceof XYZTilesLayerEntryConfig) gvLayer = new GVXYZTiles(mapId, olLayer, config);
-    else if (olLayer instanceof VectorImageLayer && config instanceof EsriFeatureLayerEntryConfig)
-      gvLayer = new GVEsriFeature(mapId, olLayer, config);
-    else if (olLayer instanceof BaseVectorLayer && config instanceof GeoJSONLayerEntryConfig)
-      gvLayer = new GVGeoJSON(mapId, olLayer, config);
-    else if (olLayer instanceof BaseVectorLayer && config instanceof OgcFeatureLayerEntryConfig)
-      gvLayer = new GVOGCFeature(mapId, olLayer, config);
-    else if (olLayer instanceof VectorTileLayer && config instanceof VectorTilesLayerEntryConfig)
-      gvLayer = new GVVectorTiles(mapId, olLayer, config);
+    if (olSource instanceof ImageArcGISRest && config instanceof EsriDynamicLayerEntryConfig)
+      gvLayer = new GVEsriDynamic(mapId, olSource, config);
+    else if (olSource instanceof ImageArcGISRest && config instanceof EsriImageLayerEntryConfig)
+      gvLayer = new GVEsriImage(mapId, olSource, config);
+    else if (olSource instanceof Static && config instanceof ImageStaticLayerEntryConfig)
+      gvLayer = new GVImageStatic(mapId, olSource, config);
+    else if (olSource instanceof ImageWMS && config instanceof OgcWmsLayerEntryConfig)
+      gvLayer = new GVWMS(mapId, olSource, config, extraConfig.layerCapabilities);
+    else if (olSource instanceof VectorSource && config instanceof EsriFeatureLayerEntryConfig)
+      gvLayer = new GVEsriFeature(mapId, olSource, config);
+    else if (olSource instanceof VectorSource && config instanceof GeoJSONLayerEntryConfig)
+      gvLayer = new GVGeoJSON(mapId, olSource, config);
+    else if (olSource instanceof VectorSource && config instanceof OgcFeatureLayerEntryConfig)
+      gvLayer = new GVOGCFeature(mapId, olSource, config);
+    else if (olSource instanceof VectorSource && config instanceof WfsLayerEntryConfig) gvLayer = new GVWFS(mapId, olSource, config);
+    else if (olSource instanceof VectorTile && config instanceof VectorTilesLayerEntryConfig)
+      gvLayer = new GVVectorTiles(mapId, olSource, config);
+    else if (olSource instanceof XYZ && config instanceof XYZTilesLayerEntryConfig) gvLayer = new GVXYZTiles(mapId, olSource, config);
 
     // If created
     if (gvLayer) {
@@ -887,6 +891,8 @@ export class LayerApi {
 
       // If any time dimension to inject
       if (timeDimension) gvLayer.setTemporalDimension(timeDimension);
+      // If any style to inject
+      if (style) gvLayer.setStyle(config.layerPath, style);
 
       // Initialize the layer, triggering the loaded/error status
       gvLayer.init();
@@ -1100,12 +1106,14 @@ export class LayerApi {
   /**
    * Checks if the layer results sets are all ready using the resultSet from the FeatureInfo LayerSet
    */
-  checkFeatureInfoLayerResultSetsReady(callbackNotReady?: (layerEntryConfig: ConfigBaseClass) => void): boolean {
+  checkFeatureInfoLayerResultSetsReady(callbackNotReady?: (layerEntryConfig: AbstractBaseLayerEntryConfig) => void): boolean {
     // For each registered layer entry
     let allGood = true;
     this.getLayerEntryConfigs().forEach((layerConfig) => {
+      // If not instance of AbstractBaseLayerEntryConfig, don't expect a result set
+      if (!(layerConfig instanceof AbstractBaseLayerEntryConfig)) return;
       // If not queryable, don't expect a result set
-      if (!(layerConfig as AbstractBaseLayerEntryConfig).source?.featureInfo?.queryable) return;
+      if (!layerConfig.source?.featureInfo?.queryable) return;
 
       const { resultSet } = this.featureInfoLayerSet;
       const layerResultSetReady = Object.keys(resultSet).includes(layerConfig.layerPath);
@@ -1227,13 +1235,10 @@ export class LayerApi {
     theLayerMain?.setOpacity(1, layerPath);
 
     // If it is a group layer, highlight sublayers
-    if (layerEntryIsGroupLayer(this.#layerEntryConfigs[layerPath] as TypeLayerEntryConfig)) {
+    if (layerEntryIsGroupLayer(this.#layerEntryConfigs[layerPath])) {
       Object.keys(this.#layerEntryConfigs).forEach((registeredLayerPath) => {
         const theLayer = this.getGeoviewLayerHybrid(registeredLayerPath)!;
-        if (
-          !registeredLayerPath.startsWith(layerPath) &&
-          !layerEntryIsGroupLayer(this.#layerEntryConfigs[registeredLayerPath] as TypeLayerEntryConfig)
-        ) {
+        if (!registeredLayerPath.startsWith(layerPath) && !layerEntryIsGroupLayer(this.#layerEntryConfigs[registeredLayerPath])) {
           const otherOpacity = theLayer.getOpacity(registeredLayerPath);
           theLayer.setOpacity((otherOpacity || 1) * 0.25, registeredLayerPath);
         } else this.getOLLayer(registeredLayerPath)!.setZIndex(999);
@@ -1242,10 +1247,7 @@ export class LayerApi {
       Object.keys(this.#layerEntryConfigs).forEach((registeredLayerPath) => {
         const theLayer = this.getGeoviewLayerHybrid(registeredLayerPath)!;
         // check for otherOlLayer is undefined. It would be undefined if a layer status is error
-        if (
-          registeredLayerPath !== layerPath &&
-          !layerEntryIsGroupLayer(this.#layerEntryConfigs[registeredLayerPath] as TypeLayerEntryConfig)
-        ) {
+        if (registeredLayerPath !== layerPath && !layerEntryIsGroupLayer(this.#layerEntryConfigs[registeredLayerPath])) {
           const otherOpacity = theLayer.getOpacity(registeredLayerPath);
           theLayer.setOpacity((otherOpacity || 1) * 0.25, registeredLayerPath);
         }
@@ -1261,13 +1263,10 @@ export class LayerApi {
     this.featureHighlight.removeBBoxHighlight();
     if (this.#highlightedLayer.layerPath !== undefined) {
       const { layerPath, originalOpacity } = this.#highlightedLayer;
-      if (layerEntryIsGroupLayer(this.#layerEntryConfigs[layerPath] as TypeLayerEntryConfig)) {
+      if (layerEntryIsGroupLayer(this.#layerEntryConfigs[layerPath])) {
         Object.keys(this.#layerEntryConfigs).forEach((registeredLayerPath) => {
           const theLayer = this.getGeoviewLayerHybrid(registeredLayerPath)!;
-          if (
-            !registeredLayerPath.startsWith(layerPath) &&
-            !layerEntryIsGroupLayer(this.#layerEntryConfigs[registeredLayerPath] as TypeLayerEntryConfig)
-          ) {
+          if (!registeredLayerPath.startsWith(layerPath) && !layerEntryIsGroupLayer(this.#layerEntryConfigs[registeredLayerPath])) {
             const otherOpacity = theLayer.getOpacity(registeredLayerPath);
             theLayer.setOpacity(otherOpacity ? otherOpacity * 4 : 1, registeredLayerPath);
           } else theLayer.setOpacity(originalOpacity || 1, registeredLayerPath);
@@ -1276,10 +1275,7 @@ export class LayerApi {
         Object.keys(this.#layerEntryConfigs).forEach((registeredLayerPath) => {
           // check for otherOlLayer is undefined. It would be undefined if a layer status is error
           const theLayer = this.getGeoviewLayerHybrid(registeredLayerPath)!;
-          if (
-            registeredLayerPath !== layerPath &&
-            !layerEntryIsGroupLayer(this.#layerEntryConfigs[registeredLayerPath] as TypeLayerEntryConfig)
-          ) {
+          if (registeredLayerPath !== layerPath && !layerEntryIsGroupLayer(this.#layerEntryConfigs[registeredLayerPath])) {
             const otherOpacity = theLayer.getOpacity(registeredLayerPath);
             theLayer.setOpacity(otherOpacity ? otherOpacity * 4 : 1, registeredLayerPath);
           } else theLayer.setOpacity(originalOpacity || 1, registeredLayerPath);
@@ -1350,7 +1346,7 @@ export class LayerApi {
    */
   setItemVisibility(layerPath: string, item: TypeLegendItem, visibility: boolean, updateLegendLayers: boolean = true): void {
     // Get registered layer config
-    const registeredLayer = this.#layerEntryConfigs[layerPath] as VectorLayerEntryConfig;
+    const layer = this.getGeoviewLayerHybrid(layerPath);
 
     if (visibility && !MapEventProcessor.getMapVisibilityFromOrderedLayerInfo(this.getMapId(), layerPath)) {
       MapEventProcessor.setOrToggleMapLayerVisibility(this.getMapId(), layerPath, true);
@@ -1359,13 +1355,13 @@ export class LayerApi {
     // Assign value to registered layer. This is use by applyFilter function to set visibility
     // TODO: check if we need to refactor to centralize attribute setting....
     // TODO: know issue when we toggle a default visibility item https://github.com/Canadian-Geospatial-Platform/geoview/issues/1564
-    if (registeredLayer.style![item.geometryType]?.styleType === 'classBreaks') {
-      const geometryStyleConfig = registeredLayer.style![item.geometryType]! as TypeClassBreakStyleConfig;
+    if (layer?.getStyle(layerPath)?.[item.geometryType]?.styleType === 'classBreaks') {
+      const geometryStyleConfig = layer.getStyle(layerPath)![item.geometryType] as TypeClassBreakStyleConfig;
       const classBreakStyleInfo = geometryStyleConfig.classBreakStyleInfo.find((styleInfo) => styleInfo.label === item.name);
       if (classBreakStyleInfo) classBreakStyleInfo.visible = visibility;
       else geometryStyleConfig.defaultVisible = visibility;
-    } else if (registeredLayer.style![item.geometryType]?.styleType === 'uniqueValue') {
-      const geometryStyleConfig = registeredLayer.style![item.geometryType]! as TypeUniqueValueStyleConfig;
+    } else if (layer?.getStyle(layerPath)?.[item.geometryType]?.styleType === 'uniqueValue') {
+      const geometryStyleConfig = layer.getStyle(layerPath)![item.geometryType] as TypeUniqueValueStyleConfig;
       const uniqueStyleInfo = geometryStyleConfig.uniqueValueStyleInfo.find((styleInfo) => styleInfo.label === item.name);
       if (uniqueStyleInfo) uniqueStyleInfo.visible = visibility;
       else geometryStyleConfig.defaultVisible = visibility;
@@ -1524,7 +1520,7 @@ export class LayerApi {
 /**
  * Define a delegate for the event handler function signature
  */
-type LayerAddedDelegate = EventDelegateBase<LayerApi, LayerAddedEvent>;
+type LayerAddedDelegate = EventDelegateBase<LayerApi, LayerAddedEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1537,7 +1533,7 @@ export type LayerAddedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type LayerRemovedDelegate = EventDelegateBase<LayerApi, LayerRemovedEvent>;
+type LayerRemovedDelegate = EventDelegateBase<LayerApi, LayerRemovedEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1550,7 +1546,7 @@ export type LayerRemovedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type LayerItemVisibilityToggledDelegate = EventDelegateBase<LayerApi, LayerItemVisibilityToggledEvent>;
+type LayerItemVisibilityToggledDelegate = EventDelegateBase<LayerApi, LayerItemVisibilityToggledEvent, void>;
 
 /**
  * Define an event for the delegate

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -163,7 +163,8 @@ export const convertLayerTypeToEntry = (layerType: TypeGeoviewLayerType): TypeLa
   }
 };
 
-export const layerEntryIsGroupLayer = (verifyIfLayer: ConfigBaseClass): verifyIfLayer is GroupLayerEntryConfig => {
+// It seems sometimes this type guard is called with a TypeLayerEntryConfig and sometimes with a ConfigBaseClass
+export const layerEntryIsGroupLayer = (verifyIfLayer: TypeLayerEntryConfig | ConfigBaseClass): verifyIfLayer is GroupLayerEntryConfig => {
   return verifyIfLayer?.entryType === CONST_LAYER_ENTRY_TYPES.GROUP;
 };
 

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -163,7 +163,7 @@ export const convertLayerTypeToEntry = (layerType: TypeGeoviewLayerType): TypeLa
   }
 };
 
-// It seems sometimes this type guard is called with a TypeLayerEntryConfig and sometimes with a ConfigBaseClass
+// It seems sometimes this type guard is called with a TypeLayerEntryConfig and sometimes with a ConfigBaseClass, so I'm putting it explicit
 export const layerEntryIsGroupLayer = (verifyIfLayer: TypeLayerEntryConfig | ConfigBaseClass): verifyIfLayer is GroupLayerEntryConfig => {
   return verifyIfLayer?.entryType === CONST_LAYER_ENTRY_TYPES.GROUP;
 };

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -823,6 +823,7 @@ export type TypeStyleSettings = TypeBaseStyleConfig | TypeSimpleStyleConfig | Ty
 /** ******************************************************************************************************************************
  * Valid keys for the TypeStyleConfig object.
  */
+// TODO: Refactor - Layers/Config refactoring. The values here have been renamed to lower case, make sure to lower here and adjust everywhere as part of config migration.
 export type TypeStyleGeometry = 'Point' | 'LineString' | 'Polygon';
 
 /** ******************************************************************************************************************************

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -1415,9 +1415,13 @@ export class MapViewer {
    * @returns {Coordinate} The coordinate in the map projection
    */
   convertCoordinateFromProjToMapProj(coordinate: Coordinate, fromProj: ProjectionLike): Coordinate {
-    // TODO: In this function and equivalent 3 others below, make it so that if the given projection is the same as the map projection
-    // TO.DOCONT: it just skips and returns the same geometry. It'd save many 'if' like 'if projA <> projB then call this' in the code base
-    return Projection.transform(coordinate, fromProj, this.getProjection());
+    // If different projections
+    if (fromProj !== this.getProjection().getCode()) {
+      return Projection.transform(coordinate, fromProj, this.getProjection());
+    }
+
+    // Same projection
+    return coordinate;
   }
 
   /**
@@ -1427,7 +1431,13 @@ export class MapViewer {
    * @returns {Coordinate} The coordinate in the map projection
    */
   convertCoordinateFromMapProjToProj(coordinate: Coordinate, toProj: ProjectionLike): Coordinate {
-    return Projection.transform(coordinate, this.getProjection(), toProj);
+    // If different projections
+    if (toProj !== this.getProjection().getCode()) {
+      return Projection.transform(coordinate, this.getProjection(), toProj);
+    }
+
+    // Same projection
+    return coordinate;
   }
 
   /**
@@ -1437,17 +1447,29 @@ export class MapViewer {
    * @returns {Extent} The extent in the map projection
    */
   convertExtentFromProjToMapProj(extent: Extent, fromProj: ProjectionLike): Extent {
-    return Projection.transformExtent(extent, fromProj, this.getProjection());
+    // If different projections
+    if (fromProj !== this.getProjection().getCode()) {
+      return Projection.transformExtent(extent, fromProj, this.getProjection());
+    }
+
+    // Same projection
+    return extent;
   }
 
   /**
-   * Transforms extent from map projection to given projection.
+   * Transforms extent from map projection to given projection. If the projects are the same, the extent is simply returned.
    * @param {Extent} extent - The given extent
    * @param {ProjectionLike} toProj - The projection that should be output
    * @returns {Extent} The extent in the map projection
    */
   convertExtentFromMapProjToProj(extent: Extent, toProj: ProjectionLike): Extent {
-    return Projection.transformExtent(extent, this.getProjection(), toProj);
+    // If different projections
+    if (toProj !== this.getProjection().getCode()) {
+      return Projection.transformExtent(extent, this.getProjection(), toProj);
+    }
+
+    // Same projection
+    return extent;
   }
 
   // #region EVENTS

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -1830,22 +1830,22 @@ export type TypeMapMouseInfo = {
 /**
  * Define a delegate for the event handler function signature
  */
-type MapInitDelegate = EventDelegateBase<MapViewer, undefined>;
+type MapInitDelegate = EventDelegateBase<MapViewer, undefined, void>;
 
 /**
  * Define a delegate for the event handler function signature
  */
-type MapReadyDelegate = EventDelegateBase<MapViewer, undefined>;
+type MapReadyDelegate = EventDelegateBase<MapViewer, undefined, void>;
 
 /**
  * Define a delegate for the event handler function signature
  */
-type MapLayersProcessedDelegate = EventDelegateBase<MapViewer, undefined>;
+type MapLayersProcessedDelegate = EventDelegateBase<MapViewer, undefined, void>;
 
 /**
  * Define a delegate for the event handler function signature
  */
-type MapLayersLoadedDelegate = EventDelegateBase<MapViewer, undefined>;
+type MapLayersLoadedDelegate = EventDelegateBase<MapViewer, undefined, void>;
 
 /**
  * Define an event for the delegate
@@ -1857,7 +1857,7 @@ export type MapMoveEndEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type MapMoveEndDelegate = EventDelegateBase<MapViewer, MapMoveEndEvent>;
+type MapMoveEndDelegate = EventDelegateBase<MapViewer, MapMoveEndEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1867,7 +1867,7 @@ export type MapPointerMoveEvent = TypeMapMouseInfo;
 /**
  * Define a delegate for the event handler function signature
  */
-type MapPointerMoveDelegate = EventDelegateBase<MapViewer, MapPointerMoveEvent>;
+type MapPointerMoveDelegate = EventDelegateBase<MapViewer, MapPointerMoveEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1877,7 +1877,7 @@ export type MapSingleClickEvent = TypeMapMouseInfo;
 /**
  * Define a delegate for the event handler function signature
  */
-type MapSingleClickDelegate = EventDelegateBase<MapViewer, MapSingleClickEvent>;
+type MapSingleClickDelegate = EventDelegateBase<MapViewer, MapSingleClickEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1889,7 +1889,7 @@ export type MapZoomEndEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type MapZoomEndDelegate = EventDelegateBase<MapViewer, MapZoomEndEvent>;
+type MapZoomEndDelegate = EventDelegateBase<MapViewer, MapZoomEndEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1901,7 +1901,7 @@ export type MapRotationEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type MapRotationDelegate = EventDelegateBase<MapViewer, MapRotationEvent>;
+type MapRotationDelegate = EventDelegateBase<MapViewer, MapRotationEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1913,7 +1913,7 @@ export type MapChangeSizeEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type MapChangeSizeDelegate = EventDelegateBase<MapViewer, MapChangeSizeEvent>;
+type MapChangeSizeDelegate = EventDelegateBase<MapViewer, MapChangeSizeEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1926,7 +1926,7 @@ export type MapComponentAddedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type MapComponentAddedDelegate = EventDelegateBase<MapViewer, MapComponentAddedEvent>;
+type MapComponentAddedDelegate = EventDelegateBase<MapViewer, MapComponentAddedEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1938,7 +1938,7 @@ export type MapComponentRemovedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type MapComponentRemovedDelegate = EventDelegateBase<MapViewer, MapComponentRemovedEvent>;
+type MapComponentRemovedDelegate = EventDelegateBase<MapViewer, MapComponentRemovedEvent, void>;
 
 /**
  * Define an event for the delegate
@@ -1950,4 +1950,4 @@ export type MapLanguageChangedEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type MapLanguageChangedDelegate = EventDelegateBase<MapViewer, MapLanguageChangedEvent>;
+type MapLanguageChangedDelegate = EventDelegateBase<MapViewer, MapLanguageChangedEvent, void>;

--- a/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-param-reassign */
-// We have many reassign for node-layerConfig. We keep it global...
 import { asArray, asString } from 'ol/color';
 import { Style, Stroke, Fill, RegularShape, Circle as StyleCircle, Icon as StyleIcon } from 'ol/style';
 import { Geometry, LineString, Point, Polygon } from 'ol/geom';
@@ -39,6 +37,7 @@ import {
   isClassBreakStyleConfig,
   TypeUniqueValueStyleConfig,
   TypeClassBreakStyleConfig,
+  TypeBaseStyleConfig,
 } from '@/geo/map/map-schema-types';
 import {
   binaryKeywors,
@@ -54,9 +53,6 @@ import {
 } from './geoview-renderer-types';
 import { TypeVectorLayerStyles } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { logger } from '@/core/utils/logger';
-import { VectorLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-layer-entry-config';
-import { VectorTilesLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/vector-tiles-layer-entry-config';
-import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
 
 type TypeStyleProcessor = (
   styleSettings: TypeStyleSettings | TypeKindOfVectorSettings,
@@ -325,9 +321,12 @@ function createPolygonCanvas(polygonStyle?: Style): HTMLCanvasElement {
  * @returns {StrokeOptions} The stroke options created.
  */
 function createStrokeOptions(settings: TypeSimpleSymbolVectorConfig | TypeLineStringVectorConfig | TypePolygonVectorConfig): StrokeOptions {
+  // eslint-disable-next-line no-param-reassign
   if (settings.stroke === undefined) settings.stroke = {};
   if (settings.stroke.color === undefined) {
+    // eslint-disable-next-line no-param-reassign
     if ('color' in settings) settings.stroke.color = asString(setAlphaColor(asArray((settings as TypeSimpleSymbolVectorConfig).color!), 1));
+    // eslint-disable-next-line no-param-reassign
     else settings.stroke.color = getDefaultColor(1, true);
   }
   const strokeOptions: StrokeOptions = {
@@ -618,6 +617,7 @@ function featureIsNotVisible(feature: Feature, filterEquation: FilterNodeArrayTy
  * @returns {Style | undefined} The Style created. Undefined if unable to create it.
  */
 function processCircleSymbol(settings: TypeSimpleSymbolVectorConfig): Style | undefined {
+  // eslint-disable-next-line no-param-reassign
   if (settings.color === undefined) settings.color = getDefaultColor(0.25, true);
   const fillOptions: FillOptions = { color: settings.color };
   const strokeOptions: StrokeOptions = createStrokeOptions(settings);
@@ -641,6 +641,7 @@ function processCircleSymbol(settings: TypeSimpleSymbolVectorConfig): Style | un
  * @returns {Style | undefined} The Style created. Undefined if unable to create it.
  */
 function processStarShapeSymbol(settings: TypeSimpleSymbolVectorConfig, points: number, angle: number): Style | undefined {
+  // eslint-disable-next-line no-param-reassign
   if (settings.color === undefined) settings.color = getDefaultColor(0.25, true);
   const fillOptions: FillOptions = { color: settings.color };
   const strokeOptions: StrokeOptions = createStrokeOptions(settings);
@@ -708,6 +709,7 @@ function processRegularShape(
   angle: number,
   scale: [number, number]
 ): Style | undefined {
+  // eslint-disable-next-line no-param-reassign
   if (settings.color === undefined) settings.color = getDefaultColor(0.25, true);
   const fillOptions: FillOptions = { color: settings.color };
   const strokeOptions: StrokeOptions = createStrokeOptions(settings);
@@ -852,6 +854,7 @@ function processSimpleLineString(
  * @returns {Style | undefined} The Style created. Undefined if unable to create it.
  */
 function processSolidFill(settings: TypePolygonVectorConfig, geometry?: Geometry): Style | undefined {
+  // eslint-disable-next-line no-param-reassign
   if (settings.color === undefined) settings.color = getDefaultColor(0.25, true);
   const fillOptions: FillOptions = { color: settings.color };
   const strokeOptions: StrokeOptions = createStrokeOptions(settings);
@@ -870,6 +873,7 @@ function processSolidFill(settings: TypePolygonVectorConfig, geometry?: Geometry
  * @returns {Style | undefined} The Style created. Undefined if unable to create it.
  */
 function processNullFill(settings: TypePolygonVectorConfig, geometry?: Geometry): Style | undefined {
+  // eslint-disable-next-line no-param-reassign
   if (settings.color === undefined) settings.color = getDefaultColor(0, true);
   const fillOptions: FillOptions = { color: settings.color };
   const strokeOptions: StrokeOptions = createStrokeOptions(settings);
@@ -890,6 +894,7 @@ function processNullFill(settings: TypePolygonVectorConfig, geometry?: Geometry)
  */
 function processPaternFill(settings: TypePolygonVectorConfig, fillPaternLines: FillPaternLine[], geometry?: Geometry): Style | undefined {
   const paternSize = settings.paternSize !== undefined ? settings.paternSize : 8;
+  // eslint-disable-next-line no-param-reassign
   if (settings.color === undefined) settings.color = getDefaultColor(0.25, true);
   const fillOptions: FillOptions = { color: settings.color };
   const strokeOptions: StrokeOptions = createStrokeOptions(settings);
@@ -1129,17 +1134,12 @@ async function getPointStyleSubRoutine(
 /** ***************************************************************************************************************************
  * This method gets the legend styles used by the the layer as specified by the style configuration.
  *
- * @param {AbstractBaseLayerEntryConfig & {style: TypeStyleConfig;}} layerConfig - Layer configuration.
+ * @param {TypeStyleConfig} styleConfig - The style configuration.
  *
  * @returns {Promise<TypeVectorLayerStyles>} A promise that the layer styles are processed.
  */
-export async function getLegendStyles(
-  layerConfig: AbstractBaseLayerEntryConfig & {
-    style: TypeStyleConfig;
-  }
-): Promise<TypeVectorLayerStyles> {
+export async function getLegendStyles(styleConfig: TypeStyleConfig | undefined): Promise<TypeVectorLayerStyles> {
   try {
-    const styleConfig: TypeStyleConfig = layerConfig.style;
     if (!styleConfig) return {};
 
     const legendStyles: TypeVectorLayerStyles = {};
@@ -1231,7 +1231,7 @@ export async function getLegendStyles(
  * @param {TypeStyleGeometry} geometryType - Type of geometry (Point, LineString, Polygon).
  * @param {TypeDisplayLanguage} language - Language for the style
  *
- * @returns {TypeSimpleStyleConfig | undefined} The Style configurationcreated. Undefined if unable to create it.
+ * @returns {TypeSimpleStyleConfig | undefined} The Style configuration created. Undefined if unable to create it.
  */
 function createDefaultStyle(geometryType: TypeStyleGeometry, label: string): TypeSimpleStyleConfig | undefined {
   if (geometryType === 'Point') {
@@ -1524,40 +1524,47 @@ const processStyle: Record<TypeBaseStyleType, Record<TypeStyleGeometry, TypeStyl
 /** ***************************************************************************************************************************
  * This method gets the style of the feature using the layer entry config. If the style does not exist for the geometryType,
  * create it using the default style strategy.
- *
  * @param {FeatureLike} feature - Feature that need its style to be defined.
- * @param {VectorTileLayerEntryConfig | VectorLayerEntryConfig} layerConfig - Layer
- * entry config that may have a style configuration for the feature. If style does not exist for the geometryType, create it.
+ * @param {TypeStyleConfig} style - The style to use
  * @param {string} label - The style label when one has to be created
- *
+ * @param {FilterNodeArrayType} filterEquation - Filter equation associated to the layer.
+ * @param {boolean} legendFilterIsOff - When true, do not apply legend filter.
+ * @param {() => Promise<string | null>} callbackWhenCreatingStyle - An optional callback to execute when a new style had to be created
  * @returns {Style | undefined} The style applied to the feature or undefined if not found.
  */
 export function getAndCreateFeatureStyle(
   feature: FeatureLike,
-  layerConfig: VectorTilesLayerEntryConfig | VectorLayerEntryConfig,
-  label: string
+  style: TypeStyleConfig,
+  label: string,
+  filterEquation?: FilterNodeArrayType,
+  legendFilterIsOff?: boolean,
+  callbackWhenCreatingStyle?: (geometryType: TypeStyleGeometry, style: TypeBaseStyleConfig) => void
 ): Style | undefined {
+  // Get the geometry type
   const geometryType = getGeometryType(feature);
+
+  // The style to work on
+  let styleWorkOn = style;
+
   // If style does not exist for the geometryType, create it.
-  if (!layerConfig.style || !layerConfig.style[geometryType]) {
+  if (!style || !style[geometryType]) {
     // Create a style on-the-fly for the geometry type, because the layer config didn't have one already
     const styleConfig = createDefaultStyle(geometryType, label);
 
-    // Add a default style to the layer config
-    if (styleConfig) layerConfig.addDefaultStyle(geometryType, styleConfig);
+    // If a style has been created on-the-fly
+    if (styleConfig) {
+      if (style) styleWorkOn[geometryType] = styleConfig;
+      else styleWorkOn = { [geometryType]: styleConfig };
+      callbackWhenCreatingStyle?.(geometryType, styleConfig);
+    }
   }
 
   // Get the style accordingly to its type and geometry.
-  if (layerConfig.style![geometryType]) {
-    const styleSettings = layerConfig.style![geometryType]!;
+  if (styleWorkOn![geometryType]) {
+    const styleSettings = style![geometryType]!;
     const { styleType } = styleSettings;
-    return processStyle[styleType][geometryType].call(
-      '',
-      styleSettings,
-      feature as Feature,
-      layerConfig.filterEquation,
-      layerConfig.legendFilterIsOff
-    );
+    // TODO: Refactor - Rewrite this to use explicit function calls instead, for clarity and references finding
+    return processStyle[styleType][geometryType].call('', styleSettings, feature as Feature, filterEquation, legendFilterIsOff);
   }
   return undefined;
 }
@@ -1565,13 +1572,17 @@ export function getAndCreateFeatureStyle(
 /** ***************************************************************************************************************************
  * This method gets the canvas icon from the style of the feature using the layer entry config.
  * @param {Feature} feature - The feature that need its canvas icon to be defined.
- * @param {AbstractBaseLayerEntryConfig} layerConfig - The layer entry config that may have a style configuration for the feature.
+ * @param {TypeStyleConfig} style - The style to use
+ * @param {FilterNodeArrayType} filterEquation - Filter equation associated to the layer.
+ * @param {boolean} legendFilterIsOff - When true, do not apply legend filter.
  * @param {() => Promise<string | null>} callbackForDataUrl - An optional callback to execute when struggling to build a canvas and have to use a data url to make one
  * @returns {Promise<HTMLCanvasElement>} The canvas icon associated to the feature or a default empty canvas.
  */
 export async function getFeatureCanvas(
   feature: Feature,
-  layerConfig: AbstractBaseLayerEntryConfig,
+  style: TypeStyleConfig,
+  filterEquation?: FilterNodeArrayType,
+  legendFilterIsOff?: boolean,
   callbackForDataUrl?: () => Promise<string | null>
 ): Promise<HTMLCanvasElement> {
   // The canvas that will be returned (if calculated successfully)
@@ -1580,18 +1591,12 @@ export async function getFeatureCanvas(
   // If the feature has a geometry
   if (feature.getGeometry()) {
     const geometryType = getGeometryType(feature);
-    const { style } = layerConfig as VectorLayerEntryConfig;
 
     // Get the style accordingly to its type and geometry.
-    if (style![geometryType] !== undefined) {
-      const styleSettings = style![geometryType]!;
+    if (style[geometryType]) {
+      const styleSettings = style[geometryType]!;
       const { styleType } = styleSettings;
-      const featureStyle = processStyle[styleType][geometryType](
-        styleSettings,
-        feature,
-        layerConfig.filterEquation,
-        layerConfig.legendFilterIsOff
-      );
+      const featureStyle = processStyle[styleType][geometryType](styleSettings, feature, filterEquation, legendFilterIsOff);
       if (featureStyle) {
         if (geometryType === 'Point') {
           if (
@@ -1650,20 +1655,28 @@ function classifyUnprocessedNodes(keywordArray: FilterNodeArrayType): FilterNode
       if (Number.isNaN(Number((node.nodeValue as string).slice(0, 1)))) {
         if (['+', '-'].includes(node.nodeValue as string))
           if (i !== 0 && [NodeType.number, NodeType.string, NodeType.variable].includes(keywordArray[i - 1].nodeType))
+            // eslint-disable-next-line no-param-reassign
             node.nodeType = NodeType.binary;
           else {
+            // eslint-disable-next-line no-param-reassign
             node.nodeType = NodeType.unary;
+            // eslint-disable-next-line no-param-reassign
             node.nodeValue = `u${node.nodeValue}`;
           }
         else if (typeof node.nodeValue === 'string' && node.nodeValue.toLowerCase() === 'null') {
+          // eslint-disable-next-line no-param-reassign
           node.nodeType = NodeType.variable;
+          // eslint-disable-next-line no-param-reassign
           node.nodeValue = null;
         } else {
+          // eslint-disable-next-line no-param-reassign
           node.nodeType = NodeType.variable;
         }
         return node;
       }
+      // eslint-disable-next-line no-param-reassign
       node.nodeType = NodeType.number;
+      // eslint-disable-next-line no-param-reassign
       node.nodeValue = Number(node.nodeValue);
       if (Number.isNaN(node.nodeValue)) throw new Error(`${node.nodeValue} is an invalid number`);
       return node;
@@ -1695,6 +1708,7 @@ function extractKeyword(filterNodeArray: FilterNodeArrayType, keyword: string, r
   return filterNodeArray.reduce((newKeywordArray, node) => {
     if (node.nodeType !== NodeType.unprocessedNode) newKeywordArray.push(node);
     else {
+      // eslint-disable-next-line no-param-reassign
       newKeywordArray = newKeywordArray.concat(
         (node.nodeValue as string)
           .trim()

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -325,6 +325,7 @@ export function convertTypeFeatureStyleToOpenLayersStyle(style?: TypeFeatureStyl
  * @returns {Extent} the smallest or largest set from the extents
  */
 export function getMinOrMaxExtents(extentsA: Extent, extentsB: Extent, minmax = 'max'): Extent {
+  // TODO: Check - Obsolete function? Use getExtentUnion or getExtentIntersection
   let bounds: Extent = [];
   if (minmax === 'max')
     bounds = [
@@ -341,6 +342,72 @@ export function getMinOrMaxExtents(extentsA: Extent, extentsB: Extent, minmax = 
       Math.min(extentsA[3], extentsB[3]),
     ];
   return bounds;
+}
+
+/**
+ * Returns the union of 2 extents.
+ * @param {Extent} extentA First extent
+ * @param {Extent} extentB Optional second extent
+ * @returns {Extent} The union of the extents
+ */
+export function getExtentUnion(extentA: Extent, extentB?: Extent): Extent {
+  // If no B, return A
+  if (!extentB) return extentA;
+
+  // Return the union of A and B
+  return [
+    Math.min(extentA[0], extentB[0]),
+    Math.min(extentA[1], extentB[1]),
+    Math.max(extentA[2], extentB[2]),
+    Math.max(extentA[3], extentB[3]),
+  ];
+}
+
+/**
+ * Returns the union of 2 extents supporting the case where extentA might be undefined.
+ * @param {Extent | undefined} extentA First extent or undefined
+ * @param {Extent | undefined} extentB Optional second extent
+ * @returns {Extent | undefined} The union of the extents
+ */
+export function getExtentUnionMaybe(extentA: Extent | undefined, extentB?: Extent): Extent | undefined {
+  // If no A, return undefined
+  if (!extentA) return undefined;
+
+  // Redirect
+  return getExtentUnion(extentA, extentB);
+}
+
+/**
+ * Returns the intersection of 2 extents.
+ * @param {Extent} extentA First extent
+ * @param {Extent} extentB Optional second extent
+ * @returns {Extent} The intersection of the extents
+ */
+export function getExtentIntersection(extentA: Extent, extentB?: Extent): Extent {
+  // If no B, return A
+  if (!extentB) return extentA;
+
+  // Return the intersection of A and B
+  return [
+    Math.max(extentA[0], extentB[0]),
+    Math.max(extentA[1], extentB[1]),
+    Math.min(extentA[2], extentB[2]),
+    Math.min(extentA[3], extentB[3]),
+  ];
+}
+
+/**
+ * Returns the intersection of 2 extents supporting the case where extentA might be undefined.
+ * @param {Extent | undefined} extentA First extent or undefined
+ * @param {Extent | undefined} extentB Optional second extent
+ * @returns {Extent | undefined} The intersection of the extents
+ */
+export function getExtentIntersectionMaybe(extentA: Extent | undefined, extentB?: Extent): Extent | undefined {
+  // If no A, return undefined
+  if (!extentA) return undefined;
+
+  // Redirect
+  return getExtentIntersection(extentA, extentB);
 }
 
 /**

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -17,7 +17,6 @@ import { xmlToJson } from '@/core/utils/utilities';
 
 import { CONST_LAYER_TYPES, TypeVectorLayerStyles } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { getLegendStyles } from '@/geo/utils/renderer/geoview-renderer';
-import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
 import { TypeStyleConfig } from '@/geo/map/map-schema-types';
 
 import { TypeBasemapLayer } from '../layer/basemap/basemap-types';
@@ -234,16 +233,12 @@ export function createEmptyBasemap(): TileLayer<XYZ> {
 /** ***************************************************************************************************************************
  * This method gets the legend styles used by the the layer as specified by the style configuration.
  *
- * @param {AbstractBaseLayerEntryConfig & {style: TypeStyleConfig;}} layerConfig - Layer configuration.
+ * @param {TypeStyleConfig} styleConfig - Layer style configuration.
  *
  * @returns {Promise<TypeVectorLayerStyles>} A promise that the layer styles are processed.
  */
-export function getLegendStylesFromConfig(
-  layerConfig: AbstractBaseLayerEntryConfig & {
-    style: TypeStyleConfig;
-  }
-): Promise<TypeVectorLayerStyles> {
-  return getLegendStyles(layerConfig);
+export function getLegendStylesFromConfig(styleConfig: TypeStyleConfig): Promise<TypeVectorLayerStyles> {
+  return getLegendStyles(styleConfig);
 }
 
 /**

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -370,8 +370,8 @@ export function getExtentUnion(extentA: Extent, extentB?: Extent): Extent {
  * @returns {Extent | undefined} The union of the extents
  */
 export function getExtentUnionMaybe(extentA: Extent | undefined, extentB?: Extent): Extent | undefined {
-  // If no A, return undefined
-  if (!extentA) return undefined;
+  // If no A, return B which may be undefined too
+  if (!extentA) return extentB;
 
   // Redirect
   return getExtentUnion(extentA, extentB);
@@ -403,8 +403,8 @@ export function getExtentIntersection(extentA: Extent, extentB?: Extent): Extent
  * @returns {Extent | undefined} The intersection of the extents
  */
 export function getExtentIntersectionMaybe(extentA: Extent | undefined, extentB?: Extent): Extent | undefined {
-  // If no A, return undefined
-  if (!extentA) return undefined;
+  // If no A, return B which may be undefined too
+  if (!extentA) return extentB;
 
   // Redirect
   return getExtentIntersection(extentA, extentB);

--- a/packages/geoview-core/src/ui/modal/modal-api.ts
+++ b/packages/geoview-core/src/ui/modal/modal-api.ts
@@ -130,9 +130,9 @@ export type ModalEvent = {
 /**
  * Define a delegate for the event handler function signature
  */
-type ModalOpenedDelegate = EventDelegateBase<ModalApi, ModalEvent>;
+type ModalOpenedDelegate = EventDelegateBase<ModalApi, ModalEvent, void>;
 
 /**
  * Define a delegate for the event handler function signature
  */
-type ModalClosedDelegate = EventDelegateBase<ModalApi, ModalEvent>;
+type ModalClosedDelegate = EventDelegateBase<ModalApi, ModalEvent, void>;

--- a/packages/geoview-swiper/package.json
+++ b/packages/geoview-swiper/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "geoview-core": "workspace:~0.1.0",
     "lodash": "^4.17.21",
-    "ol": "^9.0.0",
+    "ol": "9.1.0",
     "react-draggable": "^4.4.5"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description

Fifth spring-board PR focusing on the new layers, bounds calculation, layerStatus propagation and:
- Supporting the styles in the new GV classes
- More `getGeoviewLayer()` --> `getGeoviewLayerHybrid()` renaming
- More `TypeLayerEntryConfig` --> `ConfigBaseClass` and `TypeLayerEntryConfig` -- > `AbstractBaseLayerEntryConfig` renaming
- Added the new `GV-CSV` and `GV-WFS` layer classes
- Moved `style` and the `style` check in the constructor, along with `getTypeGeometries` and `getFirstStyleSettings` to the mother layer entry class
- Fixed the legend processor `propagateLegendToStore` to better propagate layer names in the case of group-layers
- Fixed the legend processor `propagateLegendToStore` to better propagate bounds
- Moved the `calculateBounds` function from the layer classes to the `LayerApi` class to better support the layers migration
- Improved the `EventHelper` class to support events with return types (a rare design)
- Patched the 'loaded' status not being propagated correctly to the parent(s) as the children get 'loaded' (big underlying bug there)
- Moved the `LayerStyleChangedEvent` from the `ConfigBaseClass` to the layer class instead as the config should be static as much as possible and the style change only happening on the layer
- Rewritten 2 main functions in geoview-rendered to uncouple the Layer Config from it
- Added 'getters' to `getSourceProjection`, `getMetadataProjection`, `getMetadataExtent` on layer raster classes
- Rewritten all `getBounds()` methods and simplified them by removing a parameter to distinguish the retrieval of bounds from the layer properties and the performing of the union of the extents in the calculation method only
- Improved the `getBounds` on the wms to support more projections according to the projections supported by the metadata
- Changed all new GV Layers to receive a OL Source instead of an OL Layer in their constructors. This allows bridging the gap between config/layer better when it comes to `processOneLayerEntry`
- Fixed an issue preventing the layer-tiles from rendering layer on a map with the same projection as the layer (a `===` vs `==` thing!)
- The new GV Layers class have a function `initOptionsWithInitialSettings` used to regroup all the common code, clarifying a lot the layer initialization
- Added multiple TODOs, cleaned up some types, cleaned up some unnecessary 'as' typings

Fixes #1927 #1999 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted, June 12, 16h00: https://alex-nrcan.github.io/geoview/
Hosted, June 13, 18h15: https://alex-nrcan.github.io/geoview/
Hosted, June 13, 21h00: https://alex-nrcan.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2245)
<!-- Reviewable:end -->
