### PR TITLE
fix(feature style): attaches style to features and streamlines icon c…

### DIFF
--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -668,7 +668,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
     // Filter features based on visibility
     return features.filter((feature) => {
-      const fieldValues = uniqueValueStyle.fields.map((field) => feature.fieldInfo[field]!.value).join(';');
+      const fieldValues = uniqueValueStyle.fields.map((field) => feature.fieldInfo[field]?.value).join(';');
 
       return (
         visibleValues.has(fieldValues.toString()) ||

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -120,8 +120,8 @@ export function Datapanel({ fullWidth = false, containerType = CONTAINER_TYPE.FO
         return `${datatableSettings[layerPath].rowsFilteredRecord} ${t('dataTable.featureFiltered')}`;
       }
       let featureStr = t('dataTable.noFeatures');
-      const features = orderedLayerData?.find((layer) => layer.layerPath === layerPath)?.features?.length ?? 0;
-      if (features > 0) {
+      const features = orderedLayerData?.find((layer) => layer.layerPath === layerPath)?.features?.length;
+      if (features !== undefined) {
         featureStr = `${features} ${t('dataTable.features')}`;
       }
       return featureStr;

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -7,6 +7,8 @@ import { Layer } from 'ol/layer';
 import Source from 'ol/source/Source';
 import { shared as iconImageCache } from 'ol/style/IconImageCache';
 
+import { Style } from 'ol/style';
+import cloneDeep from 'lodash/cloneDeep';
 import { TimeDimension, DateMgt, TypeDateFragments } from '@/core/utils/date-mgt';
 import { logger } from '@/core/utils/logger';
 import { EsriDynamicLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/esri-dynamic-layer-entry-config';
@@ -23,7 +25,7 @@ import {
   QueryType,
   TypeStyleGeometry,
 } from '@/geo/map/map-schema-types';
-import { getLegendStyles, getFeatureCanvas } from '@/geo/utils/renderer/geoview-renderer';
+import { getLegendStyles, getFeatureImageSource } from '@/geo/utils/renderer/geoview-renderer';
 import { TypeLegend } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
 import { MapViewer } from '@/geo/map/map-viewer';
@@ -547,41 +549,16 @@ export abstract class AbstractGVLayer extends AbstractBaseLayer {
    * Converts the feature information to an array of TypeFeatureInfoEntry[] | undefined | null.
    * @param {Feature[]} features - The array of features to convert.
    * @param {OgcWmsLayerEntryConfig | EsriDynamicLayerEntryConfig | VectorLayerEntryConfig} layerConfig - The layer configuration.
-   * @returns {Promise<TypeFeatureInfoEntry[] | undefined | null>} The Array of feature information.
+   * @returns {TypeFeatureInfoEntry[] | undefined | null} The Array of feature information.
    */
-  protected async formatFeatureInfoResult(
+  protected formatFeatureInfoResult(
     features: Feature[],
     layerConfig: OgcWmsLayerEntryConfig | EsriDynamicLayerEntryConfig | VectorLayerEntryConfig
-  ): Promise<TypeFeatureInfoEntry[] | undefined | null> {
+  ): TypeFeatureInfoEntry[] | undefined | null {
     try {
       if (!features.length) return [];
 
       const outfields = layerConfig?.source?.featureInfo?.outfields;
-
-      // Loop on the features to build the array holding the promises for their canvas
-      const promisedAllCanvasFound: Promise<{ feature: Feature; canvas: HTMLCanvasElement }>[] = [];
-      features.forEach((featureNeedingItsCanvas) => {
-        promisedAllCanvasFound.push(
-          new Promise((resolveCanvas) => {
-            // GV: Callback function was added by PR #1997 and removed by #2590
-            // The PR added an AsyncSemaphore with a callback on geoview renderer to be able to fetch an image with a dataurl from the kernel function geoview-renderer.getFeatureCanvas()
-
-            // GV: Call the function with layerConfig.legendFilterIsOff = true to force the feature to get is canvas
-            // GV: If we don't, it will create canvas only for visible elements and because tables are stored feature will never get its canvas
-            getFeatureCanvas(featureNeedingItsCanvas, this.getStyle()!, layerConfig.filterEquation, true, true)
-              .then((canvas) => {
-                resolveCanvas({ feature: featureNeedingItsCanvas, canvas });
-              })
-              .catch((error) => {
-                // Log
-                logger.logPromiseFailed(
-                  'getFeatureCanvas in featureNeedingItsCanvas loop in formatFeatureInfoResult in AbstractGVLayer',
-                  error
-                );
-              });
-          })
-        );
-      });
 
       // Hold a dictionary built on the fly for the field domains
       const dictFieldDomains: { [fieldName: string]: codedValueType | rangeDomainType | null } = {};
@@ -592,8 +569,29 @@ export abstract class AbstractGVLayer extends AbstractBaseLayer {
       let featureKeyCounter = 0;
       let fieldKeyCounter = 0;
       const queryResult: TypeFeatureInfoEntry[] = [];
-      const arrayOfFeatureInfo = await Promise.all(promisedAllCanvasFound);
-      arrayOfFeatureInfo.forEach(({ feature, canvas }) => {
+
+      // Dict to store created image sources to avoid recreating
+      const imageSourceDict: { [styleAsJsonString: string]: string } = {};
+
+      features.forEach((feature) => {
+        // Check dict for existing image source and create it if it does not exist
+        let imageSource: string | undefined;
+        const layerStyle = this.getStyle()!;
+        const featureStyle = feature.getStyle();
+        if (featureStyle) {
+          const geometryType = feature.getGeometry() ? feature.getGeometry()!.getType() : (Object.keys(layerStyle)[0] as TypeStyleGeometry);
+          // Create a string unique to the style, but geometry agnostic
+          const styleClone = cloneDeep(featureStyle) as Style;
+          styleClone.setGeometry('');
+          const styleString = `${geometryType}${JSON.stringify(styleClone)}`;
+          // Use string as dict key
+          if (!imageSourceDict[styleString])
+            imageSourceDict[styleString] = getFeatureImageSource(feature, layerStyle, layerConfig.filterEquation, true);
+          imageSource = imageSourceDict[styleString];
+        }
+
+        if (!imageSource) imageSource = getFeatureImageSource(feature, layerStyle, layerConfig.filterEquation, true);
+
         let extent;
         if (feature.getGeometry()) extent = feature.getGeometry()!.getExtent();
 
@@ -603,7 +601,7 @@ export abstract class AbstractGVLayer extends AbstractBaseLayer {
           geoviewLayerType: this.getLayerConfig().geoviewLayerConfig.geoviewLayerType as TypeGeoviewLayerType,
           extent,
           geometry: feature,
-          featureIcon: canvas.toDataURL(),
+          featureIcon: imageSource,
           fieldInfo: {},
           nameField: layerConfig?.source?.featureInfo?.nameField || null,
         };

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -400,7 +400,7 @@ export class GVEsriDynamic extends AbstractGVRaster {
       // TODO.CONT: geometry assignement must not be in an async function.
       // Transform the features in an OL feature - at this point, there is no geometry associated with the feature
       const features = new EsriJSON().readFeatures({ features: identifyJsonResponse.results }) as Feature<Geometry>[];
-      const arrayOfFeatureInfoEntries = await this.formatFeatureInfoResult(features, layerConfig);
+      const arrayOfFeatureInfoEntries = this.formatFeatureInfoResult(features, layerConfig);
 
       // If geometry is needed, use web worker to query and assign geometry later
       if (queryGeometry)

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
@@ -111,7 +111,7 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
       // Get the layer config in a loaded phase
       const layerConfig = this.getLayerConfig();
       const features = this.getOLSource()!.getFeatures();
-      return this.formatFeatureInfoResult(features, layerConfig);
+      return Promise.resolve(this.formatFeatureInfoResult(features, layerConfig));
     } catch (error) {
       // Log
       logger.logError('abstract-gv-vector.getAllFeatureInfo()\n', error);
@@ -140,7 +140,7 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
       const features = this.getMapViewer().map.getFeaturesAtPixel(location, { hitTolerance: this.hitTolerance, layerFilter }) as Feature[];
 
       // Format and return the features
-      return this.formatFeatureInfoResult(features, this.getLayerConfig());
+      return Promise.resolve(this.formatFeatureInfoResult(features, this.getLayerConfig()));
     } catch (error) {
       // Log
       logger.logError('abstract-gv-vector.getFeatureInfoAtPixel()\n', error);

--- a/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
@@ -46,7 +46,7 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
     const layerPath = layer.getLayerPath();
     this.resultSet[layerPath].eventListenerEnabled = true;
     this.resultSet[layerPath].queryStatus = 'processed';
-    this.resultSet[layerPath].features = [];
+    this.resultSet[layerPath].features = undefined;
 
     // Extra initialization of settings
     DataTableEventProcessor.setInitialSettings(this.getMapId(), layerPath);

--- a/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
@@ -188,33 +188,6 @@ async function createIconCanvas(pointStyle?: Style): Promise<HTMLCanvasElement |
   }
 }
 
-/** ***************************************************************************************************************************
- * This method creates a canvas with the image data source (base64 image) provided.
- *
- * @param {string} imageDataSource The image source information (base64 image) of the image to load
- *
- * @returns {Promise<HTMLCanvasElement>} A promise that the canvas is created.
- */
-async function createIconCanvasFromImageSource(imageDataSource: string): Promise<HTMLCanvasElement | null> {
-  try {
-    const image = await loadImage(imageDataSource);
-    if (image) {
-      const width = image.width || LEGEND_CANVAS_WIDTH;
-      const height = image.height || LEGEND_CANVAS_HEIGHT;
-      const drawingCanvas = document.createElement('canvas');
-      drawingCanvas.width = width;
-      drawingCanvas.height = height;
-      const drawingContext = drawingCanvas.getContext('2d')!;
-      drawingContext.drawImage(image, 0, 0);
-      return drawingCanvas;
-    }
-    return null;
-  } catch (error) {
-    logger.logError(`Error creating incon canvas for pointStyle`, error);
-    return null;
-  }
-}
-
 // #region CREATE CANVAS
 /** ***************************************************************************************************************************
  * This method creates a canvas with the vector point settings that are defined in the point style.
@@ -1544,31 +1517,31 @@ export function getAndCreateFeatureStyle(
     const styleSettings = style![geometryType]!;
     const { type } = styleSettings;
     // TODO: Refactor - Rewrite this to use explicit function calls instead, for clarity and references finding
-    return processStyle[type][geometryType].call('', styleSettings, feature as Feature, filterEquation, legendFilterIsOff);
+    const featureStyle = processStyle[type][geometryType].call('', styleSettings, feature as Feature, filterEquation, legendFilterIsOff);
+    // Set the feature style to avoid recreating later
+    (feature as Feature).setStyle(featureStyle);
+    return featureStyle;
   }
+
   return undefined;
 }
 
-const CANVAS_RECYCLING: { [styleAsJsonString: string]: HTMLCanvasElement } = {};
-
 /** ***************************************************************************************************************************
- * This method gets the canvas icon from the style of the feature using the layer entry config.
- * @param {Feature} feature - The feature that need its canvas icon to be defined.
+ * This method gets the image source from the style of the feature using the layer entry config.
+ * @param {Feature} feature - The feature that need its icon to be defined.
  * @param {TypeStyleConfig} style - The style to use
  * @param {FilterNodeArrayType} filterEquation - Filter equation associated to the layer.
  * @param {boolean} legendFilterIsOff - When true, do not apply legend filter.
- * @param {boolean} useRecycling - Special parameter to optimize canvas creation time when functions is called multiple times.
- * @returns {Promise<HTMLCanvasElement>} The canvas icon associated to the feature or a default empty canvas.
+ * @returns {string} The icon associated to the feature or a default empty one.
  */
-export async function getFeatureCanvas(
+export function getFeatureImageSource(
   feature: Feature,
   style: TypeLayerStyleConfig,
   filterEquation?: FilterNodeArrayType,
-  legendFilterIsOff?: boolean,
-  useRecycling?: boolean
-): Promise<HTMLCanvasElement> {
-  // The canvas that will be returned (if calculated successfully)
-  let canvas: HTMLCanvasElement | undefined;
+  legendFilterIsOff?: boolean
+): string {
+  // The image source that will be returned (if calculated successfully)
+  let imageSource: string | undefined;
 
   // GV: Sometimes, the feature will have no geometry e.g. esriDynamic as we fetch geometry only when needed
   // GV: We need to extract geometry from style instead. For esriDynamic there is only one geometry at a time
@@ -1597,7 +1570,11 @@ export async function getFeatureCanvas(
       //   });
       // });
 
-      const featureStyle = processStyle[type][geometryType](styleSettings, feature, filterEquation, legendFilterIsOff);
+      const featureStyle =
+        feature.getStyle() instanceof Style
+          ? (feature.getStyle() as Style)
+          : processStyle[type][geometryType](styleSettings, feature, filterEquation, legendFilterIsOff);
+
       if (featureStyle) {
         if (geometryType === 'Point') {
           if (
@@ -1605,39 +1582,24 @@ export async function getFeatureCanvas(
             (styleSettings.type === 'uniqueValue' && !(featureStyle.getImage() instanceof Icon)) ||
             (styleSettings.type === 'classBreaks' && !(featureStyle.getImage() instanceof Icon))
           ) {
-            canvas = createPointCanvas(featureStyle);
+            imageSource = createPointCanvas(featureStyle).toDataURL();
           } else {
-            canvas = (await createIconCanvas(featureStyle)) || undefined;
+            imageSource = (featureStyle.getImage() as Icon).getSrc() || undefined;
           }
         } else if (geometryType === 'LineString') {
-          canvas = createLineStringCanvas(featureStyle);
+          imageSource = createLineStringCanvas(featureStyle).toDataURL();
         } else {
-          // eslint-disable-next-line no-lonely-if
-          if (useRecycling) {
-            // Stringify to compare styles with each others
-            const strokeAsString = JSON.stringify(featureStyle.getStroke());
-            const fillAsString = JSON.stringify(featureStyle.getFill());
-            const featureAsString = strokeAsString + fillAsString;
-
-            // If no other style like it has been processed so far
-            if (!CANVAS_RECYCLING[featureAsString]) {
-              // Keep it as template
-              CANVAS_RECYCLING[featureAsString] = createPolygonCanvas(featureStyle);
-            }
-            canvas = CANVAS_RECYCLING[featureAsString];
-          } else {
-            canvas = createPolygonCanvas(featureStyle);
-          }
+          imageSource = createPolygonCanvas(featureStyle).toDataURL();
         }
       }
     }
   }
 
   // If set, all good
-  if (canvas) return canvas;
+  if (imageSource) return imageSource;
 
   // Here, nothing could be done, use the no_legend template
-  return (await createIconCanvasFromImageSource(FORMATTING_NO_LEGEND))!;
+  return FORMATTING_NO_LEGEND;
 }
 
 /** ***************************************************************************************************************************


### PR DESCRIPTION
…reation

# Description

Style is set for features when created, allowing it to be accessed without recreating. formatFeatureInfo is simplified, no longer async, and caches icon sources. getFeatureCanvas is now getFeatureImageSource, returning a image source string instead of a canvas promise. Image sources in feature style are used directly instead of being turned into a canvas to be turned into a data URL.

Additionally, layers in the data table with no features will display that, instead of being unknown and appearing to have failed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/outlier-ESRI-maxRecordCount.html
https://damonu2.github.io/geoview/outlier-elections-2019.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2770)
<!-- Reviewable:end -->
