### PR TITLE
bug(datacube): replaces RAMP wrapper

### DIFF
--- a/packages/geoview-core/src/core/utils/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
@@ -36,8 +36,11 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
 
     // When the dataAccessPath is undefined and the metadataAccessPath does not end with ".xml", the dataAccessPath is set
     // to the same value of the corresponding metadataAccessPath.
+    this.geoviewLayerConfig.metadataAccessPath = this.geoviewLayerConfig.metadataAccessPath!.replace('wrapper/ramp/ogc', 'ows');
     if (this.geoviewLayerConfig.metadataAccessPath!.slice(-4).toLowerCase() !== '.xml')
       this.source.dataAccessPath = this.geoviewLayerConfig.metadataAccessPath;
+
+    this.source.dataAccessPath = this.source.dataAccessPath!.replace('wrapper/ramp/ogc', 'ows');
 
     // Default value for layerConfig.source.serverType is 'mapserver'.
     if (!this.source.serverType) this.source.serverType = 'mapserver';

--- a/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/esri-feature-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/vector-validation-classes/esri-feature-layer-entry-config.ts
@@ -29,5 +29,16 @@ export class EsriFeatureLayerEntryConfig extends VectorLayerEntryConfig {
     // If undefined, we assign the metadataAccessPath of the GeoView layer to the dataAccessPath.
     if (!this.source.dataAccessPath) this.source.dataAccessPath = this.geoviewLayerConfig.metadataAccessPath;
     if (!this.source.dataAccessPath!.endsWith('/')) this.source.dataAccessPath += '/';
+
+    // Remove ID from dataAccessPath
+    const splitAccessPath = this.source.dataAccessPath!.split('/');
+    if (
+      splitAccessPath[splitAccessPath.length - 2].toLowerCase() !== 'featureserver' &&
+      splitAccessPath[splitAccessPath.length - 2].toLowerCase() !== 'mapserver'
+    ) {
+      splitAccessPath.pop();
+      splitAccessPath.pop();
+      this.source.dataAccessPath = `${splitAccessPath.join('/')}/`;
+    }
   }
 }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -268,7 +268,7 @@ export function commonProcessTemporalDimension(
 /** ***************************************************************************************************************************
  * This method verifies if the layer is queryable and sets the outfields and aliasFields of the source feature info.
  *
- * @param {EsriDynamic | EsriFeature} layer The ESRI layer instance pointer.
+ * @param {EsriDynamic | EsriFeature | EsriImage} layer The ESRI layer instance pointer.
  * @param {EsriFeatureLayerEntryConfig |
  *         EsriDynamicLayerEntryConfig |
  *         EsriImageLayerEntryConfig} layerConfig The layer entry to configure.
@@ -349,7 +349,7 @@ export function commonProcessInitialSettings(
 
   layerConfig.initialSettings.extent = validateExtentWhenDefined(layerConfig.initialSettings.extent);
 
-  if (!layerConfig.initialSettings?.bounds) {
+  if (!layerConfig.initialSettings?.bounds && layerMetadata.extent) {
     const layerExtent = [
       layerMetadata.extent.xmin,
       layerMetadata.extent.ymin,
@@ -422,11 +422,11 @@ export async function commonProcessLayerMetadata<
           const renderer = Cast<EsriBaseRenderer>(data.drawingInfo?.renderer);
           if (renderer) EsriLayerConfig.layerStyle = getStyleFromEsriRenderer(renderer);
         }
-        layer.processFeatureInfoConfig(
-          layerConfig as EsriDynamicLayerEntryConfig & EsriFeatureLayerEntryConfig & EsriImageLayerEntryConfig
-        );
-        layer.processInitialSettings(layerConfig as EsriDynamicLayerEntryConfig & EsriFeatureLayerEntryConfig & EsriImageLayerEntryConfig);
       }
+
+      layer.processFeatureInfoConfig(layerConfig as EsriDynamicLayerEntryConfig & EsriFeatureLayerEntryConfig & EsriImageLayerEntryConfig);
+      layer.processInitialSettings(layerConfig as EsriDynamicLayerEntryConfig & EsriFeatureLayerEntryConfig & EsriImageLayerEntryConfig);
+
       commonProcessTemporalDimension(
         layer,
         data.timeInfo as TypeJsonObject,

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -581,7 +581,6 @@ export abstract class AbstractGVLayer extends AbstractBaseLayer {
           : (Object.keys(layerStyle)[0] as TypeStyleGeometry);
 
         let featureStyle = feature.getStyle();
-
         // Feature style must be created if it does not exist on feature
         if (!featureStyle && layerStyle[geometryType]) {
           const styleSettings = layerStyle[geometryType]!;
@@ -590,15 +589,18 @@ export abstract class AbstractGVLayer extends AbstractBaseLayer {
           feature.setStyle(featureStyle);
         }
 
-        // Create a string unique to the style, but geometry agnostic
-        const styleClone = cloneDeep(featureStyle) as Style;
-        styleClone.setGeometry('');
-        const styleString = `${geometryType}${JSON.stringify(styleClone)}`;
+        let imageSource;
+        if (featureStyle) {
+          // Create a string unique to the style, but geometry agnostic
+          const styleClone = cloneDeep(featureStyle) as Style;
+          styleClone.setGeometry('');
+          const styleString = `${geometryType}${JSON.stringify(styleClone)}`;
 
-        // Use string as dict key
-        if (!imageSourceDict[styleString])
-          imageSourceDict[styleString] = getFeatureImageSource(feature, layerStyle, layerConfig.filterEquation, true);
-        const imageSource = imageSourceDict[styleString];
+          // Use string as dict key
+          if (!imageSourceDict[styleString])
+            imageSourceDict[styleString] = getFeatureImageSource(feature, layerStyle, layerConfig.filterEquation, true);
+          imageSource = imageSourceDict[styleString];
+        } else imageSource = getFeatureImageSource(feature, layerStyle, layerConfig.filterEquation, true);
 
         let extent;
         if (feature.getGeometry()) extent = feature.getGeometry()!.getExtent();

--- a/packages/geoview-core/src/geo/utils/projection.ts
+++ b/packages/geoview-core/src/geo/utils/projection.ts
@@ -41,6 +41,9 @@ export abstract class Projection {
     CSRS: 'EPSG:4617',
     CSRS98: 'EPSG:4140',
     3400: 'EPSG:3400',
+    2151: 'EPSG:2151',
+    2957: 'EPSG:2957',
+    26914: 'EPSG:26914',
   };
 
   // Incremental number when creating custom WKTs on the fly
@@ -510,6 +513,45 @@ function init3400Projection(): void {
   if (projection) Projection.PROJECTIONS['3400'] = projection;
 }
 
+/**
+ * Initializes the EPSG:2151 projection
+ */
+function init2151Projection(): void {
+  proj4.defs(Projection.PROJECTION_NAMES[2151], '+proj=utm +zone=13 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs');
+  register(proj4);
+
+  const projection = olGetProjection(Projection.PROJECTION_NAMES[2151]);
+
+  if (projection) Projection.PROJECTIONS['2151'] = projection;
+}
+
+/**
+ * Initializes the EPSG:2957 projection
+ */
+function init2957Projection(): void {
+  proj4.defs(
+    Projection.PROJECTION_NAMES[2957],
+    '+proj=utm +zone=13 +ellps=GRS80 +towgs84=-0.991,1.9072,0.5129,-1.25033e-07,-4.6785e-08,-5.6529e-08,0 +units=m +no_defs +type=crs'
+  );
+  register(proj4);
+
+  const projection = olGetProjection(Projection.PROJECTION_NAMES[2957]);
+
+  if (projection) Projection.PROJECTIONS['2957'] = projection;
+}
+
+/**
+ * Initializes the EPSG:26914 projection
+ */
+function init26914Projection(): void {
+  proj4.defs(Projection.PROJECTION_NAMES[26914], '+proj=utm +zone=14 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs');
+  register(proj4);
+
+  const projection = olGetProjection(Projection.PROJECTION_NAMES[26914]);
+
+  if (projection) Projection.PROJECTIONS['26914'] = projection;
+}
+
 // Initialize the supported projections
 initCRS84Projection();
 init4326Projection();
@@ -525,4 +567,7 @@ init102100Projection();
 init102184Projection();
 init102190Projection();
 init3400Projection();
+init2151Projection();
+init2957Projection();
+init26914Projection();
 logger.logInfo('Projections initialized');

--- a/packages/geoview-time-slider/src/time-slider.tsx
+++ b/packages/geoview-time-slider/src/time-slider.tsx
@@ -531,7 +531,7 @@ export function TimeSlider(props: TimeSliderProps): JSX.Element {
         {fieldAlias && (
           <Grid item xs={12}>
             <Typography component="div" sx={{ px: '20px', py: '5px' }}>
-              {`${getLocalizedMessage('timeSlider.slider.temporalField', displayLanguage)}${fieldAlias} (${field})`}
+              {`${getLocalizedMessage('timeSlider.slider.temporalField', displayLanguage)}${fieldAlias !== field ? `${fieldAlias}(${field})` : fieldAlias}`}
             </Typography>
           </Grid>
         )}


### PR DESCRIPTION
Also fixes:
Issues with ESRI feature access paths
Issues with ESRI Image metadata processing
Missing style causing formatting to fail
ESRI feature query issues
Added projections 2151, 2957, 26914
Duplication of field name in time-slider
Closes #2736
Close #2779
Closes #2783

# Description

Replaces RAMP wrapper in datacube WMS services with "ows" which covers all the layers that I looked at. Will not have to be changed if the datacube layers are changed, will just do nothing.
Fixes some issues with ESRI Image metadata processing causing errors.
Fixes issue with ESRI Feature geocore layer providing URL with layer ID appended instead of as layerEntries index.
Fixes ESRI Feature query to not expect sequential OBJECTID's starting at 1. Adds maxAllowableOffset of 5 to the query, and increases default featureLimit to 1000 (It is hard to find differences with the offset at 5, while at 10 they are more noticeable).
Also simplified feature fetch as it was not behaving as intended, so had a lot of unnecessary code.
Fixes issue where features whose style was undefined and could not be generated caused the formatting to fail and return 0 features.
Removes duplication of field name in time slider if alias is the same or not provided.
Adds support for EPSG: 2151, 2957, 26914.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demo-osdp-integration.html
For new projections and ESRI feature issues:
2397ca65-5414-7829-5730-7f34e402ed44
d9d0dcd6-3058-b986-922f-427dda7f8068
f061b5e6-6b5d-d417-18b2-d40b8e8cb889

For datacube wrapper and ESRI Image issues:
cf29bdb2-bbdb-48c3-b09f-118600801836
d7b177e0-274a-4be9-b69a-2030faf83c78
d708877c-56b8-4255-99e3-3c4abc54597d

https://damonu2.github.io/geoview/outlier-elections-2019.html for performance improvements to ESRI Dynamic feature fetch

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
