### PR TITLE
feat(performance): changed featureIcon to data URL at creation

### DIFF
--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -363,14 +363,7 @@ function DataTable({ data, layerPath, tableHeight = '500px' }: DataTableProps): 
 
     return (filterArray ?? []).map((feature) => {
       const featureInfo = {
-        ICON: (
-          <Box
-            component="img"
-            alt={feature?.nameField ?? ''}
-            src={feature.featureIcon.toDataURL('image/webp', 0.5)}
-            className="layer-icon"
-          />
-        ),
+        ICON: <Box component="img" alt={feature?.nameField ?? ''} src={feature.featureIcon} className="layer-icon" />,
         ZOOM: (
           <IconButton
             color="primary"

--- a/packages/geoview-core/src/core/components/details/feature-detail-modal.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-detail-modal.tsx
@@ -67,7 +67,7 @@ export default function FeatureDetailModal(): JSX.Element {
       <DialogTitle>{t('details.featureDetailModalTitle')}</DialogTitle>
       <DialogContent>
         <Box display="flex" flexDirection="row" alignItems="center" pb={10}>
-          <Box component="img" alt={feature?.nameField ?? ''} src={feature.featureIcon.toDataURL().toString()} className="layer-icon" />
+          <Box component="img" alt={feature?.nameField ?? ''} src={feature.featureIcon} className="layer-icon" />
           <Typography sx={{ display: 'inline-block' }} component="div">
             {nameFieldValue}
           </Typography>

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -100,7 +100,7 @@ export function FeatureInfo({ feature }: FeatureInfoProps): JSX.Element | null {
 
     return {
       uid: feature.geometry ? (feature.geometry as TypeGeometry).ol_uid : null,
-      iconSrc: feature.featureIcon.toDataURL(),
+      iconSrc: feature.featureIcon,
       name: feature.nameField ? (feature.fieldInfo?.[feature.nameField]?.value as string) || '' : 'No name',
       extent: feature.extent,
       geometry: feature.geometry,

--- a/packages/geoview-core/src/core/components/hover-tooltip/hover-tooltip.tsx
+++ b/packages/geoview-core/src/core/components/hover-tooltip/hover-tooltip.tsx
@@ -82,7 +82,7 @@ export const HoverTooltip = memo(function HoverTooltip(): JSX.Element | null {
     return {
       content: {
         value: (hoverFeatureInfo.fieldInfo?.value as string) || '',
-        icon: hoverFeatureInfo.featureIcon ? hoverFeatureInfo.featureIcon.toDataURL() : '',
+        icon: hoverFeatureInfo.featureIcon ? hoverFeatureInfo.featureIcon : '',
       },
       isVisible: true,
     };

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
@@ -162,7 +162,7 @@ export type TypeFeatureInfoResultSet = TypeResultSet<TypeFeatureInfoResultSetEnt
 export type TypeHoverFeatureInfo =
   | {
       geoviewLayerType: TypeGeoviewLayerType;
-      featureIcon: HTMLCanvasElement;
+      featureIcon: string;
       fieldInfo: TypeFieldEntry | undefined;
       nameField: string | null;
     }

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -584,7 +584,7 @@ export abstract class AbstractGVLayer extends AbstractBaseLayer {
           geoviewLayerType: this.getLayerConfig().geoviewLayerConfig.geoviewLayerType as TypeGeoviewLayerType,
           extent,
           geometry: feature,
-          featureIcon: canvas,
+          featureIcon: canvas.toDataURL(),
           fieldInfo: {},
           nameField: layerConfig?.source?.featureInfo?.nameField || null,
         };

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -461,7 +461,7 @@ export class GVWMS extends AbstractGVRaster {
       geoviewLayerType: CONST_LAYER_TYPES.WMS,
       extent: [clickCoordinate[0], clickCoordinate[1], clickCoordinate[0], clickCoordinate[1]],
       geometry: null,
-      featureIcon: document.createElement('canvas'),
+      featureIcon: document.createElement('canvas').toDataURL(),
       fieldInfo: {},
       nameField: null,
     };

--- a/packages/geoview-core/src/geo/map/feature-highlight.ts
+++ b/packages/geoview-core/src/geo/map/feature-highlight.ts
@@ -154,8 +154,6 @@ export class FeatureHighlight {
       const featureUid = getUid(feature.geometry);
       this.#styleHighlightedFeature(newFeature, featureUid);
     } else if (geometry instanceof MultiPoint) {
-      const { height, width } = feature.featureIcon;
-      const radius = Math.min(height, width) / 2 - 2 < 7 ? 7 : Math.min(height, width) / 2 - 2;
       const coordinates: Coordinate[] = geometry.getCoordinates();
       const featureUid = getUid(feature.geometry);
 
@@ -166,7 +164,7 @@ export class FeatureHighlight {
         this.#styleHighlightedFeature(newFeature, id);
         const radStyle = new Style({
           image: new CircleStyle({
-            radius,
+            radius: 10,
             stroke: new Stroke({ color: this.#highlightColor, width: 1.25 }),
             fill: this.#highlightFill,
           }),
@@ -184,8 +182,6 @@ export class FeatureHighlight {
         this.#styleHighlightedFeature(newFeature, id);
       }
     } else if (feature.extent) {
-      const { height, width } = feature.featureIcon;
-      const radius = Math.min(height, width) / 2 - 2 < 7 ? 7 : Math.min(height, width) / 2 - 2;
       const center = getCenter(feature.extent);
       const newPoint = new Point(center);
       const newFeature = new Feature(newPoint);
@@ -193,7 +189,7 @@ export class FeatureHighlight {
       this.#styleHighlightedFeature(newFeature, featureUid);
       const radStyle = new Style({
         image: new CircleStyle({
-          radius,
+          radius: 10,
           stroke: new Stroke({ color: this.#highlightColor, width: 1.25 }),
           fill: this.#highlightFill,
         }),

--- a/packages/geoview-core/src/geo/map/map-schema-types.ts
+++ b/packages/geoview-core/src/geo/map/map-schema-types.ts
@@ -219,7 +219,7 @@ export type TypeFeatureInfoEntry = {
   geoviewLayerType: TypeGeoviewLayerType;
   extent: Extent | undefined;
   geometry: TypeGeometry | Feature | null;
-  featureIcon: HTMLCanvasElement;
+  featureIcon: string;
   fieldInfo: Partial<Record<string, TypeFieldEntry>>;
   nameField: string | null;
 };


### PR DESCRIPTION
Closes #2719

# Description

featureIcon changed to string from HTML canvas element. Now changed to a data URL before assignment. Feature highlight for points now uses a set value for the size of the highlight circle.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
https://damonu2.github.io/geoview/outlier-ESRI-maxRecordCount.html Feb. 6 at 2:20 Eastern

Best way to see the speed increase in the data table is to load both tables and then switch between them - no query, you just see how long to render. Tried the same for loading the map - keeping layer info in cache and reloading.

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2738)
<!-- Reviewable:end -->
