### PR TITLE
Fixes #2831 regarding addding a geocore layer with a supported geochart

### DIFF
--- a/packages/geoview-core/src/core/utils/config/reader/uuid-config-reader.ts
+++ b/packages/geoview-core/src/core/utils/config/reader/uuid-config-reader.ts
@@ -434,7 +434,7 @@ export class UUIDmapConfigReader {
 
     // Find all Geochart configs
     const foundConfigs = result.data.response.gcs
-      .map((gcs) => gcs?.[lang]?.packages?.geochart as GeoChartGeoCoreConfig)
+      .flatMap((gcs) => gcs?.[lang]?.packages?.geochart as unknown as GeoChartGeoCoreConfig[])
       .filter((geochartValue) => !!geochartValue);
 
     // For each found config, parse

--- a/packages/geoview-core/src/geo/layer/other/geocore.ts
+++ b/packages/geoview-core/src/geo/layer/other/geocore.ts
@@ -57,8 +57,11 @@ export class GeoCore {
 
       // For each found geochart associated with the Geocore UUIDs
       response.geocharts?.forEach((geochartConfig) => {
+        // Get the layerPath from geocore response
+        const layerPath = geochartConfig.layers[0].layerId;
+
         // Add a GeoChart
-        GeochartEventProcessor.addGeochartChart(this.#mapId, uuid, geochartConfig);
+        GeochartEventProcessor.addGeochartChart(this.#mapId, layerPath, geochartConfig);
       });
 
       // Use user supplied listOfLayerEntryConfig if provided


### PR DESCRIPTION
# Description

Fixes an issue regarding addding a geocore layer with a supported geochart. Confusion between layerId and layerPath.
Also, now supporting a geochart ARRAY in the json schema returned by Geocore.

Fixes #2831

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted April 4th 13h15: https://alex-nrcan.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2833)
<!-- Reviewable:end -->
