### PR TITLE
fix(notification): implement close icon for notificaiton and version 

### DIFF
--- a/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
@@ -3,11 +3,13 @@ import { useTranslation } from 'react-i18next';
 import { Typography, Box, Link, Theme, SvgIcon, ClickAwayListener, Paper } from '@mui/material';
 
 import { GITHUB_REPO, GEO_URL_TEXT } from '@/core/utils/constant';
-import { GeoCaIcon, IconButton, Popper } from '@/ui';
+import { GeoCaIcon, IconButton, Popper, CloseIcon } from '@/ui';
 import { useGeoViewMapId } from '@/core/stores/geoview-store';
 import { useMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { GitHubIcon } from '@/ui/icons';
 import { handleEscapeKey } from '@/core/utils/utilities';
+import { FocusTrapContainer } from '../../common';
+import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 
 // eslint-disable-next-line no-underscore-dangle
 declare const __VERSION__: TypeAppVersion;
@@ -31,6 +33,7 @@ export default function Version(): JSX.Element {
 
   const mapId = useGeoViewMapId();
   const interaction = useMapInteraction();
+  const activeTrapGeoView = useUIActiveTrapGeoView();
 
   const mapElem = document.getElementById(`shell-${mapId}`);
 
@@ -62,12 +65,16 @@ export default function Version(): JSX.Element {
         textDecoration: 'underLine',
       },
     },
+    versionHeading: {
+      display: 'flex',
+      alignItems: 'center',
+      borderBottom: (theme: Theme) => `1px solid ${theme.palette.geoViewColor.bgColor.dark[100]}}`,
+    },
     versionsInfoTitle: {
       fontSize: (theme: Theme) => theme.palette.geoViewFontSize.default,
       fontWeight: '700',
       padding: '20px',
       color: (theme: Theme) => theme.palette.geoViewColor.textColor.main,
-      borderBottom: (theme: Theme) => `1px solid ${theme.palette.geoViewColor.bgColor.dark[100]}}`,
       marginBottom: '10px',
     },
     versionInfoContent: {
@@ -101,30 +108,38 @@ export default function Version(): JSX.Element {
           onClose={handleClickAway}
           container={mapElem}
           handleKeyDown={(key, callBackFn) => handleEscapeKey(key, '', false, callBackFn)}
+          disablePortal
         >
-          <Paper sx={sxClasses.versionInfoPanel}>
-            <Typography sx={sxClasses.versionsInfoTitle} component="h3">
-              {t('appbar.version')}
-            </Typography>
-            <Box sx={sxClasses.versionInfoContent}>
-              <Box sx={{ display: 'flex', flexDirection: 'row', alignContent: 'center', gap: '6px' }}>
-                <SvgIcon viewBox="-4 -2 38 36">
-                  <GeoCaIcon />
-                </SvgIcon>
-                <Link rel="noopener" href={GEO_URL_TEXT.url} target="_black">
-                  {GEO_URL_TEXT.text}
-                </Link>
+          <FocusTrapContainer id={`${mapId}-version`} open={open && activeTrapGeoView}>
+            <Paper sx={sxClasses.versionInfoPanel}>
+              <Box sx={sxClasses.versionHeading}>
+                <Typography sx={sxClasses.versionsInfoTitle} component="h3">
+                  {t('appbar.version')}
+                </Typography>
+                <IconButton onClick={handleClickAway}>
+                  <CloseIcon />
+                </IconButton>
               </Box>
-              <Box sx={{ display: 'flex', flexDirection: 'row', alignContent: 'center', gap: '6px' }}>
-                <GitHubIcon />
-                <Link rel="noopener" href={GITHUB_REPO} target="_black">
-                  {t('appbar.repoLink')}
-                </Link>
+              <Box sx={sxClasses.versionInfoContent}>
+                <Box sx={{ display: 'flex', flexDirection: 'row', alignContent: 'center', gap: '6px' }}>
+                  <SvgIcon viewBox="-4 -2 38 36">
+                    <GeoCaIcon />
+                  </SvgIcon>
+                  <Link rel="noopener" href={GEO_URL_TEXT.url} target="_black">
+                    {GEO_URL_TEXT.text}
+                  </Link>
+                </Box>
+                <Box sx={{ display: 'flex', flexDirection: 'row', alignContent: 'center', gap: '6px' }}>
+                  <GitHubIcon />
+                  <Link rel="noopener" href={GITHUB_REPO} target="_black">
+                    {t('appbar.repoLink')}
+                  </Link>
+                </Box>
+                <Typography component="div">{`v.${__VERSION__.major}.${__VERSION__.minor}.${__VERSION__.patch}`}</Typography>
+                <Typography component="div">{new Date(__VERSION__.timestamp).toLocaleDateString()}</Typography>
               </Box>
-              <Typography component="div">{`v.${__VERSION__.major}.${__VERSION__.minor}.${__VERSION__.patch}`}</Typography>
-              <Typography component="div">{new Date(__VERSION__.timestamp).toLocaleDateString()}</Typography>
-            </Box>
-          </Paper>
+            </Paper>
+          </FocusTrapContainer>
         </Popper>
       </Box>
     </ClickAwayListener>

--- a/packages/geoview-core/src/core/components/common/focus-trap-container.tsx
+++ b/packages/geoview-core/src/core/components/common/focus-trap-container.tsx
@@ -31,7 +31,7 @@ export function FocusTrapContainer({ children, open = false, id, containerType }
   const focusItem = useUIActiveFocusItem();
 
   const handleClose = (): void => {
-    disableFocusTrap();
+    disableFocusTrap(id);
   };
 
   // #region REACT HOOKS

--- a/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
@@ -148,7 +148,7 @@ export default function DataTableModal(): JSX.Element {
   }, [layersData, selectedLayer]);
 
   return (
-    <Dialog open={activeModalId === 'layerDataTable'} onClose={disableFocusTrap} maxWidth="xl">
+    <Dialog open={activeModalId === 'layerDataTable'} onClose={() => disableFocusTrap()} maxWidth="xl">
       <DialogTitle>{`${t('legend.tableDetails')} ${layer?.layerName ?? selectedLayer}`}</DialogTitle>
       <DialogContent sx={{ overflow: 'hidden' }}>
         {isLoading && (
@@ -187,7 +187,7 @@ export default function DataTableModal(): JSX.Element {
         )}
       </DialogContent>
       <DialogActions>
-        <Button fullWidth variant="contained" className="buttonOutlineFilled" onClick={disableFocusTrap} type="text" autoFocus>
+        <Button fullWidth variant="contained" className="buttonOutlineFilled" onClick={() => disableFocusTrap()} type="text" autoFocus>
           {t('general.close')}
         </Button>
       </DialogActions>

--- a/packages/geoview-core/src/core/components/details/feature-detail-modal.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-detail-modal.tsx
@@ -54,7 +54,7 @@ export default function FeatureDetailModal(): JSX.Element {
   return (
     <Dialog
       open={activeModalId === 'featureDetailDataTable' && !!feature}
-      onClose={disableFocusTrap}
+      onClose={() => disableFocusTrap()}
       maxWidth="lg"
       disablePortal
       sx={sxClasses.featureDetailModal}
@@ -72,7 +72,15 @@ export default function FeatureDetailModal(): JSX.Element {
         </List>
       </DialogContent>
       <DialogActions>
-        <Button fullWidth variant="contained" className="buttonOutlineFilled" onClick={disableFocusTrap} type="text" size="small" autoFocus>
+        <Button
+          fullWidth
+          variant="contained"
+          className="buttonOutlineFilled"
+          onClick={() => disableFocusTrap()}
+          type="text"
+          size="small"
+          autoFocus
+        >
           {t('general.close')}
         </Button>
       </DialogActions>

--- a/packages/geoview-core/src/core/components/export/export-modal.tsx
+++ b/packages/geoview-core/src/core/components/export/export-modal.tsx
@@ -159,7 +159,7 @@ export default function ExportModal(): JSX.Element {
   }, [activeModalId, isOpen]);
 
   return (
-    <Dialog open={activeModalId === 'export'} onClose={disableFocusTrap} fullWidth maxWidth="xl" disablePortal>
+    <Dialog open={activeModalId === 'export'} onClose={() => disableFocusTrap()} fullWidth maxWidth="xl" disablePortal>
       <DialogTitle>{t('exportModal.title')}</DialogTitle>
       <DialogContent dividers ref={dialogRef}>
         <Box ref={exportContainerRef} textAlign="center">

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -192,7 +192,7 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
     logger.logTraceUseEffect('FOOTER-TABS - arrayOfLayerDataBatch', arrayOfLayerDataBatch, selectedTab, isCollapsed);
 
     // If we're on the details panel and the footer is collapsed
-    if (selectedTab === 'details' && isCollapsed) {
+    if (selectedTab === `${mapId}-details-2` && isCollapsed) {
       // Uncollapse it
       setFooterBarIsCollapsed(false);
     }

--- a/packages/geoview-core/src/core/components/notifications/notifications-style.ts
+++ b/packages/geoview-core/src/core/components/notifications/notifications-style.ts
@@ -20,7 +20,7 @@ export const getSxClasses = (theme: Theme): any => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    padding: '20px',
+    padding: '1.25rem 0.25rem 1.25rem 1.25rem',
     borderBottom: `1px solid ${theme.palette.geoViewColor.bgColor.dark[100]}}`,
   },
   notificationsTitle: {

--- a/packages/geoview-core/src/core/components/notifications/notifications.tsx
+++ b/packages/geoview-core/src/core/components/notifications/notifications.tsx
@@ -27,6 +27,8 @@ import { logger } from '@/core/utils/logger';
 import { useMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { useShake } from '@/core/utils/useSpringAnimations';
 import { handleEscapeKey } from '@/core/utils/utilities';
+import { FocusTrapContainer } from '../common';
+import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 
 export type NotificationDetailsType = {
   key: string;
@@ -63,6 +65,8 @@ export default function Notifications(): JSX.Element {
   // get values from the store
   const notifications = useAppNotifications();
   const interaction = useMapInteraction();
+  const activeTrapGeoView = useUIActiveTrapGeoView();
+
   const { removeNotification, removeAllNotifications } = useAppStoreActions();
 
   useEffect(() => {
@@ -175,34 +179,42 @@ export default function Notifications(): JSX.Element {
           placement="right-end"
           onClose={handleClickAway}
           container={mapElem}
+          disablePortal
           handleKeyDown={(key, callBackFn) => handleEscapeKey(key, '', false, callBackFn)}
         >
-          <Paper sx={sxClasses.notificationPanel}>
-            <Box sx={sxClasses.notificationsHeader}>
-              <Typography component="h3" sx={sxClasses.notificationsTitle}>
-                {t('appbar.notifications')}
-              </Typography>
-              <Button
-                type="text"
-                variant="contained"
-                disabled={notifications.length === 0}
-                size="small"
-                onClick={handleRemoveAllNotificationsClick}
-                aria-label={t('appbar.removeAllNotifications') ?? ''}
-              >
-                {t('appbar.removeAllNotifications')}
-              </Button>
-            </Box>
-            <Box sx={sxClasses.notificationsList}>
-              {notifications.length > 0 ? (
-                notifications.map((notification, index) => renderNotification(notification, index))
-              ) : (
-                <Typography component="div" sx={{ padding: '10px 15px' }}>
-                  {t('appbar.no_notifications_available')}
+          <FocusTrapContainer id={`${mapId}-notification`} open={open && activeTrapGeoView}>
+            <Paper sx={sxClasses.notificationPanel}>
+              <Box sx={sxClasses.notificationsHeader}>
+                <Typography component="h3" sx={sxClasses.notificationsTitle}>
+                  {t('appbar.notifications')}
                 </Typography>
-              )}
-            </Box>
-          </Paper>
+                <Box>
+                  <Button
+                    type="text"
+                    variant="contained"
+                    disabled={notifications.length === 0}
+                    size="small"
+                    onClick={handleRemoveAllNotificationsClick}
+                    aria-label={t('appbar.removeAllNotifications') ?? ''}
+                  >
+                    {t('appbar.removeAllNotifications')}
+                  </Button>
+                  <IconButton sx={{ ml: '0.25rem' }} onClick={handleClickAway}>
+                    <CloseIcon />
+                  </IconButton>
+                </Box>
+              </Box>
+              <Box sx={sxClasses.notificationsList}>
+                {notifications.length > 0 ? (
+                  notifications.map((notification, index) => renderNotification(notification, index))
+                ) : (
+                  <Typography component="div" sx={{ padding: '10px 15px' }}>
+                    {t('appbar.no_notifications_available')}
+                  </Typography>
+                )}
+              </Box>
+            </Paper>
+          </FocusTrapContainer>
         </Popper>
       </Box>
     </ClickAwayListener>

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
@@ -38,7 +38,7 @@ export interface IUIState {
   actions: {
     hideTab: (tab: string) => void;
     enableFocusTrap: (uiFocus: FocusItemProps) => void;
-    disableFocusTrap: () => void;
+    disableFocusTrap: (callbackElementId?: string) => void;
     showTab: (tab: string) => void;
     setActiveFooterBarTab: (id: string) => void;
     setActiveAppBarTab: (tabId: string, tabGroup: string, isOpen: boolean, isFocusTrapped: boolean) => void;
@@ -51,7 +51,7 @@ export interface IUIState {
 
   setterActions: {
     enableFocusTrap: (uiFocus: FocusItemProps) => void;
-    disableFocusTrap: () => void;
+    disableFocusTrap: (callbackElementId?: string) => void;
     setActiveFooterBarTab: (id: string) => void;
     setActiveAppBarTab: (tabId: string, tabGroup: string, isOpen: boolean, isFocusTrapped: boolean) => void;
     setActiveTrapGeoView: (active: boolean) => void;
@@ -120,9 +120,9 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
         // Redirect to setter
         get().uiState.setterActions.enableFocusTrap(uiFocus);
       },
-      disableFocusTrap: () => {
+      disableFocusTrap: (callbackElementId: string) => {
         // Redirect to setter
-        get().uiState.setterActions.disableFocusTrap();
+        get().uiState.setterActions.disableFocusTrap(callbackElementId);
       },
       showTab: (tab: string): void => {
         // Redirect to event processor
@@ -167,8 +167,9 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
           },
         });
       },
-      disableFocusTrap: () => {
-        document.getElementById(get().uiState.focusItem.callbackElementId as string)?.focus();
+      disableFocusTrap: (callBackElementId: string) => {
+        const id = callBackElementId ?? (get().uiState.focusItem.callbackElementId as string);
+        document.getElementById(id)?.focus();
         set({
           uiState: {
             ...get().uiState,

--- a/packages/geoview-core/src/ui/tabs/tabs-style.ts
+++ b/packages/geoview-core/src/ui/tabs/tabs-style.ts
@@ -27,6 +27,10 @@ export const getSxClasses = (theme: Theme): any => ({
       marginRight: '7px',
       maxWidth: '18px',
     },
+    ':focus-visible': {
+      border: `2px solid ${theme.palette.common.black}`,
+      outline: 'none',
+    },
   },
   mobileDropdown: {
     maxWidth: '200px',


### PR DESCRIPTION
# Description
Implement focus trap and close icon for notification and version popover so that user can ability to close it.
Fix the exit button of tab panel when access through keyboard.

Fixes #2522 
Fixes #2523

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

__Add the URL for your deploy!__
https://kaminderpal.github.io/geoview/demos-navigator.html?config=./configs/navigator/07-basic-appbar.json

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2527)
<!-- Reviewable:end -->
