### PR TITLE
feat(OSDP): updates handling of simplified geocore config

### DIFF
--- a/packages/geoview-core/public/templates/demos/demo-osdp-integration.html
+++ b/packages/geoview-core/public/templates/demos/demo-osdp-integration.html
@@ -126,6 +126,7 @@ function addLayers(layers) {
               <option value="Airborne Radioactivity">Airborne Radioactivity</option>
               <option value="IAAC">IAAC</option>
               <option value="CESI">CESI</option>
+              <option value="DFO">DFO</option>
             </select>
           </div>
   
@@ -522,6 +523,12 @@ cgpv.api.maps.Map1.replaceMapConfigLayerNames(pairs, mapConfig, true);
                 layerId: '7',
               },
             ],
+          },
+        ],
+        DFO: 'db177a8c-5d7d-49eb-8290-31e6a45d786c',
+        DFOConfig: [
+          {
+            layerName: 'Critical Habitat for Aquatic Species at Risk - Canada'
           },
         ],
       };

--- a/packages/geoview-core/src/geo/layer/other/geocore.ts
+++ b/packages/geoview-core/src/geo/layer/other/geocore.ts
@@ -64,8 +64,13 @@ export class GeoCore {
         return newLayerConfig as TypeGeoviewLayerConfig[];
       }
 
-      // In case of simplified geocoreConfig being provided, just update geoviewLayerName
-      if (layerConfig?.geoviewLayerName) response.layers[0].geoviewLayerName = layerConfig.geoviewLayerName;
+      // In case of simplified geocoreConfig being provided, just update geoviewLayerName and the first layer
+      // TODO refactor: this is a terrible patch to get it to work the way OSDP wants, should be changed after refactor
+      if (layerConfig?.geoviewLayerName) {
+        response.layers[0].geoviewLayerName = layerConfig.geoviewLayerName;
+        if (response.layers[0].listOfLayerEntryConfig.length === 1)
+          response.layers[0].listOfLayerEntryConfig[0].layerName = layerConfig.geoviewLayerName;
+      }
 
       // For each found geochart associated with the Geocore UUIDs
       response.geocharts?.forEach((geochartConfig) => {


### PR DESCRIPTION
Closes #2484

# Description

Issue is actually unrelated. This fixes the issue mentioned in the last comment with handling of simplified geocore configs. I think that this handles the configs in the way OSDP is requesting, but who knows.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted Feb. 12, 10:25PM
https://damonu2.github.io/geoview/demo-osdp-integration.html
UUID: b177a8c-5d7d-49eb-8290-31e6a45d786c
config: [{"layerName":"Critical Habitat for Aquatic Species at Risk - Canada"}]

Also tested with existing custom configs and with reducing them to just a layerName

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2745)
<!-- Reviewable:end -->
