### PR TITLE
feat(event): Event added to API for map ready

### DIFF
--- a/packages/geoview-core/src/api/api.ts
+++ b/packages/geoview-core/src/api/api.ts
@@ -34,6 +34,9 @@ export class API {
   utilities;
 
   // Keep all callback delegates references
+  #onMapViewerReadyHandlers: MapViewerReadyDelegate[] = [];
+
+  // Keep all callback delegates references
   #onMapAddedToDivHandlers: MapAddedToDivDelegate[] = [];
 
   /**
@@ -124,6 +127,41 @@ export class API {
   }
 
   /**
+   * Triggers the mapViewerReady event for users who need map status outside of cgpv.init
+   * @param {string} mapId - The ID of the map
+   */
+  mapViewerReady(mapId: string): void {
+    this.#emitMapViewerReady({ mapId });
+  }
+
+  /**
+   * Emits a map viewer ready event to all handlers.
+   * @private
+   */
+  #emitMapViewerReady(event: MapViewerReadyEvent): void {
+    // Emit the event for all handlers
+    EventHelper.emitEvent(this, this.#onMapViewerReadyHandlers, event);
+  }
+
+  /**
+   * Registers a map viewer ready event callback.
+   * @param {MapViewerReadyDelegate} callback - The callback to be executed whenever the event is emitted
+   */
+  onMapViewerReady(callback: MapViewerReadyDelegate): void {
+    // Register the event handler
+    EventHelper.onEvent(this.#onMapViewerReadyHandlers, callback);
+  }
+
+  /**
+   * Unregisters a map viewer ready event callback.
+   * @param {MapViewerReadyDelegate} callback - The callback to stop being called whenever the event is emitted
+   */
+  offMapViewerReady(callback: MapViewerReadyDelegate): void {
+    // Unregister the event handler
+    EventHelper.offEvent(this.#onMapViewerReadyHandlers, callback);
+  }
+
+  /**
    * Emits an event to all handlers.
    * @param {MapAddedToDivEvent} event - The event to emit
    * @private
@@ -155,12 +193,25 @@ export class API {
 /**
  * Define a delegate for the event handler function signature
  */
+type MapViewerReadyDelegate = EventDelegateBase<API, MapViewerReadyEvent, void>;
+
+/**
+ * Define an event for the delegate
+ */
+export type MapViewerReadyEvent = {
+  // The added map
+  mapId: string;
+};
+
+/**
+ * Define a delegate for the event handler function signature
+ */
 type MapAddedToDivDelegate = EventDelegateBase<API, MapAddedToDivEvent, void>;
 
 /**
  * Define an event for the delegate
  */
 export type MapAddedToDivEvent = {
-  // The added layer
+  // The added map
   mapId: string;
 };

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -561,6 +561,9 @@ export class MapViewer {
     this.#mapReady = true;
     this.#emitMapReady();
 
+    // Emit API event for use outside of cgpv.init
+    api.mapViewerReady(this.mapId);
+
     // Load the Map itself and the UI controls
     MapEventProcessor.initMapControls(this.mapId);
 


### PR DESCRIPTION
# Description

Added an API event to inform user when the map viewer is ready, for use outside of cgpv.init

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested using event to log map ID in the console
https://damonu2.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
