### PR TITLE
fix(layer-extent) - Fixes an issue with layer extent vs service extent for esri dynamic and esri image layers

### DIFF
--- a/packages/geoview-core/public/templates/outliers/outlier-metadata.html
+++ b/packages/geoview-core/public/templates/outliers/outlier-metadata.html
@@ -43,6 +43,7 @@
             <td>
               <a href="#HMap1">1. Metadata Issue Layers</a><br />
               <a href="#HMap2">2. ESRI service Issue Layers</a><br />
+              <a href="#HMap3">3. Metadata Extent Issue Layers</a><br />
             </td>
           </tr>
         </tbody>
@@ -211,10 +212,88 @@
       Outlier Service:
       <ul>
         <li>
-          Sewer Overflow - Services has inexistant layer index (https://maps-cartes.ec.gc.ca/arcgis/rest/services/DMS/CSO_volume/MapServer/)
+          Sewer Overflow - Service has inexistant layer index (https://maps-cartes.ec.gc.ca/arcgis/rest/services/DMS/CSO_volume/MapServer/)
         </li>
       </ul>
     </div>
+
+    <div class="map-title-holder">
+      <h4 id="HMap3">3. Metadata Extent Issue Layers</h4>
+      <a class="ref-link" href="#top">Top</a>
+    </div>
+    <div
+      id="Map3"
+      class="geoview-map"
+      data-lang="en"
+      data-config="{
+        'map': {
+          'interaction': 'dynamic',
+          'viewSettings': {
+            'projection': 3857
+          },
+          'basemapOptions': {
+            'basemapId': 'transport',
+            'shaded': true,
+            'labeled': true
+          },
+          'listOfGeoviewLayerConfig': [
+            {
+              'geoviewLayerId': 'LYR1',
+              'geoviewLayerName': { 'en': 'Water quality in Canadian rivers' },
+              'metadataAccessPath': {
+                'en': 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/'
+              },
+              'geoviewLayerType': 'esriDynamic',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': '5',
+                  'layerName': { 'en': 'Water quality at monitoring sites, Canada' }
+                }
+              ]
+            },
+            {
+              'geoviewLayerId': 'LYR2',
+              'geoviewLayerName': { 'en': 'Reported releases to surface water for 2020' },
+              'metadataAccessPath': {
+                'en': 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/NPRI_INRP/NPRI_INRP/MapServer/'
+              },
+              'geoviewLayerType': 'esriDynamic',
+              'listOfLayerEntryConfig': [
+                {
+                  'layerId': '3',
+                  'layerName': { 'en': 'Reported releases to surface water for 2020' }
+                }
+              ]
+            }
+          ]
+        },
+        'components': ['north-arrow', 'overview-map'],
+        'overviewMap': {'hideOnZoom': 6},
+        'navBar': ['zoom', 'fullscreen', 'home', 'location', 'basemap-select'],
+        'appBar': {
+          'tabs': {
+            'core': ['geolocator', 'export']
+          }
+        },
+        'footerBar': {
+          'tabs': {
+            'core': ['legend', 'layers', 'details', 'data-table']
+          }
+        },
+        'corePackages': [],
+        'theme': 'geo.ca'
+        }"
+    ></div>
+    <hr />
+    <div>
+      Outlier Service:
+      <ul>
+        <li>
+          Water Quality and Reported releases - Services have extent metadata not covering the entirety of the actual data (https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/ and https://maps-cartes.ec.gc.ca/arcgis/rest/services/NPRI_INRP/NPRI_INRP/MapServer/)
+        </li>
+      </ul>
+    </div>
+
     <script src="codedoc.js"></script>
     <script src="layerlib.js"></script>
     <script>

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -51,7 +51,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
   }
 
   /**
-   * Get a specific state.
+   * Gets a specific state.
    * @param {string} mapId - The mapId
    * @param {'highlightedLayer' | 'selectedLayerPath' | 'displayState' | 'layerDeleteInProgress'} state - The state to get
    * @returns {string | boolean | null | undefined} The requested state
@@ -64,7 +64,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
   }
 
   /**
-   * Get a legend layer.
+   * Gets a legend layer.
    * @param {string} mapId - The mapId
    * @param {string} layerPath - The path of the layer to get
    * @returns {TypeLegendLayer | undefined} The requested legend layer
@@ -76,8 +76,8 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Gets the layer bounds for a layer path
-   * @param mapId - The map id
-   * @param layerPath - The layer path
+   * @param {string} mapId - The map id
+   * @param {string} layerPath - The layer path
    * @returns {Extent | undefined} The extent of the layer at the given path
    */
   static getLayerBounds(mapId: string, layerPath: string): Extent | undefined {
@@ -108,10 +108,10 @@ export class LegendEventProcessor extends AbstractEventProcessor {
   }
 
   /**
-   * Gets the layer bounds for a layer path
-   * @param mapId - The map id
-   * @param layerPath - The layer path
-   * @returns {Extent | undefined} The extent of the layer at the given path
+   * Sets the layer bounds for a layer path
+   * @param {string} mapId - The map id
+   * @param {string} layerPath - The layer path
+   * @param {Extent | undefined} bounds - The extent of the layer at the given path
    */
   static setLayerBounds(mapId: string, layerPath: string, bounds: Extent): void {
     // Find the layer for the given layer path
@@ -127,7 +127,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
   }
 
   /**
-   * Get the extent of a feature or group of features
+   * Gets the extent of a feature or group of features
    * @param {string} mapId - The map identifier
    * @param {string} layerPath - The layer path
    * @param {string[]} objectIds - The IDs of features to get extents from.

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/abstract-geoview-raster.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/abstract-geoview-raster.ts
@@ -59,15 +59,26 @@ export abstract class AbstractGeoViewRaster extends AbstractGeoViewLayer {
    * Gets the metadata extent, if any.
    * @returns {Extent | undefined} The OpenLayer projection
    */
-  getMetadataExtent(): Extent | undefined {
+  getMetadataExtent(layerPath: string): Extent | undefined {
+    // Get the layer metadata precisely
+    const { extent } = this.getLayerMetadata(layerPath);
+
+    // If found
+    if (extent) {
+      return [extent.xmin, extent.ymin, extent.xmax, extent.ymax] as Extent;
+    }
+
+    // Here, we couldn't find the layer metadata, so we use the layer parent definition metadata
     if (this.metadata?.fullExtent) {
       return [
-        this.metadata?.fullExtent.xmin as number,
-        this.metadata?.fullExtent.ymin as number,
-        this.metadata?.fullExtent.xmax as number,
-        this.metadata?.fullExtent.ymax as number,
+        this.metadata?.fullExtent.xmin,
+        this.metadata?.fullExtent.ymin,
+        this.metadata?.fullExtent.xmax,
+        this.metadata?.fullExtent.ymax,
       ] as Extent;
     }
+
+    // No layer metadata extent could be found
     return undefined;
   }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -989,7 +989,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   override getBounds(layerPath: string): Extent | undefined {
     // Get the metadata extent
-    const metadataExtent = this.getMetadataExtent();
+    const metadataExtent = this.getMetadataExtent(layerPath);
 
     // If found
     let layerBounds;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
@@ -450,7 +450,7 @@ export class EsriImage extends AbstractGeoViewRaster {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   override getBounds(layerPath: string): Extent | undefined {
     // Get the metadata extent
-    const metadataExtent = this.getMetadataExtent();
+    const metadataExtent = this.getMetadataExtent(layerPath);
 
     // If found
     let layerBounds;

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/abstract-gv-raster.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/abstract-gv-raster.ts
@@ -37,16 +37,21 @@ export abstract class AbstractGVRaster extends AbstractGVLayer {
    * @returns {Extent | undefined} The OpenLayer projection
    */
   getMetadataExtent(): Extent | undefined {
-    // TODO: Layers refactoring. Johann: This should be converted to geoview schema in config
+    // Get the layer metadata precisely
+    const extent = this.getLayerConfig().getLayerMetadata()?.extent;
+
+    // If found
+    if (extent) {
+      return [extent.xmin, extent.ymin, extent.xmax, extent.ymax] as Extent;
+    }
+
+    // Here, we couldn't find the layer metadata, so we use the layer parent definition metadata
     const metadata = this.getLayerConfig().getServiceMetadata();
     if (metadata?.fullExtent) {
-      return [
-        metadata?.fullExtent.xmin as number,
-        metadata?.fullExtent.ymin as number,
-        metadata?.fullExtent.xmax as number,
-        metadata?.fullExtent.ymax as number,
-      ] as Extent;
+      return [metadata?.fullExtent.xmin, metadata?.fullExtent.ymin, metadata?.fullExtent.xmax, metadata?.fullExtent.ymax] as Extent;
     }
+
+    // No layer metadata extent could be found
     return undefined;
   }
 }


### PR DESCRIPTION
# Description

- Fixed an issue where the layer extent highlighted on the map was actually the layer extent of the whole service, not the extent of the layer service itself.
- Added example in outlier metadata demo page demonstrating how some services have metadata extent not covering the entire records. What seems to be a metadata problem, more than an application issue.

Fixes #2515

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted as Oct 18th @ 13h: https://alex-nrcan.github.io/geoview/demo-osdp-water.html and https://alex-nrcan.github.io/geoview/outlier-metadata.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2557)
<!-- Reviewable:end -->
