### PR TITLE
feat(initialView): empty layerIds array defaults to all layers

### DIFF
--- a/packages/geoview-core/public/configs/navigator/12-a-package-swiper.json
+++ b/packages/geoview-core/public/configs/navigator/12-a-package-swiper.json
@@ -2,6 +2,9 @@
   "map": {
     "interaction": "dynamic",
     "viewSettings": {
+      "initialView": {
+        "layerIds": []
+      },
       "projection": 3978
     },
     "basemapOptions": {

--- a/packages/geoview-core/public/templates/layers/esri-dynamic.html
+++ b/packages/geoview-core/public/templates/layers/esri-dynamic.html
@@ -64,6 +64,9 @@
         'map': {
           'interaction': 'dynamic',
           'viewSettings': {
+            'initialView': {
+              'layerIds': []
+            },
             'projection': 3857
           },
           'basemapOptions': {

--- a/packages/geoview-core/public/templates/layers/geocore.html
+++ b/packages/geoview-core/public/templates/layers/geocore.html
@@ -62,6 +62,9 @@
           'map': {
             'interaction': 'dynamic',
             'viewSettings': {
+              'initialView': {
+                'layerIds': []
+              },
               'projection': 3978
             },
             'basemapOptions': {

--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -1562,11 +1562,10 @@
         },
         "layerIds": {
           "type": "array",
-          "minItems": 1,
           "items": {
             "type": "string"
           },
-          "description": "Geoview layer ID(s) or layer path(s) of layer(s) to use as initial map focus."
+          "description": "Geoview layer ID(s) or layer path(s) of layer(s) to use as initial map focus. If empty, will use all layers."
         }
       }
     },

--- a/packages/geoview-core/src/api/config/types/config-validation-schema.json
+++ b/packages/geoview-core/src/api/config/types/config-validation-schema.json
@@ -668,9 +668,8 @@
           }
         },
         "layerIds": {
-          "description": "ID(s) of layer(s) to use as initial map focus.",
+          "description": "Geoview layer ID(s) or layer path(s) of layer(s) to use as initial map focus. If empty, will use all layers.",
           "type": "array",
-          "minItems": 1,
           "items": {
             "type": "string"
           }

--- a/packages/geoview-core/src/api/config/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/config/types/map-schema-types.ts
@@ -207,7 +207,7 @@ export type TypeMapViewSettings = {
    * Option to set initial view by extent.
    * Called with [minX, minY, maxX, maxY] extent coordinates. */
   extent?: Extent;
-  /** Geoview layer ID(s) or layer path(s) of layer(s) to use as initial map focus. */
+  /** Geoview layer ID(s) or layer path(s) of layer(s) to use as initial map focus. If empty, will use all layers. */
   layerIds?: string[];
 };
 

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -614,7 +614,12 @@ export class MapViewer {
 
     // Zoom to extents of layers selected in config, if provided.
     if (this.mapFeaturesConfig.map.viewSettings.initialView?.layerIds) {
-      let layerExtents = this.layer.getExtentOfMultipleLayers(this.mapFeaturesConfig.map.viewSettings.initialView.layerIds);
+      // If the layerIds array is empty, use all layers
+      const layerIdsToZoomTo = this.mapFeaturesConfig.map.viewSettings.initialView.layerIds.length
+        ? this.mapFeaturesConfig.map.viewSettings.initialView.layerIds
+        : this.layer.getGeoviewLayerIds();
+
+      let layerExtents = this.layer.getExtentOfMultipleLayers(layerIdsToZoomTo);
 
       // If extents have infinity, use default instead
       if (layerExtents.includes(Infinity))


### PR DESCRIPTION
Closes #2370

# Description

If an empty array is passed to the layerIds in initialSettings, will default to using all layers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/12-a-package-swiper.json
https://damonu2.github.io/geoview/esri-dynamic.html
https://damonu2.github.io/geoview/geocore.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2386)
<!-- Reviewable:end -->
