### PR TITLE
fix(lightbox): WCAG and fullscreen fail

### DIFF
--- a/packages/geoview-core/src/core/components/common/use-lightbox.tsx
+++ b/packages/geoview-core/src/core/components/common/use-lightbox.tsx
@@ -16,6 +16,7 @@ export function useLightBox(): UseLightBoxReturnType {
   const [slides, setSlides] = useState<LightBoxSlides[]>([]);
   const [slidesIndex, setSlidesIndex] = useState(0);
   const [imgScale, setImgScale] = useState<number | undefined>();
+  const [aliasIndex, setAliasIndex] = useState(0);
 
   /**
    * Initialize lightbox with state.
@@ -35,6 +36,7 @@ export function useLightBox(): UseLightBoxReturnType {
     setSlides(slidesList);
     setSlidesIndex(index ?? 0);
     setImgScale(scale);
+    setAliasIndex(alias.split('_')[0]);
   };
 
   /**
@@ -52,6 +54,8 @@ export function useLightBox(): UseLightBoxReturnType {
           setIsLightBoxOpen(false);
           setSlides([]);
           setSlidesIndex(0);
+
+          document.querySelector('.returnLightboxFocusItem')?.focus();
         }}
       />
     ) : (

--- a/packages/geoview-core/src/core/components/common/use-lightbox.tsx
+++ b/packages/geoview-core/src/core/components/common/use-lightbox.tsx
@@ -49,6 +49,7 @@ export function useLightBox(): UseLightBoxReturnType {
    * @returns {JSX.Element}
    */
   function LightBoxComponent(): JSX.Element {
+    // TODO: fix bug https://github.com/Canadian-Geospatial-Platform/geoview/issues/2553
     return isLightBoxOpen ? (
       <LightboxImg
         open={isLightBoxOpen}

--- a/packages/geoview-core/src/core/components/common/use-lightbox.tsx
+++ b/packages/geoview-core/src/core/components/common/use-lightbox.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Box } from '@/ui';
 import { LightBoxSlides, LightboxImg } from '@/core/components/lightbox/lightbox';
+import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 
 interface UseLightBoxReturnType {
   initLightBox: (images: string, alias: string, index: number | undefined, scale?: number) => void;
@@ -12,11 +13,15 @@ interface UseLightBoxReturnType {
  * @returns {UseLightBoxReturnType}
  */
 export function useLightBox(): UseLightBoxReturnType {
+  // Internal state
   const [isLightBoxOpen, setIsLightBoxOpen] = useState(false);
   const [slides, setSlides] = useState<LightBoxSlides[]>([]);
   const [slidesIndex, setSlidesIndex] = useState(0);
   const [imgScale, setImgScale] = useState<number | undefined>();
-  const [aliasIndex, setAliasIndex] = useState(0);
+  const [aliasIndex, setAliasIndex] = useState('0');
+
+  // Store state
+  const activeTrapGeoView = useUIActiveTrapGeoView();
 
   /**
    * Initialize lightbox with state.
@@ -55,7 +60,14 @@ export function useLightBox(): UseLightBoxReturnType {
           setSlides([]);
           setSlidesIndex(0);
 
-          document.querySelector('.returnLightboxFocusItem')?.focus();
+          // If keyboard navigation mode enable, focus to caller item (with timeout so keyboard-focused class can be applied)
+          if (activeTrapGeoView) {
+            setTimeout(() => {
+              const element = document.querySelector(`.returnLightboxFocusItem-${aliasIndex}`) as HTMLElement;
+              element?.focus();
+              element?.classList.add('keyboard-focused');
+            }, 250);
+          }
         }}
       />
     ) : (

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -136,6 +136,7 @@ function DataTable({ data, layerPath, tableHeight = '500px' }: DataTableProps): 
           <Button
             type="text"
             size="small"
+            className={`returnLightboxFocusItem-${cellId.split('_')[0]}`}
             onClick={() => initLightBox(cellValue, cellId, 0)}
             sx={{ height: '2.5rem', paddingLeft: '0.5rem', paddingRight: '0.5rem', textTransform: 'none' }}
           >

--- a/packages/geoview-core/src/core/components/details/feature-info-table.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info-table.tsx
@@ -71,7 +71,7 @@ export function FeatureInfoTable({ featureInfoList }: FeatureInfoTableProps): JS
             click={() => initLightBox(featureInfoItem.value as string, featureInfoItem.alias, index)}
             keyDown={(e: KeyboardEvent) => {
               if (e.key === 'Enter') {
-                initLightBox(featureInfoItem.value as string, featureInfoItem.alias, index);
+                initLightBox(featureInfoItem.value as string, `${index}_${featureInfoItem.alias}`, index);
               }
             }}
           />

--- a/packages/geoview-core/src/core/components/details/feature-info-table.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info-table.tsx
@@ -65,6 +65,7 @@ export function FeatureInfoTable({ featureInfoList }: FeatureInfoTableProps): JS
             key={generateId()}
             sx={{ ...sxClasses.featureInfoItemValue, cursor: 'pointer' }}
             alt={`${alias} ${index}`}
+            className={`returnLightboxFocusItem-${index}`}
             src={item}
             tabIndex={0}
             click={() => initLightBox(featureInfoItem.value as string, featureInfoItem.alias, index)}

--- a/packages/geoview-core/src/core/components/legend/legend-layer.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer.tsx
@@ -183,7 +183,14 @@ export function LegendLayer({ layer }: LegendLayerProps): JSX.Element {
       const imgSrc = layer.icons[0].iconImage;
       return (
         <Collapse in={legendExpanded} sx={sxClasses.collapsibleContainer} timeout="auto">
-          <Box component="img" src={imgSrc} sx={{ maxWidth: '100%', cursor: 'pointer' }} onClick={() => initLightBox(imgSrc, '', 0, 2)} />
+          <Box
+            component="img"
+            tabIndex={0}
+            src={imgSrc}
+            sx={{ maxWidth: '100%', cursor: 'pointer' }}
+            onClick={() => initLightBox(imgSrc, '', 0, 2)}
+            onKeyDown={(e) => (e.code === 'Space' || e.code === 'Enter' ? initLightBox(imgSrc, '', 0, 2) : null)}
+          />
         </Collapse>
       );
     }

--- a/packages/geoview-core/src/core/components/lightbox/lightbox.tsx
+++ b/packages/geoview-core/src/core/components/lightbox/lightbox.tsx
@@ -8,6 +8,7 @@ import 'yet-another-react-lightbox/styles.css';
 
 import { CloseIcon, ArrowRightIcon, ArrowLeftIcon, DownloadIcon, Tooltip } from '@/ui';
 import { logger } from '@/core/utils/logger';
+import { useGeoViewMapId } from '@/core/stores/geoview-store';
 
 /**
  * Interface used for lightbox properties and slides
@@ -46,6 +47,9 @@ export function LightboxImg(props: LightboxProps): JSX.Element {
   const [fade] = useState(250);
   const [swipe] = useState(500);
 
+  // get mapId
+  const mapId = useGeoViewMapId();
+
   useEffect(() => {
     // Log
     logger.logTraceUseEffect('LIGHTBOX - open', open);
@@ -60,6 +64,7 @@ export function LightboxImg(props: LightboxProps): JSX.Element {
         container: { backgroundColor: 'rgba(0, 0, 0, .9)' },
         slide: { transform: `scale(${scale})` },
       }}
+      portal={{ root: document.getElementById(`shell-${mapId}`) }}
       open={isOpen}
       close={() => setIsOpen(false)}
       slides={slides}
@@ -75,7 +80,8 @@ export function LightboxImg(props: LightboxProps): JSX.Element {
       }}
       on={{
         entered: () => {
-          // TODO: Focus on close button on open #1113
+          // document.getElementsByClassName('yarl__button')[1] does not work, use main container
+          document.getElementsByClassName('yarl__root')[0].getElementsByTagName('button')[1].focus();
         },
         exited,
       }}

--- a/packages/geoview-core/src/ui/style/vendor.css
+++ b/packages/geoview-core/src/ui/style/vendor.css
@@ -8,3 +8,28 @@ OpenLayers
 .ol-scale-line-inner {
   display: none;
 }
+
+/*
+yet-another-react-lightbox
+*/
+.yarl__button {
+  width: 44px !important;
+  height: 44px !important;
+  padding: 0px !important;
+}
+
+.yarl__button > svg {
+  width: 24px !important;
+  height: 24px !important;
+}
+
+.yarl__navigation_prev > svg, .yarl__navigation_next > svg {
+  width: 36px !important;
+  height: 36px !important;
+}
+
+.yarl__button:focus {
+  background-color: white !important;
+  color: #000 !important;
+  border-radius: 50% !important;
+}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Fix lightbox not showing on full screen
- Make buttons bigger on lightbox component
- Focus trap when lightbox is enable (focus mode on)
- Focus back to origin image for legend, data table and details

Fixes #2525, #1113

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

Hosted, October 15 - 1pm

https://jolevesq.github.io/geoview/demos-navigator.html?config=./configs/navigator/14-wms-layer.json
- Tab to map, enable focus  trap
- Tab to legend tab and go inside
- Tab to a WMS legend image and press space or enter to enter lightbox
- Tab to see focus trap, close lightbox and see focus return to caller element

https://jolevesq.github.io/geoview/demos-navigator.html?config=./configs/navigator/19-geojson.json
- Click on polygon purple
- Tab to map, enable focus  trap
- Tab to details tab and go inside
- Tab to an image in right panel and press space or enter to enter lightbox
- Tab to see focus trap, close lightbox and see focus return to caller element

Repeat the procedure with data table and image button

Open the lightbox when map is in full screen

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2549)
<!-- Reviewable:end -->
