### PR TITLE
fix(size):remove hard code map height

### DIFF
--- a/packages/geoview-core/src/core/containers/shell.tsx
+++ b/packages/geoview-core/src/core/containers/shell.tsx
@@ -195,17 +195,6 @@ export function Shell(props: ShellProps): JSX.Element {
   }, [footerPanelResizeValue, footerPanelResizeValues]);
 
   /**
-   * Set the map container height to fit content when map is first loaded.
-   * This replaces the hard coded height added by map reload.
-   */
-  useEffect(() => {
-    if (mapLoaded) {
-      const mapContainer = document.getElementById(mapId);
-      if (mapContainer?.style?.height.endsWith('px')) mapContainer.style.height = 'fit-content';
-    }
-  }, [mapId, mapLoaded]);
-
-  /**
    * Set the map height based on mapDiv
    */
   useEffect(() => {

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -1194,12 +1194,6 @@ export class MapViewer {
     // If no config is provided, get the original from the store
     const config = mapConfig || MapEventProcessor.getGeoViewMapConfig(this.mapId);
 
-    const mapContainer = document.getElementById(this.mapId)!;
-
-    // Set map container height to current height to avoid shifting
-    const height = mapContainer.offsetHeight;
-    mapContainer.style.height = `${height}px`;
-
     // Remove the map
     const mapDiv = await this.remove(false);
 


### PR DESCRIPTION
# Description

Fixes issue with resizing of map in rare cases. Reverts fix to keep map div size when reloading map.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

__Add the URL for your deploy!__

# Checklist:

- [ ] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2436)
<!-- Reviewable:end -->
