### PR TITLE
fix(layer-projection) Added support for the CRS:84 projection

### DIFF
--- a/packages/geoview-core/src/geo/utils/projection.ts
+++ b/packages/geoview-core/src/geo/utils/projection.ts
@@ -23,11 +23,6 @@ import { TypeJsonObject } from '@/core/types/global-types';
  */
 export abstract class Projection {
   /**
-   * constant for the CRS84 URL
-   */
-  static CRS_84_URL = 'http://www.opengis.net/def/crs/OGC/1.3/CRS84';
-
-  /**
    * constant used for the available projection names
    */
   static PROJECTION_NAMES = {
@@ -40,6 +35,7 @@ export abstract class Projection {
     WM: 'EPSG:3857',
     4269: 'EPSG:4269',
     LNGLAT: 'EPSG:4326',
+    CRS84: 'CRS:84', // Supporting CRS:84 which is equivalent to 4326 except it's long-lat, whereas the 4326 standard is lat-long.
     CSRS: 'EPSG:4617',
     CSRS98: 'EPSG:4140',
   };
@@ -323,13 +319,23 @@ export abstract class Projection {
  * Initializes the CRS84 Projection
  */
 function initCRS84Projection(): void {
-  const newDefinition = proj4.defs(Projection.PROJECTION_NAMES.LNGLAT);
-  newDefinition.axis = 'neu';
-  proj4.defs(Projection.CRS_84_URL, newDefinition);
+  // define 3978 projection
+  proj4.defs(Projection.PROJECTION_NAMES.CRS84, '+proj=longlat +datum=WGS84 +no_defs +type=crs');
+  register(proj4);
 
-  const projection = olGetProjection(Projection.CRS_84_URL);
+  const projection = olGetProjection(Projection.PROJECTION_NAMES.CRS84);
+  if (projection) Projection.PROJECTIONS['CRS:84'] = projection;
+}
 
-  if (projection) Projection.PROJECTIONS[Projection.CRS_84_URL] = projection;
+/**
+ * Initializes the 4326 Projection
+ */
+function init4326Projection(): void {
+  proj4.defs(Projection.PROJECTION_NAMES.LNGLAT, '+proj=longlat +datum=WGS84 +no_defs +type=crs');
+  register(proj4);
+
+  const projection = olGetProjection(Projection.PROJECTION_NAMES.LNGLAT);
+  if (projection) Projection.PROJECTIONS['4326'] = projection;
 }
 
 /**
@@ -469,6 +475,7 @@ function init102190Projection(): void {
 
 // Initialize the supported projections
 initCRS84Projection();
+init4326Projection();
 initWMProjection();
 initLCCProjection();
 initCSRSProjection();


### PR DESCRIPTION
# Description

Added support for the CRS:84 projection and better distinction between 4326 and CRS:84.

Fixes #2591

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted Dec 18th @ 12h30: https://alex-nrcan.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2667)
<!-- Reviewable:end -->
