### PR TITLE
bug(legend): disable highlight and zoom to extent buttons by config

### DIFF
--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -339,7 +339,13 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
     if (isLayerAlwaysVisible) {
       if (isLayerVisibleCapable) {
         return (
-          <IconButton edge="end" size="small" tooltip={t('layers.visibilityIsAlways') as string} className="buttonOutline" disabled>
+          <IconButton
+            edge="end"
+            size="small"
+            tooltip={t('layers.visibilityIsAlways') as string}
+            className="buttonOutline"
+            disabled={!inVisibleRange}
+          >
             <VisibilityOutlinedIcon color="disabled" />
           </IconButton>
         );

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -87,7 +87,6 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
   const inVisibleRange = useSelectorLayerInVisibleRange(layerPath);
   const legendExpanded = !useSelectorLayerLegendCollapsed(layerPath);
 
-  // TODO: I think we should favor using this pattern here, with the store, instead of working with the whole 'layer' object from the props
   const layerId: string | undefined = useSelectorLayerId(layerPath);
   const layerName: string | undefined = useSelectorLayerName(layerPath);
   const layerStatus: TypeLayerStatus | undefined = useSelectorLayerStatus(layerPath);

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -87,9 +87,6 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
   const inVisibleRange = useSelectorLayerInVisibleRange(layerPath);
   const legendExpanded = !useSelectorLayerLegendCollapsed(layerPath);
 
-  // Is visibility button disabled?
-  const isLayerVisibleCapable = (layer.controls?.visibility && inVisibleRange) ?? false;
-
   // TODO: I think we should favor using this pattern here, with the store, instead of working with the whole 'layer' object from the props
   const layerId: string | undefined = useSelectorLayerId(layerPath);
   const layerName: string | undefined = useSelectorLayerName(layerPath);
@@ -98,6 +95,9 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
   const layerControls: TypeLayerControls | undefined = useSelectorLayerControls(layerPath);
   const layerChildren: TypeLegendLayer[] | undefined = useSelectorLayerChildren(layerPath);
   const layerItems: TypeLegendItem[] | undefined = useSelectorLayerItems(layerPath);
+
+  // Is visibility button disabled?
+  const isLayerVisibleCapable = layerControls?.visibility;
 
   // if any of the child layers is selected return true
   const isLayerChildSelected = useCallback(

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -87,6 +87,9 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
   const inVisibleRange = useSelectorLayerInVisibleRange(layerPath);
   const legendExpanded = !useSelectorLayerLegendCollapsed(layerPath);
 
+  // Is visibility button disabled?
+  const isLayerVisibleCapable = (layer.controls?.visibility && inVisibleRange) ?? false;
+
   // TODO: I think we should favor using this pattern here, with the store, instead of working with the whole 'layer' object from the props
   const layerId: string | undefined = useSelectorLayerId(layerPath);
   const layerName: string | undefined = useSelectorLayerName(layerPath);
@@ -334,11 +337,14 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
     }
 
     if (isLayerAlwaysVisible) {
-      return (
-        <IconButton edge="end" size="small" tooltip={t('layers.visibilityIsAlways') as string} className="buttonOutline" disabled>
-          <VisibilityOutlinedIcon color="disabled" />
-        </IconButton>
-      );
+      if (isLayerVisibleCapable) {
+        return (
+          <IconButton edge="end" size="small" tooltip={t('layers.visibilityIsAlways') as string} className="buttonOutline" disabled>
+            <VisibilityOutlinedIcon color="disabled" />
+          </IconButton>
+        );
+      }
+      return <Box />;
     }
 
     // Is zoom to visible scale button visible?
@@ -355,16 +361,18 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
         >
           <CenterFocusScaleIcon />
         </IconButton>
-        <IconButton
-          edge={inVisibleRange ? false : 'end'}
-          size="small"
-          onClick={handleToggleVisibility}
-          tooltip={t('layers.toggleVisibility') as string}
-          className="buttonOutline"
-          disabled={!inVisibleRange}
-        >
-          {isVisible ? <VisibilityOutlinedIcon /> : <VisibilityOffOutlinedIcon />}
-        </IconButton>
+        {isLayerVisibleCapable && (
+          <IconButton
+            edge={inVisibleRange ? false : 'end'}
+            size="small"
+            onClick={handleToggleVisibility}
+            tooltip={t('layers.toggleVisibility') as string}
+            className="buttonOutline"
+            disabled={!inVisibleRange}
+          >
+            {isVisible ? <VisibilityOutlinedIcon /> : <VisibilityOffOutlinedIcon />}
+          </IconButton>
+        )}
       </Box>
     );
   }, [
@@ -374,6 +382,7 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
     displayState,
     handleToggleVisibility,
     isLayerAlwaysVisible,
+    isLayerVisibleCapable,
     isVisible,
     layerControls?.remove,
     layerId,

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -244,7 +244,6 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
           tooltip={t('legend.highlightLayer') as string}
           onClick={handleHighlightLayer}
           className={highlightedLayer === layerDetails.layerPath ? 'buttonOutline active' : 'buttonOutline'}
-          disabled={!inVisibleRange}
         >
           <HighlightOutlinedIcon />
         </IconButton>
@@ -259,7 +258,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
           tooltip={t('legend.zoomTo') as string}
           onClick={handleZoomTo}
           className="buttonOutline"
-          disabled={layerDetails.bounds === undefined || !inVisibleRange}
+          disabled={layerDetails.bounds === undefined}
         >
           <ZoomInSearchIcon />
         </IconButton>

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -64,10 +64,10 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   const selectedLayer = layersData.find((_layer) => _layer.layerPath === layerDetails?.layerPath);
 
   // Is highlight button disabled?
-  const isLayerHighlightCapable = layerDetails.controls?.highlight ?? false;
+  const isLayerHighlightCapable = layerDetails.controls?.highlight;
 
   // Is zoom to extent button disabled?
-  const isLayerZoomToExtentCapable = layerDetails.controls?.zoom ?? false;
+  const isLayerZoomToExtentCapable = layerDetails.controls?.zoom;
 
   useEffect(() => {
     // Log

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -66,10 +66,10 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   const inVisibleRange = useSelectorLayerInVisibleRange(layerDetails?.layerPath);
 
   // Is highlight button disabled?
-  const isLayerHighlightCapable = (layerDetails.controls?.highlight && inVisibleRange) ?? false;
+  const isLayerHighlightCapable = layerDetails.controls?.highlight ?? false;
 
   // Is zoom to extent button disabled?
-  const isLayerZoomToExtentCapable = (layerDetails.controls?.zoom && inVisibleRange) ?? false;
+  const isLayerZoomToExtentCapable = layerDetails.controls?.zoom ?? false;
 
   useEffect(() => {
     // Log
@@ -244,6 +244,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
           tooltip={t('legend.highlightLayer') as string}
           onClick={handleHighlightLayer}
           className={highlightedLayer === layerDetails.layerPath ? 'buttonOutline active' : 'buttonOutline'}
+          disabled={!inVisibleRange}
         >
           <HighlightOutlinedIcon />
         </IconButton>
@@ -258,7 +259,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
           tooltip={t('legend.zoomTo') as string}
           onClick={handleZoomTo}
           className="buttonOutline"
-          disabled={layerDetails.bounds === undefined}
+          disabled={layerDetails.bounds === undefined || !inVisibleRange}
         >
           <ZoomInSearchIcon />
         </IconButton>

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -35,6 +35,7 @@ import { LayerIcon } from '@/core/components/common/layer-icon';
 import { LayerOpacityControl } from './layer-opacity-control/layer-opacity-control';
 import { logger } from '@/core/utils/logger';
 import { LAYER_STATUS } from '@/core/utils/constant';
+import { useSelectorLayerInVisibleRange } from '@/app';
 
 interface LayerDetailsProps {
   layerDetails: TypeLegendLayer;
@@ -62,6 +63,13 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   const datatableSettings = useDataTableLayerSettings();
   const layersData = useDataTableAllFeaturesDataArray();
   const selectedLayer = layersData.find((_layer) => _layer.layerPath === layerDetails?.layerPath);
+  const inVisibleRange = useSelectorLayerInVisibleRange(layerDetails?.layerPath);
+
+  // Is highlight button disabled?
+  const isLayerHighlightCapable = (layerDetails.controls?.highlight && inVisibleRange) ?? false;
+
+  // Is zoom to extent button disabled?
+  const isLayerZoomToExtentCapable = (layerDetails.controls?.zoom && inVisibleRange) ?? false;
 
   useEffect(() => {
     // Log
@@ -230,7 +238,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   }
 
   function renderHighlightButton(): JSX.Element {
-    if (layerDetails.controls?.highlight !== false)
+    if (isLayerHighlightCapable)
       return (
         <IconButton
           tooltip={t('legend.highlightLayer') as string}
@@ -240,15 +248,11 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
           <HighlightOutlinedIcon />
         </IconButton>
       );
-    return (
-      <IconButton className="buttonOutline" disabled>
-        <HighlightOutlinedIcon color="disabled" />
-      </IconButton>
-    );
+    return <Box />;
   }
 
   function renderZoomButton(): JSX.Element {
-    if (layerDetails.controls?.zoom !== false)
+    if (isLayerZoomToExtentCapable)
       return (
         <IconButton
           tooltip={t('legend.zoomTo') as string}
@@ -259,11 +263,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
           <ZoomInSearchIcon />
         </IconButton>
       );
-    return (
-      <IconButton className="buttonOutline" disabled>
-        <ZoomInSearchIcon color="disabled" />
-      </IconButton>
-    );
+    return <Box />;
   }
 
   function renderLayerButtons(): JSX.Element {

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -35,7 +35,6 @@ import { LayerIcon } from '@/core/components/common/layer-icon';
 import { LayerOpacityControl } from './layer-opacity-control/layer-opacity-control';
 import { logger } from '@/core/utils/logger';
 import { LAYER_STATUS } from '@/core/utils/constant';
-import { useSelectorLayerInVisibleRange } from '@/app';
 
 interface LayerDetailsProps {
   layerDetails: TypeLegendLayer;
@@ -63,7 +62,6 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   const datatableSettings = useDataTableLayerSettings();
   const layersData = useDataTableAllFeaturesDataArray();
   const selectedLayer = layersData.find((_layer) => _layer.layerPath === layerDetails?.layerPath);
-  const inVisibleRange = useSelectorLayerInVisibleRange(layerDetails?.layerPath);
 
   // Is highlight button disabled?
   const isLayerHighlightCapable = layerDetails.controls?.highlight ?? false;

--- a/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
@@ -153,18 +153,12 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
             sx={styles.btnMargin}
             className="buttonOutline"
             onClick={controls.handleHighlightLayer}
-            disabled={!isInVisibleRange}
           >
             {highlightedLayer === layerPath ? <HighlightIcon /> : <HighlightOutlinedIcon />}
           </IconButton>
         )}
         {isLayerZoomToExtentCapable && (
-          <IconButton
-            tooltip={t('legend.zoomTo') as string}
-            className="buttonOutline"
-            onClick={controls.handleZoomTo}
-            disabled={!isInVisibleRange}
-          >
+          <IconButton tooltip={t('legend.zoomTo') as string} className="buttonOutline" onClick={controls.handleZoomTo}>
             <ZoomInSearchIcon />
           </IconButton>
         )}

--- a/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
@@ -112,10 +112,10 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
   const isLayerVisibleCapable = (layerControls?.visibility && isInVisibleRange) ?? false;
 
   // Is highlight button disabled?
-  const isHighlightCapable = (layerControls?.highlight && isInVisibleRange) ?? false;
+  const isLayerHighlightCapable = (layerControls?.highlight && isInVisibleRange) ?? false;
 
   // Is zoom to extent button disabled?
-  const isZoomToExtentCapable = (layerControls?.zoom && isInVisibleRange) ?? false;
+  const isLayerZoomToExtentCapable = (layerControls?.zoom && isInVisibleRange) ?? false;
 
   // Is zoom to visible scale button visible?
   const isZoomToVisibleScaleCapable = !!((layerType as string) !== 'group' && !isInVisibleRange);
@@ -136,32 +136,31 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
         >
           <CenterFocusScaleIcon />
         </IconButton>
-        <IconButton
-          edge={isInVisibleRange ? false : 'end'}
-          tooltip={t('layers.toggleVisibility') as string}
-          className="buttonOutline"
-          onClick={controls.handleToggleVisibility}
-          disabled={!isLayerVisibleCapable}
-        >
-          {isVisible ? <VisibilityOutlinedIcon /> : <VisibilityOffOutlinedIcon />}
-        </IconButton>
-        <IconButton
-          tooltip={t('legend.highlightLayer') as string}
-          sx={styles.btnMargin}
-          className="buttonOutline"
-          onClick={controls.handleHighlightLayer}
-          disabled={!isHighlightCapable}
-        >
-          {highlightedLayer === layerPath ? <HighlightIcon /> : <HighlightOutlinedIcon />}
-        </IconButton>
-        <IconButton
-          tooltip={t('legend.zoomTo') as string}
-          className="buttonOutline"
-          onClick={controls.handleZoomTo}
-          disabled={!isZoomToExtentCapable}
-        >
-          <ZoomInSearchIcon />
-        </IconButton>
+        {isLayerVisibleCapable && (
+          <IconButton
+            edge={isInVisibleRange ? false : 'end'}
+            tooltip={t('layers.toggleVisibility') as string}
+            className="buttonOutline"
+            onClick={controls.handleToggleVisibility}
+          >
+            {isVisible ? <VisibilityOutlinedIcon /> : <VisibilityOffOutlinedIcon />}
+          </IconButton>
+        )}
+        {isLayerHighlightCapable && (
+          <IconButton
+            tooltip={t('legend.highlightLayer') as string}
+            sx={styles.btnMargin}
+            className="buttonOutline"
+            onClick={controls.handleHighlightLayer}
+          >
+            {highlightedLayer === layerPath ? <HighlightIcon /> : <HighlightOutlinedIcon />}
+          </IconButton>
+        )}
+        {isLayerZoomToExtentCapable && (
+          <IconButton tooltip={t('legend.zoomTo') as string} className="buttonOutline" onClick={controls.handleZoomTo}>
+            <ZoomInSearchIcon />
+          </IconButton>
+        )}
       </Box>
     </Stack>
   );

--- a/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
@@ -109,13 +109,13 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
   const highlightedLayer = useLayerHighlightedLayer();
 
   // Is visibility button disabled?
-  const isLayerVisibleCapable = (layerControls?.visibility && isInVisibleRange) ?? false;
+  const isLayerVisibleCapable = layerControls?.visibility ?? false;
 
   // Is highlight button disabled?
-  const isLayerHighlightCapable = (layerControls?.highlight && isInVisibleRange) ?? false;
+  const isLayerHighlightCapable = layerControls?.highlight ?? false;
 
   // Is zoom to extent button disabled?
-  const isLayerZoomToExtentCapable = (layerControls?.zoom && isInVisibleRange) ?? false;
+  const isLayerZoomToExtentCapable = layerControls?.zoom ?? false;
 
   // Is zoom to visible scale button visible?
   const isZoomToVisibleScaleCapable = !!((layerType as string) !== 'group' && !isInVisibleRange);
@@ -142,6 +142,7 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
             tooltip={t('layers.toggleVisibility') as string}
             className="buttonOutline"
             onClick={controls.handleToggleVisibility}
+            disabled={!isInVisibleRange}
           >
             {isVisible ? <VisibilityOutlinedIcon /> : <VisibilityOffOutlinedIcon />}
           </IconButton>
@@ -152,12 +153,18 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
             sx={styles.btnMargin}
             className="buttonOutline"
             onClick={controls.handleHighlightLayer}
+            disabled={!isInVisibleRange}
           >
             {highlightedLayer === layerPath ? <HighlightIcon /> : <HighlightOutlinedIcon />}
           </IconButton>
         )}
         {isLayerZoomToExtentCapable && (
-          <IconButton tooltip={t('legend.zoomTo') as string} className="buttonOutline" onClick={controls.handleZoomTo}>
+          <IconButton
+            tooltip={t('legend.zoomTo') as string}
+            className="buttonOutline"
+            onClick={controls.handleZoomTo}
+            disabled={!isInVisibleRange}
+          >
             <ZoomInSearchIcon />
           </IconButton>
         )}

--- a/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
@@ -111,6 +111,12 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
   // Is visibility button disabled?
   const isLayerVisibleCapable = (layerControls?.visibility && isInVisibleRange) ?? false;
 
+  // Is highlight button disabled?
+  const isHighlightCapable = (layerControls?.highlight && isInVisibleRange) ?? false;
+
+  // Is zoom to extent button disabled?
+  const isZoomToExtentCapable = (layerControls?.zoom && isInVisibleRange) ?? false;
+
   // Is zoom to visible scale button visible?
   const isZoomToVisibleScaleCapable = !!((layerType as string) !== 'group' && !isInVisibleRange);
 
@@ -144,10 +150,16 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
           sx={styles.btnMargin}
           className="buttonOutline"
           onClick={controls.handleHighlightLayer}
+          disabled={!isHighlightCapable}
         >
           {highlightedLayer === layerPath ? <HighlightIcon /> : <HighlightOutlinedIcon />}
         </IconButton>
-        <IconButton tooltip={t('legend.zoomTo') as string} className="buttonOutline" onClick={controls.handleZoomTo}>
+        <IconButton
+          tooltip={t('legend.zoomTo') as string}
+          className="buttonOutline"
+          onClick={controls.handleZoomTo}
+          disabled={!isZoomToExtentCapable}
+        >
           <ZoomInSearchIcon />
         </IconButton>
       </Box>

--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -672,11 +672,6 @@ export class Basemap {
               resolutions: tileGrid.getResolutions(),
             }).catch((err) => logger.logError(err));
           }
-          if (layer.basemapId !== 'label') {
-            basemapLayer.setZIndex(0);
-          } else {
-            basemapLayer.setZIndex(5);
-          }
         } else {
           basemapLayer = new TileLayer({
             opacity: layer.opacity,

--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -657,7 +657,10 @@ export class Basemap {
           basemapLayer = new VectorTileLayer({
             opacity: layer.opacity,
             source: layer.source,
+            renderMode: 'vector',
+            renderBuffer: 100,
             updateWhileAnimating: true,
+            updateWhileInteracting: true,
             // Only declutter labels and add className otherwise (https://github.com/openlayers/openlayers/issues/10096)
             ...(layer.basemapId === 'label' ? { declutter: true } : { className: 'geom' }),
           });
@@ -668,6 +671,11 @@ export class Basemap {
             applyStyle(basemapLayer, layer.styleUrl, {
               resolutions: tileGrid.getResolutions(),
             }).catch((err) => logger.logError(err));
+          }
+          if (layer.basemapId !== 'label') {
+            basemapLayer.setZIndex(0);
+          } else {
+            basemapLayer.setZIndex(5);
           }
         } else {
           basemapLayer = new TileLayer({

--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -662,6 +662,7 @@ export class Basemap {
             opacity: layer.opacity,
             source: layer.source,
             declutter: true,
+            updateWhileAnimating: true,
           });
 
           // Apply Style to Vector Tile Basemap
@@ -691,6 +692,15 @@ export class Basemap {
       // Emit basemap changed event
       this.#emitBasemapChanged({ basemap });
     }
+  }
+
+  /**
+   * Refreshes the basemap layers
+   */
+  refreshBasemap(): void {
+    this.activeBasemap?.layers.forEach((layer) => {
+      layer.source.refresh();
+    });
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -243,7 +243,8 @@ export class Basemap {
     basemapId: string,
     basemapLayer: TypeJsonObject,
     opacity: number,
-    rest: boolean
+    rest: boolean,
+    className?: string
   ): Promise<null | TypeBasemapLayer> {
     const resolutions: number[] = [];
     let minZoom = 0;
@@ -324,6 +325,8 @@ export class Basemap {
                 origin,
                 resolutions,
               }),
+              // Optionally add className if present. Necessary when using multiple vector tiles and one with the declutter option on
+              ...(className ? { className } : {}),
             });
           } else {
             source = new XYZ({
@@ -411,7 +414,8 @@ export class Basemap {
           'transport',
           this.basemapsList[projectionCode].transport,
           coreBasemapOptions.shaded ? 0.75 : defaultOpacity,
-          true
+          true,
+          'geom'
         );
         if (transportLayer) {
           basemapLayers.push(transportLayer);
@@ -687,6 +691,15 @@ export class Basemap {
       // Emit basemap changed event
       this.#emitBasemapChanged({ basemap });
     }
+  }
+
+  /**
+   * Refreshes the basemap layers
+   */
+  refreshBasemap(): void {
+    this.activeBasemap?.layers.forEach((layer) => {
+      layer.source.refresh();
+    });
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -243,8 +243,7 @@ export class Basemap {
     basemapId: string,
     basemapLayer: TypeJsonObject,
     opacity: number,
-    rest: boolean,
-    className?: string
+    rest: boolean
   ): Promise<null | TypeBasemapLayer> {
     const resolutions: number[] = [];
     let minZoom = 0;
@@ -325,8 +324,6 @@ export class Basemap {
                 origin,
                 resolutions,
               }),
-              // Optionally add className if present. Necessary when using multiple vector tiles and one with the declutter option on
-              ...(className ? { className } : {}),
             });
           } else {
             source = new XYZ({
@@ -414,8 +411,7 @@ export class Basemap {
           'transport',
           this.basemapsList[projectionCode].transport,
           coreBasemapOptions.shaded ? 0.75 : defaultOpacity,
-          true,
-          'geom'
+          true
         );
         if (transportLayer) {
           basemapLayers.push(transportLayer);
@@ -661,8 +657,9 @@ export class Basemap {
           basemapLayer = new VectorTileLayer({
             opacity: layer.opacity,
             source: layer.source,
-            declutter: true,
             updateWhileAnimating: true,
+            // Only declutter labels and add className otherwise (https://github.com/openlayers/openlayers/issues/10096)
+            ...(layer.basemapId === 'label' ? { declutter: true } : { className: 'geom' }),
           });
 
           // Apply Style to Vector Tile Basemap

--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -694,15 +694,6 @@ export class Basemap {
   }
 
   /**
-   * Refreshes the basemap layers
-   */
-  refreshBasemap(): void {
-    this.activeBasemap?.layers.forEach((layer) => {
-      layer.source.refresh();
-    });
-  }
-
-  /**
    * Emits a component removed event to all handlers.
    * @private
    */

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -1016,13 +1016,15 @@ export class LayerApi {
     // be handled in the map-viewer's handleMapZoomEnd by checking the children visibility
     const mapView = this.mapViewer.getView();
     if ((layerConfig.initialSettings.maxZoom || layerConfig.maxScale) && !(gvLayer instanceof GVGroupLayer)) {
-      const maxScaleZoomLevel = getZoomFromScale(mapView, layerConfig.maxScale);
+      let maxScaleZoomLevel = getZoomFromScale(mapView, layerConfig.maxScale);
+      maxScaleZoomLevel = maxScaleZoomLevel ? Math.round(maxScaleZoomLevel) : undefined;
       const maxZoom = Math.min(layerConfig.initialSettings.maxZoom ?? Infinity, maxScaleZoomLevel ?? Infinity);
       gvLayer.setMaxZoom(maxZoom);
     }
 
     if ((layerConfig.initialSettings.minZoom || layerConfig.minScale) && !(gvLayer instanceof GVGroupLayer)) {
-      const minScaleZoomLevel = getZoomFromScale(mapView, layerConfig.minScale);
+      let minScaleZoomLevel = getZoomFromScale(mapView, layerConfig.minScale);
+      minScaleZoomLevel = minScaleZoomLevel ? Math.round(minScaleZoomLevel) : undefined;
       const minZoom = Math.max(layerConfig.initialSettings.minZoom ?? -Infinity, minScaleZoomLevel ?? -Infinity);
       gvLayer.setMinZoom(minZoom);
     }

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -518,23 +518,18 @@ export function getMetersPerPixel(projection: TypeValidMapProjectionCodes, resol
  * @param targetScale The desired scale (e.g. 50000 for 1:50,000)
  * @returns number representing the closest zoom level for the given scale
  */
-export const getZoomFromScale = (view: View, targetScale: number | undefined): number | undefined => {
+export const getZoomFromScale = (view: View, targetScale: number | undefined, dpiValue?: number): number | undefined => {
   if (!targetScale) return undefined;
   const projection = view.getProjection();
   const mpu = projection.getMetersPerUnit();
-  const dpi = 25.4 / 0.28; // OpenLayers default DPI
+  const dpi = dpiValue ?? 25.4 / 0.28; // OpenLayers default DPI
 
   // Calculate resolution from scale
   if (!mpu) return undefined;
   // Resolution = Scale / ( metersPerUnit * inchesPerMeter * DPI )
   const targetResolution = targetScale / (mpu * 39.37 * dpi);
 
-  // Get the constrained resolution that matches our tile matrix
-  const constrainedResolution = view.getConstrainedResolution(targetResolution);
-
-  // Convert resolution to zoom
-  if (!constrainedResolution) return undefined;
-  return view.getZoomForResolution(constrainedResolution) || undefined;
+  return view.getZoomForResolution(targetResolution) || undefined;
 };
 
 /**


### PR DESCRIPTION
# Description

2692 - Properly disables the highlight and zoom to extent legend buttons if they are disabled in the map config.
2806 - Basemap re-renders properly when quickly zooming from higher zoom levels to lower zoom levels
2807 - Min scale is properly calculated at layer creation and no longer constrained to OL internal constraints.

Fixes # 2692, 2806, 2807

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

### Last hosted 2025-03-25 11:00AM
[GeoView](https://matthewmuehlhausernrcan.github.io/geoview)

Issue 2692
Use the below config in the sandbox map, disabled controls are no longer rendered in layers or legend tabs:
[Sandbox Map](https://matthewmuehlhausernrcan.github.io/geoview/sandbox.html)
{
  'map': {
    'interaction': 'dynamic',
    'viewSettings': {
      'projection': 3978
    },
    'basemapOptions': {
      'basemapId': 'transport',
      'shaded': false,
      'labeled': true
    },
    'listOfGeoviewLayerConfig': [{
    "geoviewLayerType": "ogcWms",
    "geoviewLayerId": "ReginaPhoto1",
    "metadataAccessPath": "https://datacube.services.geo.ca/web/napl-regina.xml",
    "listOfLayerEntryConfig": [
      {
        "layerId": "regina",
        "layerName": "Regina Airphoto",
        "initialSettings": {
          "states": {
            "opacity": 0.5
          },
          "controls": {
            "highlight": false,
            "hover": false,
            "opacity": true,
            "query": false,
            "remove": true,
            "table": false,
            "visibility": false,
            "zoom": false
          }
        }
      }
    ]
  }]
  },
  'components': ['overview-map'],
  'footerBar': {
    'tabs': {
      'core': ['legend', 'layers', 'details', 'data-table']
    }
  },
  'corePackages': [],
  'theme': 'geo.ca'
}

2806 - Add layers to the map. Zoom in closely and then click the zoom to the extent control of a layer. The basemap should reload properly at the new zoom level. 
[OSDP Integration](https://matthewmuehlhausernrcan.github.io/geoview/demo-osdp-integration.html)

2807 - Go to navigator page for vector tile layers. Layers will be visible right away since the min scale is now set to 3 instead of 4.9 ... which was from using the constrained resolution of the map in the zoom level calculation.
[Vector Tiles Navigator Page](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/24-vector-tile.json)


# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2801)
<!-- Reviewable:end -->
