### PR TITLE
fix(details): Display detail fields when service returns alias instea…

### DIFF
--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -579,11 +579,14 @@ export abstract class AbstractGVLayer extends AbstractBaseLayer {
               dictFieldTypes[fieldName] = this.getFieldType(fieldName);
             }
             const fieldType = dictFieldTypes[fieldName];
-            const fieldEntry = outfields?.find((outfield) => outfield.name === fieldName);
+            const fieldEntry = outfields?.find((outfield) => outfield.name === fieldName || outfield.alias === fieldName);
             if (fieldEntry) {
-              featureInfoEntry.fieldInfo[fieldName] = {
+              featureInfoEntry.fieldInfo[fieldEntry.name] = {
                 fieldKey: fieldKeyCounter++,
-                value: this.getFieldValue(feature, fieldName, fieldEntry!.type as 'string' | 'number' | 'date'),
+                value:
+                  // If fieldName is the alias for the entry, we will not get a value, so we try the fieldEntry name.
+                  this.getFieldValue(feature, fieldName, fieldEntry!.type as 'string' | 'number' | 'date') ||
+                  this.getFieldValue(feature, fieldEntry.name, fieldEntry!.type as 'string' | 'number' | 'date'),
                 dataType: fieldEntry!.type,
                 alias: fieldEntry!.alias,
                 domain: fieldDomain,

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -283,6 +283,7 @@ export class GVEsriDynamic extends AbstractGVRaster {
         logger.logInfo('There is a problem with this query: ', identifyUrl);
         throw new Error(`Error code = ${jsonResponse.error.code} ${jsonResponse.error.message}` || '');
       }
+
       const features = new EsriJSON().readFeatures(
         { features: jsonResponse.results },
         { dataProjection: Projection.PROJECTION_NAMES.LNGLAT, featureProjection: mapViewer.getProjection().getCode() }

--- a/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
@@ -1260,7 +1260,7 @@ function searchUniqueValueEntry(fields: string[], uniqueValueStyleInfo: TypeLaye
       // For obscure reasons, it seems that sometimes the field names in the feature do not have the same case as those in the
       // unique value definition.
       const fieldName = feature.getKeys().find((key) => {
-        return key.toLowerCase() === fields?.[j]?.toLowerCase();
+        return key.toLowerCase() === fields[j]?.toLowerCase();
       });
       if (fieldName) {
         // TODO: info - explain why we need to use == instead of ===


### PR DESCRIPTION
…d of field name

Fixes some of #2596, info is displayed properly, but icons are not fixed.

# Description

Fixes issue with some layers returning the field alias instead of the field name when fetching feature properties. Icons remain broken.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/add-layers.html

4baa66ad-aa29-4233-a6a8-7f5cbefb5ea8
8ad80782-d468-44dc-af4f-ddf8ed44ce0a
dbe22a3d-0f34-40f5-a40b-83e68f9c3c37
4efad8d5-b7c7-4ea8-b95c-f41f76f24e63
a88f1437-f93f-42e8-9b44-6cdc2213a172
9edee77a-4cb9-4e64-bb37-c5e66a82108d
0b88062f-ebbe-46c6-ab19-54fd226e9aa7

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2658)
<!-- Reviewable:end -->
