### PR TITLE
feat(geocore): take simplified layerName config for geocore

### DIFF
--- a/packages/geoview-core/src/geo/layer/other/geocore.ts
+++ b/packages/geoview-core/src/geo/layer/other/geocore.ts
@@ -37,7 +37,10 @@ export class GeoCore {
    * @param {GeoCoreLayerConfig} layerConfig the layer configuration
    * @returns {Promise<TypeGeoviewLayerConfig[]>} list of layer configurations to add to the map
    */
-  async createLayersFromUUID(uuid: string, layerConfig?: GeoCoreLayerConfig): Promise<TypeGeoviewLayerConfig[]> {
+  async createLayersFromUUID(
+    uuid: string,
+    layerConfig?: GeoCoreLayerConfig | Record<'layerName', string>
+  ): Promise<TypeGeoviewLayerConfig[]> {
     // Get the map config
     const mapConfig = MapEventProcessor.getGeoViewMapConfig(this.#mapId);
 
@@ -52,7 +55,7 @@ export class GeoCore {
       ConfigValidation.validateListOfGeoviewLayerConfig(this.#displayLanguage, response.layers);
 
       // Use user supplied listOfLayerEntryConfig if provided
-      if (layerConfig?.listOfLayerEntryConfig || layerConfig?.initialSettings) {
+      if ((layerConfig as GeoCoreLayerConfig)?.listOfLayerEntryConfig || (layerConfig as GeoCoreLayerConfig)?.initialSettings) {
         const tempLayerConfig = { ...layerConfig } as unknown as TypeGeoviewLayerConfig;
         tempLayerConfig.metadataAccessPath = response.layers[0].metadataAccessPath;
         tempLayerConfig.geoviewLayerType = response.layers[0].geoviewLayerType;
@@ -63,6 +66,8 @@ export class GeoCore {
         const newLayerConfig = config.getValidMapConfig([tempLayerConfig]);
         return newLayerConfig as TypeGeoviewLayerConfig[];
       }
+      if ((layerConfig as Record<'layerName', string>)?.layerName)
+        response.layers[0].listOfLayerEntryConfig[0].layerName = (layerConfig as Record<'layerName', string>).layerName;
 
       // For each found geochart associated with the Geocore UUIDs
       response.geocharts?.forEach((geochartConfig) => {


### PR DESCRIPTION
# Description

Allows for simplified version of GeoCoreLayerConfig with just layerName property to be passed to createLayersFromUUID

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demo-osdp-integration.html - Feb. 6 at 3:40PM Eastern
Delete everything in a config except layerName and add.

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
