### PR TITLE
fix(geojson): clear details on feature override

### DIFF
--- a/packages/geoview-core/src/api/event-processors/event-processor-children/feature-info-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/feature-info-event-processor.ts
@@ -112,6 +112,11 @@ export class FeatureInfoEventProcessor extends AbstractEventProcessor {
     }
   }
 
+  static setSelectedLayerPath(mapId: string, layerPath: string): void {
+    // Save in store
+    this.getFeatureInfoState(mapId).setterActions.setSelectedLayerPath(layerPath);
+  }
+
   /**
    * Propagates feature info layer sets to the store. The update of the array will also trigger an update in a batched manner.
    *

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -33,6 +33,7 @@ import { Projection } from '@/geo/utils/projection';
 import { LegendEventProcessor } from '@/api/event-processors/event-processor-children/legend-event-processor';
 import { DataTableEventProcessor } from '@/api/event-processors/event-processor-children/data-table-event-processor';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
+import { FeatureInfoEventProcessor } from '@/api/event-processors/event-processor-children/feature-info-event-processor';
 
 export interface TypeSourceGeoJSONInitialConfig extends Omit<TypeVectorSourceInitialConfig, 'format'> {
   format: 'GeoJSON';
@@ -275,6 +276,8 @@ export class GeoJSON extends AbstractGeoViewVector {
       MapEventProcessor.removeHighlightedFeature(this.mapId, 'all');
 
       // Update feature info
+      FeatureInfoEventProcessor.deleteFeatureInfo(this.mapId, layerPath);
+      FeatureInfoEventProcessor.setSelectedLayerPath(this.mapId, '');
       DataTableEventProcessor.triggerGetAllFeatureInfo(this.mapId, layerPath).catch((error) => {
         // Log
         logger.logPromiseFailed(`Update all feature info in overrideGeojsonSource failed for layer ${layerPath}`, error);


### PR DESCRIPTION
# Description

Clears details when geojson features are overridden. Remnants remain: the number of features still appears in the layer in the left panel, and the skeleton is shown instead of the guide.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demo-geojson-inject.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2455)
<!-- Reviewable:end -->
