### PR TITLE
feat(settings): added canRemoveSublayers global setting

### DIFF
--- a/packages/geoview-core/public/configs/navigator/06-basic-footer.json
+++ b/packages/geoview-core/public/configs/navigator/06-basic-footer.json
@@ -111,7 +111,10 @@
               },
               {
                 "layerId": "points_1.json",
-                "layerName": { "en": "Points 1" }
+                "layerName": { "en": "Points 1" },
+                "initialSettings": {
+                  "controls": { "remove": true }
+                }
               },
               {
                 "layerId": "points_2.json",
@@ -140,5 +143,8 @@
     "tabs": {
       "core": ["geolocator", "export"]
     }
+  },
+  "globalSettings": {
+    "canRemoveSublayers": false
   }
 }

--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -1801,6 +1801,17 @@
       "enum": ["1.0"],
       "description": "The schema version that can be used to validate the configuration file. The schema should enumerate the list of versions accepted by this version of the viewer."
     },
+    "TypeGlobalSettings": {
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Universal map settings",
+      "properties": {
+        "canRemoveSublayers": {
+          "type": "boolean",
+          "description": "Whether or not sublayers can be removed from layer groups. Default = true."
+        }
+      }
+    },
     "TypeMapFeaturesInstance": {
       "description": "The map features configuration. This type is used by the IsValidTypeMapFeaturesInstance method coded in config-validation.ts file. It does the validation down to the list of layer entry config.",
       "additionalProperties": false,
@@ -1843,6 +1854,9 @@
         },
         "schemaVersionUsed": {
           "$ref": "#/definitions/TypeValidVersions"
+        },
+        "globalSettings": {
+          "$ref": "#/definitions/TypeGlobalSettings"
         }
       },
       "required": ["map"]

--- a/packages/geoview-core/src/api/config/types/classes/map-feature-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/map-feature-config.ts
@@ -26,6 +26,7 @@ import {
   TypeDisplayTheme,
   TypeExternalPackages,
   TypeFooterBarProps,
+  TypeGlobalSettings,
   TypeMapComponents,
   TypeMapConfig,
   TypeMapCorePackages,
@@ -75,6 +76,9 @@ export class MapFeatureConfig {
 
   /** List of external packages. */
   externalPackages?: TypeExternalPackages;
+
+  /** Global map settings */
+  globalSettings: TypeGlobalSettings;
 
   /** Service URLs. */
   serviceUrls: TypeServiceUrls;
@@ -126,6 +130,7 @@ export class MapFeatureConfig {
     this.externalPackages = [
       ...((providedMapFeatureConfig.externalPackages || CV_DEFAULT_MAP_FEATURE_CONFIG.externalPackages) as TypeExternalPackages),
     ];
+    this.globalSettings = providedMapFeatureConfig.globalSettings || CV_DEFAULT_MAP_FEATURE_CONFIG.globalSettings;
     this.schemaVersionUsed =
       (providedMapFeatureConfig.schemaVersionUsed as TypeValidVersions) || CV_DEFAULT_MAP_FEATURE_CONFIG.schemaVersionUsed;
     if (this.#errorDetectedFlag) this.#makeMapConfigValid(providedMapFeatureConfig); // Tries to apply a correction to invalid properties

--- a/packages/geoview-core/src/api/config/types/config-constants.ts
+++ b/packages/geoview-core/src/api/config/types/config-constants.ts
@@ -191,6 +191,7 @@ export const CV_DEFAULT_MAP_FEATURE_CONFIG = Cast<MapFeatureConfig>({
     geolocator: CV_CONFIG_GEOLOCATOR_URL,
     proxyUrl: CV_CONFIG_PROXY_URL,
   },
+  globalSettings: { canRemoveSublayers: true },
   schemaVersionUsed: '1.0',
 });
 

--- a/packages/geoview-core/src/api/config/types/config-validation-schema.json
+++ b/packages/geoview-core/src/api/config/types/config-validation-schema.json
@@ -45,6 +45,9 @@
         },
         "schemaVersionUsed": {
           "$ref": "#/definitions/TypeValidVersions"
+        },
+        "globalSettings": {
+          "$ref": "#/definitions/TypeGlobalSettings"
         }
       },
       "required": ["map"]
@@ -302,6 +305,17 @@
     "TypeValidVersions": {
       "description": "The schema version that can be used to validate the configuration file. The schema should enumerate the list of versions accepted by this version of the viewer.",
       "enum": ["1.0"]
+    },
+    "TypeGlobalSettings": {
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Universal map settings",
+      "properties": {
+        "canRemoveSublayers": {
+          "type": "boolean",
+          "description": "Whether or not sublayers can be removed from layer groups. Default = true."
+        }
+      }
     },
     "TypeBasemapOptions": {
       "additionalProperties": false,

--- a/packages/geoview-core/src/api/config/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/config/types/map-schema-types.ts
@@ -132,6 +132,14 @@ export type TypeServiceUrls = {
 /** Valid schema version number. */
 export type TypeValidVersions = '1.0';
 
+/** Service endpoint urls. */
+export type TypeGlobalSettings = {
+  /**
+   * Whether or not sublayers can be removed from layer groups. Default = true.
+   */
+  canRemoveSublayers?: boolean;
+};
+
 /** Definition of the map configuration settings. */
 export type TypeMapConfig = {
   /** Basemap options settings for this map configuration. */

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -217,13 +217,15 @@ export class LegendEventProcessor extends AbstractEventProcessor {
     const { layerPath } = legendResultSetEntry;
     const layerPathNodes = layerPath.split('/');
 
-    const setLayerControls = (layerConfig: ConfigBaseClass): TypeLayerControls => {
+    const setLayerControls = (layerConfig: ConfigBaseClass, isChild: boolean = false): TypeLayerControls => {
+      const removeDefault = isChild ? MapEventProcessor.getGeoViewMapConfig(mapId)?.globalSettings?.canRemoveSublayers !== false : true;
+
       const controls: TypeLayerControls = {
         highlight: layerConfig.initialSettings?.controls?.highlight !== undefined ? layerConfig.initialSettings?.controls?.highlight : true,
         hover: layerConfig.initialSettings?.controls?.hover !== undefined ? layerConfig.initialSettings?.controls?.hover : true,
         opacity: layerConfig.initialSettings?.controls?.opacity !== undefined ? layerConfig.initialSettings?.controls?.opacity : true,
         query: layerConfig.initialSettings?.controls?.query !== undefined ? layerConfig.initialSettings?.controls?.query : true,
-        remove: layerConfig.initialSettings?.controls?.remove !== undefined ? layerConfig.initialSettings?.controls?.remove : true,
+        remove: layerConfig.initialSettings?.controls?.remove !== undefined ? layerConfig.initialSettings?.controls?.remove : removeDefault,
         table: layerConfig.initialSettings?.controls?.table !== undefined ? layerConfig.initialSettings?.controls?.table : true,
         visibility:
           layerConfig.initialSettings?.controls?.visibility !== undefined ? layerConfig.initialSettings?.controls?.visibility : true,
@@ -264,7 +266,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
           bounds = MapEventProcessor.getMapViewerLayerAPI(mapId).calculateBounds(layerConfig.layerPath);
         }
 
-        const controls: TypeLayerControls = setLayerControls(layerConfig);
+        const controls: TypeLayerControls = setLayerControls(layerConfig, currentLevel > 2);
         if (entryIndex === -1) {
           const legendLayerEntry: TypeLegendLayer = {
             bounds,
@@ -306,7 +308,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
           bounds = MapEventProcessor.getMapViewerLayerAPI(mapId).calculateBounds(layerConfig.layerPath);
         }
 
-        const controls: TypeLayerControls = setLayerControls(layerConfig);
+        const controls: TypeLayerControls = setLayerControls(layerConfig, currentLevel > 2);
         const legendLayerEntry: TypeLegendLayer = {
           bounds,
           controls,

--- a/packages/geoview-core/src/core/containers/shell.tsx
+++ b/packages/geoview-core/src/core/containers/shell.tsx
@@ -195,6 +195,17 @@ export function Shell(props: ShellProps): JSX.Element {
   }, [footerPanelResizeValue, footerPanelResizeValues]);
 
   /**
+   * Set the map container height to fit content when map is first loaded.
+   * This replaces the hard coded height added by map reload.
+   */
+  useEffect(() => {
+    if (mapLoaded) {
+      const mapContainer = document.getElementById(mapId);
+      if (mapContainer) mapContainer.style.height = 'fit-content';
+    }
+  }, [mapId, mapLoaded]);
+
+  /**
    * Set the map height based on mapDiv
    */
   useEffect(() => {

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -24,6 +24,7 @@ import {
   TypeMapComponents,
   TypeMapCorePackages,
   TypeExternalPackages,
+  TypeGlobalSettings,
 } from '@config/types/map-schema-types';
 
 import { CONST_LAYER_TYPES, TypeGeoviewLayerType } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
@@ -520,6 +521,8 @@ export type TypeMapFeaturesInstance = {
    * this version of the viewer.
    */
   schemaVersionUsed?: '1.0';
+  /** Global settings. */
+  globalSettings?: TypeGlobalSettings; //! config
 };
 
 /** ******************************************************************************************************************************

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -1193,12 +1193,19 @@ export class MapViewer {
   }
 
   /**
-   * Reload a map from a config object stored in store. It first removes then recreates the map.
+   * Reload a map from a config object stored in store, or provided. It first removes then recreates the map.
+   * @param {TypeMapFeaturesConfig} mapConfig - Optional map config to use for reload.
    */
-  reload(): void {
+  reload(mapConfig?: TypeMapFeaturesConfig): void {
+    const mapContainer = document.getElementById(this.mapId)!;
+
+    // Set map container height to current height to avoid shifting
+    const height = mapContainer.offsetHeight;
+    mapContainer.style.height = `${height}px`;
+
     // remove the map, then get config to use to recreate it
     const mapDiv = this.remove(false);
-    const config = MapEventProcessor.getGeoViewMapConfig(this.mapId);
+    const config = mapConfig || MapEventProcessor.getGeoViewMapConfig(this.mapId);
     // TODO: Remove time out and make this async so remove/recreate work one after the other
     // TO.DOCONT: There is still as problem with bad config schema value and layers loading... should be refactor when config is done
     setTimeout(
@@ -1216,20 +1223,8 @@ export class MapViewer {
    * Reload a map from a config object created using current map state. It first removes then recreates the map.
    */
   reloadWithCurrentState(): void {
-    // remove the map, then get config to use to recreate it
-    const mapDiv = this.remove(false);
-    const config = this.createMapConfigFromMapState();
-    // TODO: Remove time out and make this async so remove/recreate work one after the other
-    // TO.DOCONT: There is still as problem with bad config schema value and layers loading... should be refactor when config is done
-    setTimeout(
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      () =>
-        api.createMapFromConfig(mapDiv.id, JSON.stringify(config)).catch((error) => {
-          // Log
-          logger.logError(`Couldn't reload the map in map-viewer`, error);
-        }),
-      1500
-    );
+    const currentMapConfig = this.createMapConfigFromMapState();
+    this.reload(currentMapConfig);
   }
 
   /**


### PR DESCRIPTION
Closes #2379
Closes #2423 

# Description

Added a global settings section of the config, with only one setting currently, canRemoveSublayers per request from OSDP. If set to false, sublayers will not be removable without removing the full layer. Also added a way to maintain map container div height when reloading, to avoid the div collapsing and resizing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/06-basic-footer.json - canRemoveSublayers is false for this map.
Can resize maps on https://damonu2.github.io/geoview/sandbox.html and call cgpv.api.maps.sandboxMap.reloadWithCurrentState() to check resizing issue.

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2429)
<!-- Reviewable:end -->
