### PR TITLE
fix(layers): fixes geocore layers not appearing in service order

### DIFF
--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -359,6 +359,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
         ? 1
         : -1
     );
+    this.sortLegendLayersChildren(mapId, sortedLayers);
 
     this.getLayerState(mapId).setterActions.setLegendLayers(sortedLayers);
   }
@@ -397,7 +398,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
         foundLayer = layer;
       }
 
-      if (layerPath?.startsWith(layer.layerPath) && layer.children?.length > 0) {
+      if (layerPath.startsWith(`${layer.layerPath}/`) && layer.children?.length > 0) {
         const result: TypeLegendLayer | undefined = LegendEventProcessor.findLayerByPath(layer.children, layerPath);
         if (result) {
           foundLayer = result;
@@ -742,4 +743,22 @@ export class LegendEventProcessor extends AbstractEventProcessor {
       return matchingBreak ? matchingBreak.visible : classBreakStyle.info[classBreakStyle.info.length - 1].visible;
     });
   }
+
+  /**
+   * Sorts legend layers children recursively in given legend layers list.
+   * @param {string} mapId - The ID of the map.
+   * @param {TypeLegendLayer[]} legendLayerList - The list to sort.
+   */
+  static sortLegendLayersChildren = (mapId: string, legendLayerList: TypeLegendLayer[]): void => {
+    legendLayerList.forEach((legendLayer) => {
+      if (legendLayer.children.length)
+        legendLayer.children.sort((a, b) =>
+          MapEventProcessor.getMapIndexFromOrderedLayerInfo(mapId, a.layerPath) >
+          MapEventProcessor.getMapIndexFromOrderedLayerInfo(mapId, b.layerPath)
+            ? 1
+            : -1
+        );
+      this.sortLegendLayersChildren(mapId, legendLayer.children);
+    });
+  };
 }

--- a/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
@@ -2,7 +2,7 @@ import { useTheme } from '@mui/material/styles';
 import { SingleLayer } from './single-layer';
 import { getSxClasses } from './left-panel-styles';
 import { Box } from '@/ui';
-import { useGeoViewMapId, useMapStoreActions } from '@/core/stores';
+import { useGeoViewMapId, useLayerStoreActions, useMapStoreActions } from '@/core/stores';
 import { logger } from '@/core/utils/logger';
 import { TypeLegendLayer } from '@/core/components/layers/types';
 import { TABS } from '@/core/utils/constant';
@@ -23,10 +23,12 @@ export function LayersList({ layersList, showLayerDetailsPanel, isLayoutEnlarged
 
   const mapId = useGeoViewMapId();
   const { getIndexFromOrderedLayerInfo } = useMapStoreActions();
+  const { sortLegendLayersChildren } = useLayerStoreActions();
 
   const sortedLayers = layersList.sort((a, b) =>
     getIndexFromOrderedLayerInfo(a.layerPath) > getIndexFromOrderedLayerInfo(b.layerPath) ? 1 : -1
   );
+  sortLegendLayersChildren(sortedLayers);
 
   const textToSlug = (text: string): string => {
     return text

--- a/packages/geoview-core/src/core/stores/state-api.ts
+++ b/packages/geoview-core/src/core/stores/state-api.ts
@@ -114,7 +114,7 @@ export class StateApi {
     let startingIndex = -1;
     for (let i = 0; i < orderedLayers.length; i++) if (orderedLayers[i].layerPath === layerPath) startingIndex = i;
     const layerInfo = orderedLayers[startingIndex];
-    const movedLayers = orderedLayers.filter((layer) => layer.layerPath.startsWith(layerPath));
+    const movedLayers = MapEventProcessor.getMapLayerAndChildrenOrderedInfo(mapId, layerPath, orderedLayers);
     orderedLayers.splice(startingIndex, movedLayers.length);
     let nextIndex = startingIndex;
     const pathLength = layerInfo.layerPath.split('/').length;

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -52,6 +52,7 @@ export interface ILayerState {
     setLayerDeleteInProgress: (newVal: boolean) => void;
     setLayerOpacity: (layerPath: string, opacity: number) => void;
     setSelectedLayerPath: (layerPath: string) => void;
+    sortLegendLayersChildren: (legendLayerList: TypeLegendLayer[]) => void;
     toggleItemVisibility: (layerPath: string, item: TypeLegendItem) => void;
     zoomToLayerExtent: (layerPath: string) => Promise<void>;
     setSelectedLayerSortingArrowId: (layerId: string) => void;
@@ -234,6 +235,14 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
       setSelectedLayerPath: (layerPath: string): void => {
         // Redirect to event processor
         LegendEventProcessor.setSelectedLayersTabLayer(get().mapId, layerPath);
+      },
+
+      /**
+       * Sorts legend layers children recursively in given legend layers list.
+       * @param {TypeLegendLayer[]} legendLayerList - The list to sort.
+       */
+      sortLegendLayersChildren: (legendLayerList: TypeLegendLayer[]): void => {
+        LegendEventProcessor.sortLegendLayersChildren(get().mapId, legendLayerList);
       },
 
       /**


### PR DESCRIPTION
Closes #2644

# Description

Sorts geocore child layers properly, in ordered layer info and legend layers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Not deployed yet.
Layer: 4bece602-04cf-4520-a512-9f4d8720b683

# Checklist:

- [ ] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
