### PR TITLE
fix(initialView): zoom to layer more consistent

### DIFF
--- a/packages/geoview-core/public/configs/navigator/05-zoom-layer.json
+++ b/packages/geoview-core/public/configs/navigator/05-zoom-layer.json
@@ -3,7 +3,7 @@
     "interaction": "dynamic",
     "viewSettings": {
       "initialView": {
-        "layerIds": ["polygons.json", "lines.json"]
+        "layerIds": ["geojsonLYR1/geojsonLYR1/polygons.json", "geojsonLYR1/geojsonLYR1/lines.json"]
       },
       "projection": 3978
     },

--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -1566,7 +1566,7 @@
           "items": {
             "type": "string"
           },
-          "description": "ID(s) of layer(s) to use as initial map focus."
+          "description": "Geoview layer ID(s) or layer path(s) of layer(s) to use as initial map focus."
         }
       }
     },

--- a/packages/geoview-core/src/api/config/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/config/types/map-schema-types.ts
@@ -206,7 +206,7 @@ export type TypeMapViewSettings = {
    * Option to set initial view by extent.
    * Called with [minX, minY, maxX, maxY] extent coordinates. */
   extent?: Extent;
-  /** IDs of layers to use for initial map extent. */
+  /** Geoview layer ID(s) or layer path(s) of layer(s) to use as initial map focus. */
   layerIds?: string[];
 };
 

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -85,12 +85,24 @@ export class LegendEventProcessor extends AbstractEventProcessor {
     const layers = LegendEventProcessor.getLayerState(mapId).legendLayers;
     const layer = this.findLayerByPath(layers, layerPath);
 
+    // If layer bounds are not set, or have infinity (can be due to setting before features load), recalculate
+    if (layer && (!layer.bounds || layer.bounds?.includes(Infinity))) {
+      const newBounds = MapEventProcessor.getMapViewerLayerAPI(mapId).calculateBounds(layerPath);
+      if (newBounds) {
+        // Set layer bounds
+        layer.bounds = newBounds;
+
+        // Set updated legend layers
+        this.getLayerState(mapId).setterActions.setLegendLayers(layers);
+      }
+    }
+
     // If found and bounds found
     if (layer && layer.bounds) {
       return layer.bounds;
     }
 
-    // No bounds founds
+    // No bounds found
     return undefined;
   }
 

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -17,7 +17,7 @@ import { CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-l
 import { Projection } from '@/geo/utils/projection';
 import { GeoviewStoreType } from '@/core/stores/geoview-store';
 import { getGeoViewStore } from '@/core/stores/stores-managers';
-import { NORTH_POLE_POSITION, OL_ZOOM_DURATION, OL_ZOOM_PADDING } from '@/core/utils/constant';
+import { NORTH_POLE_POSITION, OL_ZOOM_DURATION, OL_ZOOM_MAXZOOM, OL_ZOOM_PADDING } from '@/core/utils/constant';
 import { logger } from '@/core/utils/logger';
 import { whenThisThen } from '@/core/utils/utilities';
 
@@ -699,12 +699,12 @@ export class MapEventProcessor extends AbstractEventProcessor {
    *
    * @param {string} mapId The map id.
    * @param {Extent} extent The extent to zoom to.
-   * @param {FitOptions} options The options to configure the zoomToExtent (default: { padding: [100, 100, 100, 100], maxZoom: 11 }).
+   * @param {FitOptions} options The options to configure the zoomToExtent (default: { padding: [100, 100, 100, 100], maxZoom: 11, duration: 500 }).
    */
   static zoomToExtent(
     mapId: string,
     extent: Extent,
-    options: FitOptions = { padding: [100, 100, 100, 100], maxZoom: 11, duration: 1000 }
+    options: FitOptions = { padding: OL_ZOOM_PADDING, maxZoom: OL_ZOOM_MAXZOOM, duration: OL_ZOOM_DURATION }
   ): Promise<void> {
     // Validate the extent coordinates
     if (
@@ -719,7 +719,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
       return new Promise((resolve) => {
         setTimeout(() => {
           resolve();
-        }, (options.duration || 1000) + 150);
+        }, (options.duration || OL_ZOOM_DURATION) + 150);
       });
       // The +150 is to make sure the logic before turning these function async remains
       // TODO: Refactor - Check the +150 relevancy and try to remove it by clarifying the reason for its existance

--- a/packages/geoview-core/src/core/utils/constant.ts
+++ b/packages/geoview-core/src/core/utils/constant.ts
@@ -10,6 +10,8 @@ export const GEO_URL_TEXT = {
 // OpenLayer constants
 export const OL_ZOOM_DURATION = 500;
 
+export const OL_ZOOM_MAXZOOM = 11;
+
 // The north pole position use for north arrow marker and get north arrow rotation angle
 // north value (set longitude to be half of Canada extent (142° W, 52° W)) - projection central meridian is -95
 export const NORTH_POLE_POSITION: [number, number] = [90, -95];


### PR DESCRIPTION
Closes #2274

# Description

Improves the consistency of zooming to a layer extent on initial map load.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with: https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/05-zoom-layer.json

Also checked with all layers in: https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/06-basic-footer.json
And some on: https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/10-package-time-slider.json

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2314)
<!-- Reviewable:end -->
