### PR TITLE
2288-Input and internal config validation

### DIFF
--- a/packages/geoview-core/src/api/config/types/classes/geoview-config/raster-config/esri-dynamic-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/geoview-config/raster-config/esri-dynamic-config.ts
@@ -4,7 +4,7 @@ import { EsriDynamicLayerEntryConfig } from '@config/types/classes/sub-layer-con
 import { GroupLayerEntryConfig } from '@config/types/classes/sub-layer-config/group-layer-entry-config';
 import { TypeJsonObject } from '@config/types/config-types';
 import { TypeDisplayLanguage, TypeLayerInitialSettings } from '@config/types/map-schema-types';
-import { isvalidComparedToSchema } from '@config/utils';
+import { isvalidComparedToInputSchema, isvalidComparedToInternalSchema } from '@config/utils';
 import { MapFeatureConfig } from '@config/types/classes/map-feature-config';
 import { AbstractGeoviewEsriLayerConfig } from '@config/types/classes/geoview-config/abstract-geoview-esri-layer-config';
 import { EntryConfigBaseClass } from '@/api/config/types/classes/sub-layer-config/entry-config-base-class';
@@ -28,8 +28,11 @@ export class EsriDynamicLayerConfig extends AbstractGeoviewEsriLayerConfig {
    */
   constructor(layerConfig: TypeJsonObject, language: TypeDisplayLanguage, mapFeatureConfig?: MapFeatureConfig) {
     super(layerConfig, language, mapFeatureConfig);
-    // Input schema validation.
-    if (!isvalidComparedToSchema(this.geoviewLayerSchema, layerConfig)) this.setErrorDetectedFlag();
+
+    // validate the structure
+    if (!isvalidComparedToInputSchema(this.geoviewLayerSchema, layerConfig)) this.setErrorDetectedFlag();
+    if (!isvalidComparedToInternalSchema(this.geoviewLayerSchema, this, true)) this.setErrorDetectedFlag();
+    // validate the values.
     this.validate();
   }
 

--- a/packages/geoview-core/src/api/config/types/classes/geoview-config/vector-config/esri-feature-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/geoview-config/vector-config/esri-feature-config.ts
@@ -4,7 +4,7 @@ import { EsriFeatureLayerEntryConfig } from '@config/types/classes/sub-layer-con
 import { GroupLayerEntryConfig } from '@config/types/classes/sub-layer-config/group-layer-entry-config';
 import { TypeJsonObject } from '@config/types/config-types';
 import { TypeDisplayLanguage, TypeLayerInitialSettings } from '@config/types/map-schema-types';
-import { isvalidComparedToSchema } from '@config/utils';
+import { isvalidComparedToInputSchema, isvalidComparedToInternalSchema } from '@config/utils';
 import { MapFeatureConfig } from '@config/types/classes/map-feature-config';
 import { AbstractGeoviewEsriLayerConfig } from '@config/types/classes/geoview-config/abstract-geoview-esri-layer-config';
 import { EntryConfigBaseClass } from '@/api/config/types/classes/sub-layer-config/entry-config-base-class';
@@ -28,8 +28,11 @@ export class EsriFeatureLayerConfig extends AbstractGeoviewEsriLayerConfig {
    */
   constructor(layerConfig: TypeJsonObject, language: TypeDisplayLanguage, mapFeatureConfig?: MapFeatureConfig) {
     super(layerConfig, language, mapFeatureConfig);
-    // Input schema validation.
-    if (!isvalidComparedToSchema(this.geoviewLayerSchema, layerConfig)) this.setErrorDetectedFlag();
+
+    // validate the structure
+    if (!isvalidComparedToInputSchema(this.geoviewLayerSchema, layerConfig)) this.setErrorDetectedFlag();
+    if (!isvalidComparedToInternalSchema(this.geoviewLayerSchema, this, true)) this.setErrorDetectedFlag();
+    // validate the values.
     this.validate();
   }
 

--- a/packages/geoview-core/src/api/config/types/classes/map-feature-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/map-feature-config.ts
@@ -18,7 +18,7 @@ import {
   VALID_PROJECTION_CODES,
   CV_MAP_CENTER,
 } from '@config/types/config-constants';
-import { isvalidComparedToSchema } from '@config/utils';
+import { isvalidComparedToInputSchema, isvalidComparedToInternalSchema } from '@config/utils';
 import {
   Extent,
   TypeAppBarProps,
@@ -96,7 +96,7 @@ export class MapFeatureConfig {
    */
   constructor(providedMapFeatureConfig: TypeJsonObject, language: TypeDisplayLanguage) {
     // Input schema validation.
-    this.#errorDetected = !isvalidComparedToSchema(CV_MAP_CONFIG_SCHEMA_PATH, providedMapFeatureConfig);
+    this.#errorDetected = !isvalidComparedToInputSchema(CV_MAP_CONFIG_SCHEMA_PATH, providedMapFeatureConfig);
 
     this.#language = language;
     // set map configuration
@@ -130,6 +130,7 @@ export class MapFeatureConfig {
     this.schemaVersionUsed =
       (providedMapFeatureConfig.schemaVersionUsed as TypeValidVersions) || CV_DEFAULT_MAP_FEATURE_CONFIG.schemaVersionUsed;
     if (this.#errorDetected) this.#makeMapConfigValid(providedMapFeatureConfig); // Tries to apply a correction to invalid properties
+    if (!isvalidComparedToInternalSchema(CV_MAP_CONFIG_SCHEMA_PATH, this)) this.setErrorDetectedFlag();
   }
 
   /**

--- a/packages/geoview-core/src/api/config/types/classes/sub-layer-config/raster-leaf/esri-dynamic-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/sub-layer-config/raster-leaf/esri-dynamic-layer-entry-config.ts
@@ -4,7 +4,7 @@ import { CV_CONST_SUB_LAYER_TYPES, CV_CONST_LEAF_LAYER_SCHEMA_PATH } from '@conf
 import { Cast, TypeJsonObject } from '@config/types/config-types';
 import { AbstractGeoviewLayerConfig } from '@config/types/classes/geoview-config/abstract-geoview-layer-config';
 import { AbstractBaseEsriLayerEntryConfig } from '@config/types/classes/sub-layer-config/abstract-base-esri-layer-entry-config';
-import { isvalidComparedToSchema } from '@config/utils';
+import { isvalidComparedToInputSchema, isvalidComparedToInternalSchema } from '@config/utils';
 import {
   TypeStyleConfig,
   TypeLayerEntryType,
@@ -48,8 +48,9 @@ export class EsriDynamicLayerEntryConfig extends AbstractBaseEsriLayerEntryConfi
       this.setErrorDetectedFlag();
       throw new GeoviewLayerInvalidParameterError('LayerIdInvalidType', [this.layerPath]);
     }
-    // Input schema validation. When the entryType property is undefined, isvalidComparedToSchema uses the input schema.
-    if (!isvalidComparedToSchema(this.schemaPath, layerConfig)) this.setErrorDetectedFlag();
+    // Validate the structure
+    if (!isvalidComparedToInputSchema(this.schemaPath, layerConfig)) this.setErrorDetectedFlag();
+    if (!isvalidComparedToInternalSchema(this.schemaPath, this, true)) this.setErrorDetectedFlag();
   }
 
   /**

--- a/packages/geoview-core/src/api/config/types/classes/sub-layer-config/vector-leaf/esri-feature-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/sub-layer-config/vector-leaf/esri-feature-layer-entry-config.ts
@@ -4,7 +4,7 @@ import { CV_CONST_SUB_LAYER_TYPES, CV_CONST_LEAF_LAYER_SCHEMA_PATH } from '@conf
 import { Cast, TypeJsonObject } from '@config/types/config-types';
 import { AbstractGeoviewLayerConfig } from '@config/types/classes/geoview-config/abstract-geoview-layer-config';
 import { AbstractBaseEsriLayerEntryConfig } from '@config/types/classes/sub-layer-config/abstract-base-esri-layer-entry-config';
-import { isvalidComparedToSchema } from '@config/utils';
+import { isvalidComparedToInputSchema, isvalidComparedToInternalSchema } from '@config/utils';
 import {
   TypeStyleConfig,
   TypeLayerEntryType,
@@ -48,8 +48,9 @@ export class EsriFeatureLayerEntryConfig extends AbstractBaseEsriLayerEntryConfi
       this.setErrorDetectedFlag();
       throw new GeoviewLayerInvalidParameterError('LayerIdInvalidType', [this.layerPath]);
     }
-    // Input schema validation. When the entryType property is undefined, isvalidComparedToSchema uses the input schema.
-    if (!isvalidComparedToSchema(this.schemaPath, layerConfig)) this.setErrorDetectedFlag();
+    // Validate the structure
+    if (!isvalidComparedToInputSchema(this.schemaPath, layerConfig)) this.setErrorDetectedFlag();
+    if (!isvalidComparedToInternalSchema(this.schemaPath, this, true)) this.setErrorDetectedFlag();
   }
 
   /**

--- a/packages/geoview-core/src/api/config/types/config-validation-schema.json
+++ b/packages/geoview-core/src/api/config/types/config-validation-schema.json
@@ -327,6 +327,10 @@
           "description": "The id of the layer for referencing within the viewer (does not relate directly to any external service). The id will have the language extension (id-'lang').",
           "type": "string"
         },
+        "useInternalSchema": {
+          "description": "Flag used to select the type of schema validation to apply (input/internal).",
+          "type": "boolean"
+        },
         "geoviewLayerName": {
           "description": "The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information.",
           "oneOf": [
@@ -751,6 +755,10 @@
         "layerId": {
           "description": "The id of the layer to display on the map.",
           "type": "string"
+        },
+        "useInternalSchema": {
+          "description": "Flag used to select the type of schema validation to apply (input/internal).",
+          "type": "boolean"
         },
         "layerName": {
           "description": "The display name of the layer (English/French). If it is not present the viewer will make an attempt to scrape this information.",

--- a/packages/geoview-core/src/api/config/utils.ts
+++ b/packages/geoview-core/src/api/config/utils.ts
@@ -1,4 +1,5 @@
 import Ajv from 'ajv';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { CV_CONST_SUB_LAYER_TYPES, CV_CONST_LAYER_TYPES } from '@config/types/config-constants';
 import { TypeJsonObject } from '@config/types/config-types';
@@ -6,6 +7,7 @@ import schema from '@config/types/config-validation-schema.json';
 import { MapFeatureConfig } from '@config/types/classes/map-feature-config';
 import { TypeGeoviewLayerType, TypeLayerEntryType, TypeLocalizedString } from '@config/types/map-schema-types';
 import { EntryConfigBaseClass } from '@/api/config/types/classes/sub-layer-config/entry-config-base-class';
+
 import { logger } from '@/core/utils/logger';
 
 type NewType = TypeGeoviewLayerType;
@@ -39,17 +41,13 @@ export const convertLayerTypeToEntry = (layerType: NewType): TypeLayerEntryType 
 
 /**
  * Validate a section of the configuration against the schema identified by the schema path.
- * 
- * Since the useInternalSchema is never provided by the users and set internally before the
- * call to this method, we use it as a flag to indicate the schema type (input/internal) to
- * use for the schema validation.
-
+ *
  * @param {string} schemaPath The path to the schema section to use for the validation.
  * @param {object} targetObject The map feature configuration to validate.
  *
  * @returns {boolean} A boolean indicating that the schema section is valid (true) or invalide (false).
  */
-export function isvalidComparedToSchema(schemaPath: string, targetObject: object): boolean {
+export function isvalidComparedToInputSchema(schemaPath: string, targetObject: object): boolean {
   // create a validator object
   const validator = new Ajv({
     strict: false,
@@ -77,7 +75,6 @@ export function isvalidComparedToSchema(schemaPath: string, targetObject: object
         }
         logger.logWarning('='.repeat(200), '\nSchema error: ', error, '\nObject affected: ', node);
       }
-      (targetObject as MapFeatureConfig | EntryConfigBaseClass)?.setErrorDetectedFlag?.();
       return false;
     }
     return true;
@@ -85,6 +82,31 @@ export function isvalidComparedToSchema(schemaPath: string, targetObject: object
   logger.logError(`Cannot find schema ${schemaPath}`);
   (targetObject as MapFeatureConfig | EntryConfigBaseClass)?.setErrorDetectedFlag?.();
   return false;
+}
+
+/**
+ * Validate a section of the configuration against the schema identified by the schema path.
+ * The internal schema is used internally by the viewer when we instanciate or modify a configuration object
+ * to make sure nothing has been broken and prove that the GeoView metadata are conform.
+ *
+ * Since the useInternalSchema is never provided by the users and set internally before the
+ * validation call, we use it as a flag to indicate we want to use the internal schema type
+ * for the schema validation.
+ *
+ * The addInternalFlag must be set to true when we want to validate a GeoView layer or a sublayer.
+ * All other types have the same definition for the input and internal schemas.
+ *
+ * @param {string} schemaPath The path to the schema section to use for the validation.
+ * @param {object} targetObject The map feature configuration to validate.
+ * @param {boolean} useInternalSchema Adds useInternalSchema flag to the object to be validated.
+ *
+ * @returns {boolean} A boolean indicating that the schema section is valid (true) or invalide (false).
+ */
+export function isvalidComparedToInternalSchema(schemaPath: string, targetObject: object, useInternalSchema = false): boolean {
+  // The clone operation copies only the public properties, no private using #.
+  const targetObjectToValidate: object = cloneDeep(targetObject);
+  if (useInternalSchema) Object.assign(targetObjectToValidate, { useInternalSchema });
+  return isvalidComparedToInputSchema(schemaPath, targetObjectToValidate);
 }
 
 /**


### PR DESCRIPTION
# Description

Making input and internal config validation uniform.

Fixes #2288

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using chrome Devtool to trace and debug the code.

__Deploy URL:__ https://ychoquet.github.io/GeoView/config-sandbox.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2289)
<!-- Reviewable:end -->
