### PR TITLE
2599 Update outfields in metadata files

### DIFF
--- a/packages/geoview-core/public/datasets/geojson/metadata1.meta
+++ b/packages/geoview-core/public/datasets/geojson/metadata1.meta
@@ -10,13 +10,11 @@
           "queryable": true,
           "nameField": "Project",
           "outfields": [
-            [
-              { "name": "program", "alias": "Program", "type": "string", "domain": null },
-              { "name": "project_id", "alias": "Project ID", "type": "string", "domain": null },
-              { "name": "geom_type", "alias": "Geometry type", "type": "string", "domain": null },
-              { "name": "geom_area", "alias": "Geometry area", "type": "string", "domain": null },
-              { "name": "SRID", "alias": "SRID", "type": "string", "domain": null }
-            ]
+            { "name": "program", "alias": "Program", "type": "string", "domain": null },
+            { "name": "project_id", "alias": "Project ID", "type": "string", "domain": null },
+            { "name": "geom_type", "alias": "Geometry type", "type": "string", "domain": null },
+            { "name": "geom_area", "alias": "Geometry area", "type": "string", "domain": null },
+            { "name": "SRID", "alias": "SRID", "type": "string", "domain": null }
           ]
         }
       },

--- a/packages/geoview-core/public/datasets/geojson/processes-metadata.meta
+++ b/packages/geoview-core/public/datasets/geojson/processes-metadata.meta
@@ -24,19 +24,17 @@
           "queryable": "true",
           "nameField": "label_en",
           "outfields": [
-            [
-              { "name": "label_en", "alias": "label_en", "type": "string", "domain": null },
-              { "name": "percentile_en", "alias": "percentile_en", "type": "string", "domain": null },
-              { "name": "period_en", "alias": "period_en", "type": "string", "domain": null },
-              { "name": "scenario_en", "alias": "scenario_en", "type": "string", "domain": null },
-              { "name": "time_begin", "alias": "time_begin", "type": "date", "domain": null },
-              { "name": "time_end", "alias": "time_end Date", "type": "date", "domain": null },
-              { "name": "time_step", "alias": "time_step", "type": "string", "domain": null },
-              { "name": "uom", "alias": "uom", "type": "string", "domain": null },
-              { "name": "value_type_en", "alias": "value_type_en", "type": "string", "domain": null },
-              { "name": "variable_en", "alias": "variable_en", "type": "string", "domain": null },
-              { "name": "values", "alias": "values", "type": "number", "domain": null }
-            ]
+            { "name": "label_en", "alias": "label_en", "type": "string", "domain": null },
+            { "name": "percentile_en", "alias": "percentile_en", "type": "string", "domain": null },
+            { "name": "period_en", "alias": "period_en", "type": "string", "domain": null },
+            { "name": "scenario_en", "alias": "scenario_en", "type": "string", "domain": null },
+            { "name": "time_begin", "alias": "time_begin", "type": "date", "domain": null },
+            { "name": "time_end", "alias": "time_end Date", "type": "date", "domain": null },
+            { "name": "time_step", "alias": "time_step", "type": "string", "domain": null },
+            { "name": "uom", "alias": "uom", "type": "string", "domain": null },
+            { "name": "value_type_en", "alias": "value_type_en", "type": "string", "domain": null },
+            { "name": "variable_en", "alias": "variable_en", "type": "string", "domain": null },
+            { "name": "values", "alias": "values", "type": "number", "domain": null }
           ]
         }
       },

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -579,10 +579,8 @@ export abstract class AbstractGVLayer extends AbstractBaseLayer {
               dictFieldTypes[fieldName] = this.getFieldType(fieldName);
             }
             const fieldType = dictFieldTypes[fieldName];
-
-            if (outfields?.find((outfield) => outfield.name === fieldName)) {
-              const fieldEntry = outfields.find((outfield) => outfield.name === fieldName);
-
+            const fieldEntry = outfields?.find((outfield) => outfield.name === fieldName);
+            if (fieldEntry) {
               featureInfoEntry.fieldInfo[fieldName] = {
                 fieldKey: fieldKeyCounter++,
                 value: this.getFieldValue(feature, fieldName, fieldEntry!.type as 'string' | 'number' | 'date'),


### PR DESCRIPTION
# Description

Updated metadata files to change the fieldInfo -> outfields from an array of an array of field objects, to an array of field objects. Also a slight adjustment to the fieldEntry. 

Style seems to already be applied properly.

Fixes # 2599

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Go to the PyGeoAPI Process page, run the raster drill process, click on the feature, click on the feature in the Details Tab. The feature information will be there.

[__PyGeoAPI Process__](https://matthewmuehlhausernrcan.github.io/geoview/pygeoapi-processes.html)

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2641)
<!-- Reviewable:end -->
