### PR TITLE
fix(apostrophe): fixes issue with apostrophe breaking config

### DIFF
--- a/packages/geoview-core/public/templates/demos/demo-osdp-integration.html
+++ b/packages/geoview-core/public/templates/demos/demo-osdp-integration.html
@@ -93,7 +93,7 @@
                 return new Promise (resolve => {
                   removeMap('Map1')
                     .then(() => {
-                      cgpv.api.createMapFromConfig('Map1', JSON.stringify(mapConfig).replace(/'/g, "\\'"), 800)
+                      cgpv.api.createMapFromConfig('Map1', JSON.stringify(mapConfig), 800)
                       .then(() => {
                           resolve();
                         });

--- a/packages/geoview-core/src/app.tsx
+++ b/packages/geoview-core/src/app.tsx
@@ -189,7 +189,7 @@ export async function initMapDivFromFunctionCall(mapDiv: HTMLElement, mapConfig:
     // Create a data-config attribute and set config value on the div
     const att = document.createAttribute(url ? 'data-config-url' : 'data-config');
     // Clean apostrophes in the config
-    att.value = JSON.stringify(mapConfig).replace(/'/g, "\\'");
+    att.value = mapConfig.replace(/'/g, "\\'");
     mapDiv.setAttributeNode(att);
 
     // Set the geoview-map class on the div so that this class name is standard for all maps (either created via init or via func call)


### PR DESCRIPTION
# Description

Fixes issue breaking configs by using JSON.stringify on config already stringified

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/06-basic-footer.json
https://damonu2.github.io/geoview/demo-osdp-integration.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
