### PR TITLE
bug(clone): removes deep clone of config

### DIFF
--- a/packages/geoview-core/public/configs/many-groups.json
+++ b/packages/geoview-core/public/configs/many-groups.json
@@ -1,0 +1,39 @@
+{
+  "map": {
+    "interaction": "dynamic",
+    "viewSettings": {
+      "projection": 3857
+    },
+    "basemapOptions": {
+      "basemapId": "transport",
+      "shaded": true,
+      "labeled": false
+    },
+    "listOfGeoviewLayerConfig": [
+      {
+        "geoviewLayerType": "geoCore",
+        "geoviewLayerId": "44ef4d33-20b7-45fc-974c-d73a0a8fbae8"
+      }
+    ]
+  },
+  "components": [
+    "overview-map"
+  ],
+  "overviewMap": {
+    "hideOnZoom": 7
+  },
+  "footerBar": {
+    "tabs": {
+      "core": [
+        "legend",
+        "layers",
+        "details",
+        "geochart",
+        "time-slider",
+        "data-table"
+      ]
+    }
+  },
+  "corePackages": [],
+  "theme": "geo.ca"
+}

--- a/packages/geoview-core/public/templates/outliers/outlier-many-groups.html
+++ b/packages/geoview-core/public/templates/outliers/outlier-many-groups.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Many Group Layers - Canadian Geospatial Platform Viewer</title>
+    <link rel="shortcut icon" href="./favicon.ico" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="msapplication-config" content="./img/browserconfig.xml" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="theme-color" content="#ffffff" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto|Montserrat:200,300,400,900|Merriweather" rel="stylesheet" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+
+  <body>
+    <div class="header-table">
+      <table>
+        <tbody>
+          <tr>
+            <td><img class="header-logo" alt="logo" src="./img/Logo.png" /></td>
+            <td class="header-title">
+              <h1><strong>Outlier geocore with many group layers</strong></h1>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <a href="./index.html">Main</a><br />
+              <a href="./outliers.html">Outlier Layers</a><br />
+            </td>
+          </tr>
+          <tr>
+            <td><p>This page is used to showcase a geocore uuid with many group layers</p></td>
+          </tr>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="map-title-holder">
+      <h4 id="HMap1">Many Group Layers</h4>
+    </div>
+    <button class="collapsible active">Layers Status</button>
+    <pre id="HMap1-state" class="panel map-title-holder"></pre>
+    <hr />
+
+    <select name="projections" id="projections">
+      <option value="3857">Web Mercator (3857)</option>
+      <option value="3978">LCC (3978)</option>
+    </select>
+    <button type="button" onclick="reloadMap()">Set Projection</button>
+
+    <div
+      id="Map1"
+      class="geoview-map"
+      data-lang="en"
+      data-config-url="./configs/many-groups.json"
+    ></div>
+
+    <div>
+      Outlier Layers:
+      <ul>
+        <li>
+          Huge number of group layers and layers: <a href="https://github.com/Canadian-Geospatial-Platform/geoview/issues/2642">Issue #2642</a>
+        </li>
+      </ul>
+    </div>
+    <hr />
+
+    <script src="codedoc.js"></script>
+    <script>
+      // initialize cgpv and api events, a callback is optional, used if calling api's after the rendering is ready
+      cgpv.init((mapId) => {
+          listenToLegendLayerSetChanges(`H${mapId}-state`, mapId);
+      });
+
+      function reloadMap() {
+        cgpv.api.maps['Map1'].setProjection(Number(document.getElementById('projections').value));
+      }
+
+      // create snippets
+      window.addEventListener('load', () => {
+        createCodeSnippet();
+        createConfigSnippet();
+      });
+    </script>
+  </body>
+</html>

--- a/packages/geoview-core/public/templates/outliers/outliers.html
+++ b/packages/geoview-core/public/templates/outliers/outliers.html
@@ -35,6 +35,7 @@
       <a href="./outlier-GeoAI.html">GeoAI</a><br />
       <a href="./outlier-elections-2019.html">Elections 2019</a><br />
       <a href="./outlier-performance.html">Many slow layers in different projection</a><br />
+      <a href="./outlier-many-groups.html">Many group layers</a><br />
       <br />
     </div>
   </body>

--- a/packages/geoview-core/src/api/config/types/classes/geoview-config/abstract-geoview-esri-layer-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/geoview-config/abstract-geoview-esri-layer-config.ts
@@ -7,6 +7,7 @@ import { EntryConfigBaseClass } from '@/api/config/types/classes/sub-layer-confi
 
 import { getXMLHttpRequest } from '@/core/utils/utilities';
 import { logger } from '@/core/utils/logger';
+import { Projection } from '@/geo/utils/projection';
 
 // ========================
 // #region CLASS HEADER
@@ -77,6 +78,10 @@ export abstract class AbstractGeoviewEsriLayerConfig extends AbstractGeoviewLaye
           throw new GeoviewLayerConfigError('See error description above');
         } else {
           this.setServiceMetadata(jsonMetadata);
+
+          if (jsonMetadata?.spatialReference && !Projection.getProjectionFromObj(jsonMetadata.spatialReference))
+            await Projection.addProjection(jsonMetadata.data.spatialReference);
+
           this.listOfLayerEntryConfig = this.processListOfLayerEntryConfig(this.listOfLayerEntryConfig);
           await this.fetchListOfLayerMetadata();
 

--- a/packages/geoview-core/src/api/config/types/classes/sub-layer-config/group-node/esri-group-layer-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/sub-layer-config/group-node/esri-group-layer-config.ts
@@ -94,7 +94,7 @@ export class EsriGroupLayerConfig extends GroupLayerEntryConfig {
       layerMetadata.initialExtent.xmax,
       layerMetadata.initialExtent.ymax,
     ] as Extent;
-    const sourceProj = layerMetadata.initialExtent.spatialReference.wkid;
+    const sourceProj = layerMetadata.initialExtent.spatialReference.latestWkid || layerMetadata.initialExtent.spatialReference.wkid;
     if (sourceProj === '4326') this.initialSettings.extent = validateExtentWhenDefined(metadataExtent);
     else
       this.initialSettings.extent = validateExtentWhenDefined(
@@ -129,7 +129,7 @@ export class EsriGroupLayerConfig extends GroupLayerEntryConfig {
       serviceMetadata.initialExtent.xmax,
       serviceMetadata.initialExtent.ymax,
     ] as Extent;
-    const sourceProj = serviceMetadata.initialExtent.spatialReference.wkid;
+    const sourceProj = serviceMetadata.initialExtent.spatialReference.latestWkid || serviceMetadata.initialExtent.spatialReference.wkid;
     if (sourceProj === '4326') this.initialSettings.extent = validateExtentWhenDefined(metadataExtent);
     else
       this.initialSettings.extent = validateExtentWhenDefined(

--- a/packages/geoview-core/src/api/config/types/classes/sub-layer-config/leaf/abstract-base-esri-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/sub-layer-config/leaf/abstract-base-esri-layer-entry-config.ts
@@ -88,7 +88,7 @@ export abstract class AbstractBaseEsriLayerEntryConfig extends AbstractBaseLayer
       layerMetadata.extent.ymax,
     ] as Extent;
 
-    const sourceProj = layerMetadata.extent.spatialReference.wkid;
+    const sourceProj = layerMetadata.extent.spatialReference.latestWkid || layerMetadata.extent.spatialReference.wkid;
     if (sourceProj === '4326') this.initialSettings.extent = validateExtentWhenDefined(metadataExtent);
     else {
       metadataExtent = Projection.transformExtentFromObj(

--- a/packages/geoview-core/src/api/config/types/classes/sub-layer-config/leaf/raster/esri-dynamic-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/sub-layer-config/leaf/raster/esri-dynamic-layer-entry-config.ts
@@ -70,7 +70,9 @@ export class EsriDynamicLayerEntryConfig extends AbstractBaseEsriLayerEntryConfi
       featureInfo: this.createFeatureInfoUsingMetadata(),
       format: 'png' as TypeEsriFormatParameter,
       transparent: true,
-      projection: layerMetadata.sourceSpatialReference.wkid as TypeValidMapProjectionCodes,
+      projection:
+        (layerMetadata.sourceSpatialReference.latestWkid as TypeValidMapProjectionCodes) ||
+        (layerMetadata.sourceSpatialReference.wkid as TypeValidMapProjectionCodes),
     };
 
     const renderer = Cast<EsriBaseRenderer>(layerMetadata.drawingInfo?.renderer);

--- a/packages/geoview-core/src/api/config/types/classes/sub-layer-config/leaf/vector/esri-feature-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/sub-layer-config/leaf/vector/esri-feature-layer-entry-config.ts
@@ -69,7 +69,9 @@ export class EsriFeatureLayerEntryConfig extends AbstractBaseEsriLayerEntryConfi
       featureInfo: this.createFeatureInfoUsingMetadata(),
       format: 'EsriJSON' as TypeVectorSourceFormats, // The only possible value
       strategy: 'all', // default value
-      projection: layerMetadata.sourceSpatialReference.wkid as TypeValidMapProjectionCodes,
+      projection:
+        (layerMetadata.sourceSpatialReference.latestWkid as TypeValidMapProjectionCodes) ||
+        (layerMetadata.sourceSpatialReference.wkid as TypeValidMapProjectionCodes),
     };
 
     const renderer = Cast<EsriBaseRenderer>(layerMetadata.drawingInfo?.renderer);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -3,8 +3,6 @@
 import axios from 'axios';
 import { Extent } from 'ol/extent';
 
-import cloneDeep from 'lodash/cloneDeep';
-
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
 import { Cast, TypeJsonArray, TypeJsonObject } from '@/core/types/global-types';
 import { getXMLHttpRequest } from '@/core/utils/utilities';
@@ -138,7 +136,9 @@ export function commonValidateListOfLayerEntryConfig(
     if (layer.metadata!.layers[esriIndex]?.subLayerIds?.length) {
       // We will create dynamically a group layer.
       const newListOfLayerEntryConfig: TypeLayerEntryConfig[] = [];
-      const switchToGroupLayer = Cast<GroupLayerEntryConfig>(cloneDeep(layerConfig));
+      // If we cloneDeep the layerConfig, it seems to clone pointer for parentLayerConfig and geoviewLayerConfig to objects
+      // GV: previously used cloneDeep (before refactor began), not sure why, has been fine this way through testing
+      const switchToGroupLayer = Cast<GroupLayerEntryConfig>({ ...layerConfig });
       switchToGroupLayer.entryType = CONST_LAYER_ENTRY_TYPES.GROUP;
 
       // Only switch the layer name by the metadata if there were none pre-set (config wins over metadata rule?)
@@ -412,6 +412,9 @@ export async function commonProcessLayerMetadata<
           if (renderer) EsriLayerConfig.layerStyle = getStyleFromEsriRenderer(renderer);
         }
       }
+
+      if (data.spatialReference && !Projection.getProjectionFromObj(data.spatialReference))
+        await Projection.addProjection(data.spatialReference);
 
       layer.processFeatureInfoConfig(layerConfig as EsriDynamicLayerEntryConfig & EsriFeatureLayerEntryConfig & EsriImageLayerEntryConfig);
       layer.processInitialSettings(layerConfig as EsriDynamicLayerEntryConfig & EsriFeatureLayerEntryConfig & EsriImageLayerEntryConfig);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
@@ -17,6 +17,7 @@ import {
 } from '@/geo/map/map-schema-types';
 import { TypeJsonObject } from '@/core/types/global-types';
 import { validateExtentWhenDefined } from '@/geo/utils/utilities';
+import { Projection } from '@/geo/utils/projection';
 import { api } from '@/app';
 import { VectorTilesLayerEntryConfig } from '@/core/utils/config/validation-classes/raster-validation-classes/vector-tiles-layer-entry-config';
 import { logger } from '@/core/utils/logger';
@@ -225,7 +226,7 @@ export class VectorTiles extends AbstractGeoViewRaster {
    * @returns {Promise<AbstractBaseLayerEntryConfig>} A promise that the vector layer configuration has its metadata processed.
    */
   // GV Layers Refactoring - Obsolete (in config?)
-  protected override processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<AbstractBaseLayerEntryConfig> {
+  protected override async processLayerMetadata(layerConfig: AbstractBaseLayerEntryConfig): Promise<AbstractBaseLayerEntryConfig> {
     // Instance check
     const updatedLayerConfig = layerConfig;
     if (!(updatedLayerConfig instanceof VectorTilesLayerEntryConfig)) throw new Error('Invalid layer configuration type provided');
@@ -241,6 +242,9 @@ export class VectorTiles extends AbstractGeoViewRaster {
       updatedLayerConfig.source!.tileGrid = newTileGrid;
 
       updatedLayerConfig.initialSettings.extent = validateExtentWhenDefined(updatedLayerConfig.initialSettings.extent);
+
+      if (fullExtent.spatialReference && !Projection.getProjectionFromObj(fullExtent.spatialReference))
+        await Projection.addProjection(fullExtent.spatialReference);
 
       // Set zoom levels. Vector tiles may be unique as they can have both scale and zoom level properties
       // First set the min/max scales based on the service / config

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -83,7 +83,8 @@ export class GVEsriDynamic extends AbstractGVRaster {
     // Set the image spatial reference to the service source - performance is better when open layers does the conversion
     // Older versions of ArcGIS Server are not properly converted, so this is only used for version 10.8+
     const version = layerConfig.getLayerMetadata()?.currentVersion as number;
-    const sourceSr = layerConfig.getLayerMetadata()?.sourceSpatialReference?.wkid;
+    const sourceSr =
+      layerConfig.getLayerMetadata()?.sourceSpatialReference?.latestWkid || layerConfig.getLayerMetadata()?.sourceSpatialReference?.wkid;
     if (sourceSr && version && version >= 10.8) imageLayerOptions.source?.updateParams({ imageSR: sourceSr });
 
     // Init the layer options with initial settings
@@ -964,7 +965,7 @@ export class GVEsriDynamic extends AbstractGVRaster {
         if (extent) {
           const projExtent = Projection.transformExtentFromProj(
             [extent.xmin, extent.ymin, extent.xmax, extent.ymax],
-            `EPSG:${extent.spatialReference.wkid}`,
+            `EPSG:${extent.spatialReference.latestWkid || extent.spatialReference.wkid}`,
             this.getMapViewer().getProjection().getCode()
           );
           return validateExtent(projExtent, this.getMapViewer().getProjection().getCode());

--- a/packages/geoview-core/src/geo/utils/projection.ts
+++ b/packages/geoview-core/src/geo/utils/projection.ts
@@ -27,7 +27,7 @@ export abstract class Projection {
   /**
    * constant used for the available projection names
    */
-  static PROJECTION_NAMES = {
+  static PROJECTION_NAMES: Record<string, string> = {
     3578: 'EPSG:3578',
     LCC: 'EPSG:3978',
     3979: 'EPSG:3979',
@@ -225,6 +225,37 @@ export abstract class Projection {
    */
   static transformToLonLat(coordinate: Coordinate, projection: ProjectionLike): Coordinate {
     return toLonLat(coordinate, projection);
+  }
+
+  /**
+   * Fetches definitions for unsupported projections and adds them.
+   * @param {TypeJsonObject} projection - Object containing wkid and possibly latestWkid from service metadata.
+   */
+  static async addProjection(projection: TypeJsonObject): Promise<void> {
+    // Add latestWkid if provided
+    if (projection.latestWkid && projection.latestWkid !== projection.wkid) await this.addProjection({ wkid: projection.latestWkid });
+
+    const code = projection.wkid as string;
+    const projectionName = `EPSG:${code}`;
+
+    try {
+      // Fetch proj4 definition from epsg.io
+      const response = await fetch(`https://epsg.io/${code}.proj4`);
+      const definition = await response.text();
+
+      if (definition) {
+        // Register in proj4 if fetched
+        proj4.defs(projectionName, definition);
+        register(proj4);
+
+        // Register in supported projections
+        this.PROJECTION_NAMES = { ...this.PROJECTION_NAMES, [code]: projectionName };
+        const foundOlProjection = olGetProjection(projectionName);
+        if (foundOlProjection) this.PROJECTIONS[code] = foundOlProjection;
+      } else logger.logError(`Unable to add projection ${projectionName}, definiton not found`);
+    } catch {
+      logger.logError(`Unable to add projection ${projectionName}, definiton not found`);
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #2642
Closes #2791

# Description
Fixes issue with cloning parentLayerConfig and geoviewLayerConfig causing massive slowdown with many group layers. Also adds lookup for unsupported projections.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demo-osdp-integration.html
44ef4d33-20b7-45fc-974c-d73a0a8fbae8

For the projections, deleted some definitions and loaded the layers.

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2797)
<!-- Reviewable:end -->
