### PR TITLE
2302-BUG WMS getFeatureInfo Correction

### DIFF
--- a/packages/geoview-core/public/templates/layers/wms.html
+++ b/packages/geoview-core/public/templates/layers/wms.html
@@ -88,11 +88,7 @@
                           'layerId': 'CURRENT_CONDITIONS',
                           'source': {
                             'featureInfo': {
-                              'queryable': true,
-                              'nameField': { 'en': 'plain_text', 'fr': 'plain_texte' },
-                              'fieldTypes': 'string',
-                              'outfields': { 'en': 'plain_text', 'fr': 'plain_texte' },
-                              'aliasFields':  { 'en': 'Forcast', 'fr': 'Prévision' }
+                              'queryable': true
                             }
                           }
                         },
@@ -142,6 +138,19 @@
                       'source': {
                         'style': 'Radar-Snow_14colors'
                       }
+                    }
+                  ]
+                },
+                {
+                  'geoviewLayerId': 'LYR1',
+                  'geoviewLayerName': { 'en': 'Canada Energy Regulator' },
+                  'metadataAccessPath': {
+                    'en': 'https://maps-cartes.services.geo.ca/server_serveur/services/NRCan/CER_Assessments_EN/MapServer/WMSServer'
+                  },
+                  'geoviewLayerType': 'ogcWms',
+                  'listOfLayerEntryConfig': [
+                    {
+                      'layerId': '0'
                     }
                   ]
                 }

--- a/packages/geoview-core/src/api/plugin/abstract-plugin.ts
+++ b/packages/geoview-core/src/api/plugin/abstract-plugin.ts
@@ -25,7 +25,7 @@ export abstract class AbstractPlugin {
   // Plugin properties
   pluginProps: TypePluginOptions;
 
-  // NOTE START !! ****************************************************************************************************
+  // #region NOTE START
   // The following attributes are attached, after instantiation, by the plugin loader addPlugin function ref 'Object.defineProperties'(!)
   // In this refactoring at the time of coding, I'm, simply, explicitely, writing them here so it's clear that this AbstractPlugin class has (and expects) those attributes.
   // See plugin.addPlugin function for more details.
@@ -47,7 +47,7 @@ export abstract class AbstractPlugin {
   // TODO: Refactor - Plugin - Maybe useTheme is not necessary here.. This might get removed eventually. Don't forget to remove in plugin class too in 'Object.defineProperties'(!)
   useTheme?: typeof useTheme;
 
-  // NOTE END !! ******************************************************************************************************
+  // #region NOTE END
 
   /**
    * Constructs a Plugin


### PR DESCRIPTION
# Description

Geoview WMS layer implementation doesn't read properly the information returned by a getFeatureInfo processed by esri WMS services. A small adjustment to the code would resolve this issue.

Fixes #2302

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using Chrome Devtool to trace and debug the code.

__Deploy URL:__ https://ychoquet.github.io/GeoView/wms.html (use getFeatureInfo on Current Conditions and Canada Energy Regulator)

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2308)
<!-- Reviewable:end -->
