### PR TITLE
fix(config): single quote issue

### DIFF
--- a/packages/geoview-core/public/templates/default-config.html
+++ b/packages/geoview-core/public/templates/default-config.html
@@ -245,7 +245,7 @@
     <script>
       cgpv.api.createMapFromConfig(
         'CONF7',
-        `{
+        JSON.stringify({
               'map': {
                 'interaction': 'dynamic',
                 'viewSettings': {
@@ -273,7 +273,7 @@
               'components': ['overview-map'],
               'corePackages': [],
               'theme': 'geo.ca'
-        }`
+        })
       );
 
       // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready

--- a/packages/geoview-core/public/templates/sandbox.html
+++ b/packages/geoview-core/public/templates/sandbox.html
@@ -244,7 +244,7 @@
         // TODO: the delete has a timeout so we need to wait before trying to recreate the map...
         // TO.DOCONT: this should be cleaner
         setTimeout(() => {
-          cgpv.api.createMapFromConfig('sandboxMap', document.getElementById('configGeoview').value)
+          cgpv.api.createMapFromConfig('sandboxMap', document.getElementById('configGeoview').value.replaceAll("'", '"'))
             .then(() => listenToLegendLayerSetChanges('sandboxMap-state', 'sandboxMap'));
         }, 1500);
       });
@@ -320,9 +320,7 @@
       });
 
       // Create default map==========================================================================================================
-      cgpv.api.createMapFromConfig(
-        'sandboxMap',
-        `{
+      cgpv.api.createMapFromConfig('sandboxMap', JSON.stringify({
               'map': {
                 'interaction': 'dynamic',
                 'viewSettings': {
@@ -353,7 +351,7 @@
               },
               'corePackages': [],
               'theme': 'geo.ca'
-        }`
+        })
       ).then(() => listenToLegendLayerSetChanges('sandboxMap-state', 'sandboxMap'));
 
       // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready


### PR DESCRIPTION
# Description

Fixes errors on sandbox.html and default-config.html with how apostrophes are handled by in the config.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/sandbox.html
https://damonu2.github.io/geoview/default-config.html?p=3857&z=4&c=-100,40&l=en&t=dark&b=basemapId:transport,shaded:false,labeled:true&i=dynamic&cc=overview-map&keys=12acd145-626a-49eb-b850-0a59c9bc7506,ccc75c12-5acc-4a6a-959f-ef6f621147b9#HLCONF7

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2683)
<!-- Reviewable:end -->
