### PR TITLE
fix?(metadata): replace getXMLHttpRequest with fetch

### DIFF
--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -6,8 +6,8 @@ import Collection from 'ol/Collection';
 import LayerGroup, { Options as LayerGroupOptions } from 'ol/layer/Group';
 import Source from 'ol/source/Source';
 
-import { generateId, getXMLHttpRequest, isJsonString, whenThisThen } from '@/core/utils/utilities';
-import { TypeJsonObject, toJsonObject } from '@/core/types/global-types';
+import { generateId, whenThisThen } from '@/core/utils/utilities';
+import { TypeJsonObject } from '@/core/types/global-types';
 import { TimeDimension, TypeDateFragments, DateMgt } from '@/core/utils/date-mgt';
 import { logger } from '@/core/utils/logger';
 import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-classes/abstract-base-layer-entry-config';
@@ -418,10 +418,16 @@ export abstract class AbstractGeoViewLayer {
   protected async fetchServiceMetadata(): Promise<void> {
     if (this.metadataAccessPath) {
       try {
-        const metadataString = await getXMLHttpRequest(`${this.metadataAccessPath}?f=json`);
-        if (metadataString === '{}' || !isJsonString(metadataString)) this.metadata = null;
+        // GV: checking for .meta here instead of in geojson specific layer so it can be used for other layer types going forward
+        const url =
+          this.metadataAccessPath.toLowerCase().endsWith('json') || this.metadataAccessPath.toLowerCase().endsWith('meta')
+            ? this.metadataAccessPath
+            : `${this.metadataAccessPath}?f=json`;
+        const response = await fetch(url);
+        const metadataJson: TypeJsonObject = await response.json();
+        if (!metadataJson) this.metadata = null;
         else {
-          this.metadata = toJsonObject(JSON.parse(metadataString));
+          this.metadata = metadataJson;
           const copyrightText = this.metadata.copyrightText as string;
           const attributions = this.getAttributions();
           if (copyrightText && !attributions.includes(copyrightText)) {


### PR DESCRIPTION
# Description

Replaces XMLHttpRequest with fetch, and checks url for .meta or json. Theoretically fixes the issue experienced by GSC Minerals Analytics Section

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2802)
<!-- Reviewable:end -->
