### PR TITLE
feat(names): function added to replace layer names

### DIFF
--- a/packages/geoview-core/public/css/style.css
+++ b/packages/geoview-core/public/css/style.css
@@ -254,21 +254,6 @@ table.state {
   color: #506882;
 }
 
-textarea {
-  height: 99999px;
-  line-height: 21px;
-  overflow-y: hidden;
-  padding: 0;
-  border: 0;
-  background: #282a3a;
-  color: #fff;
-  min-width: 500px;
-  outline: none;
-  resize: none;
-  overflow-x: auto;
-  white-space: nowrap;
-}
-
 @media only screen and (max-width: 767px) {
   body {
     padding: 2px; /* Adjust the value as needed */

--- a/packages/geoview-core/public/templates/demos/demo-esri-renderer.html
+++ b/packages/geoview-core/public/templates/demos/demo-esri-renderer.html
@@ -22,6 +22,21 @@
     #serviceUrlInput {
       width: 700px;
     }
+
+    textarea {
+      height: 99999px;
+      line-height: 21px;
+      overflow-y: hidden;
+      padding: 0;
+      border: 0;
+      background: #282a3a;
+      color: #fff;
+      min-width: 500px;
+      outline: none;
+      resize: none;
+      overflow-x: auto;
+      white-space: nowrap;
+    }
   </style>
 </head>
 

--- a/packages/geoview-core/public/templates/demos/demo-osdp-integration.html
+++ b/packages/geoview-core/public/templates/demos/demo-osdp-integration.html
@@ -47,151 +47,187 @@
       <div id="Map1" class="geoview-map" data-lang="fr" data-config-url="./configs/OSDP/osdp-empty.json"></div>
     </div>
 
+    <div style="display: flex">
+      <h3>Changes to map div:</h3>
+      <div>
+        <button id="deleteMap" style="margin: 10px;margin-left: 30px;" title="Deletes map div if it exists, leaving the map object in cgpv.maps - Simulates moving away from map tab.">Delete map div</button>
+        <details style="margin-left: 30px;">
+          <summary>Code</summary>
+          <pre>document.getElementById('Map1').remove();</pre>
+        </details>
+      </div>
+
+      <div>
+        <button id="createMap" style="margin: 10px" title="Creates a new div for the map, if the original div has been deleted">Create map div</button>
+        <details style="margin-left: 30px;">
+          <summary>Code</summary>
+          <pre>
+if (!document.getElementById('Map1')) {
+  const newDiv = document.createElement('div');
+  const id = document.createAttribute('id');
+  id.value = 'Map1';
+  newDiv.setAttributeNode(id);
+  const dataLang = document.createAttribute('data-lang');
+  dataLang.value = lang;
+  newDiv.setAttributeNode(dataLang);
+  document.getElementById('mapSection').appendChild(newDiv);
+}
+          </pre>
+        </details>
+      </div>
+
+      <div>
+        <button id="changeLanguage" style="margin: 10px" title="Changes the div language setting from french to english or english to french.">Change <code>data-lang</code> Attribute</button>
+        Note: Will not effect the map until reloaded.
+        <details style="margin-left: 30px;">
+          <summary>Code</summary>
+          <pre>
+lang = lang === 'fr' ? 'en' : 'fr';
+const mapDiv = document.getElementById('Map1');
+if (mapDiv) {
+  mapDiv.setAttribute('data-lang', lang);
+            }
+          </pre>
+        </details>
+      </div>
+    </div>
+    <br><br>
+
     <div>
-      <ul>
-        <li>
-          <button id="deleteMap" style="margin: 10px">Delete map div</button>
-          Deletes map div if it exists, leaving the map object in cgpv.maps - Simulates moving away from map tab.
-          <details>
+      <div style="display: flex">
+        <h3>Add Layers:</h3>
+        <div style="margin-left: 30px;">
+          <textarea id="layerUuids" cols="40" rows="5">21b821cf-0f1c-40ee-8925-eab12d357668,ccc75c12-5acc-4a6a-959f-ef6f621147b9,0fca08b5-e9d0-414b-a3c4-092ff9c5e326</textarea>
+          <br>
+          <button id="addLayers" style="margin: 10px" title="Add entered Geocore UUID's to the map. Can be separated with commas or each on a new line">Add Layers</button>
+          <details style="margin-left: 30px;">
             <summary>Code</summary>
             <pre>
-              document.getElementById('Map1').remove();
-            </pre>
-          </details>
-        </li>
-        <li>
-          <button id="createMap" style="margin: 10px">Create map div</button>
-          Creates a new div for the map, if the original div has been deleted
-          <details>
-            <summary>Code</summary>
-            <pre>
-              if (!document.getElementById('Map1')) {
-                const newDiv = document.createElement('div');
-                const id = document.createAttribute('id');
-                id.value = 'Map1';
-                newDiv.setAttributeNode(id);
-                const dataLang = document.createAttribute('data-lang');
-                dataLang.value = lang;
-                newDiv.setAttributeNode(dataLang);
-                document.getElementById('mapSection').appendChild(newDiv);
-              }
-            </pre>
-          </details>
-        </li>
-        <li>
-          <button id="refreshMap" style="margin: 10px">Refresh map</button>
-          Recreates the map using the stored config, creating a new div if it has been deleted
-          <details>
-            <summary>Code</summary>
-            <pre>
-              <pre>
-                return new Promise (resolve => {
-                  removeMap('Map1')
-                    .then(() => {
-                      cgpv.api.createMapFromConfig('Map1', JSON.stringify(mapConfig), 800)
-                      .then(() => {
-                          resolve();
-                        });
-                    });
-                  });
+if (document.getElementById('Map1')) {
+  const layerUuids = document.getElementById('layerUuids').value;
+  const uuidList = layerUuids.split('\n').join(',').split(',');
+  addLayers(uuidList);
+}
 
-                  function removeMap(map) {
-                    return new Promise(resolve => {
-                      if (cgpv.api.maps[map]) {
-                        cgpv.api.maps[map].remove(false)
-                          .then(() => {
-                            resolve();
-                          });
-                      } else {
-                        resolve();
-                      }
-                    });
-                  }
-              </pre>
+function addLayers(layers) {
+  layers.forEach((layer) => {
+    cgpv.api.maps.Map1.layer.addGeoviewLayerByGeoCoreUUID(layer);
+  });
+}
             </pre>
           </details>
-        </li>
-        <li>
-          <button id="updateState" style="margin: 10px">Update State</button>
-          Updates the stored config with the current map state
-          <details>
-            <summary>Code</summary>
-            <pre>
-              mapConfig = cgpv.api.maps.Map1.createMapConfigFromMapState();
-            </pre>
-          </details>
-        </li>
-        <li>
-          <button id="changeLanguage" style="margin: 10px">Change Language</button>
-          Changes the language from french to english or english to french and reloads the map if it exists. Note: this will change the
-          names of the layers, as maintainGeocoreLayerNames is set to false. In this case, we will lose any custom names, and they will 
-          have to be reinserted (in the new language). If set to true, the layer names will remain as they were.
-          <details>
-            <summary>Code</summary>
-            <pre>
-              lang = lang === 'fr' ? 'en' : 'fr';
-              const mapDiv = document.getElementById('Map1');
-              if (mapDiv) {
-                mapDiv.setAttribute('data-lang', lang);
-                cgpv.api.maps.Map1.reloadWithCurrentState(false);
-              }
-            </pre>
-          </details>
-        </li>
-      </ul>
+      </div>
+      <br>
+      <div>
+        <div style="margin-left: 30px;">
+          <div class="selector">
+            <select name="Select custom config" id="switchCustom">
+              <option value="Airborne Radioactivity">Airborne Radioactivity</option>
+              <option value="IAAC">IAAC</option>
+              <option value="CESI">CESI</option>
+            </select>
+          </div>
+  
+          <div style="display: grid">
+            <input id="layerUuidCustom" style="margin-top: 10px; margin-bottom: 10px; width: 300px" />
+            <textarea id="layerUuidCustomEntries" cols="80" rows="25"></textarea>
+          </div>
+          <div>
+            <button id="addLayersCustom" style="margin: 10px" title="Add entered Geocore UUID's to the map with a custom configuration (List of layer entries)">Add Layers With Custom Config</button>
+            <details style="margin-left: 30px;">
+              <summary>Code</summary>
+              <pre>cgpv.api.maps.Map1.layer.addGeoviewLayerByGeoCoreUUID(uuid, customListOfLayerEntries);</pre>
+            </details>
+          </div>
+        </div>
+      </div>
+    </div>
+    <br><br>
+
+    <div style="display: flex">
+      <h3>Current Stored Config:</h3>
+      <div>
+        <button id="refreshMap" style="margin: 10px" title="Recreates the map using the config below, creating a new div if it has been deleted">Refresh map</button>
+        <details style="margin-left: 30px;">
+          <summary>Code</summary>
+          <pre>
+return new Promise (resolve => {
+  removeMap('Map1')
+    .then(() => {
+      cgpv.api.createMapFromConfig('Map1', JSON.stringify(mapConfig), 800)
+      .then(() => {
+          resolve();
+        });
+    });
+  });
+
+  function removeMap(map) {
+    return new Promise(resolve => {
+      if (cgpv.api.maps[map]) {
+        cgpv.api.maps[map].remove(false)
+          .then(() => {
+            resolve();
+          });
+      } else {
+        resolve();
+      }
+    });
+  }
+          </pre>
+        </details>
+      </div>
+      <div>
+        <button id="updateState" style="margin: 10px" title="Updates the stored config with the current map state">Update Config With Current Map State</button>
+        <div class="selector" style="margin: 10px">
+          <label for="keepNames">Override Geocore Service Names:</label>
+          <select name="keepNames" id="keepNames">
+            <option value="true">true</option>
+            <option value="false">false</option>
+            <option value="hybrid">hybrid</option>
+          </select>
+        </div>
+        <details style="margin-left: 30px;">
+          <summary>Modes</summary>
+          <pre>true - All names are kept as they appear on the map
+false - All geocore names are set to undefined, to be reapplied by the service
+hybrid - Geocore layer names are kept, style to be reapplied by the service
+          </pre>
+        </details>
+        <details style="margin-left: 30px;">
+          <summary>Code</summary>
+          <pre>mapConfig = cgpv.api.maps.Map1.createMapConfigFromMapState(overrideGeocoreServiceNames);</pre>
+        </details>
+      </div>
+    </div>
+    <br>
+
+    <div>
+      <textarea id="configTextArea"  cols="100" rows="50" readonly>
+      </textarea>
     </div>
 
-    <div class="selector">
-      <textarea id="layerUuids" cols="40" rows="5">
-21b821cf-0f1c-40ee-8925-eab12d357668,ccc75c12-5acc-4a6a-959f-ef6f621147b9,0fca08b5-e9d0-414b-a3c4-092ff9c5e326</textarea
-      >
-      <ul>
-        <li>
-          <button id="addLayers" style="margin: 10px">Add Layers</button>
-          Add entered Geocore UUID's to the map. Can be separated with commas or each on a new line
-          <details>
-            <summary>Code</summary>
-            <pre>
-              if (document.getElementById('Map1')) {
-                const layerUuids = document.getElementById('layerUuids').value;
-                const uuidList = layerUuids.split('\n').join(',').split(',');
-                addLayers(uuidList);
-              }
-
-              function addLayers(layers) {
-                layers.forEach((layer) => {
-                  cgpv.api.maps.Map1.layer.addGeoviewLayerByGeoCoreUUID(layer);
-                });
-              }
-            </pre>
-          </details>
-        </li>
-      </ul>
-
-      <div class="selector">
-        <select name="Selecty custom config" id="switchCustom">
-          <option value="Airborne Radioactivity">Airborne Radioactivity</option>
-          <option value="IAAC">IAAC</option>
-          <option value="CESI">CESI</option>
-        </select>
-      </div>
-      <div style="display: grid">
-        <input id="layerUuidCustom" style="margin-top: 10px; margin-bottom: 10px; width: 300px" />
-        <textarea id="layerUuidCustomEntries" cols="80" rows="25"></textarea>
-      </div>
-      <ul>
-        <li>
-          <button id="addLayersCustom" style="margin: 10px">Add Layers</button>
-          Add entered Geocore UUID's to the map with a custom configuration (List of layer entries)
-          <details>
-            <summary>Code</summary>
-            <pre>
-                cgpv.api.maps.Map1.layer.addGeoviewLayerByGeoCoreUUID(uuid, customListOfLayerEntries);
-            </pre>
-          </details>
-        </li>
-      </ul>
+    <div>
+      <h3>Change the layer names in the config:</h3>
+      <p>The examples provided below are for the default three layers in the add layers box above. To see this work, click the "Add Layers" button with the default layers,
+ click "Update With Map State" once the layers are loaded, and then click "Change Names". The names in the config will be updated.
+      </p>
+      <p>To try it yourself, add any layer to the map, update the config, and then copy the layer name you would like to change. Put it in square brackets in the box below,
+ followed by a comma, and then the name you would like to replace it with - [name to change, new name]. Note that the order of the names in the pair, and the order of the pairs
+ do not matter, [Radioactivité de l'air, Radioactivity] and [Radioactivity, Radioactivité de l'air] will function the same - any provided layer name will be replaced with its pair,
+ so the same call can be used to switch a name and switch it back.
+      </p>
+      <textarea id="layerNames" cols="100" rows="4">[Radioactivité de l'air, Radioactivity], [Périmètre de localisation des stations, Perimeter], [Carte commémorative du Canada, Commemorative Map]</textarea>
+      <br>
+      <button id="changeNames" style="margin: 10px" title="Replaces listed layer names with thei provided pair in the config">Change Names</button>
+      <details>
+        <summary>Code</summary>
+        <pre>
+const pairs = [["Radioactivité de l'air", 'Radioactivity'], ['Périmètre de localisation des stations', 'Perimeter'], ['Carte commémorative du Canada', 'Commemorative Map']];
+cgpv.api.maps.Map1.replaceMapConfigLayerNames(pairs, mapConfig);
+        </pre>
+      </details>
     </div>
+    <br><br>
 
     <script src="codedoc.js"></script>
     <script>
@@ -226,6 +262,13 @@
       };
 
       let lang = 'fr';
+
+      function updateConfigTextArea() {
+        const configTextArea = document.getElementById('configTextArea');
+        configTextArea.value = JSON.stringify(mapConfig, null, 2);
+      }
+
+      updateConfigTextArea();
 
       function createMapDiv() {
         if (!document.getElementById('Map1')) {
@@ -313,13 +356,16 @@
         refreshMap();
       });
 
-      // Update Button============================================================================================================
-      const updateMapButton = document.getElementById('updateState');
+      // Update Config Button============================================================================================================
+      const updateConfigButton = document.getElementById('updateState');
 
       // add an event listener when a button is clicked
-      updateMapButton.addEventListener('click', function () {
-        mapConfig = cgpv.api.maps.Map1.createMapConfigFromMapState();
+      updateConfigButton.addEventListener('click', function () {
+        const keepNames = document.getElementById('keepNames').value;
+        const overrideGeocoreServiceNames = keepNames === "hybrid" ? "hybrid" : keepNames === "true";
+        mapConfig = cgpv.api.maps.Map1.createMapConfigFromMapState(overrideGeocoreServiceNames);
         console.log(mapConfig);
+        updateConfigTextArea();
       });
 
       // Change Language Button============================================================================================================
@@ -329,10 +375,7 @@
       changeLanguageButton.addEventListener('click', function () {
         lang = lang === 'fr' ? 'en' : 'fr';
         const mapDiv = document.getElementById('Map1');
-        if (mapDiv) {
-          mapDiv.setAttribute('data-lang', lang);
-          cgpv.api.maps.Map1.reloadWithCurrentState(false);
-        }
+        if (mapDiv) mapDiv.setAttribute('data-lang', lang);
       });
 
       // Add Layers Button============================================================================================================
@@ -347,18 +390,18 @@
         }
       });
 
-      // Add Layers Custom Button============================================================================================================
-      const addLayersCustomButton = document.getElementById('addLayersCustom');
+      // Change Names Button============================================================================================================
+      const changeNamesButton = document.getElementById('changeNames');
 
       // add an event listener when a button is clicked
-      addLayersCustomButton.addEventListener('click', function () {
-        if (document.getElementById('Map1')) {
-          const layerUuid = document.getElementById('layerUuidCustom').value;
-          const layerUuidEntries = document.getElementById('layerUuidCustomEntries').value;
-
-          if (layerUuidEntries === '') cgpv.api.maps.Map1.layer.addGeoviewLayerByGeoCoreUUID(layerUuid);
-          else cgpv.api.maps.Map1.layer.addGeoviewLayerByGeoCoreUUID(layerUuid, layerUuidEntries);
-        }
+      changeNamesButton.addEventListener('click', function () {
+        const pairs = document.getElementById('layerNames').value.replace(/\[|\]/g,'').split(',').map((name) => name.trim()).reduce((result, value, index, array) => {
+          if (index % 2 === 0)
+            result.push(array.slice(index, index + 2));
+            return result;
+          }, []);
+        cgpv.api.maps.Map1.replaceMapConfigLayerNames(pairs, mapConfig);
+        updateConfigTextArea();
       });
 
       const uuidConfig = {
@@ -458,6 +501,21 @@
           },
         ],
       };
+
+
+      // Add Layers Custom Button============================================================================================================
+      const addLayersCustomButton = document.getElementById('addLayersCustom');
+
+      // add an event listener when a button is clicked
+      addLayersCustomButton.addEventListener('click', function () {
+        if (document.getElementById('Map1')) {
+          const layerUuid = document.getElementById('layerUuidCustom').value;
+          const layerUuidEntries = document.getElementById('layerUuidCustomEntries').value;
+
+          if (layerUuidEntries === '') cgpv.api.maps.Map1.layer.addGeoviewLayerByGeoCoreUUID(layerUuid);
+          else cgpv.api.maps.Map1.layer.addGeoviewLayerByGeoCoreUUID(layerUuid, layerUuidEntries);
+        }
+      });
 
       // Add a samples selector
       const layerUuid = document.getElementById('layerUuidCustom');

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -1051,6 +1051,48 @@ export class MapEventProcessor extends AbstractEventProcessor {
   };
 
   /**
+   * Get all active filters for layer.
+   *
+   * @param {string} mapId The map id.
+   * @param {string} layerPath The path for the layer to get filters from.
+   */
+  static getActiveVectorFilters(mapId: string, layerPath: string): (string | undefined)[] | undefined {
+    const geoviewLayer = MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayer(layerPath);
+    if (geoviewLayer) {
+      const initialFilter = this.getInitialFilter(mapId, layerPath);
+      const tableFilter = DataTableEventProcessor.getTableFilter(mapId, layerPath);
+      const sliderFilter = TimeSliderEventProcessor.getTimeSliderFilter(mapId, layerPath);
+      return [initialFilter, tableFilter, sliderFilter].filter((filter) => filter);
+    }
+    return undefined;
+  }
+
+  /**
+   * Apply all available filters to layer.
+   *
+   * @param {string} mapId The map id.
+   * @param {string} layerPath The path of the layer to apply filters to.
+   */
+  static applyLayerFilters(mapId: string, layerPath: string): void {
+    const geoviewLayer = MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayer(layerPath);
+    if (geoviewLayer) {
+      if (geoviewLayer instanceof GVWMS || geoviewLayer instanceof GVEsriImage) {
+        const filter = TimeSliderEventProcessor.getTimeSliderFilter(mapId, layerPath);
+        if (filter) geoviewLayer.applyViewFilter(filter);
+      } else {
+        const filters = this.getActiveVectorFilters(mapId, layerPath) || [''];
+
+        // Force the layer to applyfilter so it refresh for layer class selection (esri layerDef) even if no other filter are applied.
+        (geoviewLayer as AbstractGVVector | GVEsriDynamic).applyViewFilter(filters.join(' and '));
+      }
+    }
+  }
+
+  // #endregion
+
+  // #region CONFIG FROM MAP STATE
+
+  /**
    * Creates layer initial settings according to provided configs.
    * @param {ConfigBaseClass} layerEntryConfig - Layer entry config for the layer.
    * @param {TypeOrderedLayerInfo} orderedLayerInfo - Ordered layer info for the layer.
@@ -1084,14 +1126,14 @@ export class MapEventProcessor extends AbstractEventProcessor {
    * @param {string} mapId - Id of map.
    * @param {string} layerPath - Path of the layer to create config for.
    * @param {boolean} isGeocore - Indicates if it is a geocore layer.
-   * @param {boolean} maintainGeocoreLayerNames - Indicates if geocore layer names should be kept as is or returned to defaults.
+   * @param {boolean | 'hybrid'} overrideGeocoreServiceNames - Indicates if geocore layer names should be kept as is or returned to defaults.
    * @returns {TypeLayerEntryConfig} Entry config object.
    */
   static #createLayerEntryConfig(
     mapId: string,
     layerPath: string,
     isGeocore: boolean,
-    maintainGeocoreLayerNames: boolean
+    overrideGeocoreServiceNames: boolean | 'hybrid'
   ): TypeLayerEntryConfig {
     // Get needed info
     const layerEntryConfig = MapEventProcessor.getMapViewerLayerAPI(mapId).getLayerEntryConfig(layerPath);
@@ -1127,7 +1169,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
           entryLayerPath.startsWith(`${layerPath}/`) && entryLayerPath.split('/').length === layerPath.split('/').length + 1
       );
       sublayerPaths.forEach((sublayerPath) =>
-        listOfLayerEntryConfig.push(MapEventProcessor.#createLayerEntryConfig(mapId, sublayerPath, isGeocore, maintainGeocoreLayerNames))
+        listOfLayerEntryConfig.push(MapEventProcessor.#createLayerEntryConfig(mapId, sublayerPath, isGeocore, overrideGeocoreServiceNames))
       );
     }
 
@@ -1138,28 +1180,30 @@ export class MapEventProcessor extends AbstractEventProcessor {
       ? { ...(layerEntryConfig! as VectorLayerEntryConfig).source }
       : undefined;
 
+    // Only use feature info specified in original config, not drawn from services
+    if (source?.featureInfo) delete source?.featureInfo;
+    if (configLayerEntryConfig?.source?.featureInfo && source) source.featureInfo = configLayerEntryConfig.source.featureInfo;
+
     if (source?.dataAccessPath && isGeocore) source.dataAccessPath = '';
 
     const layerStyle =
-      legendLayerInfo!.styleConfig && (!isGeocore || (isGeocore && maintainGeocoreLayerNames)) ? legendLayerInfo!.styleConfig : undefined;
+      legendLayerInfo!.styleConfig && (!isGeocore || (isGeocore && overrideGeocoreServiceNames === true))
+        ? legendLayerInfo!.styleConfig
+        : undefined;
 
     // Construct layer entry config
     const newLayerEntryConfig = {
       layerId: layerEntryConfig!.layerId,
-      layerName: isGeocore && !maintainGeocoreLayerNames ? undefined : layerEntryConfig!.layerName,
+      layerName: isGeocore && overrideGeocoreServiceNames === false ? undefined : layerEntryConfig!.layerName,
       layerFilter: (configLayerEntryConfig as VectorLayerEntryConfig)?.layerFilter
         ? (configLayerEntryConfig as VectorLayerEntryConfig).layerFilter
         : undefined,
       initialSettings,
       layerStyle,
-      source,
       entryType: listOfLayerEntryConfig.length ? 'group' : undefined,
-      listOfLayerEntryConfig: listOfLayerEntryConfig.length ? listOfLayerEntryConfig : [],
+      source: listOfLayerEntryConfig.length ? undefined : source,
+      listOfLayerEntryConfig: listOfLayerEntryConfig.length ? listOfLayerEntryConfig : undefined,
     };
-
-    // Only use feature info specified in original config, not drawn from services
-    if (newLayerEntryConfig.source?.featureInfo) delete newLayerEntryConfig.source?.featureInfo;
-    if (configLayerEntryConfig?.source?.featureInfo) newLayerEntryConfig.source!.featureInfo = configLayerEntryConfig.source.featureInfo;
 
     return newLayerEntryConfig as unknown as TypeLayerEntryConfig;
   }
@@ -1168,10 +1212,10 @@ export class MapEventProcessor extends AbstractEventProcessor {
    * Creates a geoview layer config based on current layer state.
    * @param {string} mapId - Id of map.
    * @param {string} layerPath - Path of the layer to create config for.
-   * @param {boolean} maintainGeocoreLayerNames - Indicates if geocore layer names should be kept as is or returned to defaults.
+   * @param {boolean | "hybrid"} overrideGeocoreServiceNames - Indicates if geocore layer names should be kept as is or returned to defaults.
    * @returns {MapConfigLayerEntry} Geoview layer config object.
    */
-  static #createGeoviewLayerConfig(mapId: string, layerPath: string, maintainGeocoreLayerNames: boolean): MapConfigLayerEntry {
+  static #createGeoviewLayerConfig(mapId: string, layerPath: string, overrideGeocoreServiceNames: boolean | 'hybrid'): MapConfigLayerEntry {
     // Get needed info
     const layerEntryConfig = MapEventProcessor.getMapViewerLayerAPI(mapId).getLayerEntryConfig(layerPath)!;
 
@@ -1196,9 +1240,9 @@ export class MapEventProcessor extends AbstractEventProcessor {
     const listOfLayerEntryConfig: TypeLayerEntryConfig[] = [];
     if (sublayerPaths.length)
       sublayerPaths.forEach((sublayerPath) =>
-        listOfLayerEntryConfig.push(MapEventProcessor.#createLayerEntryConfig(mapId, sublayerPath, isGeocore, maintainGeocoreLayerNames))
+        listOfLayerEntryConfig.push(MapEventProcessor.#createLayerEntryConfig(mapId, sublayerPath, isGeocore, overrideGeocoreServiceNames))
       );
-    else listOfLayerEntryConfig.push(this.#createLayerEntryConfig(mapId, layerPath, isGeocore, maintainGeocoreLayerNames));
+    else listOfLayerEntryConfig.push(this.#createLayerEntryConfig(mapId, layerPath, isGeocore, overrideGeocoreServiceNames));
 
     // Get initial settings
     const initialSettings = this.#getInitialSettings(layerEntryConfig!, orderedLayerInfo!, legendLayerInfo!);
@@ -1207,7 +1251,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
     const newGeoviewLayerConfig: MapConfigLayerEntry = isGeocore
       ? {
           geoviewLayerId: geoviewLayerConfig.geoviewLayerId,
-          geoviewLayerName: !maintainGeocoreLayerNames ? undefined : geoviewLayerConfig.geoviewLayerName,
+          geoviewLayerName: overrideGeocoreServiceNames === false ? undefined : geoviewLayerConfig.geoviewLayerName,
           geoviewLayerType: 'geoCore',
           initialSettings,
           listOfLayerEntryConfig,
@@ -1230,9 +1274,12 @@ export class MapEventProcessor extends AbstractEventProcessor {
   /**
    * Creates a map config based on current map state.
    * @param {string} mapId - Id of map.
-   * @param {boolean} maintainGeocoreLayerNames - Indicates if geocore layer names should be kept as is or returned to defaults.
+   * @param {boolean | "hybrid"} overrideGeocoreServiceNames - Indicates if geocore layer names should be kept as is or returned to defaults.
    */
-  static createMapConfigFromMapState(mapId: string, maintainGeocoreLayerNames: boolean = true): TypeMapFeaturesInstance | undefined {
+  static createMapConfigFromMapState(
+    mapId: string,
+    overrideGeocoreServiceNames: boolean | 'hybrid' = true
+  ): TypeMapFeaturesInstance | undefined {
     const config = MapEventProcessor.getGeoViewMapConfig(mapId);
 
     if (config) {
@@ -1243,7 +1290,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
 
       // Build list of geoview layer configs
       const listOfGeoviewLayerConfig = layerOrder.map((layerPath) =>
-        this.#createGeoviewLayerConfig(mapId, layerPath, maintainGeocoreLayerNames)
+        this.#createGeoviewLayerConfig(mapId, layerPath, overrideGeocoreServiceNames)
       );
 
       // Get info for view
@@ -1315,42 +1362,43 @@ export class MapEventProcessor extends AbstractEventProcessor {
   }
 
   /**
-   * Apply all available filters to layer.
+   * Searches through a map config and replaces any matching layer names with their provided partner.
    *
-   * @param {string} mapId The map id.
-   * @param {string} layerPath The path of the layer to apply filters to.
+   * @param {string[][]} namePairs -  The array of name pairs. Presumably one english and one french name in each pair.
+   * @param {TypeMapFeaturesInstance} mapConfig - The config to modify.
+   * @returns {TypeMapFeaturesInstance} Map config with updated names.
    */
-  static applyLayerFilters(mapId: string, layerPath: string): void {
-    const geoviewLayer = MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayer(layerPath);
-    if (geoviewLayer) {
-      if (geoviewLayer instanceof GVWMS || geoviewLayer instanceof GVEsriImage) {
-        const filter = TimeSliderEventProcessor.getTimeSliderFilter(mapId, layerPath);
-        if (filter) geoviewLayer.applyViewFilter(filter);
-      } else {
-        const filters = this.getActiveVectorFilters(mapId, layerPath) || [''];
+  static replaceMapConfigLayerNames(namePairs: string[][], mapConfig: TypeMapFeaturesInstance): TypeMapFeaturesInstance {
+    const pairsDict: Record<string, string> = {};
+    namePairs.forEach((pair) => {
+      [pairsDict[pair[1]], pairsDict[pair[0]]] = pair;
+    });
 
-        // Force the layer to applyfilter so it refresh for layer class selection (esri layerDef) even if no other filter are applied.
-        (geoviewLayer as AbstractGVVector | GVEsriDynamic).applyViewFilter(filters.join(' and '));
-      }
-    }
+    mapConfig.map.listOfGeoviewLayerConfig?.forEach((geoviewLayerConfig) => {
+      if (geoviewLayerConfig.geoviewLayerName && pairsDict[geoviewLayerConfig.geoviewLayerName])
+        // eslint-disable-next-line no-param-reassign
+        geoviewLayerConfig.geoviewLayerName = pairsDict[geoviewLayerConfig.geoviewLayerName];
+      if (geoviewLayerConfig.listOfLayerEntryConfig?.length)
+        this.#replaceLayerEntryConfigNames(pairsDict, geoviewLayerConfig.listOfLayerEntryConfig);
+    });
+
+    return mapConfig;
   }
 
   /**
-   * Get all active filters for layer.
+   * Searches through a list of layer entry configs and replaces any matching layer names with their provided partner.
    *
-   * @param {string} mapId The map id.
-   * @param {string} layerPath The path for the layer to get filters from.
+   * @param {Record<string, string>} pairsDict -  The dict of name pairs. Presumably one english and one french name in each pair.
+   * @param {TypeLayerEntryConfig[]} listOfLayerEntryConfigs - The layer entry configs to modify.
    */
-  static getActiveVectorFilters(mapId: string, layerPath: string): (string | undefined)[] | undefined {
-    const geoviewLayer = MapEventProcessor.getMapViewerLayerAPI(mapId).getGeoviewLayer(layerPath);
-    if (geoviewLayer) {
-      const initialFilter = this.getInitialFilter(mapId, layerPath);
-      const tableFilter = DataTableEventProcessor.getTableFilter(mapId, layerPath);
-      const sliderFilter = TimeSliderEventProcessor.getTimeSliderFilter(mapId, layerPath);
-      return [initialFilter, tableFilter, sliderFilter].filter((filter) => filter);
-    }
-    return undefined;
+  static #replaceLayerEntryConfigNames(pairsDict: Record<string, string>, listOfLayerEntryConfigs: TypeLayerEntryConfig[]): void {
+    listOfLayerEntryConfigs?.forEach((layerEntryConfig) => {
+      if (layerEntryConfig.layerName && pairsDict[layerEntryConfig.layerName])
+        // eslint-disable-next-line no-param-reassign
+        layerEntryConfig.layerName = pairsDict[layerEntryConfig.layerName];
+      if (layerEntryConfig.listOfLayerEntryConfig?.length)
+        this.#replaceLayerEntryConfigNames(pairsDict, layerEntryConfig.listOfLayerEntryConfig);
+    });
   }
-
   // #endregion
 }

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -1543,14 +1543,29 @@ export class MapViewer {
     return extent;
   }
 
+  // TODO: Move to config API after refactor?
   /**
    * Creates a map config based on current map state.
-   * @param {boolean} maintainGeocoreLayerNames - Indicates if geocore layer names should be kept as is or returned to defaults.
-   *                                              Set to false after a language change to update the layer names with the new language.
+   * @param {BooleanExpression} overrideGeocoreServiceNames - Indicates if geocore layer names should be kept as is or returned to defaults.
+   *                                                         Set to false after a language change to update the layer names with the new language.
    * @returns {TypeMapFeaturesInstance | undefined} Map config with current map state.
    */
-  createMapConfigFromMapState(maintainGeocoreLayerNames: boolean = true): TypeMapFeaturesInstance | undefined {
-    return MapEventProcessor.createMapConfigFromMapState(this.mapId, maintainGeocoreLayerNames);
+  createMapConfigFromMapState(overrideGeocoreServiceNames: boolean | 'hybrid' = true): TypeMapFeaturesInstance | undefined {
+    return MapEventProcessor.createMapConfigFromMapState(this.mapId, overrideGeocoreServiceNames);
+  }
+
+  // TODO: Move to config API after refactor?
+  /**
+   * Searches through a map config and replaces any matching layer names with their provided partner.
+   *
+   * @param {string[][]} namePairs -  The array of name pairs. Presumably one english and one french name in each pair.
+   * @param {TypeMapFeaturesInstance} mapConfig - The config to modify, or one created using the current map state if not provided.
+   * @returns {TypeMapFeaturesInstance} Map config with updated names.
+   */
+  replaceMapConfigLayerNames(namePairs: string[][], mapConfig?: TypeMapFeaturesConfig): TypeMapFeaturesInstance | undefined {
+    const mapConfigToUse = mapConfig || this.createMapConfigFromMapState();
+    if (mapConfigToUse) return MapEventProcessor.replaceMapConfigLayerNames(namePairs, mapConfigToUse);
+    return undefined;
   }
 
   // #region EVENTS


### PR DESCRIPTION
Closes #2724

# Description

Added a function to find and replace layer names throughout a map config.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
10:20(eastern) on Feb. 4
https://damonu2.github.io/geoview/demo-osdp-integration.html

Use new button or in console:
const stateConfig = cgpv.api.maps.Map1.createMapConfigFromMapState();
const pairs = [["Radioactivité de l'air", 'radioactivity'], ['Périmètre de localisation des stations', 'perimeter'], ['Carte commémorative du Canada', 'commem']]
cgpv.api.maps.Map1.replaceMapConfigLayerNames(pairs, stateConfig)
cgpv.api.maps.Map1.reload(stateConfig)

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2727)
<!-- Reviewable:end -->
