### PR TITLE
fix(datatable): ESRI Dynamic zoom in data table fixed

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -10284,7 +10284,7 @@ packages:
       webpack: 5.92.1(webpack-cli@4.10.0)
       webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@4.15.2)(webpack@5.92.1)
       webpack-dev-middleware: 5.3.4(webpack@5.92.1)
-      ws: 8.17.1
+      ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -10492,8 +10492,8 @@ packages:
         optional: true
     dev: true
 
-  /ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+  /ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -106,6 +106,17 @@ export class LegendEventProcessor extends AbstractEventProcessor {
     return undefined;
   }
 
+  /**
+   * Get the extent of a feature or group of features
+   * @param {string} mapId - The map identifier
+   * @param {string} layerPath - The layer path
+   * @param {string[]} objectIds - The IDs of features to get extents from.
+   * @returns {Promise<Extent | undefined>} The extent of the feature, if available
+   */
+  static getExtentFromFeatures(mapId: string, layerPath: string, objectIds: string[]): Promise<Extent | undefined> | undefined {
+    return MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayerHybrid(layerPath)?.getExtentFromFeatures(layerPath, objectIds);
+  }
+
   static getLayerIconImage(layerLegend: TypeLegend | null): TypeLegendLayerItem[] | undefined {
     // TODO: Refactor - Move this function to a utility class instead of at the 'processor' level so it's safer to call from a layer framework level class
     const iconDetails: TypeLegendLayerItem[] = [];

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -28,6 +28,7 @@ export interface ILayerState {
 
   actions: {
     deleteLayer: (layerPath: string) => void;
+    getExtentFromFeatures: (layerPath: string, featureIds: string[]) => Promise<Extent | undefined>;
     getLayer: (layerPath: string) => TypeLegendLayer | undefined;
     getLayerBounds: (layerPath: string) => number[] | undefined;
     getLayerDeleteInProgress: () => boolean;
@@ -74,6 +75,11 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
       deleteLayer: (layerPath: string): void => {
         LegendEventProcessor.deleteLayer(get().mapId, layerPath);
         get().layerState.setterActions.setLayerDeleteInProgress(false);
+      },
+
+      getExtentFromFeatures: (layerPath: string, featureIds: string[]) => {
+        // Redirect to event processor
+        return LegendEventProcessor.getExtentFromFeatures(get().mapId, layerPath, featureIds);
       },
 
       /**

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -1462,6 +1462,19 @@ export abstract class AbstractGeoViewLayer {
    */
   abstract getBounds(layerPath: string): Extent | undefined;
 
+  /**
+   * Overridable function that gets the extent of an array of features.
+   * @param {string} layerPath - The layer path
+   * @param {string[]} objectIds - The IDs of features to get extents from.
+   * @returns {Promise<Extent | undefined>} The extent of the features, if available
+   */
+  // Added eslint-disable here, because we do want to override this method in children and keep 'this'.
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  getExtentFromFeatures(layerPath: string, objectIds: string[]): Promise<Extent | undefined> {
+    logger.logError(`Feature geometry for ${objectIds} is unavailable from ${layerPath}`);
+    return Promise.resolve(undefined);
+  }
+
   /** ***************************************************************************************************************************
    * Set the layerStatus code of all layers in the listOfLayerEntryConfig.
    *

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -138,6 +138,19 @@ export abstract class AbstractGVLayer {
   abstract getBounds(layerPath: string): Extent | undefined;
 
   /**
+   * Overridable function that gets the extent of an array of features.
+   * @param {string} layerPath - The layer path
+   * @param {string[]} objectIds - The IDs of the features to calculate the extent from.
+   * @returns {Promise<Extent | undefined>} The extent of the features, if available
+   */
+  // Added eslint-disable here, because we do want to override this method in children and keep 'this'.
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  getExtentFromFeatures(layerPath: string, objectIds: string[]): Promise<Extent | undefined> {
+    logger.logError(`Feature geometry for ${objectIds} is unavailable from ${layerPath}`);
+    return Promise.resolve(undefined);
+  }
+
+  /**
    * Initializes the GVLayer. This function checks if the source is ready and if so it calls onLoaded() to pursue initialization of the layer.
    * If the source isn't ready, it registers to the source ready event to pursue initialization of the layer once its source is ready.
    */

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -28,6 +28,7 @@ import {
 } from '@/geo/map/map-schema-types';
 import { esriGetFieldType, esriGetFieldDomain } from '../utils';
 import { AbstractGVRaster } from './abstract-gv-raster';
+import { getMinOrMaxExtents } from '@/geo/utils/utilities';
 
 type TypeFieldOfTheSameValue = { value: string | number | Date; nbOccurence: number };
 type TypeQueryTree = { fieldValue: string | number | Date; nextField: TypeQueryTree }[];
@@ -670,5 +671,55 @@ export class GVEsriDynamic extends AbstractGVRaster {
 
     // Return the calculated layer bounds
     return layerBounds;
+  }
+
+  /**
+   * Sends a query to get ESRI Dynamic feature geometries and calculates an extent from them.
+   * @param {string} layerPath - The layer path.
+   * @param {string[]} objectIds - The IDs of the features to calculate the extent from.
+   * @returns {Promise<Extent | undefined>} The extent of the features, if available.
+   */
+  override async getExtentFromFeatures(layerPath: string, objectIds: string[]): Promise<Extent | undefined> {
+    // Get url for service from layer entry config
+    const layerEntryConfig = this.getLayerConfig();
+    let baseUrl = getLocalizedValue(layerEntryConfig.source.dataAccessPath, AppEventProcessor.getDisplayLanguage(this.getMapId()));
+
+    const idString = objectIds.join('%2C');
+    if (baseUrl) {
+      // Construct query
+      if (!baseUrl.endsWith('/')) baseUrl += '/';
+      const queryUrl = `${baseUrl}${layerEntryConfig.layerId}/query?&f=json&where=&objectIds=${idString}&returnGeometry=true`;
+
+      try {
+        const response = await fetch(queryUrl);
+        const responseJson = await response.json();
+
+        // Convert response json to OL features
+        const responseFeatures = new EsriJSON().readFeatures(
+          { features: responseJson.features },
+          {
+            dataProjection: `EPSG:${responseJson.spatialReference.wkid}`,
+            featureProjection: this.getMapViewer().getProjection().getCode(),
+          }
+        );
+
+        // Determine max extent from features
+        let calculatedExtent: Extent | undefined;
+        responseFeatures.forEach((feature) => {
+          const extent = feature.getGeometry()?.getExtent();
+
+          if (extent) {
+            // If extent has not been defined, set it to extent
+            if (!calculatedExtent) calculatedExtent = extent;
+            else getMinOrMaxExtents(calculatedExtent, extent);
+          }
+        });
+
+        return calculatedExtent;
+      } catch (error) {
+        logger.logError(`Error fetching geometry from ${queryUrl}`, error);
+      }
+    }
+    return undefined;
   }
 }


### PR DESCRIPTION
Closes #2215

# Description

ESRI Dynamic layers will now fetch there geometries when the zoom is clicked in the data table

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/16-esri-dynamic.json

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2341)
<!-- Reviewable:end -->
