### PR TITLE
fix(home): home button works for extent and ids

### DIFF
--- a/packages/geoview-core/src/api/config/types/classes/map-feature-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/map-feature-config.ts
@@ -130,6 +130,11 @@ export class MapFeatureConfig {
       // Default map config depends on map projection.
       defaultsDeep(gvMap, MapFeatureConfig.#getDefaultMapConfig(gvMap?.viewSettings?.projection as TypeValidMapProjectionCodes))
     );
+
+    // Above code will add default zoomAndCenter, remove if other initial view is provided
+    if (this.map.viewSettings.initialView?.extent || this.map.viewSettings.initialView?.layerIds)
+      delete this.map.viewSettings.initialView.zoomAndCenter;
+
     this.map.listOfGeoviewLayerConfig = this.map.listOfGeoviewLayerConfig
       .map((geoviewLayerConfig) => {
         return MapFeatureConfig.nodeFactory(toJsonObject(geoviewLayerConfig), this.#language);

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -916,16 +916,10 @@ export class MapEventProcessor extends AbstractEventProcessor {
     }
 
     // If extent is in config, use it
-    if (getGeoViewStore(mapId).getState().mapConfig!.map.viewSettings.initialView?.extent)
-      extent = getGeoViewStore(mapId).getState().mapConfig!.map.viewSettings.initialView!.extent as Extent;
-
-    // Get extents of provided layer IDs if available
-    if (getGeoViewStore(mapId).getState().mapConfig!.map.viewSettings.initialView?.layerIds) {
-      const layerExtents = api.maps[mapId].layer.getExtentOfMultipleLayers(
-        getGeoViewStore(mapId).getState().mapConfig!.map.viewSettings.initialView?.layerIds
-      );
-
-      if (layerExtents) extent = layerExtents;
+    if (getGeoViewStore(mapId).getState().mapConfig!.map.viewSettings.initialView?.extent) {
+      const lnglatExtent = getGeoViewStore(mapId).getState().mapConfig!.map.viewSettings.initialView!.extent as Extent;
+      extent = Projection.transformExtent(lnglatExtent, Projection.PROJECTION_NAMES.LNGLAT, `EPSG:${currProjection}`);
+      options.padding = [0, 0, 0, 0];
     }
 
     return this.zoomToExtent(mapId, extent, options);

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -1201,7 +1201,7 @@ export class LayerApi {
         // Unregister layer
         this.unregisterLayerConfig(this.getLayerEntryConfig(registeredLayerPath)!);
         // Remove from registered layers
-        delete this.#layerEntryConfigs[layerPath];
+        delete this.#layerEntryConfigs[registeredLayerPath];
       }
     });
 
@@ -1334,14 +1334,17 @@ export class LayerApi {
       // Get sublayerpaths and layerpaths from layer IDs.
       const subLayerPaths = Object.keys(this.#layerEntryConfigs).filter((layerPath) => layerPath.startsWith(layerId));
 
-      // Get max extents from all selected layers.
-      subLayerPaths.forEach((layerPath) => {
-        // Get the bounds for the layer path
-        const layerBounds = LegendEventProcessor.getLayerBounds(this.getMapId(), layerPath);
-        // If bounds has not yet been defined, set to this layers bounds.
-        if (!bounds.length && layerBounds) bounds = layerBounds;
-        else if (layerBounds) bounds = getMinOrMaxExtents(bounds, layerBounds);
-      });
+      if (subLayerPaths.length) {
+        // Get max extents from all selected layers.
+        subLayerPaths.forEach((layerPath) => {
+          // Get the bounds for the layer path
+          const layerBounds = LegendEventProcessor.getLayerBounds(this.getMapId(), layerPath);
+
+          // If bounds has not yet been defined, set to this layers bounds.
+          if (!bounds.length && layerBounds) bounds = layerBounds;
+          else if (layerBounds) bounds = getMinOrMaxExtents(bounds, layerBounds);
+        });
+      }
     });
 
     return bounds;


### PR DESCRIPTION
Also fixes sublayer entry configs not being deleted when parent was removed

# Description

Also fixes sublayer entry configs not being deleted when parent was removed. Slight discrepancy with zoom to layer ids remain, as the extent is converted to lat/lon and then back.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/05-zoom-layer.json

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2504)
<!-- Reviewable:end -->
