### PR TITLE
fix(layer): remove all layers changed to remove unloaded layers

### DIFF
--- a/packages/geoview-core/public/configs/navigator/05-zoom-layer.json
+++ b/packages/geoview-core/public/configs/navigator/05-zoom-layer.json
@@ -3,7 +3,10 @@
     "interaction": "dynamic",
     "viewSettings": {
       "initialView": {
-        "layerIds": ["geojsonLYR1/geojsonLYR1/polygons.json", "geojsonLYR1/geojsonLYR1/lines.json"]
+        "layerIds": [
+          "geojsonLYR1/base-group/polygons.json",
+          "geojsonLYR1/base-group/lines.json"
+        ]
       },
       "projection": 3978
     },
@@ -67,16 +70,31 @@
   "theme": "geo.ca",
   "appBar": {
     "tabs": {
-      "core": ["geolocator", "export"]
+      "core": [
+        "geolocator",
+        "export"
+      ]
     }
   },
-  "navBar": ["zoom", "fullscreen", "home", "location"],
+  "navBar": [
+    "zoom",
+    "fullscreen",
+    "home",
+    "location"
+  ],
   "footerBar": {
     "tabs": {
-      "core": ["legend", "layers", "details", "data-table"]
+      "core": [
+        "legend",
+        "layers",
+        "details",
+        "data-table"
+      ]
     }
   },
-  "components": ["north-arrow"],
+  "components": [
+    "north-arrow"
+  ],
   "corePackages": [],
   "externalPackages": []
 }

--- a/packages/geoview-core/public/configs/navigator/12-package-geochart-geochart.json
+++ b/packages/geoview-core/public/configs/navigator/12-package-geochart-geochart.json
@@ -279,7 +279,7 @@
     {
       "layers": [
         {
-          "layerId": "geojsonLYR5/geojsonLYR5/point-feature-group/points.json"
+          "layerId": "geojsonLYR5/base-group/point-feature-group/points.json"
         }
       ],
       "chart": "bar",

--- a/packages/geoview-core/public/templates/demos/demo-function-event.html
+++ b/packages/geoview-core/public/templates/demos/demo-function-event.html
@@ -81,7 +81,7 @@
           cgpv.api.maps.Map1.layer.addGeoviewLayer(config)
         </li>
         <li><button id="Remove-layer">Remove GeoJSON layer</button><br />
-          cgpv.api.maps.Map1.layer.removeLayerUsingPath('geojsonLYR1/geojsonLYR1')
+          cgpv.api.maps.Map1.layer.removeLayerUsingPath('geojsonLYR1/base-group')
         </li>
         <li><button id="Remove-all-layers">Remove All layers</button><br />
           cgpv.api.maps.Map1.layer.removeAllGeoviewLayers()
@@ -114,7 +114,7 @@
           cgpv.api.utilities.geo.polygonToExtent(polygon)
         </li>
         <li><button id="Redefine-alias-fields">Redefine alias fields for polygons layer</button><br />
-          cgpv.api.maps.Map1.layer.redefineFeatureFields('geojsonLYR1/geojsonLYR1/polygons.json', 'Location Province,Date Created,Images', 'alias')
+          cgpv.api.maps.Map1.layer.redefineFeatureFields('geojsonLYR1/base-group/polygons.json', 'Location Province,Date Created,Images', 'alias')
         </li>
         <li><button id="Open-details">Open details tab in footer</button><br />
           cgpv.api.maps.Map1.footerBarApi.selectTab('details')
@@ -416,8 +416,8 @@
 
       // add an event listener when a button is clicked
       removeLayerButton.addEventListener('click', async () => {
-        const geojsonLayerAlreadyExists = cgpv.api.maps.Map1.layer.getLayerEntryConfigIds().includes('geojsonLYR1/geojsonLYR1');
-        if (geojsonLayerAlreadyExists) cgpv.api.maps.Map1.layer.removeLayerUsingPath('geojsonLYR1/geojsonLYR1');
+        const geojsonLayerAlreadyExists = cgpv.api.maps.Map1.layer.getLayerEntryConfigIds().includes('geojsonLYR1/base-group');
+        if (geojsonLayerAlreadyExists) cgpv.api.maps.Map1.layer.removeLayerUsingPath('geojsonLYR1/base-group');
         else console.log('GeoJSON layer does not exist');
       });
 
@@ -519,7 +519,7 @@
 
       // add an event listener when a button is clicked
       redefineAliasFieldsButton.addEventListener('click', async () => {
-        cgpv.api.maps.Map1.layer.redefineFeatureFields('geojsonLYR1/geojsonLYR1/polygons.json', 'Location Province,Date Created,Images', 'alias')
+        cgpv.api.maps.Map1.layer.redefineFeatureFields('geojsonLYR1/base-group/polygons.json', 'Location Province,Date Created,Images', 'alias')
       });
 
       // Open details Button========================================================================================================

--- a/packages/geoview-core/src/api/config/types/classes/geoview-config/abstract-geoview-layer-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/geoview-config/abstract-geoview-layer-config.ts
@@ -123,7 +123,7 @@ export abstract class AbstractGeoviewLayerConfig {
         // We create a group because the node at the top of the layer tree cannot be an array.
         (this.#userGeoviewLayerConfig.listOfLayerEntryConfig as TypeJsonArray) = [
           Cast<TypeJsonObject>({
-            layerId: this.#userGeoviewLayerConfig.geoviewLayerId,
+            layerId: 'base-group',
             layerName: this.#userGeoviewLayerConfig.geoviewLayerName,
             isLayerGroup: true,
             listOfLayerEntryConfig: this.#userGeoviewLayerConfig.listOfLayerEntryConfig as TypeJsonArray,

--- a/packages/geoview-core/src/api/config/types/classes/geoview-config/vector-config/geojson-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/geoview-config/vector-config/geojson-config.ts
@@ -209,7 +209,7 @@ export class GeoJsonLayerConfig extends AbstractGeoviewLayerConfig {
     if (!layerTree) return [];
     if (layerTree.length > 1)
       layerTree = Cast<TypeJsonArray>({
-        layerId: this.geoviewLayerId,
+        layerId: 'base-group',
         layerName: 'Layer Tree',
         isLayerGroup: true,
         listOfLayerEntryConfig: layerTree,

--- a/packages/geoview-core/src/api/config/types/classes/geoview-config/vector-config/wfs-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/geoview-config/vector-config/wfs-config.ts
@@ -136,7 +136,7 @@ export class WfsLayerConfig extends AbstractGeoviewLayerConfig {
     // If the feature list contains more than one layer, create a group node.
     if (featureType.length > 1) {
       const groupConfig = toJsonObject({
-        layerId: this.geoviewLayerId,
+        layerId: 'base-group',
         layerName: this.getLanguage() === 'en' ? 'Layer Group' : 'Groupe de couches',
         isLayerGroup: true,
         listOfLayerEntryConfig: featureType.map((layerMetadata) => {

--- a/packages/geoview-core/src/api/config/types/classes/map-feature-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/map-feature-config.ts
@@ -44,6 +44,7 @@ import {
 } from '@config/types/map-schema-types';
 
 import { logger } from '@/core/utils/logger';
+import { generateId } from '@/core/utils/utilities';
 import { ConfigApi } from '@/api/config/config-api';
 
 // ========================
@@ -150,7 +151,7 @@ export class MapFeatureConfig {
           if (layerConfig.geoviewLayerId in this.#registeredLayerPaths) {
             // Add duplicate marker ('geoviewId:uuid') so the ID is unique
             // eslint-disable-next-line no-param-reassign
-            layerConfig.geoviewLayerId = `${layerConfig.geoviewLayerId}:${crypto.randomUUID().substring(0, 8)}`;
+            layerConfig.geoviewLayerId = `${layerConfig.geoviewLayerId}:${generateId(8)}`;
           }
           this.#registeredLayerPaths[layerConfig.geoviewLayerId] = layerConfig;
         }

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -723,7 +723,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
   ): void {
     const { orderedLayerInfo } = this.getMapStateProtected(mapId);
     const layerPath = (geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId
-      ? `${(geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId}/${(geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId}`
+      ? `${(geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId}/base-group`
       : (geoviewLayerConfig as TypeLayerEntryConfig).layerPath;
     const pathToSearch = layerPathToReplace || layerPath;
     const index = this.getMapIndexFromOrderedLayerInfo(mapId, pathToSearch);

--- a/packages/geoview-core/src/core/components/app-bar/app-bar-api.ts
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar-api.ts
@@ -114,7 +114,7 @@ export class AppBarApi {
     groupName?: string | null | undefined
   ): TypeButtonPanel | null {
     if (buttonProps && panelProps) {
-      const buttonPanelId = `${this.mapId}${generateId(buttonProps.id)}`;
+      const buttonPanelId = `${this.mapId}${buttonProps.id || generateId(18)}`;
 
       const button: IconButtonPropsExtend = {
         ...buttonProps,

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -483,7 +483,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
                       fontSize: theme.palette.geoViewFontSize.sm,
                       textAlign: 'center',
                     }}
-                    key={generateId()}
+                    key={generateId(18)}
                   >
                     {attribution.indexOf('©') === -1 ? `© ${attribution}` : attribution}
                   </Typography>

--- a/packages/geoview-core/src/core/components/nav-bar/nav-bar-api.ts
+++ b/packages/geoview-core/src/core/components/nav-bar/nav-bar-api.ts
@@ -114,7 +114,7 @@ export class NavBarApi {
   ): TypeButtonPanel | null {
     if (buttonProps) {
       // generate an id if not provided
-      const buttonPanelId = generateId(buttonProps.id);
+      const buttonPanelId = buttonProps.id || generateId(18);
 
       // if group was not specified then add button panels to the default group
       const group = groupName || 'default';

--- a/packages/geoview-core/src/core/utils/config/config.ts
+++ b/packages/geoview-core/src/core/utils/config/config.ts
@@ -14,6 +14,7 @@ import { logger } from '@/core/utils/logger';
 import { ConfigValidation } from '@/core/utils/config/config-validation';
 import { ConfigBaseClass } from '@/core/utils/config/validation-classes/config-base-class';
 import { TypeDisplayLanguage } from '@/api/config/types/map-schema-types';
+import { generateId } from '@/core/utils/utilities';
 
 // ******************************************************************************************************************************
 // ******************************************************************************************************************************
@@ -57,7 +58,7 @@ export class Config {
         const firstIndex = layerArray.findIndex((layerEntry) => geoviewLayerEntry.geoviewLayerId === layerEntry.geoviewLayerId);
         if (firstIndex !== index && mapConfigLayerEntryIsGeoCore(geoviewLayerEntry)) {
           // eslint-disable-next-line no-param-reassign
-          geoviewLayerEntry.geoviewLayerId = `${geoviewLayerEntry.geoviewLayerId}:${crypto.randomUUID().substring(0, 8)}`;
+          geoviewLayerEntry.geoviewLayerId = `${geoviewLayerEntry.geoviewLayerId}:${generateId(8)}`;
         }
 
         if (mapConfigLayerEntryIsGeoCore(geoviewLayerEntry)) {

--- a/packages/geoview-core/src/core/utils/notifications.ts
+++ b/packages/geoview-core/src/core/utils/notifications.ts
@@ -52,7 +52,7 @@ export class Notifications {
    */
   #addNotification(type: NotificationType, message: string, params: TypeJsonValue[] | TypeJsonArray | string[]): void {
     const notification = {
-      key: generateId(),
+      key: generateId(18),
       notificationType: type,
       message: this.#formatMessage(message, params),
       count: 1,

--- a/packages/geoview-core/src/core/utils/utilities.ts
+++ b/packages/geoview-core/src/core/utils/utilities.ts
@@ -69,14 +69,13 @@ export function getScriptAndAssetURL(): string {
 }
 
 /**
- * Generate a unique id if an id was not provided
- * @param {string?} id - An id to return if it was already passed
- * @returns {string} The generated id
+ * Generates a unique id of the specified length.
+ * @param {8 | 18 | 36} length - Number of characters to return.
+ * @returns {string} The id.
  */
-export function generateId(id?: string): string {
-  return id !== null && id !== undefined && id.length > 0
-    ? id
-    : (Date.now().toString(36) + Math.random().toString(36).substr(2, 5)).toUpperCase();
+export function generateId(length: 8 | 18 | 36 = 36): string {
+  const generatedId = crypto.randomUUID().substring(0, length);
+  return generatedId;
 }
 
 // TODO: refactor - This is a duplicate of static config api function. Replace in api OR create utilities api functions

--- a/packages/geoview-core/src/geo/layer/geometry/geometry.ts
+++ b/packages/geoview-core/src/geo/layer/geometry/geometry.ts
@@ -9,7 +9,7 @@ import { asArray, asString } from 'ol/color';
 
 import { MapViewer } from '@/geo/map/map-viewer';
 import EventHelper, { EventDelegateBase } from '@/api/events/event-helper';
-import { generateId, setAlphaColor, getScriptAndAssetURL } from '@/core/utils/utilities';
+import { setAlphaColor, getScriptAndAssetURL, generateId } from '@/core/utils/utilities';
 import { TypeStyleGeometry } from '@/geo/map/map-schema-types';
 import { Projection } from '@/geo/utils/projection';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
@@ -116,7 +116,7 @@ export class GeometryApi {
   ): Feature {
     const polylineOptions = options || {};
 
-    const featureId = generateId(id);
+    const featureId = id || generateId();
 
     // create a line geometry
     const polyline = new Feature({
@@ -190,7 +190,7 @@ export class GeometryApi {
   ): Feature {
     const polygonOptions = options || {};
 
-    const featureId = generateId(optionalFeatureId);
+    const featureId = optionalFeatureId || generateId();
 
     // create a polygon geometry
     const polygon = new Feature({
@@ -264,7 +264,7 @@ export class GeometryApi {
   ): Feature {
     const circleOptions = options || {};
 
-    const featureId = generateId(optionalFeatureId);
+    const featureId = optionalFeatureId || generateId();
 
     const projectedCoordinates = Projection.transform(
       coordinate,
@@ -354,7 +354,7 @@ export class GeometryApi {
       },
     };
 
-    const featureId = generateId(optionalFeatureId);
+    const featureId = optionalFeatureId || generateId();
 
     // create a point feature
     const marker = new Feature({

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -147,7 +147,7 @@ export abstract class AbstractGeoViewLayer {
   constructor(type: TypeGeoviewLayerType, geoviewLayerConfig: TypeGeoviewLayerConfig, mapId: string) {
     this.mapId = mapId;
     this.type = type;
-    this.geoviewLayerId = geoviewLayerConfig.geoviewLayerId || generateId('');
+    this.geoviewLayerId = geoviewLayerConfig.geoviewLayerId || generateId();
     this.geoviewLayerName = geoviewLayerConfig?.geoviewLayerName ? geoviewLayerConfig.geoviewLayerName : DEFAULT_LAYER_NAMES[type];
     if (geoviewLayerConfig.metadataAccessPath) this.metadataAccessPath = geoviewLayerConfig.metadataAccessPath.trim();
     this.initialSettings = geoviewLayerConfig.initialSettings;
@@ -173,7 +173,7 @@ export abstract class AbstractGeoViewLayer {
     } else {
       const layerGroup = new GroupLayerEntryConfig({
         geoviewLayerConfig: listOfLayerEntryConfig[0].geoviewLayerConfig,
-        layerId: this.getGeoviewLayerId(),
+        layerId: 'base-group',
         layerName: this.geoviewLayerName,
         isMetadataLayerGroup: false,
         initialSettings: geoviewLayerConfig.initialSettings,

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -418,9 +418,7 @@ export class LayerApi {
 
     if ((geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId) {
       if ((geoviewLayerConfig as TypeGeoviewLayerConfig).listOfLayerEntryConfig.length > 1) {
-        const layerPath = `${(geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId}/${
-          (geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId
-        }`;
+        const layerPath = `${(geoviewLayerConfig as TypeGeoviewLayerConfig).geoviewLayerId}/base-group`;
         const layerInfo: TypeOrderedLayerInfo = {
           layerPath,
           legendCollapsed:
@@ -684,7 +682,7 @@ export class LayerApi {
 
     if (this.getGeoviewLayerIds().includes(uuid)) {
       // eslint-disable-next-line no-param-reassign
-      uuid = `${uuid}:${crypto.randomUUID().substring(0, 8)}`;
+      uuid = `${uuid}:${generateId(8)}`;
     }
 
     // GV: This is here as a placeholder so that the layers will appear in the proper order,
@@ -692,6 +690,8 @@ export class LayerApi {
     MapEventProcessor.addOrderedLayerInfo(this.getMapId(), layerInfo);
 
     const parsedLayerEntryConfig = layerEntryConfig ? JSON.parse(layerEntryConfig) : undefined;
+    if (parsedLayerEntryConfig && !parsedLayerEntryConfig[0].layerId) parsedLayerEntryConfig[0].layerId = 'base-group';
+
     let optionalConfig: GeoCoreLayerConfig | undefined =
       parsedLayerEntryConfig && (parsedLayerEntryConfig[0].listOfLayerEntryConfig || parsedLayerEntryConfig[0].initialSettings)
         ? {
@@ -732,7 +732,7 @@ export class LayerApi {
   addGeoviewLayer(geoviewLayerConfig: TypeGeoviewLayerConfig): GeoViewLayerAddedResult | undefined {
     // TODO: Refactor - This should be dealt with the config classes and this line commented out
     // eslint-disable-next-line no-param-reassign
-    geoviewLayerConfig.geoviewLayerId = generateId(geoviewLayerConfig.geoviewLayerId);
+    geoviewLayerConfig.geoviewLayerId = geoviewLayerConfig.geoviewLayerId || generateId();
 
     // TODO: Refactor - This should be dealt with the config classes and this line commented out
     ConfigValidation.validateListOfGeoviewLayerConfig(this.mapViewer.getDisplayLanguage(), [geoviewLayerConfig]);
@@ -1339,13 +1339,19 @@ export class LayerApi {
    * Removes all geoview layers from the map
    */
   removeAllGeoviewLayers(): void {
-    // FIXME: Layers refactoring. When working in LAYERS_HYBRID_MODE=true, the GVLayers aren't created until the layer config gets in 'processed' layer status.
-    // FIX.MECONT: Therefore, this can't remove the layers that failed due to for example bad metadataUrl.
-    // FIX.MECONT: To effectively remove all layers in the UI boxes, this removal process should be using the 'LayerConfigs' (and the layer paths). Not the 'Layer' classes.
-    // For each Geoview layers
-    this.getGeoviewLayers().forEach((geoviewLayer) => {
+    this.getLayerEntryConfigIds().forEach((layerEntryConfigId) => {
       // Remove it
-      this.removeLayerUsingPath(geoviewLayer.getGeoviewLayerId());
+      this.removeLayerUsingPath(layerEntryConfigId);
+    });
+  }
+
+  /**
+   * Removes all layers in error from the map
+   */
+  removeAllLayersInError(): void {
+    this.getLayerEntryConfigs().forEach((layerEntryConfig) => {
+      // Remove it if it is in error
+      if (layerEntryConfig.layerStatus === 'error') this.removeLayerUsingPath(layerEntryConfig.layerPath);
     });
   }
 

--- a/packages/geoview-core/src/geo/layer/other/geocore.ts
+++ b/packages/geoview-core/src/geo/layer/other/geocore.ts
@@ -5,6 +5,7 @@ import { Config } from '@/core/utils/config/config';
 import { ConfigValidation } from '@/core/utils/config/config-validation';
 import { GeochartEventProcessor } from '@/api/event-processors/event-processor-children/geochart-event-processor';
 import { logger } from '@/core/utils/logger';
+import { generateId } from '@/core/utils/utilities';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
 
 import { GeoCoreLayerConfig, TypeGeoviewLayerConfig } from '@/geo/map/map-schema-types';
@@ -41,7 +42,7 @@ export class GeoCore {
     const map = MapEventProcessor.getMapViewer(this.#mapId);
     if (map.layer.getGeoviewLayerIds().includes(uuid)) {
       // eslint-disable-next-line no-param-reassign
-      uuid = `${uuid}:${crypto.randomUUID().substring(0, 8)}`;
+      uuid = `${uuid}:${generateId(8)}`;
     }
     const mapConfig = MapEventProcessor.getGeoViewMapConfig(this.#mapId);
 
@@ -91,6 +92,7 @@ export class GeoCore {
       if (uuid.includes(':') && uuid.split(':')[0] === response.layers[0].geoviewLayerId) {
         response.layers[0].geoviewLayerId = uuid;
       }
+
       return response.layers;
     } catch (error) {
       // Log

--- a/packages/geoview-core/src/ui/accordion/accordion.tsx
+++ b/packages/geoview-core/src/ui/accordion/accordion.tsx
@@ -182,7 +182,7 @@ function AccordionUI(props: AccordionProps): ReactNode {
   );
 
   return (
-    <Box id={generateId(id)} sx={sx} className="accordion-group">
+    <Box id={id || generateId(18)} sx={sx} className="accordion-group">
       {items.map((item: AccordionItem, index: number) => (
         <MaterialAccordion
           // eslint-disable-next-line react/no-array-index-key

--- a/packages/geoview-core/src/ui/modal/modal-api.ts
+++ b/packages/geoview-core/src/ui/modal/modal-api.ts
@@ -25,7 +25,7 @@ export class ModalApi {
    */
   createModal = (modal: TypeModalProps): string | undefined => {
     if (!modal.content) return undefined;
-    const modalId = modal.modalId ? modal.modalId : generateId('');
+    const modalId = modal.modalId ? modal.modalId : generateId(18);
 
     // Make sure we handle the close
     if (!modal.close) {

--- a/packages/geoview-core/src/ui/slider/slider.tsx
+++ b/packages/geoview-core/src/ui/slider/slider.tsx
@@ -77,7 +77,7 @@ function SliderUI(props: SliderProps): JSX.Element {
   // Ref
   const sliderRef = useRef<HTMLDivElement>(null);
 
-  const containerId = `${properties.mapId}-${properties?.sliderId ?? generateId()}` || '';
+  const containerId = `${properties.mapId}-${properties?.sliderId ?? generateId(18)}` || '';
   const valueLabelDisplayOption = valueLabelDisplay === undefined ? 'on' : 'auto';
 
   // State


### PR DESCRIPTION
Also updates generateId function and removes double geoview layer ID in layer paths
Closes #2814
Closes #2828

# Description

Uses layer entry configs to remove layers instead of geoview layers so layers that have not been fully created are still removed. Also replaces naming the base group layer with the geoview layer ID with "base-group", and updates the generateId utility function to provide options.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2839)
<!-- Reviewable:end -->
