### PR TITLE
fix(extent): Extent validation

### DIFF
--- a/.github/workflows/type-build.yml
+++ b/.github/workflows/type-build.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/packages/geoview-core/src/api/config/types/classes/sub-layer-config/entry-config-base-class.ts
+++ b/packages/geoview-core/src/api/config/types/classes/sub-layer-config/entry-config-base-class.ts
@@ -10,6 +10,7 @@ import {
   TypeDisplayLanguage,
   Extent,
 } from '@config/types/map-schema-types';
+import { validateExtentWhenDefined } from '@/geo/utils/utilities';
 
 /**
  * Base type used to define a GeoView sublayer to display on the map. The sublayer can be a group or an abstract sublayer.
@@ -41,7 +42,7 @@ export abstract class EntryConfigBaseClass {
   attributions: string[];
 
   /** Bounds (in lat long) obtained from the metadata or calculated from the layers */
-  bounds: Extent;
+  bounds: Extent | undefined;
 
   /** The min scale that can be reach by the layer. */
   minScale: number;
@@ -82,7 +83,7 @@ export abstract class EntryConfigBaseClass {
     this.layerName = layerConfig.layerName ? normalizeLocalizedString(layerConfig.layerName)![this.#language]! : undefined;
     this.isLayerGroup = (layerConfig.isLayerGroup as boolean) || false;
     this.attributions = (layerConfig.attributions as string[]) || [];
-    this.bounds = layerConfig.bounds as Extent;
+    this.bounds = validateExtentWhenDefined(layerConfig.bounds as Extent);
     this.minScale = (layerConfig.minScale as number) || 0;
     this.maxScale = (layerConfig.minScale as number) || 0;
     this.entryType = this.getEntryType();

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -46,6 +46,7 @@ import {
   TypeClassBreakStyleConfig,
 } from '@/geo/map/map-schema-types';
 import { GeoViewLayerCreatedTwiceError } from '@/geo/layer/exceptions/layer-exceptions';
+import { validateExtent } from '@/geo/utils/utilities';
 import { Projection } from '@/geo/utils/projection';
 import { getLegendStyles, getFeatureCanvas } from '@/geo/utils/renderer/geoview-renderer';
 import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
@@ -1048,7 +1049,10 @@ export abstract class AbstractGeoViewLayer {
       else processGroupLayerBounds([layerConfig]);
 
       // TODO: Check - Are the bounds initially always 4326?
-      if (projectionCode && bounds) return Projection.transformExtent(bounds, `EPSG:4326`, `EPSG:${projectionCode}`);
+      if (projectionCode && bounds) {
+        bounds = validateExtent(bounds);
+        return Projection.transformExtent(bounds, Projection.PROJECTION_NAMES.LNGLAT, `EPSG:${projectionCode}`);
+      }
     }
     return bounds;
   }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -8,6 +8,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
 import { Cast, TypeJsonArray, TypeJsonObject } from '@/core/types/global-types';
 import { getLocalizedValue, getXMLHttpRequest } from '@/core/utils/utilities';
+import { validateExtent, validateExtentWhenDefined } from '@/geo/utils/utilities';
 import { Projection } from '@/geo/utils/projection';
 import { TimeDimensionESRI, DateMgt } from '@/core/utils/date-mgt';
 import { logger } from '@/core/utils/logger';
@@ -353,16 +354,8 @@ export function commonProcessInitialSettings(
   // GV if (layerConfig.initialSettings?.minZoom === undefined && minScale !== 0) layerConfig.initialSettings.minZoom = minScale;
   // GV if (layerConfig.initialSettings?.maxZoom === undefined && maxScale !== 0) layerConfig.initialSettings.maxZoom = maxScale;
 
-  // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration and handle it later?
+  layerConfig.initialSettings.extent = validateExtentWhenDefined(layerConfig.initialSettings.extent);
 
-  if (layerConfig.initialSettings?.extent)
-    layerConfig.initialSettings.extent = Projection.transformExtent(
-      layerConfig.initialSettings.extent,
-      Projection.PROJECTION_NAMES.LNGLAT,
-      `EPSG:${MapEventProcessor.getMapState(layer.mapId).currentProjection}`
-    );
-
-  // TODO: Check - Here, we're *not* converting in the map projection in the pre-processing, but for some other layers we are (ogc-feature, wfs, ..?). Should be standardized.
   if (!layerConfig.initialSettings?.bounds) {
     const layerExtent = [
       layerMetadata.extent.xmin,
@@ -370,8 +363,14 @@ export function commonProcessInitialSettings(
       layerMetadata.extent.xmax,
       layerMetadata.extent.ymax,
     ] as Extent;
-    layerConfig.initialSettings!.bounds = layerExtent;
+    const latlonExtent = Projection.transformExtent(
+      layerExtent,
+      `EPSG:${layerMetadata.extent.spatialReference.wkid}`,
+      Projection.PROJECTION_NAMES.LNGLAT
+    );
+    layerConfig.initialSettings!.bounds = latlonExtent;
   }
+  layerConfig.initialSettings!.bounds = validateExtent(layerConfig.initialSettings!.bounds);
 }
 
 /** ***************************************************************************************************************************

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -16,8 +16,8 @@ import { GeometryApi } from '@/geo/layer/geometry/geometry';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { AbstractGeoViewLayer, CONST_LAYER_TYPES } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { AbstractGeoViewRaster } from '@/geo/layer/geoview-layers/raster/abstract-geoview-raster';
+import { validateExtent, getMinOrMaxExtents } from '@/geo/utils/utilities';
 import { Projection } from '@/geo/utils/projection';
-import { getMinOrMaxExtents } from '@/geo/utils/utilities';
 import { TypeJsonObject } from '@/core/types/global-types';
 import { logger } from '@/core/utils/logger';
 import { DateMgt } from '@/core/utils/date-mgt';
@@ -925,6 +925,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
       // Get the metadata projection
       const metadataProjection = this.getMetadataProjection();
       layerBounds = this.getMapViewer().convertExtentFromProjToMapProj(metadataExtent, metadataProjection);
+      layerBounds = validateExtent(layerBounds, this.getMapViewer().getProjection().getCode());
     }
 
     // Return the calculated layer bounds

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
@@ -33,6 +33,7 @@ import {
   commonProcessTemporalDimension,
 } from '@/geo/layer/geoview-layers/esri-layer-common';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
+import { validateExtent } from '@/geo/utils/utilities';
 import { getLegendStyles } from '@/geo/utils/renderer/geoview-renderer';
 import { TypeLegend } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
@@ -457,6 +458,7 @@ export class EsriImage extends AbstractGeoViewRaster {
       // Get the metadata projection
       const metadataProjection = this.getMetadataProjection();
       layerBounds = this.getMapViewer().convertExtentFromProjToMapProj(metadataExtent, metadataProjection);
+      layerBounds = validateExtent(layerBounds, this.getMapViewer().getProjection().getCode());
     }
 
     // Return the calculated layer bounds

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
@@ -24,6 +24,7 @@ import {
 } from '@/geo/map/map-schema-types';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { Cast, TypeJsonObject } from '@/core/types/global-types';
+import { validateExtentWhenDefined } from '@/geo/utils/utilities';
 import { api } from '@/app';
 import { VectorTilesLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/vector-tiles-layer-entry-config';
 import { logger } from '@/core/utils/logger';
@@ -292,10 +293,8 @@ export class VectorTiles extends AbstractGeoViewRaster {
       // eslint-disable-next-line no-param-reassign
       layerConfig.source!.tileGrid = newTileGrid;
 
-      if (layerConfig.initialSettings?.extent)
-        // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration and handle it later?
-        // eslint-disable-next-line no-param-reassign
-        layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
+      // eslint-disable-next-line no-param-reassign
+      layerConfig.initialSettings.extent = validateExtentWhenDefined(layerConfig.initialSettings.extent);
     }
     return Promise.resolve(layerConfig);
   }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -34,7 +34,7 @@ import {
 } from '@/geo/map/map-schema-types';
 import { xmlToJson, getLocalizedValue } from '@/core/utils/utilities';
 import { DateMgt } from '@/core/utils/date-mgt';
-import { getExtentIntersection } from '@/geo/utils/utilities';
+import { getExtentIntersection, validateExtent, validateExtentWhenDefined } from '@/geo/utils/utilities';
 import { api } from '@/app';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
 import { logger } from '@/core/utils/logger';
@@ -635,18 +635,11 @@ export class WMS extends AbstractGeoViewRaster {
         //   layerConfig.initialSettings.minZoom = layerCapabilities.MinScaleDenominator as number;
         // if (layerConfig.initialSettings?.maxZoom === undefined && layerCapabilities.MaxScaleDenominator !== undefined)
         //   layerConfig.initialSettings.maxZoom = layerCapabilities.MaxScaleDenominator as number;
-        if (layerConfig.initialSettings?.extent)
-          // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration and handle it later?
-          layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
 
-        // TODO: Check - Here, we override the initialBounds with the metadata extent bounds, as part of the processing. Later on, in the wms class,
-        // TO.DOCONT: we have code in the getBounds() that check the initialSettings.bounds vs the metadata bounds. Are we shooting ourselves in the foot or doing work twice?
-        if (!layerConfig.initialSettings?.bounds && layerCapabilities.EX_GeographicBoundingBox) {
-          // TODO: Refactor - Configs refactoring. When gathering bounds from the XML data, we should validate if they are 'valid' coordinates for the projection in the XML
-          // TO.DOCONT: Because it's possible that some bound values are invalid as provided.. see this for an example, with -90.24 being an invalid value latitude in 4326:
-          // TO.DOCONT: https://geo.weather.gc.ca/geomet?service=WMS&version=1.3.0&request=GetCapabilities&Layers=GDPS.ETA_ICEC
-          layerConfig.initialSettings!.bounds = layerCapabilities.EX_GeographicBoundingBox as Extent;
-        }
+        layerConfig.initialSettings.extent = validateExtentWhenDefined(layerConfig.initialSettings.extent);
+
+        if (!layerConfig.initialSettings?.bounds && layerCapabilities.EX_GeographicBoundingBox)
+          layerConfig.initialSettings!.bounds = validateExtent(layerCapabilities.EX_GeographicBoundingBox as Extent);
 
         if (layerCapabilities.Dimension) {
           const temporalDimension: TypeJsonObject | undefined = (layerCapabilities.Dimension as TypeJsonArray).find(
@@ -1219,6 +1212,9 @@ export class WMS extends AbstractGeoViewRaster {
 
     // If both layer config had bounds and layer has real bounds, take the intersection between them
     if (layerConfigBounds && layerBounds) layerBounds = getExtentIntersection(layerBounds, layerConfigBounds);
+
+    // Validate
+    layerBounds = validateExtentWhenDefined(layerBounds, this.getMapViewer().getProjection().getCode());
 
     // Return the calculated layer bounds (favor metadataExtent, but if things are going bad, pick config bounds at least)
     return layerBounds || layerConfigBounds;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -19,6 +19,7 @@ import {
 } from '@/geo/map/map-schema-types';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { Cast, toJsonObject } from '@/core/types/global-types';
+import { validateExtentWhenDefined } from '@/geo/utils/utilities';
 import { XYZTilesLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/xyz-layer-entry-config';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
@@ -270,11 +271,8 @@ export class XYZTiles extends AbstractGeoViewRaster {
       layerConfig.source = defaultsDeep(layerConfig.source, metadataLayerConfigFound!.source);
       // eslint-disable-next-line no-param-reassign
       layerConfig.initialSettings = defaultsDeep(layerConfig.initialSettings, metadataLayerConfigFound!.initialSettings);
-
-      if (layerConfig.initialSettings?.extent)
-        // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration and handle it later?
-        // eslint-disable-next-line no-param-reassign
-        layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
+      // eslint-disable-next-line no-param-reassign
+      layerConfig.initialSettings.extent = validateExtentWhenDefined(layerConfig.initialSettings.extent);
     }
     return Promise.resolve(layerConfig);
   }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -19,6 +19,7 @@ import {
   layerEntryIsGroupLayer,
   TypeBaseSourceVectorInitialConfig,
 } from '@/geo/map/map-schema-types';
+import { validateExtentWhenDefined } from '@/geo/utils/utilities';
 import { Cast, TypeJsonObject } from '@/core/types/global-types';
 import { getLocalizedValue } from '@/core/utils/utilities';
 import { GeoJSONLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-validation-classes/geojson-layer-entry-config';
@@ -199,9 +200,7 @@ export class GeoJSON extends AbstractGeoViewVector {
         }
       }
 
-      if (layerConfig.initialSettings?.extent)
-        // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration and handle it later?
-        layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
+      layerConfig.initialSettings.extent = validateExtentWhenDefined(layerConfig.initialSettings.extent);
     }
 
     // Setting the layer metadata now with the updated config values. Setting the layer metadata with the config, directly, like it's done in CSV

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -26,6 +26,7 @@ import { WfsLayerEntryConfig } from '@/core/utils/config/validation-classes/vect
 import { VectorLayerEntryConfig } from '@/core/utils/config/validation-classes/vector-layer-entry-config';
 import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
+import { validateExtentWhenDefined } from '@/geo/utils/utilities';
 
 export interface TypeSourceWFSVectorInitialConfig extends TypeVectorSourceInitialConfig {
   format: 'WFS';
@@ -207,9 +208,7 @@ export class WFS extends AbstractGeoViewVector {
           return;
         }
 
-        if (layerConfig.initialSettings?.extent)
-          // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration and handle it later?
-          layerConfig.initialSettings.extent = this.getMapViewer().convertExtentLngLatToMapProj(layerConfig.initialSettings.extent);
+        layerConfig.initialSettings.extent = validateExtentWhenDefined(layerConfig.initialSettings.extent);
 
         if (!layerConfig.initialSettings?.bounds && foundMetadata['ows:WGS84BoundingBox']) {
           // TODO: Check - This additional processing seem valid, but is it at the right place? A bit confusing with the rest of the codebase.
@@ -218,13 +217,9 @@ export class WFS extends AbstractGeoViewVector {
           const upperCorner = (foundMetadata['ows:WGS84BoundingBox']['ows:UpperCorner']['#text'] as string).split(' ');
           const bounds = [Number(lowerCorner[0]), Number(lowerCorner[1]), Number(upperCorner[0]), Number(upperCorner[1])];
 
-          // TODO: Check - Why are we converting to the map projection in the pre-processing? It'd be better to standardize to 4326 here (or leave untouched), as it's part of the initial configuration?
-          // TO.DOCONT: We're already making sure to project the settings in the map projection when we getBounds(). Seems we're doing work twice? Should be standardized so that the
-          // TO.DOCONT: layer.getBounds() are coherent between children classes. And should probably *not* reproject in the map projection during layer metadata pre-processing if we want to
-          // TO.DOCONT: be able to, possibly, fetch metadata information in a standalone manner, outside of a map.
-          // layerConfig.initialSettings cannot be undefined because config-validation set it to {} if it is undefined.
-          layerConfig.initialSettings!.bounds = this.getMapViewer().convertExtentLngLatToMapProj(bounds);
+          layerConfig.initialSettings!.bounds = bounds;
         }
+        layerConfig.initialSettings!.bounds = validateExtentWhenDefined(layerConfig.initialSettings!.bounds);
       }
     });
   }

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -10,6 +10,7 @@ import Geometry from 'ol/geom/Geometry';
 
 import { GeometryApi } from '@/geo/layer/geometry/geometry';
 import { getLocalizedValue } from '@/core/utils/utilities';
+import { validateExtent, getMinOrMaxExtents } from '@/geo/utils/utilities';
 import { Projection } from '@/geo/utils/projection';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 import { logger } from '@/core/utils/logger';
@@ -28,7 +29,6 @@ import {
 } from '@/geo/map/map-schema-types';
 import { esriGetFieldType, esriGetFieldDomain } from '../utils';
 import { AbstractGVRaster } from './abstract-gv-raster';
-import { getMinOrMaxExtents } from '@/geo/utils/utilities';
 
 type TypeFieldOfTheSameValue = { value: string | number | Date; nbOccurence: number };
 type TypeQueryTree = { fieldValue: string | number | Date; nextField: TypeQueryTree }[];
@@ -667,6 +667,7 @@ export class GVEsriDynamic extends AbstractGVRaster {
       // Get the metadata projection
       const metadataProjection = this.getMetadataProjection();
       layerBounds = this.getMapViewer().convertExtentFromProjToMapProj(metadataExtent, metadataProjection);
+      layerBounds = validateExtent(layerBounds, this.getMapViewer().getProjection().getCode());
     }
 
     // Return the calculated layer bounds

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
@@ -17,6 +17,7 @@ import {
 } from '@/geo/map/map-schema-types';
 import { esriGetFieldType, esriGetFieldDomain } from '../utils';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
+import { validateExtent } from '@/geo/utils/utilities';
 import { getLegendStyles } from '@/geo/utils/renderer/geoview-renderer';
 import { AbstractGVRaster } from './abstract-gv-raster';
 import { TypeLegend } from '@/core/stores/store-interface-and-intial-values/layer-state';
@@ -248,6 +249,7 @@ export class GVEsriImage extends AbstractGVRaster {
       // Get the metadata projection
       const metadataProjection = this.getMetadataProjection();
       layerBounds = this.getMapViewer().convertExtentFromProjToMapProj(metadataExtent, metadataProjection);
+      layerBounds = validateExtent(layerBounds, this.getMapViewer().getProjection().getCode());
     }
 
     // Return the calculated layer bounds

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -12,7 +12,7 @@ import { Cast, TypeJsonArray, TypeJsonObject } from '@/core/types/global-types';
 import { CONST_LAYER_TYPES, TypeWmsLegend, TypeWmsLegendStyle } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { xmlToJson, getLocalizedValue } from '@/core/utils/utilities';
 import { DateMgt } from '@/core/utils/date-mgt';
-import { getExtentIntersection } from '@/geo/utils/utilities';
+import { getExtentIntersection, validateExtentWhenDefined } from '@/geo/utils/utilities';
 import { logger } from '@/core/utils/logger';
 import { OgcWmsLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config';
 import { TypeFeatureInfoEntry } from '@/geo/map/map-schema-types';
@@ -604,6 +604,9 @@ export class GVWMS extends AbstractGVRaster {
 
     // If both layer config had bounds and layer has real bounds, take the intersection between them
     if (layerConfigBounds && layerBounds) layerBounds = getExtentIntersection(layerBounds, layerConfigBounds);
+
+    // Validate
+    layerBounds = validateExtentWhenDefined(layerBounds, this.getMapViewer().getProjection().getCode());
 
     // Return the calculated bounds
     return layerBounds;

--- a/packages/geoview-core/src/geo/layer/gv-layers/tile/gv-xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/tile/gv-xyz-tiles.ts
@@ -7,6 +7,7 @@ import { AppEventProcessor } from '@/api/event-processors/event-processor-childr
 import { XYZTilesLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/xyz-layer-entry-config';
 import { AbstractGVTile } from './abstract-gv-tile';
 import { featureInfoGetFieldType } from '../utils';
+import { validateExtent } from '@/geo/utils/utilities';
 
 /**
  * Manages a Tile<XYZ> layer.
@@ -89,6 +90,7 @@ export class GVXYZTiles extends AbstractGVTile {
     if (sourceExtent) {
       // Make sure we're in the map projection
       sourceExtent = this.getMapViewer().convertExtentFromProjToMapProj(sourceExtent, sourceProjection);
+      sourceExtent = validateExtent(sourceExtent, this.getMapViewer().getProjection().getCode());
     }
 
     // Return the calculated layer bounds

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector-tile.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector-tile.ts
@@ -4,6 +4,7 @@ import Feature from 'ol/Feature';
 import { Extent } from 'ol/extent';
 
 import { AbstractGVLayer } from '../abstract-gv-layer';
+import { validateExtent } from '@/geo/utils/utilities';
 
 /**
  * Abstract Geoview Layer managing an OpenLayer vector tile type layer.
@@ -46,6 +47,7 @@ export abstract class AbstractGVVectorTile extends AbstractGVLayer {
     if (sourceExtent) {
       // Make sure we're in the map projection
       sourceExtent = this.getMapViewer().convertExtentFromProjToMapProj(sourceExtent, sourceProjection);
+      sourceExtent = validateExtent(sourceExtent, this.getMapViewer().getProjection().getCode());
     }
 
     // Return the calculated layer bounds

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -411,8 +411,7 @@ export function getExtentIntersectionMaybe(extentA: Extent | undefined, extentB?
 }
 
 /**
- * Convert an extent to a polygon
- *
+ * Converts an extent to a polygon
  * @param {Extent} extent - The extent to convert
  * @returns {Polygon} The created polygon
  */
@@ -429,8 +428,7 @@ export function extentToPolygon(extent: Extent): Polygon {
 }
 
 /**
- * Convert an polygon to an extent
- *
+ * Converts a polygon to an extent
  * @param {Polygon} polygon - The polygon to convert
  * @returns {Extent} The created extent
  */
@@ -448,4 +446,47 @@ export function polygonToExtent(polygon: Polygon): Extent {
   }
   const extent: Extent = [minx, miny, maxx, maxy];
   return extent;
+}
+
+/**
+ * Checks validity of lat long, LCC, or Web Mercator extent and updates values if invalid.
+ * @param {Extent} extent - The extent to validate.
+ * @param {string} code - The projection code of the extent. Default EPSG:4326.
+ * @returns {Extent} The validated extent
+ */
+export function validateExtent(extent: Extent, code: string = 'EPSG:4326'): Extent {
+  // Max extents for projections
+  const maxExtents: Record<string, number[]> = {
+    'EPSG:4326': [-180, -90, 180, 90],
+    'EPSG:3857': [-20037508.3427892, -20037508.3427892, 20037508.3427892, 20037508.3427892],
+    'EPSG:3978': [-7192737.96, -3004297.73, 5183275.29, 4484204.83],
+  };
+
+  // Replace any invalid entries with maximum value
+  const minX = extent[0] < maxExtents[code][0] || extent[0] === -Infinity || Number.isNaN(extent[0]) ? maxExtents[code][0] : extent[0];
+  const minY = extent[1] < maxExtents[code][1] || extent[0] === -Infinity || Number.isNaN(extent[1]) ? maxExtents[code][1] : extent[1];
+  const maxX = extent[0] > maxExtents[code][2] || extent[0] === Infinity || Number.isNaN(extent[2]) ? maxExtents[code][2] : extent[2];
+  const maxY = extent[0] > maxExtents[code][3] || extent[0] === Infinity || Number.isNaN(extent[3]) ? maxExtents[code][3] : extent[3];
+
+  // Check the order
+  const validatedExtent: Extent = [
+    minX < maxX ? minX : maxX,
+    minY < maxY ? minY : maxY,
+    maxX > minX ? maxX : minX,
+    maxY > minY ? maxY : minY,
+  ];
+
+  return validatedExtent;
+}
+
+/**
+ * Validates lat long, LCC, or Web Mercator extent if it is defined.
+ * @param {Extent} extent - The extent to validate.
+ * @param {string} code - The projection code of the extent. Default EPSG:4326.
+ * @returns {Extent | undefined} The validated extent if it was defined.
+ */
+export function validateExtentWhenDefined(extent: Extent | undefined, code: string = 'EPSG:4326'): Extent | undefined {
+  // Validate extent if it is defined
+  if (extent) return validateExtent(extent, code);
+  return undefined;
 }


### PR DESCRIPTION
Closes #2324

# Description

Added a utility extent validation function. Also updated all layers so that extent and bounds in initial settings config remains in lat/long.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/14-wms-layer.json

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2346)
<!-- Reviewable:end -->
