### PR TITLE
fix(layer): Fix the French apostophe in layerDef for ESRI and mapExte…

### DIFF
--- a/packages/geoview-core/public/templates/outliers/outlier-geometry.html
+++ b/packages/geoview-core/public/templates/outliers/outlier-geometry.html
@@ -176,6 +176,32 @@
                   }
                 }
               ]
+            },
+            {
+              'geoviewLayerId': 'layerDef',
+              'geoviewLayerName': {
+                'en': 'IACC FR',
+                'fr': 'IAAC FR'
+              },
+              'metadataAccessPath': {
+                'en': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/IAAC/assessment_inventory_fr/MapServer/',
+                'fr': 'https://maps-cartes.services.geo.ca/server_serveur/rest/services/IAAC/assessment_inventory_fr/MapServer/'
+              },
+              'geoviewLayerType': 'esriDynamic',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': '0',
+                  'layerName': {
+                    'en': 'IACC FR',
+                    'fr': 'IAAC FR'
+                  },
+                  'initialSettings': {
+                  'states': {
+                    'visible': true
+                    }
+                  }
+                }
+              ]
             }
           ]
         },
@@ -204,6 +230,9 @@
         </li>
         <li>
           Protected and conserved area - esri dynamic data table not fetching because of geometry in url - Issue #2200
+        </li>
+        <li>
+          Impact Assessment Agency of Canada – Environmental and Impact Assessments (French) - esri layer definition character in French - Issue #2413
         </li>
       </ul>
     </div>

--- a/packages/geoview-core/src/api/config/esri-renderer-parser.ts
+++ b/packages/geoview-core/src/api/config/esri-renderer-parser.ts
@@ -464,7 +464,7 @@ function processUniqueValueRenderer(renderer: EsriUniqueValueRenderer): TypeStyl
       uniqueValueStyleInfo.push({
         label: symbolInfo.label,
         visible: true,
-        values: symbolInfo.value.replace("'", "''").split(renderer.fieldDelimiter), // GV: We need to escape the ' character with double '' for ESRI
+        values: symbolInfo.value.replaceAll("'", "''").split(renderer.fieldDelimiter), // GV: We need to escape the ' character with double '' for ESRI
         settings,
       });
     }

--- a/packages/geoview-core/src/api/config/esri-renderer-parser.ts
+++ b/packages/geoview-core/src/api/config/esri-renderer-parser.ts
@@ -464,7 +464,7 @@ function processUniqueValueRenderer(renderer: EsriUniqueValueRenderer): TypeStyl
       uniqueValueStyleInfo.push({
         label: symbolInfo.label,
         visible: true,
-        values: symbolInfo.value.split(renderer.fieldDelimiter),
+        values: symbolInfo.value.replace("'", "''").split(renderer.fieldDelimiter), // GV: We need to escape the ' character with double '' for ESRI
         settings,
       });
     }

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -425,10 +425,18 @@ export class MapEventProcessor extends AbstractEventProcessor {
     pointerPosition: TypeMapMouseInfo,
     degreeRotation: string,
     isNorthVisible: boolean,
+    mapExtent: Extent,
     scale: TypeScaleInfo
   ): void {
     // Save in store
-    this.getMapStateProtected(mapId).setterActions.setMapMoveEnd(centerCoordinates, pointerPosition, degreeRotation, isNorthVisible, scale);
+    this.getMapStateProtected(mapId).setterActions.setMapMoveEnd(
+      centerCoordinates,
+      pointerPosition,
+      degreeRotation,
+      isNorthVisible,
+      mapExtent,
+      scale
+    );
   }
 
   static setInteraction(mapId: string, interaction: TypeInteraction): void {
@@ -1203,13 +1211,13 @@ export class MapEventProcessor extends AbstractEventProcessor {
         const filter = TimeSliderEventProcessor.getTimeSliderFilter(mapId, layerPath);
         if (filter) geoviewLayer.applyViewFilter(layerPath, filter);
       } else {
-        const filters = this.getActiveVectorFilters(mapId, layerPath);
+        const filters = this.getActiveVectorFilters(mapId, layerPath) || [''];
 
-        if (filters && filters.length)
-          (geoviewLayer as AbstractGeoViewVector | AbstractGVVector | EsriDynamic | GVEsriDynamic).applyViewFilter(
-            layerPath,
-            filters.join(' and ')
-          );
+        // Force the layer to applyfilter so it refresh for layer class selection (esri layerDef) even if no other filter are applied.
+        (geoviewLayer as AbstractGeoViewVector | AbstractGVVector | EsriDynamic | GVEsriDynamic).applyViewFilter(
+          layerPath,
+          filters.join(' and ')
+        );
       }
     }
   }

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
@@ -105,6 +105,7 @@ export interface IMapState {
       pointerPosition: TypeMapMouseInfo,
       degreeRotation: string,
       isNorthVisible: boolean,
+      mapExtent: Extent,
       scale: TypeScaleInfo
     ) => void;
     setPointerPosition: (pointerPosition: TypeMapMouseInfo) => void;
@@ -656,6 +657,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
         pointerPosition: TypeMapMouseInfo,
         degreeRotation: string,
         isNorthVisible: boolean,
+        mapExtent: Extent,
         scale: TypeScaleInfo
       ): void => {
         set({
@@ -666,6 +668,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
               degreeRotation,
               isNorthVisible,
             },
+            mapExtent,
             scale,
           },
         });

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -510,7 +510,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
 
       identifyUrl = identifyUrl.endsWith('/') ? identifyUrl : `${identifyUrl}/`;
 
-      // GV: We cannot direclty use the view extent and reporject. If we do so some layers (issue #2413) identify will return empty resultset
+      // GV: We cannot directly use the view extent and reproject. If we do so some layers (issue #2413) identify will return empty resultset
       // GV-CONT: This happen with max extent as initial extent and 3978 projection. If we use only the LL and UP corners for the repojection it works
       const mapViewer = this.getMapViewer();
       const mapExtent = mapViewer.getView().calculateExtent();

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -510,10 +510,13 @@ export class EsriDynamic extends AbstractGeoViewRaster {
 
       identifyUrl = identifyUrl.endsWith('/') ? identifyUrl : `${identifyUrl}/`;
 
+      // GV: We cannot direclty use the view extent and reporject. If we do so some layers (issue #2413) identify will return empty resultset
+      // GV-CONT: This happen with max extent as initial extent and 3978 projection. If we use only the LL and UP corners for the repojection it works
       const mapViewer = this.getMapViewer();
-      const bounds = mapViewer.convertExtentMapProjToLngLat(mapViewer.getView().calculateExtent());
-
-      const extent = { xmin: bounds[0], ymin: bounds[1], xmax: bounds[2], ymax: bounds[3] };
+      const mapExtent = mapViewer.getView().calculateExtent();
+      const boundsLL = mapViewer.convertCoordinateMapProjToLngLat([mapExtent[0], mapExtent[1]]);
+      const boundsUR = mapViewer.convertCoordinateMapProjToLngLat([mapExtent[2], mapExtent[3]]);
+      const extent = { xmin: boundsLL[0], ymin: boundsLL[1], xmax: boundsUR[0], ymax: boundsUR[1] };
 
       const source = layer.getSource();
       const layerDefs = source?.getParams().layerDefs || '';

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -280,10 +280,13 @@ export class GVEsriDynamic extends AbstractGVRaster {
 
       identifyUrl = identifyUrl.endsWith('/') ? identifyUrl : `${identifyUrl}/`;
 
+      // GV: We cannot direclty use the view extent and reporject. If we do so some layers (issue #2413) identify will return empty resultset
+      // GV-CONT: This happen with max extent as initial extent and 3978 projection. If we use only the LL and UP corners for the repojection it works
       const mapViewer = this.getMapViewer();
-      const bounds = mapViewer.convertExtentMapProjToLngLat(mapViewer.getView().calculateExtent());
-
-      const extent = { xmin: bounds[0], ymin: bounds[1], xmax: bounds[2], ymax: bounds[3] };
+      const mapExtent = mapViewer.getView().calculateExtent();
+      const boundsLL = mapViewer.convertCoordinateMapProjToLngLat([mapExtent[0], mapExtent[1]]);
+      const boundsUR = mapViewer.convertCoordinateMapProjToLngLat([mapExtent[2], mapExtent[3]]);
+      const extent = { xmin: boundsLL[0], ymin: boundsLL[1], xmax: boundsUR[0], ymax: boundsUR[1] };
 
       const layerDefs = this.getOLSource()?.getParams()?.layerDefs || '';
       const size = mapViewer.map.getSize()!;

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -280,7 +280,7 @@ export class GVEsriDynamic extends AbstractGVRaster {
 
       identifyUrl = identifyUrl.endsWith('/') ? identifyUrl : `${identifyUrl}/`;
 
-      // GV: We cannot direclty use the view extent and reporject. If we do so some layers (issue #2413) identify will return empty resultset
+      // GV: We cannot directly use the view extent and reproject. If we do so some layers (issue #2413) identify will return empty resultset
       // GV-CONT: This happen with max extent as initial extent and 3978 projection. If we use only the LL and UP corners for the repojection it works
       const mapViewer = this.getMapViewer();
       const mapExtent = mapViewer.getView().calculateExtent();

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -356,11 +356,14 @@ export class MapViewer {
       // Get the north visibility
       const isNorthVisible = this.getNorthVisibility();
 
+      // Get the map Extent
+      const extent = this.getView().calculateExtent();
+
       // Get the scale information
       const scale = await MapEventProcessor.getScaleInfoFromDomElement(this.mapId);
 
       // Save in the store
-      MapEventProcessor.setMapMoveEnd(this.mapId, centerCoordinates, pointerPosition, degreeRotation, isNorthVisible, scale);
+      MapEventProcessor.setMapMoveEnd(this.mapId, centerCoordinates, pointerPosition, degreeRotation, isNorthVisible, extent, scale);
 
       // Emit to the outside
       this.#emitMapMoveEnd({ lnglat: centerCoordinates });

--- a/packages/geoview-core/src/geo/utils/renderer/esri-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/esri-renderer.ts
@@ -343,7 +343,7 @@ function processUniqueValueRenderer(renderer: EsriUniqueValueRenderer): TypeStyl
       uniqueValueStyleInfo.push({
         label: symbolInfo.label,
         visible: true,
-        values: symbolInfo.value.replace("'", "''").split(renderer.fieldDelimiter), // GV: We need to escape the ' character with double '' for ESRI
+        values: symbolInfo.value.replaceAll("'", "''").split(renderer.fieldDelimiter), // GV: We need to escape the ' character with double '' for ESRI
         settings,
       });
     }

--- a/packages/geoview-core/src/geo/utils/renderer/esri-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/esri-renderer.ts
@@ -343,7 +343,7 @@ function processUniqueValueRenderer(renderer: EsriUniqueValueRenderer): TypeStyl
       uniqueValueStyleInfo.push({
         label: symbolInfo.label,
         visible: true,
-        values: symbolInfo.value.split(renderer.fieldDelimiter),
+        values: symbolInfo.value.replace("'", "''").split(renderer.fieldDelimiter), // GV: We need to escape the ' character with double '' for ESRI
         settings,
       });
     }


### PR DESCRIPTION
…nt in 3978 who return empty result set

Closes #2413

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #2413 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

Hosted August 30th, 9:15am: https://jolevesq.github.io/geoview/outlier-geometry.html

Added a IACC FR layer with ' for layerDefinition
Test the hover on the layer as it was failing after the fix because of mapExtent reprojection (only for 3978 and for this layer)

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2450)
<!-- Reviewable:end -->
