### PR TITLE
fix(footerTabs): fix scrollbtns show/hide on footerBar

### DIFF
--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar-style.ts
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar-style.ts
@@ -14,12 +14,8 @@ export const getSxClasses = (theme: Theme): any => ({
     '&.MuiGrid-container': {
       background: theme.palette.geoViewColor.bgColor.dark[50],
     },
-    '& .MuiTabs-root': {
-      height: '56px',
-    },
-    '& .MuiTabs-flexContainer': {
-      alignItems: 'center',
-      height: '56px',
+    '& .MuiButtonBase-root': {
+      minHeight: '56px',
     },
     '& .MuiTabs-indicator': {
       display: 'none',

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -372,19 +372,6 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
         onOpenKeyboard={openModal}
         onCloseKeyboard={closeModal}
         selectedTab={memoFooterBarTabs.findIndex((t) => t.id === selectedTab)}
-        tabsProps={{
-          variant: 'scrollable',
-          scrollButtons: 'auto',
-          allowScrollButtonsMobile: true,
-          sx: {
-            '& .MuiTabs-scrollButtons': {
-              // TODO: https://github.com/Canadian-Geospatial-Platform/geoview/issues/2258
-              [theme.breakpoints.up('lg')]: {
-                visibility: 'hidden',
-              },
-            },
-          },
-        }}
         tabProps={{ disableRipple: true }}
         tabs={memoFooterBarTabs}
         TabContentVisibilty={!isCollapsed ? 'visible' : 'hidden'}

--- a/packages/geoview-core/src/ui/slider/slider.tsx
+++ b/packages/geoview-core/src/ui/slider/slider.tsx
@@ -55,7 +55,7 @@ export function Slider(props: SliderProps): JSX.Element {
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
 
-  const containerId = `${properties.mapId}-${properties.sliderId}` || '';
+  const containerId = `${properties.mapId}-${properties?.sliderId ?? generateId()}` || '';
 
   // internal state
   const [value, setValue] = useState<number[] | number>(parentValue);
@@ -207,29 +207,3 @@ export function Slider(props: SliderProps): JSX.Element {
     />
   );
 }
-
-/**
- * The default props
- */
-// TODO: Refactor - Remove defaultProps as it's no longer a good practice
-Slider.defaultProps = {
-  sliderId: generateId(),
-  className: undefined,
-  style: undefined,
-
-  disabled: false,
-  marks: undefined,
-  orientation: undefined,
-  step: undefined,
-  size: undefined,
-  track: undefined,
-  ariaLabelledby: undefined,
-  valueLabelFormat: undefined,
-
-  onChange: undefined,
-  onChangeCommitted: undefined,
-  onValueDisplay: undefined,
-  onValueDisplayAriaLabel: undefined,
-
-  mapId: undefined,
-};

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -86,7 +86,8 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
   const mapSize = useMapSize();
 
   // show/hide dropdown based on map size
-  const [showMobileDropdown, setShowMobileDropdown] = useState(mapSize[0] < theme.breakpoints.values.sm);
+  const initMobileDropdown = mapSize[0] !== 0 ? mapSize[0] < theme.breakpoints.values.sm : false;
+  const [showMobileDropdown, setShowMobileDropdown] = useState(initMobileDropdown);
 
   /**
    * Update Tab panel when value change from tabs and dropdown.
@@ -175,10 +176,18 @@ export function Tabs(props: TypeTabsProps): JSX.Element {
 
   return (
     <Grid container sx={{ width: '100%', height: '100%' }}>
-      <Grid container sx={{ backgroundColor: theme.palette.geoViewColor.bgColor.dark[100] }} justifyContent="space-between">
+      <Grid container sx={{ backgroundColor: theme.palette.geoViewColor.bgColor.dark[100] }}>
         <Grid item xs={7} sm={10}>
           {!showMobileDropdown ? (
-            <MaterialTabs value={value} onChange={handleChange} aria-label="basic tabs" {...tabsProps}>
+            <MaterialTabs
+              variant="scrollable"
+              scrollButtons
+              allowScrollButtonsMobile
+              value={value}
+              onChange={handleChange}
+              aria-label="basic tabs"
+              {...tabsProps}
+            >
               {tabs.map((tab, index) => {
                 return (
                   <MaterialTab


### PR DESCRIPTION
# Description
Fix the show/hide of the scroll btns of footerBar when window is resize.
Remove default props of Slider

Fixes #2258 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

__Add the URL for your deploy!__
https://kaminderpal.github.io/geoview/add-layers.html
https://kaminderpal.github.io/geoview/demos-navigator.html?config=./configs/navigator/06-basic-footer.json

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
