### PR TITLE
fix(time dimension): Missing time extent won't crash layer

### DIFF
--- a/packages/geoview-core/public/configs/elections-canada-2019.json
+++ b/packages/geoview-core/public/configs/elections-canada-2019.json
@@ -1,0 +1,53 @@
+{
+  "map": {
+    "interaction": "dynamic",
+    "viewSettings": {
+      "initialView": {
+        "zoomAndCenter": [4, [-90, 60]]
+      },
+      "projection": 3978
+    },
+    "basemapOptions": {
+      "basemapId": "transport",
+      "shaded": false,
+      "labeled": true
+    },
+    "listOfGeoviewLayerConfig": [
+      {
+        "geoviewLayerId": "polling-division-boudnaries-2019",
+        "geoviewLayerName": {
+          "en": "Polling Division Boundaries of 2019",
+          "fr": "Limites de section de vote de 2019"
+        },
+        "geoviewLayerType": "esriFeature",
+        "initialSettings": {
+          "states": {
+            "visible": true
+          }
+        },
+        "metadataAccessPath": {
+          "en": "https://maps-cartes.services.geo.ca/server_serveur/rest/services/ELECTIONS/elections_canada_2019_en/mapserver",
+          "fr": "https://maps-cartes.services.geo.ca/server_serveur/rest/services/ELECTIONS/elections_canada_2019_fr/mapserver"
+        },
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "2"
+          }
+        ]
+      }
+    ]
+  },
+  "components": ["north-arrow", "overview-map"],
+  "navBar": ["zoom", "fullscreen", "location", "home"],
+  "appBar": {
+    "tabs": {
+      "core": ["geolocator", "legend", "basemap-panel", "export"]
+    }
+  },
+  "footerBar": {
+    "tabs": {
+      "core": ["legend", "layers", "details", "data-table"]
+    }
+  },
+  "theme": "geo.ca"
+}

--- a/packages/geoview-core/public/index.html
+++ b/packages/geoview-core/public/index.html
@@ -62,7 +62,7 @@
 
       <h4>Other</h4>
       <a class="page-link" href="./load-test.html">Performance Test</a>
-      <a class="page-link" href="./outliers.html">Outlier Layers</a>
+      <a class="page-link" href="./outliers.html">Outlier Layer Demo Pages</a>
       <br />
     </div>
   </body>

--- a/packages/geoview-core/public/templates/outliers/outlier-ESRI-feature-polygons.html
+++ b/packages/geoview-core/public/templates/outliers/outlier-ESRI-feature-polygons.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Outlier ESRI Feature - Canadian Geospatial Platform Viewer</title>
+    <link rel="shortcut icon" href="./favicon.ico" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="msapplication-config" content="./img/browserconfig.xml" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="theme-color" content="#ffffff" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto|Montserrat:200,300,400,900|Merriweather" rel="stylesheet" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+
+  <body>
+    <div class="header-table">
+      <table>
+        <tbody>
+          <tr>
+            <td><img class="header-logo" alt="logo" src="./img/Logo.png" /></td>
+            <td class="header-title">
+              <h1><strong>Outlier layer with max record count</strong></h1>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <a href="./index.html">Main</a><br />
+              <a href="./outliers.html">Outlier Layers</a><br />
+            </td>
+          </tr>
+          <tr>
+            <td><p>This page is used to showcase a layer with a max record count of 1000 and 6712 features</p></td>
+          </tr>
+          </tr>
+          <tr>
+            <td>
+              <a href="#HMap1">1. Max Record Count Layer</a><br />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="map-title-holder">
+      <h4 id="HMap1">1. Max Record Count Layer</h4>
+      <a class="ref-link" href="#top">Top</a>
+    </div>
+    <button class="collapsible active">Map Status Flags</button>
+    <pre id="HMap1-state" class="panel map-title-holder"></pre>
+    <hr />
+    <div
+      id="Map1"
+      class="geoview-map"
+      data-lang="en"
+      data-config-url="./configs/max-record-count.json"
+    ></div>
+
+    <div>
+      Outlier Layer:
+      <ul>
+        <li>
+          Advance Polling District - maxRecordCount of 1000, with 6172 features - Issue #2199
+        </li>
+      </ul>
+    </div>
+    <hr />
+
+    <script src="codedoc.js"></script>
+    <script src="layerlib.js"></script>
+    <script>
+      // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
+      cgpv.init((mapId) => {
+          listenToLegendLayerSetChanges('HMap1-state', 'Map1');
+      });
+
+      // create snippets
+      window.addEventListener('load', () => {
+        createCodeSnippet();
+        createConfigSnippet();
+      });
+    </script>
+  </body>
+</html>

--- a/packages/geoview-core/public/templates/outliers/outlier-GeoAI.html
+++ b/packages/geoview-core/public/templates/outliers/outlier-GeoAI.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>High Detail Layer - Canadian Geospatial Platform Viewer</title>
+    <link rel="shortcut icon" href="./favicon.ico" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="msapplication-config" content="./img/browserconfig.xml" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="theme-color" content="#ffffff" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto|Montserrat:200,300,400,900|Merriweather" rel="stylesheet" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+
+  <body>
+    <div class="header-table">
+      <table>
+        <tbody>
+          <tr>
+            <td><img class="header-logo" alt="logo" src="./img/Logo.png" /></td>
+            <td class="header-title">
+              <h1><strong>High Detail Layer</strong></h1>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <a href="./index.html">Main</a><br />
+              <a href="./outliers.html">Outlier Layers</a><br />
+            </td>
+          </tr>
+          <tr>
+            <td><p>This page is used to showcase a highly detailed layer that causes slow down</p></td>
+          </tr>
+          </tr>
+          <tr>
+            <td>
+              <a href="#HMap1">1. Highly detailed layers - slow</a><br />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="map-title-holder">
+      <h4 id="HMap1">1. Highly detailed layers - slow</h4>
+      <a class="ref-link" href="#top">Top</a>
+    </div>
+    <button class="collapsible active">Map Status Flags</button>
+    <pre id="HMap1-state" class="panel map-title-holder"></pre>
+    <hr />
+    <div
+      id="Map1"
+      class="geoview-map"
+      data-lang="en"
+      data-config="{
+        'map': {
+          'interaction': 'dynamic',
+          'viewSettings': {
+            'projection': 3978,
+            'initialView': {
+              'zoomAndCenter': [12, [-71.26, 46.8]]
+            }
+          },
+          'basemapOptions': {
+            'basemapId': 'transport',
+            'shaded': true,
+            'labeled': false
+          },
+          'listOfGeoviewLayerConfig': [
+            {
+              'geoviewLayerId': 'quebec-2006',
+              'geoviewLayerName': {
+                'en': 'Québec 2006'
+              },
+              'metadataAccessPath': {
+                'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/GeoAI_UseCase_en/MapServer'
+              },
+              'geoviewLayerType': 'esriDynamic',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': '8',
+                  'layerName': {
+                    'en': 'Québec 2006'
+                  },
+                  'initialSettings': {
+                    'states': {
+                      'visible': true
+                      }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        'theme': 'geo.ca',
+        'components': ['north-arrow'],
+        'corePackages': [],
+        'appBar': {
+          'tabs': {
+            'core': ['legend', 'export']
+          }
+        },
+        'footerBar': {
+          'tabs': {
+            'core': ['legend', 'layers', 'details', 'data-table']
+          }
+        }
+      }"
+    ></div>
+    <hr />
+
+    <script src="codedoc.js"></script>
+    <script src="layerlib.js"></script>
+    <script>
+      // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
+      cgpv.init((mapId) => {
+          listenToLegendLayerSetChanges('HMap1-state', 'Map1');
+      });
+
+      // create snippets
+      window.addEventListener('load', () => {
+        createCodeSnippet();
+        createConfigSnippet();
+      });
+    </script>
+  </body>
+</html>

--- a/packages/geoview-core/public/templates/outliers/outlier-elections-2019.html
+++ b/packages/geoview-core/public/templates/outliers/outlier-elections-2019.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Outlier Large Layer - Canadian Geospatial Platform Viewer</title>
+    <link rel="shortcut icon" href="./favicon.ico" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="msapplication-config" content="./img/browserconfig.xml" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="theme-color" content="#ffffff" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto|Montserrat:200,300,400,900|Merriweather" rel="stylesheet" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+
+  <body>
+    <div class="header-table">
+      <table>
+        <tbody>
+          <tr>
+            <td><img class="header-logo" alt="logo" src="./img/Logo.png" /></td>
+            <td class="header-title">
+              <h1><strong>Outlier layer with large number of features</strong></h1>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <a href="./index.html">Main</a><br />
+              <a href="./outliers.html">Outlier Layers</a><br />
+            </td>
+          </tr>
+          <tr>
+            <td><p>This page is used to showcase a layer with  many features</p></td>
+          </tr>
+          </tr>
+          <tr>
+            <td>
+              <a href="#HMap1">1. Many Features Layer</a><br />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="map-title-holder">
+      <h4 id="HMap1">1. Many Features Layer</h4>
+      <a class="ref-link" href="#top">Top</a>
+    </div>
+    <button class="collapsible active">Map Status Flags</button>
+    <pre id="HMap1-state" class="panel map-title-holder"></pre>
+    <hr />
+    <div
+      id="Map1"
+      class="geoview-map"
+      data-lang="en"
+      data-config-url="./configs/elections-canada-2019.json"
+    ></div>
+    <hr />
+
+    <script src="codedoc.js"></script>
+    <script src="layerlib.js"></script>
+    <script>
+      // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
+      cgpv.init((mapId) => {
+          listenToLegendLayerSetChanges('HMap1-state', 'Map1');
+      });
+
+      // create snippets
+      window.addEventListener('load', () => {
+        createCodeSnippet();
+        createConfigSnippet();
+      });
+    </script>
+  </body>
+</html>

--- a/packages/geoview-core/public/templates/outliers/outlier-geometry.html
+++ b/packages/geoview-core/public/templates/outliers/outlier-geometry.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Outlier Geometry Layers - Canadian Geospatial Platform Viewer</title>
+    <link rel="shortcut icon" href="./favicon.ico" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="msapplication-config" content="./img/browserconfig.xml" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="theme-color" content="#ffffff" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto|Montserrat:200,300,400,900|Merriweather" rel="stylesheet" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+
+  <body>
+    <div class="header-table">
+      <table>
+        <tbody>
+          <tr>
+            <td><img class="header-logo" alt="logo" src="./img/Logo.png" /></td>
+            <td class="header-title">
+              <h1><strong>Outlier Geometry Layers</strong></h1>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <a href="./index.html">Main</a><br />
+              <a href="./outliers.html">Outlier Layers</a><br />
+            </td>
+          </tr>
+          <tr>
+            <td><p>This page is used to showcase layers with unusual geometries or features</p></td>
+          </tr>
+          </tr>
+          <tr>
+            <td>
+              <a href="#HMap1">1. Outlier Geometry Layers</a><br />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="map-title-holder">
+      <h4 id="HMap1">1. Outlier Geometry Layers</h4>
+      <a class="ref-link" href="#top">Top</a>
+    </div>
+    <button class="collapsible active">Map Status Flags</button>
+    <pre id="HMap1-state" class="panel map-title-holder"></pre>
+    <hr />
+    <div
+      id="Map1"
+      class="geoview-map"
+      data-lang="en"
+      data-config="{
+        'map': {
+          'interaction': 'dynamic',
+          'viewSettings': {
+            'projection': 3978
+          },
+          'basemapOptions': {
+            'basemapId': 'transport',
+            'shaded': false,
+            'labeled': true
+          },
+          'listOfGeoviewLayerConfig': [
+            {
+              'geoviewLayerId': 'EPSG:4617',
+              'geoviewLayerName': { 'en': 'CSRS Layer (EPSG: 4617)' },
+              'metadataAccessPath': {
+                'en': 'https://data.sac-isc.gc.ca/geomatics/rest/services/Donnees_Ouvertes-Open_Data/Communaute_inuite_Inuit_Community/MapServer'
+              },
+              'geoviewLayerType': 'esriDynamic',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': '0',
+                  'layerName': { 'en': 'CSRS Layer' },
+                  'initialSettings': {
+                    'states': {
+                      'visible': true
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              'geoviewLayerId': 'geojsonlyr1',
+              'geoviewLayerName': { 'en': 'Multi Polygon Layer' },
+              'geoviewLayerType': 'GeoJSON',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': 'multipolygon',
+                  'layerName': { 'en': 'Multi Polygon Layer' },
+                  'initialSettings': {
+                    'states': {
+                      'visible': false
+                    }
+                  },
+                  'source': {
+                    'dataAccessPath': {
+                      'en': './datasets/geojson/multipolygons.geojson'
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              'geoviewLayerId': 'featureInfo',
+              'geoviewLayerName': { 'en': 'Coral Sponge 2016' },
+              'metadataAccessPath': {
+                'en': 'https://gisp.dfo-mpo.gc.ca/arcgis/rest/services/FGP/KDE_Analyses_Coral_Sponge_2016_EN/MapServer'
+              },
+              'geoviewLayerType': 'esriDynamic',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': '0',
+                  'layerName': { 'en': 'Coral Sponge 2016' },
+                  'initialSettings': {
+                    'states': {
+                      'visible': false
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              'geoviewLayerId': 'cpcad',
+              'geoviewLayerName': { 'en': 'Protected and conserved area' },
+              'metadataAccessPath': {
+                'en': 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CWS_SCF/CPCAD/MapServer/'
+              },
+              'geoviewLayerType': 'esriDynamic',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': '0',
+                  'layerName': { 'en': 'Protected and conserved area' },
+                  'initialSettings': {
+                    'states': {
+                      'visible': false
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        'components': ['overview-map'],
+        'footerBar': {
+          'tabs': {
+            'core': ['legend', 'layers', 'details', 'data-table']
+          }
+        },
+        'corePackages': [],
+        'theme': 'geo.ca'
+      }"
+    ></div>
+    <hr />
+    <div>
+      Outlier Geometry Layers:
+      <ul>
+        <li>
+          CSRS Layer - EPSG: 4617 - Issue #1798
+        </li>
+        <li>
+          Multi Polygon Layer - Ensure multi polygon is working - Issue #550
+        </li>
+        <li>
+          Coral Sponge - had issues with get feature info - Issue #1996
+        </li>
+        <li>
+          Protected and conserved area - esri dynamic data table not fetching because of geometry in url - Issue #2200
+        </li>
+      </ul>
+    </div>
+
+    <script src="codedoc.js"></script>
+    <script src="layerlib.js"></script>
+    <script>
+      // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
+      cgpv.init((mapId) => {
+          listenToLegendLayerSetChanges('HMap1-state', 'Map1');
+      });
+
+      // create snippets
+      window.addEventListener('load', () => {
+        createCodeSnippet();
+        createConfigSnippet();
+      });
+    </script>
+  </body>
+</html>

--- a/packages/geoview-core/public/templates/outliers/outlier-metadata.html
+++ b/packages/geoview-core/public/templates/outliers/outlier-metadata.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Outlier Metadata Layers - Canadian Geospatial Platform Viewer</title>
+    <link rel="shortcut icon" href="./favicon.ico" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="msapplication-config" content="./img/browserconfig.xml" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="theme-color" content="#ffffff" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto|Montserrat:200,300,400,900|Merriweather" rel="stylesheet" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+
+  <body>
+    <div class="header-table">
+      <table>
+        <tbody>
+          <tr>
+            <td><img class="header-logo" alt="logo" src="./img/Logo.png" /></td>
+            <td class="header-title">
+              <h1><strong>Outlier layers with metadata issues</strong></h1>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <a href="./index.html">Main</a><br />
+              <a href="./outliers.html">Outlier Layers</a><br />
+            </td>
+          </tr>
+          <tr>
+            <td><p>This page is used to showcase layers with unusual or missing metadata</p></td>
+          </tr>
+          </tr>
+          <tr>
+            <td>
+              <a href="#HMap1">1. Metadata Issue Layers</a><br />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="map-title-holder">
+      <h4 id="HMap1">1. Metadata Issue Layers</h4>
+      <a class="ref-link" href="#top">Top</a>
+    </div>
+    <button class="collapsible active">Map Status Flags</button>
+    <pre id="HMap1-state" class="panel map-title-holder"></pre>
+    <hr />
+    <div
+      id="Map1"
+      class="geoview-map"
+      data-lang="en"
+      data-config="{
+        'map': {
+          'interaction': 'dynamic',
+          'viewSettings': {
+            'projection': 3978
+          },
+          'basemapOptions': {
+            'basemapId': 'transport',
+            'shaded': false,
+            'labeled': true
+          },
+          'listOfGeoviewLayerConfig': [
+            {
+              'geoviewLayerId': 'mpmo',
+              'geoviewLayerName': { 'en': 'MPMO - Major Project' },
+              'metadataAccessPath': {
+                'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/MPMO_Major_Projects/MapServer/'
+              },
+              'geoviewLayerType': 'esriFeature',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': '0',
+                  'layerName': { 'en': 'MPMO - Major Project' },
+                  'initialSettings': {
+                    'states': {
+                      'visible': true
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              'geoviewLayerId': 'floods-canada-current-year',
+              'geoviewLayerName': {
+                'en': 'Floods in Canada - Current Year',
+                'fr': 'Inondations au Canada – Année courante'
+              },
+              'metadataAccessPath': {
+                'en': 'https://maps-cartes.services.geo.ca/egs_sgu/rest/services/Flood_Inondation/EGS_Flood_Product_Current_en/MapServer',
+                'fr': 'https://maps-cartes.services.geo.ca/egs_sgu/rest/services/Flood_Inondation/EGS_Flood_Product_Current_fr/MapServer'
+              },
+              'geoviewLayerType': 'esriDynamic',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': '0'
+                },
+                {
+                  'layerId': '1',
+                  'initialSettings' : {
+                    'states' : {
+                      'visible' : false
+                    }
+                  }
+                },
+                {
+                  'layerId': '2',
+                  'initialSettings' : {
+                    'states' : {
+                      'visible' : false
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              'geoviewLayerId': 'permafrost-by-ecoprovince',
+              'geoviewLayerName': { 'en': 'Permafrost by Ecoprovince' },
+              'metadataAccessPath': {
+                'en': 'https://agriculture.canada.ca/atlas/rest/services/mapservices/aafc_national_ecological_framework_of_canada/MapServer'
+              },
+              'geoviewLayerType': 'esriDynamic',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': '33'
+                }
+              ]
+            }
+          ]
+        },
+        'components': ['overview-map'],
+        'footerBar': {
+          'tabs': {
+            'core': ['legend', 'layers', 'details', 'data-table']
+          }
+        },
+        'corePackages': [],
+        'theme': 'geo.ca'
+      }"
+    ></div>
+    <hr />
+    <div>
+      Outlier Layers:
+      <ul>
+        <li>
+          Permafrost - Metadata has no geometry field - Issue #2212
+        </li>
+        <li>
+          Major Project - esri feature layer does not load because of null field value - Issue #2208
+        </li>
+        <li>
+          Floods in Canada - layers are missing time extent - Issue #2251
+        </li>
+      </ul>
+    </div>
+
+    <script src="codedoc.js"></script>
+    <script src="layerlib.js"></script>
+    <script>
+      // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
+      cgpv.init((mapId) => {
+          listenToLegendLayerSetChanges('HMap1-state', 'Map1');
+      });
+
+      // create snippets
+      window.addEventListener('load', () => {
+        createCodeSnippet();
+        createConfigSnippet();
+      });
+    </script>
+  </body>
+</html>

--- a/packages/geoview-core/public/templates/outliers/outlier-style.html
+++ b/packages/geoview-core/public/templates/outliers/outlier-style.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>Unusual Layers - Canadian Geospatial Platform Viewer</title>
+    <title>Outlier Style Layers - Canadian Geospatial Platform Viewer</title>
     <link rel="shortcut icon" href="./favicon.ico" />
     <meta name="msapplication-TileColor" content="#da532c" />
     <meta name="msapplication-config" content="./img/browserconfig.xml" />
@@ -22,7 +22,7 @@
           <tr>
             <td><img class="header-logo" alt="logo" src="./img/Logo.png" /></td>
             <td class="header-title">
-              <h1><strong>Unusual Layers</strong></h1>
+              <h1><strong>Outlier layers with style issues</strong></h1>
             </td>
           </tr>
         </tbody>
@@ -32,6 +32,7 @@
           <tr>
             <td>
               <a href="./index.html">Main</a><br />
+              <a href="./outliers.html">Outlier Layers</a><br />
             </td>
           </tr>
           <tr>
@@ -40,8 +41,7 @@
           </tr>
           <tr>
             <td>
-              <a href="#HMap1">1. Unusual Layers</a><br />
-              <a href="#HMap2">2. More Unusual Layers</a><br />
+              <a href="#HMap1">1. Style Issue Layers</a><br />
             </td>
           </tr>
         </tbody>
@@ -49,7 +49,7 @@
     </div>
 
     <div class="map-title-holder">
-      <h4 id="HMap1">1. Unusual Layers</h4>
+      <h4 id="HMap1">1. Style Issue Layers</h4>
       <a class="ref-link" href="#top">Top</a>
     </div>
     <button class="collapsible active">Map Status Flags</button>
@@ -72,46 +72,6 @@
           },
           'listOfGeoviewLayerConfig': [
             {
-              'geoviewLayerId': 'EPSG:4617',
-              'geoviewLayerName': { 'en': 'CSRS Layer (EPSG: 4617)' },
-              'metadataAccessPath': {
-                'en': 'https://data.sac-isc.gc.ca/geomatics/rest/services/Donnees_Ouvertes-Open_Data/Communaute_inuite_Inuit_Community/MapServer'
-              },
-              'geoviewLayerType': 'esriDynamic',
-              'listOfLayerEntryConfig': [
-                {
-                  'layerId': '0',
-                  'layerName': { 'en': 'CSRS Layer' },
-                  'initialSettings': {
-                    'states': {
-                      'visible': false
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              'geoviewLayerId': 'geojsonlyr1',
-              'geoviewLayerName': { 'en': 'Multi Polygon Layer' },
-              'geoviewLayerType': 'GeoJSON',
-              'listOfLayerEntryConfig': [
-                {
-                  'layerId': 'multipolygon',
-                  'layerName': { 'en': 'Multi Polygon Layer' },
-                  'initialSettings': {
-                    'states': {
-                      'visible': false
-                    }
-                  },
-                  'source': {
-                    'dataAccessPath': {
-                      'en': './datasets/geojson/multipolygons.geojson'
-                    }
-                  }
-                }
-              ]
-            },
-            {
               'geoviewLayerId': 'geojsonlyr2',
               'geoviewLayerName': { 'en': 'Point and Polygon Layer' },
               'geoviewLayerType': 'GeoJSON',
@@ -133,24 +93,6 @@
               ]
             },
             {
-              'geoviewLayerId': 'Canadian Disasters, by Event Type***38633a35',
-              'geoviewLayerName': { 'en': 'Canadian Disasters, by Event Type' },
-              'metadataAccessPath': {
-                'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/PS/canadian_disasters_en/MapServer'
-              },
-              'geoviewLayerType': 'esriFeature',
-              'listOfLayerEntryConfig': [
-                {
-                  'layerId': '0',
-                  'initialSettings': {
-                    'states': {
-                      'visible': false
-                    }
-                  }
-                }
-              ]
-            },
-            {
               'geoviewLayerId': 'HRDEM-dsm-hillshade',
               'geoviewLayerName': { 'en': 'DSM Hillshade' },
               'metadataAccessPath': { 'en': 'https://datacube.services.geo.ca/ows/elevation' },
@@ -159,25 +101,6 @@
                 {
                   'layerId': 'dsm-hillshade',
                   'layerName': { 'en': 'DSM-Hillshade' },
-                  'initialSettings': {
-                    'states': {
-                      'visible': false
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              'geoviewLayerId': 'featureInfo',
-              'geoviewLayerName': { 'en': 'Coral Sponge 2016' },
-              'metadataAccessPath': {
-                'en': 'https://gisp.dfo-mpo.gc.ca/arcgis/rest/services/FGP/KDE_Analyses_Coral_Sponge_2016_EN/MapServer'
-              },
-              'geoviewLayerType': 'esriDynamic',
-              'listOfLayerEntryConfig': [
-                {
-                  'layerId': '0',
-                  'layerName': { 'en': 'Coral Sponge 2016' },
                   'initialSettings': {
                     'states': {
                       'visible': false
@@ -206,44 +129,6 @@
               ]
             },
             {
-              'geoviewLayerId': 'mpmo',
-              'geoviewLayerName': { 'en': 'MPMO - Major Project' },
-              'metadataAccessPath': {
-                'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/MPMO_Major_Projects/MapServer/'
-              },
-              'geoviewLayerType': 'esriFeature',
-              'listOfLayerEntryConfig': [
-                {
-                  'layerId': '0',
-                  'layerName': { 'en': 'MPMO - Major Project' },
-                  'initialSettings': {
-                    'states': {
-                      'visible': false
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              'geoviewLayerId': 'cpcad',
-              'geoviewLayerName': { 'en': 'Protected and conserved area' },
-              'metadataAccessPath': {
-                'en': 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CWS_SCF/CPCAD/MapServer/'
-              },
-              'geoviewLayerType': 'esriDynamic',
-              'listOfLayerEntryConfig': [
-                {
-                  'layerId': '0',
-                  'layerName': { 'en': 'Protected and conserved area' },
-                  'initialSettings': {
-                    'states': {
-                      'visible': false
-                    }
-                  }
-                }
-              ]
-            },
-            {
               'geoviewLayerId': 'FSI',
               'geoviewLayerName': { 'en': 'Flood susceptibility index' },
               'metadataAccessPath': {
@@ -254,6 +139,24 @@
                 {
                   'layerId': 'FS-national-2015-index',
                   'layerName': { 'en': 'Flood susceptibility index' }
+                }
+              ]
+            },
+            {
+              'geoviewLayerId': 'Canadian Disasters, by Event Type***38633a35',
+              'geoviewLayerName': { 'en': 'Canadian Disasters, by Event Type' },
+              'metadataAccessPath': {
+                'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/PS/canadian_disasters_en/MapServer'
+              },
+              'geoviewLayerType': 'esriFeature',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': '0',
+                  'initialSettings': {
+                    'states': {
+                      'visible': false
+                    }
+                  }
                 }
               ]
             }
@@ -274,28 +177,13 @@
       Outlier Layers:
       <ul>
         <li>
-          CSRS Layer - EPSG: 4617 - Issue #1798
-        </li>
-        <li>
-          Multi Polygon Layer - Ensure multi polygon is working - Issue #550
-        </li>
-        <li>
           Point and Polygon Layer - Style for only one geometry was used - Issue #2017
         </li>
         <li>
           DSM Hillshade - Error from service not providing style - Issue #1891
         </li>
         <li>
-          Coral Sponge - had issues with get feature info - Issue #1996
-        </li>
-        <li>
           CESI - conserved areas layer was not showing in legend (layer moved - now appears as empty layer) - Issue #1816
-        </li>
-        <li>
-          Major Project - esri feature layer does not load because of null field value - Issue #2208
-        </li>
-        <li>
-          Protected and conserved area - esri dynamic data table not featching because of geometry in url - Issue #2200
         </li>
         <li>
           Flood susceptibility index - no default style, so no image legend - Issue #2220
@@ -306,35 +194,12 @@
       </ul>
     </div>
 
-    <div class="map-title-holder">
-      <h4 id="HMap2">2. More Unusual Layers</h4>
-      <a class="ref-link" href="#top">Top</a>
-    </div>
-    <button class="collapsible active">Map Status Flags</button>
-    <pre id="HMap2-state" class="panel map-title-holder"></pre>
-    <hr />
-    <div
-      id="Map2"
-      class="geoview-map"
-      data-lang="en"
-      data-config-url="./configs/max-record-count.json"
-    ></div>
-    <div>
-      More Outlier Layers:
-      <ul>
-        <li>
-          Advance Polling District - maxRecordCount of 1000, with 6172 features - Issue #2199
-        </li>
-      </ul>
-    </div>
-
     <script src="codedoc.js"></script>
     <script src="layerlib.js"></script>
     <script>
       // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
       cgpv.init((mapId) => {
           listenToLegendLayerSetChanges('HMap1-state', 'Map1');
-          listenToLegendLayerSetChanges('HMap2-state', 'Map2');
       });
 
       // create snippets

--- a/packages/geoview-core/public/templates/outliers/outliers.html
+++ b/packages/geoview-core/public/templates/outliers/outliers.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Outlier Layer Demos - Canadian Geospatial Platform Viewer</title>
+    <link rel="shortcut icon" href="./favicon.ico" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="msapplication-config" content="./img/browserconfig.xml" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="theme-color" content="#ffffff" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto|Montserrat:200,300,400,900|Merriweather" rel="stylesheet" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+
+  <body>
+    <div>
+      <img class="center-logo header-logo" alt="logo" src="./img/Logo.png" />
+      <h1 class="index-header-title"><strong>Outlier Demos</strong></h1>
+      <h2 class="index-header-title"><strong>Plateforme Géospatiale Canadienne (PGC) - Projet GeoView -</strong></h2>
+      <h2 class="index-header-title"><strong>Canadian Geospatial Platform (CGP) - GeoView Project -</strong></h2>
+      <hr />
+      <hr />
+      <a href="./index.html">Main</a>
+      <br />
+      <br />
+      <h4>Outlier Layers</h4>
+      <a href="./outlier-style.html">Style Issues</a><br />
+      <a href="./outlier-geometry.html">Feature Issues</a><br />
+      <a href="./outlier-metadata.html">Metadata Issues</a><br />
+      <h4>Performance Issue (Huge) Layers</h4>
+      <a href="./outlier-ESRI-feature-polygons.html">Max Record Count with 6712 Polygons</a><br />
+      <a href="./outlier-GeoAI.html">GeoAI</a><br />
+      <a href="./outlier-elections-2019.html">Elections 2019</a><br />
+      <br />
+    </div>
+  </body>
+</html>

--- a/packages/geoview-core/src/api/config/types/classes/geoview-config/abstract-geoview-esri-layer-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/geoview-config/abstract-geoview-esri-layer-config.ts
@@ -175,7 +175,7 @@ export abstract class AbstractGeoviewEsriLayerConfig extends AbstractGeoviewLaye
     const queryUrl = serviceUrl.endsWith('/') ? `${serviceUrl}${subLayerConfig.layerId}` : `${serviceUrl}/${subLayerConfig.layerId}`;
 
     try {
-      const { data } = await axios.get<TypeJsonObject>(`${queryUrl}?f=pjson`);
+      const { data } = await axios.get<TypeJsonObject>(`${queryUrl}?f=json`);
       if ('error' in data) logger.logError('Error detected while reading layer metadata.', data.error);
       else return data;
     } catch (error) {

--- a/packages/geoview-core/src/api/config/types/classes/sub-layer-config/abstract-base-esri-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/sub-layer-config/abstract-base-esri-layer-entry-config.ts
@@ -22,7 +22,7 @@ export abstract class AbstractBaseEsriLayerEntryConfig extends AbstractBaseLayer
     const queryUrl = serviceUrl.endsWith('/') ? `${serviceUrl}${this.layerId}` : `${serviceUrl}/${this.layerId}`;
 
     try {
-      const { data } = await axios.get<TypeJsonObject>(`${queryUrl}?f=pjson`);
+      const { data } = await axios.get<TypeJsonObject>(`${queryUrl}?f=json`);
       if ('error' in data) logger.logError('Error detected while reading layer metadata.', data.error);
       else this.metadata = data;
     } catch (error) {

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -161,7 +161,13 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
           </Grid>
         )}
         {layerDetails.items.map((item) => (
-          <Grid container direction="row" key={item.name} justifyContent="center" alignItems="stretch">
+          <Grid
+            container
+            direction="row"
+            key={`${item.name}/${layerDetails.items.indexOf(item)}`}
+            justifyContent="center"
+            alignItems="stretch"
+          >
             <Grid item xs="auto">
               {renderItemCheckbox(item)}
             </Grid>

--- a/packages/geoview-core/src/core/components/legend/legend-layer.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer.tsx
@@ -159,7 +159,7 @@ export function LegendLayer({ layer }: LegendLayerProps): JSX.Element {
     return (
       <List sx={sxClasses.subList}>
         {layer.items.map((item) => (
-          <ListItem key={`${item.icon}/${item.name}`} className={!item.isVisible ? 'unchecked' : ''}>
+          <ListItem key={`${item.icon}/${item.name}/${layer.items.indexOf(item)}`} className={!item.isVisible ? 'unchecked' : ''}>
             <ListItemIcon>{item.icon ? <Box component="img" alt={item.name} src={item.icon} /> : <BrowserNotSupportedIcon />}</ListItemIcon>
             <Tooltip title={item.name} placement="top" enterDelay={1000}>
               <ListItemText primary={item.name} />

--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -74,37 +74,37 @@ export class Basemap {
     3978: {
       transport: {
         url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer/WMTS/tile/1.0.0/CBMT_CBCT_GEOM_3978/default/default028mm/{z}/{y}/{x}.jpg',
-        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer?f=pjson',
+        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer?f=json',
       },
       simple: {
         url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer/WMTS/tile/1.0.0/Simple/default/default028mm/{z}/{y}/{x}.jpg',
-        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer?f=pjson',
+        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer?f=json',
       },
       shaded: {
         url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer/WMTS/tile/1.0.0/CBMT_CBCT_GEOM_3978/default/default028mm/{z}/{y}/{x}.jpg',
-        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer?f=pjson',
+        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer?f=json',
       },
       label: {
         url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/xxxx_TXT_3978/MapServer/WMTS/tile/1.0.0/xxxx_TXT_3978/default/default028mm/{z}/{y}/{x}.jpg',
-        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/xxxx_TXT_3978/MapServer?f=pjson',
+        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/xxxx_TXT_3978/MapServer?f=json',
       },
     },
     3857: {
       transport: {
         url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3857/MapServer/WMTS/tile/1.0.0/BaseMaps_CBMT_CBCT_GEOM_3857/default/default028mm/{z}/{y}/{x}.jpg',
-        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3857/MapServer?f=pjson',
+        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3857/MapServer?f=json',
       },
       simple: {
         url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer/WMTS/tile/1.0.0/Simple/default/default028mm/{z}/{y}/{x}.jpg',
-        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer?f=pjson',
+        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer?f=json',
       },
       shaded: {
         url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer/WMTS/tile/1.0.0/CBMT_CBCT_GEOM_3978/default/default028mm/{z}/{y}/{x}.jpg',
-        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer?f=pjson',
+        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer?f=json',
       },
       label: {
         url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/xxxx_TXT_3857/MapServer/WMTS/tile/1.0.0/xxxx_TXT_3857/default/default028mm/{z}/{y}/{x}.jpg',
-        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/xxxx_TXT_3857/MapServer?f=pjson',
+        jsonUrl: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/xxxx_TXT_3857/MapServer?f=json',
       },
     },
   });

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -251,7 +251,7 @@ export function commonProcessTemporalDimension(
   layerConfig: EsriFeatureLayerEntryConfig | EsriDynamicLayerEntryConfig | EsriImageLayerEntryConfig,
   singleHandle?: boolean
 ): void {
-  if (esriTimeDimension !== undefined) {
+  if (esriTimeDimension !== undefined && esriTimeDimension.timeExtent) {
     layer.setTemporalDimension(
       layerConfig.layerPath,
       DateMgt.createDimensionFromESRI(Cast<TimeDimensionESRI>(esriTimeDimension), singleHandle)
@@ -300,7 +300,7 @@ export function commonProcessFeatureInfoConfig(
       }
       if (processAliasFields) layerConfig.source.featureInfo.aliasFields = { en: '' };
       (layerMetadata.fields as TypeJsonArray).forEach((fieldEntry) => {
-        if (fieldEntry?.name === layerMetadata.geometryField.name) return;
+        if (layerMetadata.geometryField && fieldEntry?.name === layerMetadata.geometryField.name) return;
         if (processOutField) {
           layerConfig.source.featureInfo!.outfields!.en = `${layerConfig.source.featureInfo!.outfields!.en}${fieldEntry.name},`;
           const fieldType = commonGetFieldType(layer, fieldEntry.name as string, layerConfig);
@@ -395,7 +395,7 @@ export async function commonProcessLayerMetadata<
     if (layerConfig.geoviewLayerConfig.geoviewLayerType !== CONST_LAYER_TYPES.ESRI_IMAGE)
       queryUrl = queryUrl.endsWith('/') ? `${queryUrl}${layerConfig.layerId}` : `${queryUrl}/${layerConfig.layerId}`;
     try {
-      const { data } = await axios.get<TypeJsonObject>(`${queryUrl}?f=pjson`);
+      const { data } = await axios.get<TypeJsonObject>(`${queryUrl}?f=json`);
       if (data?.error) {
         layerConfig.layerStatus = 'error';
         throw new Error(`Error code = ${data.error.code}, ${data.error.message}`);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
@@ -139,7 +139,7 @@ export class EsriImage extends AbstractGeoViewRaster {
       const legendUrl = `${getLocalizedValue(
         layerConfig.geoviewLayerConfig.metadataAccessPath,
         AppEventProcessor.getDisplayLanguage(this.mapId)
-      )}/legend?f=pjson`;
+      )}/legend?f=json`;
       const response = await fetch(legendUrl);
       const legendJson: TypeEsriImageLayerLegend = await response.json();
       let legendInfo;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -235,7 +235,7 @@ export class EsriFeature extends AbstractGeoViewVector {
     // eslint-disable-next-line no-param-reassign
     sourceOptions.url = getLocalizedValue(layerConfig.source!.dataAccessPath!, AppEventProcessor.getDisplayLanguage(this.mapId));
     // eslint-disable-next-line no-param-reassign
-    sourceOptions.url = `${sourceOptions.url}/${layerConfig.layerId}/query?f=pjson&outfields=*&where=1%3D1`;
+    sourceOptions.url = `${sourceOptions.url}/${layerConfig.layerId}/query?f=json&outfields=*&where=1%3D1`;
     // eslint-disable-next-line no-param-reassign
     sourceOptions.format = new EsriJSON();
 

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
@@ -109,7 +109,7 @@ export class GVEsriImage extends AbstractGVRaster {
       const legendUrl = `${getLocalizedValue(
         layerConfig.geoviewLayerConfig.metadataAccessPath,
         AppEventProcessor.getDisplayLanguage(this.getMapId())
-      )}/legend?f=pjson`;
+      )}/legend?f=json`;
       const response = await fetch(legendUrl);
       const legendJson: TypeEsriImageLayerLegend = await response.json();
       let legendInfo;

--- a/packages/geoview-core/webpack.common.js
+++ b/packages/geoview-core/webpack.common.js
@@ -54,6 +54,18 @@ const multipleHtmlPluginsDemos = glob.sync('./public/templates/demos/*.html').ma
   });
 });
 
+// inject all outlier files
+const multipleHtmlPluginsOutliers = glob.sync('./public/templates/outliers/*.html').map((name) => {
+  return new HtmlWebpackPlugin({
+    template: `${name}`,
+    filename: `${name.substring(name.lastIndexOf('/') + 1, name.length)}`,
+    title: 'Canadian Geospatial Platform Viewer',
+    inject: 'head',
+    scriptLoading: 'blocking',
+    chunks: ['cgpv-main'],
+  });
+});
+
 const config = {
   entry: {
     'cgpv-main': './src/app.tsx',
@@ -186,7 +198,8 @@ const config = {
   ]
     .concat(multipleHtmlPluginsSamples)
     .concat(multipleHtmlPluginsLayers)
-    .concat(multipleHtmlPluginsDemos),
+    .concat(multipleHtmlPluginsDemos)
+    .concat(multipleHtmlPluginsOutliers),
 };
 
 module.exports = config;


### PR DESCRIPTION
Closes #2212 
Closes #2251
Also split outlier demo page

# Description

Fixed bug where a missing time extent would cause the layer to fail. Also split outlier demo page into a few, and added a small performance boost for layer loading. Fixes ESRI layers with no geometryField not loading.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/outliers.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2292)
<!-- Reviewable:end -->
