### PR TITLE
fix (shell/footer/ui) Wrong footer height in fullscreen

### DIFF
--- a/packages/geoview-core/src/core/containers/containers-style.ts
+++ b/packages/geoview-core/src/core/containers/containers-style.ts
@@ -100,15 +100,16 @@ export const getShellSxClasses = (theme: Theme): SxStyles => ({
   mapShellContainer: {
     display: 'flex',
     flexDirection: 'row',
-    minHeight: '100%',
+    height: '100%',
     width: '100%',
     position: 'relative',
     alignItems: 'stretch',
+    zIndex: 0,
   },
   mapContainer: {
     display: 'flex',
     flexDirection: 'column',
-    minHeight: '100%',
+    height: '100%',
     width: '100%',
     position: 'relative',
     alignItems: 'stretch',

--- a/packages/geoview-core/src/core/containers/shell.tsx
+++ b/packages/geoview-core/src/core/containers/shell.tsx
@@ -82,12 +82,12 @@ export function Shell(props: ShellProps): JSX.Element {
   const footerTabContainer = geoviewElement.querySelector(`[id^="${mapId}-tabsContainer"]`) as HTMLElement;
 
   // Ref for container height
-  const { mapContainerRef, mapShellContainerRef } = useMapResize({
+  const { mapShellContainerRef } = useMapResize({
     isMapFullScreen,
     isFooterBarCollapsed,
     footerPanelResizeValue,
     mapLoaded,
-    isFooterbar: !!geoviewConfig?.footerBar,
+    isFooterBar: !!geoviewConfig?.footerBar,
     geoviewElement,
     footerTabContainer,
   });
@@ -223,7 +223,7 @@ export function Shell(props: ShellProps): JSX.Element {
           <Box id={`map-${mapViewer.mapId}`} sx={sxClasses.mapShellContainer} className="mapContainer" ref={mapShellContainerRef}>
             {mapLoaded && <AppBar api={mapViewer.appBarApi} />}
             <MapInfo />
-            <Box sx={sxClasses.mapContainer} ref={mapContainerRef}>
+            <Box sx={sxClasses.mapContainer}>
               <Map viewer={mapViewer} />
             </Box>
             {interaction === 'dynamic' && <NavBar api={mapViewer.navBarApi} />}

--- a/packages/geoview-core/src/core/containers/use-map-resize.ts
+++ b/packages/geoview-core/src/core/containers/use-map-resize.ts
@@ -1,64 +1,18 @@
 import { useEffect, useRef, useState } from 'react';
 import { logger } from '../utils/logger';
 
-// #region GET MAP STYLES
-interface MapStyleProps {
-  isMapFullScreen: boolean;
-  isFooterBarCollapsed: boolean;
-  footerPanelResizeValue: number;
-  origHeight: string;
-  windowHeight?: number;
-}
-
-type TypeMapStyles = {
-  visibility: string;
-  minHeight: string;
-  height: string;
-  zIndex?: string;
-};
-
-export const getMapStyles = ({
-  isMapFullScreen,
-  isFooterBarCollapsed,
-  footerPanelResizeValue,
-  origHeight,
-  windowHeight = window.screen.height,
-}: MapStyleProps): TypeMapStyles | null => {
-  if (!isMapFullScreen) {
-    return {
-      visibility: 'visible',
-      minHeight: origHeight,
-      height: origHeight,
-      zIndex: '0',
-    };
-  }
-
-  if (isFooterBarCollapsed) {
-    return null;
-  }
-
-  const isHidden = footerPanelResizeValue === 100; // assuming 100 is max value
-  return {
-    visibility: isHidden ? 'hidden' : 'visible',
-    minHeight: isHidden ? '0px' : `${windowHeight - (windowHeight * footerPanelResizeValue) / 100}px`,
-    height: isHidden ? '0px' : `${windowHeight - (windowHeight * footerPanelResizeValue) / 100}px`,
-  };
-};
-// #end region GET MAP STYLES
-
 // #region USE MAP RESIZE
 interface UseMapResizeProps {
   isMapFullScreen: boolean;
   isFooterBarCollapsed: boolean;
   footerPanelResizeValue: number;
   mapLoaded: boolean;
-  isFooterbar: boolean;
+  isFooterBar: boolean;
   geoviewElement: HTMLElement;
   footerTabContainer: HTMLElement | null;
 }
 
 type TypeUseMapResize = {
-  mapContainerRef: React.RefObject<HTMLDivElement>;
   mapShellContainerRef: React.RefObject<HTMLDivElement>;
 };
 
@@ -67,11 +21,10 @@ export const useMapResize = ({
   isFooterBarCollapsed,
   footerPanelResizeValue,
   mapLoaded,
-  isFooterbar,
+  isFooterBar,
   geoviewElement,
   footerTabContainer,
 }: UseMapResizeProps): TypeUseMapResize => {
-  const mapContainerRef = useRef<HTMLDivElement>(null);
   const mapShellContainerRef = useRef<HTMLDivElement>(null);
   const [origHeight, setOrigHeight] = useState<string>('');
 
@@ -79,62 +32,52 @@ export const useMapResize = ({
   useEffect(() => {
     logger?.logTraceUseEffect('USE MAP RESIZE - set initial height');
 
-    if (mapContainerRef.current && mapShellContainerRef.current) {
-      const height = geoviewElement?.dataset?.height ?? `${geoviewElement?.clientHeight}px`;
-      setOrigHeight(height);
-    }
-  }, [geoviewElement]);
+    const height = geoviewElement?.dataset?.height ?? `${geoviewElement?.clientHeight}px`;
+    setOrigHeight(height);
 
-  // Handle footer bar collapse on map full screen
-  useEffect(() => {
-    logger?.logTraceUseEffect('SHELL - isFooterBarCollapsed.isMapFullScreen', isFooterBarCollapsed, isMapFullScreen);
-
-    if (isMapFullScreen && mapContainerRef.current && mapShellContainerRef.current) {
-      const tabHeight = footerTabContainer?.clientHeight ?? 0;
-      const fullScreenStyles: TypeMapStyles = {
-        visibility: 'visible',
-        minHeight: `${window.screen.height - tabHeight}px`,
-        height: `${window.screen.height - tabHeight}px`,
-      };
-
-      // Apply styles to map container
-      Object.assign(mapContainerRef.current.style, fullScreenStyles);
-
-      // Apply styles to shell container with additional z-index
-      Object.assign(mapShellContainerRef.current.style, {
-        ...fullScreenStyles,
-        zIndex: '-1',
+    // Update mapDiv height to accomodate the footerbar
+    if (isFooterBar) {
+      Object.assign(geoviewElement.style, {
+        height: 'fit-content',
+        transition: 'height 0.2s ease-out 0.2s',
       });
     }
-  }, [isFooterBarCollapsed, isMapFullScreen, footerTabContainer]);
+  }, [geoviewElement, isFooterBar]);
 
-  // Handle resize and fullscreen changes
+  /**
+   * Update map height when toggling fullscreen and changing footer panel size
+   */
   useEffect(() => {
-    if (!mapLoaded || !mapContainerRef.current || !mapShellContainerRef.current) {
+    if (!mapShellContainerRef.current) {
       return;
     }
 
-    const styles = getMapStyles({
-      isMapFullScreen,
-      isFooterBarCollapsed,
-      footerPanelResizeValue,
-      origHeight,
-    });
-    logger?.logTraceUseEffect('USE MAP RESIZE - resize and fullscreen changes', styles);
+    // default values as set by the height of the div
+    let containerHeight = origHeight;
+    let visibility = 'visible';
 
-    if (styles) {
-      Object.assign(mapContainerRef.current.style, styles);
-      Object.assign(mapShellContainerRef.current.style, styles);
+    // adjust values from px to % to accomodate fullscreen plus page zoom
+    if (isMapFullScreen) {
+      const tabHeight = footerTabContainer?.clientHeight ?? 0;
 
-      if (isFooterbar && !isMapFullScreen) {
-        Object.assign(geoviewElement.style, {
-          height: 'fit-content',
-          transition: 'height 0.2s ease-out 0.2s',
-        });
+      // by default the footerbar is collapsed when a user goes fullscreen
+      if (isFooterBarCollapsed) {
+        containerHeight = `calc(100% - ${tabHeight}px)`;
+      } else {
+        containerHeight = `${100 - footerPanelResizeValue}%`;
+
+        // footerPanelResizeValue is 100
+        if (footerPanelResizeValue === 100) {
+          visibility = 'hidden';
+          containerHeight = '0';
+        }
       }
     }
-  }, [footerPanelResizeValue, isMapFullScreen, origHeight, mapLoaded, isFooterBarCollapsed, geoviewElement, isFooterbar]);
 
-  return { mapContainerRef, mapShellContainerRef };
+    mapShellContainerRef.current.style.visibility = visibility;
+    mapShellContainerRef.current.style.height = containerHeight;
+  }, [footerTabContainer, footerPanelResizeValue, isFooterBarCollapsed, isMapFullScreen, origHeight]);
+
+  return { mapShellContainerRef };
 };
 // #end region USE MAP SIZE


### PR DESCRIPTION

# Description

Adjust map/footer heights to use percentage values instead of pixel values in fullscreen so that the footer and map containers are correctly sized regardless of browser zoom level

Fixes #2633 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Go to demo page. Zoom browser out to 80% and fullscreen the viewer. There should be no empty space beneath the footer.

https://jaredkinger.github.io/geoview/demos-navigator.html?config=./configs/navigator/06-basic-footer.json

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2747)
<!-- Reviewable:end -->
