### PR TITLE
2412 add extent to aoi

### DIFF
--- a/packages/geoview-aoi-panel/src/aoi-panel.tsx
+++ b/packages/geoview-aoi-panel/src/aoi-panel.tsx
@@ -1,4 +1,6 @@
 import { Extent } from 'geoview-core/src/api/config/types/map-schema-types';
+import { useMapStoreActions } from 'geoview-core/src/core/stores/store-interface-and-intial-values/map-state';
+import { delay } from 'geoview-core/src/core/utils/utilities';
 import { getSxClasses } from './area-of-interest-style';
 
 interface AoiPanelProps {
@@ -33,6 +35,8 @@ export function AoiPanel(props: AoiPanelProps): JSX.Element {
   const theme = ui.useTheme();
   const sxClasses = getSxClasses(theme);
 
+  const { zoomToExtent, highlightBBox, transformPoints } = useMapStoreActions();
+
   return (
     <Box sx={sxClasses.aoiCard}>
       {aoiList.map((aoiItem: AoiItem, index) => {
@@ -40,7 +44,11 @@ export function AoiPanel(props: AoiPanelProps): JSX.Element {
           <Card
             tabIndex={0}
             className="aoiCardThumbnail"
-            onClick={() => myMap.zoomToLngLatExtentOrCoordinate(aoiItem.extent, { maxZoom: 14 })}
+            onClick={() =>
+              myMap.zoomToLngLatExtentOrCoordinate(aoiItem.extent, { maxZoom: 14 }).then(() => {
+                highlightBBox(myMap.convertExtentLngLatToMapProj(aoiItem.extent), false);
+              })
+            }
             // eslint-disable-next-line react/no-array-index-key
             key={index}
             title={aoiItem.aoiTitle}

--- a/packages/geoview-aoi-panel/src/aoi-panel.tsx
+++ b/packages/geoview-aoi-panel/src/aoi-panel.tsx
@@ -1,6 +1,5 @@
 import { Extent } from 'geoview-core/src/api/config/types/map-schema-types';
 import { useMapStoreActions } from 'geoview-core/src/core/stores/store-interface-and-intial-values/map-state';
-import { delay } from 'geoview-core/src/core/utils/utilities';
 import { getSxClasses } from './area-of-interest-style';
 
 interface AoiPanelProps {
@@ -35,7 +34,7 @@ export function AoiPanel(props: AoiPanelProps): JSX.Element {
   const theme = ui.useTheme();
   const sxClasses = getSxClasses(theme);
 
-  const { zoomToExtent, highlightBBox, transformPoints } = useMapStoreActions();
+  const { highlightBBox } = useMapStoreActions();
 
   return (
     <Box sx={sxClasses.aoiCard}>


### PR DESCRIPTION
# Description

I added to extent to Area of Interest as asked. Now when you click on a Area of Interest in the side panel, you should see a square around that AOI.

Fixes # (2412)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I ran a rush serve and made sure both my AOI present in the side panel in the demo package worked properly.

[__URL for your deploy!__](https://guichoquette.github.io/geoview/)

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2418)
<!-- Reviewable:end -->
