### PR TITLE
feat(event): Event added for map added to div

### DIFF
--- a/packages/geoview-core/public/templates/demos-navigator.html
+++ b/packages/geoview-core/public/templates/demos-navigator.html
@@ -291,6 +291,11 @@
         cgpv.api.maps['sandboxMap'].remove(true);
       });
 
+      // listen to map language changed event
+      cgpv.api.onMapAddedToDiv((sender, payload) => {
+        cgpv.api.maps[payload.mapId].notifications.addNotificationSuccess(`Map ${payload.mapId} added`);
+      });
+
       // create snippets
       window.addEventListener('load', () => {
         createCodeSnippet();

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/data-table-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/data-table-event-processor.ts
@@ -70,8 +70,8 @@ export class DataTableEventProcessor extends AbstractEventProcessor {
    * @param {string} filter - The filter
    */
   static addOrUpdateTableFilter(mapId: string, layerPath: string, filter: string): void {
-    const curSliderFilters = this.getDataTableState(mapId)?.tableFilters;
-    this.getDataTableState(mapId)?.setterActions.setTableFilters({ ...curSliderFilters, [layerPath]: filter });
+    const curTableFilters = this.getDataTableState(mapId)?.tableFilters;
+    this.getDataTableState(mapId)?.setterActions.setTableFilters({ ...curTableFilters, [layerPath]: filter });
   }
 
   /**
@@ -88,8 +88,7 @@ export class DataTableEventProcessor extends AbstractEventProcessor {
    * Propagates feature info layer sets to the store.
    * The propagation actually happens only if it wasn't already there. Otherwise, no update is propagated.
    * @param {string} mapId - The map identifier of the modified result set.
-   * @param {string} layerPath - The layer path that has changed.
-   * @param {TypeFeatureInfoResultSet} resultSet - The result set associated to the map.
+   * @param {TypeAllFeatureInfoResultSetEntry} resultSetEntry - The result set associated to the map.
    */
   static propagateFeatureInfoToStore(mapId: string, resultSetEntry: TypeAllFeatureInfoResultSetEntry): void {
     /**

--- a/packages/geoview-core/src/api/plugin/footer-plugin.ts
+++ b/packages/geoview-core/src/api/plugin/footer-plugin.ts
@@ -53,7 +53,7 @@ export abstract class FooterPlugin extends AbstractPlugin {
     // No need to log, parent class does it well already via removed() function.
 
     // Remove the footer tab
-    if (this.value) this.mapViewer().footerBarApi.removeTab(this.footerProps!.id);
+    if (this.value && this.mapViewer()?.footerBarApi) this.mapViewer().footerBarApi.removeTab(this.footerProps!.id);
   }
 
   /**

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
@@ -827,6 +827,7 @@ export const useMapClickCoordinates = (): TypeMapMouseInfo | undefined =>
   useStore(useGeoViewStore(), (state) => state.mapState.clickCoordinates);
 export const useMapExtent = (): Extent | undefined => useStore(useGeoViewStore(), (state) => state.mapState.mapExtent);
 export const useMapFixNorth = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.fixNorth);
+export const useMapInitialFilters = (): Record<string, string> => useStore(useGeoViewStore(), (state) => state.mapState.initialFilters);
 export const useMapInteraction = (): TypeInteraction => useStore(useGeoViewStore(), (state) => state.mapState.interaction);
 export const useMapHoverFeatureInfo = (): TypeHoverFeatureInfo => useStore(useGeoViewStore(), (state) => state.mapState.hoverFeatureInfo);
 export const useMapLoaded = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.mapLoaded);

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/time-slider-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/time-slider-state.ts
@@ -254,6 +254,6 @@ export interface TypeTimeSliderValues {
 export const useTimeSliderLayers = (): TimeSliderLayerSet => useStore(useGeoViewStore(), (state) => state.timeSliderState.timeSliderLayers);
 export const useTimeSliderSelectedLayerPath = (): string => useStore(useGeoViewStore(), (state) => state.timeSliderState.selectedLayerPath);
 export const useTimeSliderFilters = (): Record<string, string> =>
-  useStore(useGeoViewStore(), (state) => state.timeSliderState.sliderFilters);
+  useStore(useGeoViewStore(), (state) => state.timeSliderState?.sliderFilters);
 
 export const useTimeSliderStoreActions = (): TimeSliderActions => useStore(useGeoViewStore(), (state) => state.timeSliderState.actions);

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -605,12 +605,18 @@ export class MapViewer {
 
     // Zoom to extent provided in config, it present
     if (this.mapFeaturesConfig.map.viewSettings.initialView?.extent)
-      await this.zoomToExtent(
-        Projection.transformExtent(
-          this.mapFeaturesConfig.map.viewSettings.initialView?.extent,
-          Projection.PROJECTION_NAMES.LNGLAT,
-          `EPSG:${this.mapFeaturesConfig.map.viewSettings.projection}`
-        )
+      setTimeout(
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        () =>
+          this.zoomToExtent(
+            Projection.transformExtent(
+              this.mapFeaturesConfig.map.viewSettings.initialView?.extent as Extent,
+              Projection.PROJECTION_NAMES.LNGLAT,
+              `EPSG:${this.mapFeaturesConfig.map.viewSettings.projection}`
+            ),
+            { padding: [0, 0, 0, 0] }
+          ).catch((error) => logger.logPromiseFailed('promiseMapLayers in #checkMapLayersProcessed in map-viewer', error)),
+        200
       );
 
     // Zoom to extents of layers selected in config, if provided.


### PR DESCRIPTION
# Description

Added an event to the API for a map being added to a div. Necessary because the reload destroys listeners and they can't be re-added until the map is back. Also removes padding from initial settings zoom to extent.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/06-basic-footer.json
Notification show up for map being added

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2444)
<!-- Reviewable:end -->
