### PR TITLE
fix(layer-group-visibility) - Fixes when a layer group visibility is false and the sub layers wouldn't get 'loaded'

### DIFF
--- a/packages/geoview-core/public/templates/sandbox.html
+++ b/packages/geoview-core/public/templates/sandbox.html
@@ -205,7 +205,7 @@
           const configArea = document.getElementById('configGeoview');
           const configJSON = JSON.parse(configArea.value.replaceAll(`'`, `"`));
 
-          const validConfig = cgpv.api.configApi.getMapConfig(document.getElementById('configGeoview').value.replaceAll("'", '"'), 'en');
+          const validConfig = cgpv.api.configApi.createMapConfig(document.getElementById('configGeoview').value.replaceAll("'", '"'), 'en');
 
           // set class and message
           message.classList.add('config-json-valid');

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -978,7 +978,6 @@ export abstract class AbstractGeoViewLayer {
     if (initialSettings?.maxZoom !== undefined) layerGroupOptions.maxZoom = initialSettings.maxZoom;
     if (initialSettings?.minZoom !== undefined) layerGroupOptions.minZoom = initialSettings.minZoom;
     if (initialSettings?.states?.opacity !== undefined) layerGroupOptions.opacity = initialSettings.states.opacity;
-    if (initialSettings?.states?.visible !== undefined) layerGroupOptions.visible = initialSettings.states.visible;
 
     // Create the OpenLayer layer
     const layerGroup = new LayerGroup(layerGroupOptions);


### PR DESCRIPTION
# Description

Fixes when a layer group visibility is false and the sub layers wouldn't get 'loaded'.

Fixes #2169

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Pending host

# Checklist:

- [ ] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2268)
<!-- Reviewable:end -->
