### PR TITLE
fix(ESRI Dynamic): raster layers in ESRI Dynamic geocore layers now load

### DIFF
--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -278,6 +278,12 @@ export class EsriDynamic extends AbstractGeoViewRaster {
     // Create the source
     const source = new ImageArcGISRest(sourceOptions);
 
+    // Raster layer queries do not accept any layerDefs
+    if (this.metadata?.layers[0].type === 'Raster Layer') {
+      const params = source.getParams();
+      source.updateParams({ ...params, layerDefs: '' });
+    }
+
     // GV Time to request an OpenLayers layer!
     const requestResult = this.emitLayerRequesting({ config: layerConfig, source });
 

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
@@ -255,7 +255,8 @@ export class GVEsriImage extends AbstractGVRaster {
   }
 }
 
-interface TypeEsriImageLayerLegend {
+// Exported for use in ESRI Dynamic raster layers
+export interface TypeEsriImageLayerLegend {
   layers: {
     layerId: number | string;
     layerName: string;

--- a/packages/geoview-core/src/geo/utils/projection.ts
+++ b/packages/geoview-core/src/geo/utils/projection.ts
@@ -38,6 +38,7 @@ export abstract class Projection {
     CRS84: 'CRS:84', // Supporting CRS:84 which is equivalent to 4326 except it's long-lat, whereas the 4326 standard is lat-long.
     CSRS: 'EPSG:4617',
     CSRS98: 'EPSG:4140',
+    3400: 'EPSG:3400',
   };
 
   // Incremental number when creating custom WKTs on the fly
@@ -473,6 +474,21 @@ function init102190Projection(): void {
   if (projection) Projection.PROJECTIONS['102190'] = projection;
 }
 
+/**
+ * Initializes the EPSG:3400 projection
+ */
+function init3400Projection(): void {
+  proj4.defs(
+    Projection.PROJECTION_NAMES[3400],
+    '+proj=tmerc +lat_0=0 +lon_0=-115 +k=0.9992 +x_0=500000 +y_0=0 +datum=NAD83 +units=m +no_defs +type=crs'
+  );
+  register(proj4);
+
+  const projection = olGetProjection(Projection.PROJECTION_NAMES[3400]);
+
+  if (projection) Projection.PROJECTIONS['3400'] = projection;
+}
+
 // Initialize the supported projections
 initCRS84Projection();
 init4326Projection();
@@ -486,4 +502,5 @@ init4269Projection();
 init102100Projection();
 init102184Projection();
 init102190Projection();
+init3400Projection();
 logger.logInfo('Projections initialized');

--- a/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
@@ -1136,7 +1136,6 @@ async function getPointStyleSubRoutine(
 export async function getLegendStyles(styleConfig: TypeLayerStyleConfig | undefined): Promise<TypeVectorLayerStyles> {
   try {
     if (!styleConfig) return {};
-
     const legendStyles: TypeVectorLayerStyles = {};
     if (styleConfig.Point) {
       // ======================================================================================================================


### PR DESCRIPTION
Closes #2598

# Description

Fixes issue with raster layers not loading in ESRI Dynamic geocore layers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/add-layers.html

06be2cfe-d334-4f92-94ae-62a7615e9d28 -fixed
5095a5e0-e574-4769-84d3-acaac529399b - fixed
37b59b8b-1c1c-4869-802f-c09571cc984b - fixed
3d52693e-39d1-4e7f-b4fa-b72ccb605006 - fixed
42478434-e0ac-4f40-a4ac-aec40f161a9c - fixed
c094782e-0d6f-4cc0-b5a3-58908493a433 - fixed
ac2096a6-7b4a-464e-9e08-eca7873dd88c - fixed
47a60179-83aa-4750-ad59-5797da909748 - all layers load, layers 0 and 17 are in RCS but don't exist, and two layers have no legend (15 and 16) - does not load at all in RAMP
6c7e9bb6-17e1-4e41-b49c-23261c8eefbc - fixed
bd71df53-543d-4359-9d17-8f1bb3b5ab90 - fixed

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2670)
<!-- Reviewable:end -->
