### PR TITLE
fix(performance): no prefetch for layers table

### DIFF
--- a/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
@@ -137,18 +137,15 @@ export default function DataTableModal(): JSX.Element {
 
   useEffect(() => {
     // Log
-    logger.logTraceUseEffect('DATA-TABLE-MODAL - isLoading', isLoading, selectedLayer);
+    logger.logTraceUseEffect('DATA-TABLE-MODAL - query status');
 
-    const clearLoading = setTimeout(
-      () => {
-        setIsLoading(false);
-      },
-      // set timeout delay 1 sec when layer has more than 100 features.
-      (layer?.features?.length ?? 0) > 100 ? 1000 : 0
-    );
-    return () => clearTimeout(clearLoading);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading, selectedLayer]);
+    // Get feature info result for selected layer to check if it is loading
+    const selectedLayerData = layersData.find((_layer) => _layer.layerPath === selectedLayer);
+
+    if (selectedLayerData?.queryStatus !== 'error' && selectedLayerData?.queryStatus !== 'processed') {
+      setIsLoading(true);
+    } else setIsLoading(false);
+  }, [layersData, selectedLayer]);
 
   return (
     <Dialog open={activeModalId === 'layerDataTable'} onClose={closeModal} maxWidth="xl">

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -29,12 +29,7 @@ import { DeleteUndoButton } from './delete-undo-button';
 import { LayersList } from './layers-list';
 import { LayerIcon } from '@/core/components/common/layer-icon';
 import { logger } from '@/core/utils/logger';
-import {
-  useDataTableLayerSettings,
-  useDataTableStoreActions,
-  useDataTableAllFeaturesDataArray,
-} from '@/core/stores/store-interface-and-intial-values/data-table-state';
-import { LAYER_STATUS } from '@/core/utils/constant';
+import { useDataTableLayerSettings, useDataTableStoreActions } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { ArrowDownwardIcon, ArrowUpIcon, TableViewIcon } from '@/ui/icons';
 import { Divider } from '@/ui/divider/divider';
 
@@ -75,9 +70,7 @@ export function SingleLayer({
   const displayState = useLayerDisplayState();
   const datatableSettings = useDataTableLayerSettings();
 
-  const layerData = useDataTableAllFeaturesDataArray();
-
-  const { triggerGetAllFeatureInfo } = useDataTableStoreActions();
+  useDataTableStoreActions();
 
   const legendExpanded = !getLegendCollapsedFromOrderedLayerInfo(layer.layerPath);
 
@@ -163,16 +156,6 @@ export function SingleLayer({
     setSelectedLayerPath(layer.layerPath);
     if (setIsLayersListPanelVisible) {
       setIsLayersListPanelVisible(true);
-      // trigger the fetching of the features when not available OR when layer status is in error
-      if (
-        !layerData.filter((layers) => layers.layerPath === layer.layerPath && !!layers?.features?.length).length ||
-        layer.layerStatus === LAYER_STATUS.ERROR
-      ) {
-        triggerGetAllFeatureInfo(layer.layerPath).catch((error) => {
-          // Log
-          logger.logPromiseFailed('Failed to triggerGetAllFeatureInfo in single-layer.handleLayerClick', error);
-        });
-      }
     }
   };
 


### PR DESCRIPTION
Closes #2300
Closes #2271

# Description

Get all features is only triggered once the button is clicked in the layers panel

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested mainly with outlier-GeoAI.html, and several others.

# Checklist:

- [ ] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2326)
<!-- Reviewable:end -->
