### PR TITLE
fix(temporal): fix add default time dimension and filter out invalid …

### DIFF
--- a/packages/geoview-core/public/templates/demos/demo-osdp-integration.html
+++ b/packages/geoview-core/public/templates/demos/demo-osdp-integration.html
@@ -127,6 +127,7 @@ function addLayers(layers) {
               <option value="IAAC">IAAC</option>
               <option value="CESI">CESI</option>
               <option value="DFO">DFO</option>
+              <option value="landCover">Land Cover 2010</option>
             </select>
           </div>
   
@@ -531,6 +532,19 @@ cgpv.api.maps.Map1.replaceMapConfigLayerNames(pairs, mapConfig, true);
             layerName: 'Critical Habitat for Aquatic Species at Risk - Canada'
           },
         ],
+        landCover: 'c688b87f-e85f-4842-b0e1-a8f79ebf1133',
+        landCoverConfig: [
+          {
+            "layerId": "landcover-2010",
+            "layerName": "2010 Land Cover of Canada",
+            "initialSettings": {
+              "states": {
+                "legendCollapsed": true,
+                "visible": false
+                }
+            }
+          }
+        ]
       };
 
 

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/time-slider-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/time-slider-event-processor.ts
@@ -263,7 +263,8 @@ export class TimeSliderEventProcessor extends AbstractEventProcessor {
     if (geoviewLayer instanceof WMS || geoviewLayer instanceof GVWMS) {
       if (filtering) {
         const newValue = DateMgt.formatDateToISO(values[0]);
-        filter = `${field}=date '${newValue}'`;
+        if (newValue !== 'Invalid DateZ') filter = `${field}=date '${newValue}'`;
+        else filter = '';
       } else {
         filter = `${field}=date '${defaultValue}'`;
       }

--- a/packages/geoview-core/src/core/utils/date-mgt.ts
+++ b/packages/geoview-core/src/core/utils/date-mgt.ts
@@ -390,7 +390,7 @@ export abstract class DateMgt {
     const rangeItem = this.createRangeOGC(dimensionObject.values);
     const timeDimension: TimeDimension = {
       field: dimensionObject.name,
-      default: dimensionObject.default,
+      default: dimensionObject.default || rangeItem.range[0],
       unitSymbol: dimensionObject.unitSymbol || '',
       range: rangeItem,
       nearestValues: dimensionObject.nearestValues !== false ? 'absolute' : 'discrete',

--- a/packages/geoview-core/src/geo/layer/other/geocore.ts
+++ b/packages/geoview-core/src/geo/layer/other/geocore.ts
@@ -56,6 +56,8 @@ export class GeoCore {
         const tempLayerConfig = { ...layerConfig } as unknown as TypeGeoviewLayerConfig;
         tempLayerConfig.metadataAccessPath = response.layers[0].metadataAccessPath;
         tempLayerConfig.geoviewLayerType = response.layers[0].geoviewLayerType;
+        if (response.layers[0].isTimeAware === true || response.layers[0].isTimeAware === false)
+          tempLayerConfig.isTimeAware = response.layers[0].isTimeAware;
         // Use the name from the first layer if none is provided in the config
         if (!tempLayerConfig.geoviewLayerName) tempLayerConfig.geoviewLayerName = response.layers[0].geoviewLayerName;
 


### PR DESCRIPTION
…dates

Fixes some issues in #2746

# Description

Carries service isTimeAware over to custom geocore config, adds default to WMS temporal dimension, and filters out invalid dates from WMS time slider filters

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demo-osdp-integration.html Feb. 13 2:45
c688b87f-e85f-4842-b0e1-a8f79ebf1133
[
 {
  "layerId": "landcover-2010",
  "layerName": "2010 Land Cover of Canada",
  "initialSettings": {
   "states": {
     "legendCollapsed": true,
     "visible": false
   }
  }
 }
]

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2750)
<!-- Reviewable:end -->
