### PR TITLE
feat(ESRI Dynamic): use service projection for imageLayerOptions source

### DIFF
--- a/packages/geoview-core/public/templates/demos/demo-osdp-integration.html
+++ b/packages/geoview-core/public/templates/demos/demo-osdp-integration.html
@@ -78,8 +78,9 @@ if (!document.getElementById('Map1')) {
 
       <div>
         <button id="changeLanguage" style="margin: 10px" title="Changes the div language setting from french to english or english to french.">Change <code>data-lang</code> Attribute</button>
-        Note: Will not effect the map until reloaded.
-        <details style="margin-left: 30px;">
+        <p style="margin: 10px;margin-top: 0px;">Currently: <i id="dataLang">fr</i></p>
+        <p style="margin: 10px;margin-top: 0px;">Note: Will not effect the map until reloaded.</p>
+        <details style="margin-left: 30px;margin-top: 10px;">
           <summary>Code</summary>
           <pre>
 lang = lang === 'fr' ? 'en' : 'fr';
@@ -382,6 +383,7 @@ cgpv.api.maps.Map1.replaceMapConfigLayerNames(pairs, mapConfig, true);
       // add an event listener when a button is clicked
       changeLanguageButton.addEventListener('click', function () {
         lang = lang === 'fr' ? 'en' : 'fr';
+        document.getElementById('dataLang').innerHTML = lang;
         const mapDiv = document.getElementById('Map1');
         if (mapDiv) mapDiv.setAttribute('data-lang', lang);
       });

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -74,24 +74,15 @@ export class GVEsriDynamic extends AbstractGVRaster {
     // TODO.CONT: We can use the layers and layersDef parameters to set what should be visible.
     // TODO.CONT: layers=show:layerId ; layerDefs={ "layerId": "layer def" }
     // TODO.CONT: There is no allowableOffset on esri dynamic to speed up. We will need to see what can be done for layers in wrong projection
-    // TODO.CONT: We may try to use the service projection imageLayerOptions.source?.updateParams({ imageSR: 3978 }); and let OL project on the fly
-    // TODO.CONT: from some test, it reduce time by half
     // Create the image layer options.
     const imageLayerOptions: ImageOptions<ImageArcGISRest> = {
       source: olSource,
       properties: { layerConfig },
     };
 
-    // TODO: Performance - For testing purpose on projection and performance
-    if (layerConfig.geoviewLayerConfig.geoviewLayerId === '6c343726-1e92-451a-876a-76e17d398a1c') {
-      imageLayerOptions.source?.updateParams({ imageSR: 3978 });
-    }
-    if (layerConfig.geoviewLayerConfig.geoviewLayerId === 'e2424b6c-db0c-4996-9bc0-2ca2e6714d71') {
-      imageLayerOptions.source?.updateParams({ imageSR: 3857 });
-    }
-    if (layerConfig.geoviewLayerConfig.geoviewLayerId === '1dcd28aa-99da-4f62-b157-15631379b170') {
-      imageLayerOptions.source?.updateParams({ imageSR: 4269 });
-    }
+    // Set the image spatial reference to the service source - performance is better when open layers does the conversion
+    const sourceSr = layerConfig.getLayerMetadata()?.sourceSpatialReference?.wkid;
+    if (sourceSr) imageLayerOptions.source?.updateParams({ imageSR: sourceSr });
 
     // Init the layer options with initial settings
     AbstractGVRaster.initOptionsWithInitialSettings(imageLayerOptions, layerConfig);


### PR DESCRIPTION
Closes #2480

# Description

Updates ESRI Dynamic layers to use the service spatial reference instead of the map one, also adds a field to show the current map language in the OSDP integration page.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted Feb. 11 12:30
https://damonu2.github.io/geoview/outlier-performance.html
https://damonu2.github.io/geoview/demo-osdp-integration.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2744)
<!-- Reviewable:end -->
