### PR TITLE
fix(encoding): encode layerDefs in ESRI Dynamic identify

### DIFF
--- a/packages/geoview-core/src/core/utils/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
@@ -33,7 +33,12 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
     if (
       this.geoviewLayerConfig.metadataAccessPath &&
       !this.geoviewLayerConfig.metadataAccessPath?.startsWith(WMS_PROXY_URL) &&
-      !this.geoviewLayerConfig.metadataAccessPath.includes('datacube.services.geo.ca')
+      !this.geoviewLayerConfig.metadataAccessPath.includes('datacube.services.geo.ca') &&
+      // Weird case that also fails with proxy
+      !(
+        this.geoviewLayerConfig.metadataAccessPath.includes('maps-cartes.ec.gc.ca/arcgis/services/') &&
+        this.geoviewLayerConfig.metadataAccessPath.includes('MapServer/WMSServer')
+      )
     )
       this.geoviewLayerConfig.metadataAccessPath = `${WMS_PROXY_URL}${this.geoviewLayerConfig.metadataAccessPath}`;
 
@@ -41,7 +46,7 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
     if (!this.source) this.source = {};
 
     // Append all WMS links with proxy url to avoid CORS issues
-    // TODO: Currently datacube layers are not working with the proxy, this should not be the case. Check and remove exception when possible
+    // TODO: Currently datacube layers and some other layers are not working with the proxy, this should not be the case. Check and remove exception when possible
     if (
       this.source.dataAccessPath &&
       !this.source.dataAccessPath.startsWith(WMS_PROXY_URL) &&

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -81,8 +81,10 @@ export class GVEsriDynamic extends AbstractGVRaster {
     };
 
     // Set the image spatial reference to the service source - performance is better when open layers does the conversion
+    // Older versions of ArcGIS Server are not properly converted, so this is only used for version 10.8+
+    const version = layerConfig.getLayerMetadata()?.currentVersion as number;
     const sourceSr = layerConfig.getLayerMetadata()?.sourceSpatialReference?.wkid;
-    if (sourceSr) imageLayerOptions.source?.updateParams({ imageSR: sourceSr });
+    if (sourceSr && version && version >= 10.8) imageLayerOptions.source?.updateParams({ imageSR: sourceSr });
 
     // Init the layer options with initial settings
     AbstractGVRaster.initOptionsWithInitialSettings(imageLayerOptions, layerConfig);
@@ -346,7 +348,7 @@ export class GVEsriDynamic extends AbstractGVRaster {
         `&mapExtent=${extent.xmin},${extent.ymin},${extent.xmax},${extent.ymax}` +
         `&imageDisplay=${size[0]},${size[1]},96` +
         `&layers=visible:${layerConfig.layerId}` +
-        `&layerDefs=${layerDefs}` +
+        `&layerDefs=${encodeURI(layerDefs)}` +
         `&geometryType=esriGeometryPoint&geometry=${lnglat[0]},${lnglat[1]}` +
         `&returnGeometry=false&sr=4326&returnFieldName=true`;
 


### PR DESCRIPTION
Closes #2733
Also fixes one of the layers mentioned in #2746

# Description

Added encodeURI to the layerDefs in identify URL to allow them to work with older versions of ArcGIS Server. Also adds some services at maps-cartes.ec.gc.ca/arcgis/services/ to the proxy exemption.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Feb. 13 at 5:15
https://damonu2.github.io/geoview/demo-osdp-integration.html

Add: https://nronk1awvasp039.nrn.nrcan.gc.ca:6443/arcgis/rest/services/GeoAnalytics/earthquakes/MapServer/ layers 1 and/or 2
Click point on map. No return (service issue) but query is successful.

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2748)
<!-- Reviewable:end -->
