### PR TITLE
fix(layer): Ignore complex fields and specify ESRI layers when escaping setting the style to avoid looping

### DIFF
--- a/packages/geoview-core/public/configs/navigator/17-esri-feature.json
+++ b/packages/geoview-core/public/configs/navigator/17-esri-feature.json
@@ -20,6 +20,7 @@
             "layerName": "Toronto Neighbourhoods",
             "source": {
               "featureInfo": {
+                "queryable": true,
                 "nameField": "AREA_NA7"
               }
             }
@@ -36,7 +37,15 @@
             "layerName": "U2 Tour Locations",
             "source": {
               "featureInfo": {
-                "nameField": "Venue"
+                "queryable": true,
+                "nameField": "Venue",
+                "outfields": [
+                  { "name": "Venue", "alias": "Venue", "type": "string", "domain": null },
+                  { "name": "Event", "alias": "Event", "type": "string", "domain": null },
+                  { "name": "Tour", "alias": "Tour", "type": "string", "domain": null },
+                  { "name": "City", "alias": "City", "type": "string", "domain": null },
+                  { "name": "Date", "alias": "Date", "type": "date", "domain": null }
+                ]
               }
             }
           }

--- a/packages/geoview-core/public/configs/navigator/17-esri-feature.json
+++ b/packages/geoview-core/public/configs/navigator/17-esri-feature.json
@@ -11,6 +11,38 @@
     },
     "listOfGeoviewLayerConfig": [
       {
+        "geoviewLayerId": "FeatureServerLyr1",
+        "metadataAccessPath": "https://services.arcgis.com/V6ZHFr6zdgNZuVG0/ArcGIS/rest/services/Toronto_Neighbourhoods/FeatureServer/",
+        "geoviewLayerType": "esriFeature",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "0",
+            "layerName": "Toronto Neighbourhoods",
+            "source": {
+              "featureInfo": {
+                "nameField": "AREA_NA7"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "geoviewLayerId": "FeatureServerLyr2",
+        "metadataAccessPath": "https://services.arcgis.com/V6ZHFr6zdgNZuVG0/ArcGIS/rest/services/U2/FeatureServer/",
+        "geoviewLayerType": "esriFeature",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "0",
+            "layerName": "U2 Tour Locations",
+            "source": {
+              "featureInfo": {
+                "nameField": "Venue"
+              }
+            }
+          }
+        ]
+      },
+      {
         "geoviewLayerId": "uniqueValueId",
         "geoviewLayerName": "uniqueValue",
         "metadataAccessPath": "https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/",
@@ -18,17 +50,6 @@
         "listOfLayerEntryConfig": [
           {
             "layerId": "1"
-          }
-        ]
-      },
-      {
-        "geoviewLayerId": "esriFeatureLYR1",
-        "geoviewLayerName": "Temporal_Test_Bed_en",
-        "metadataAccessPath": "https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/Temporal_Test_Bed_en/MapServer/",
-        "geoviewLayerType": "esriFeature",
-        "listOfLayerEntryConfig": [
-          {
-            "layerId": "0"
           }
         ]
       },

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -774,7 +774,12 @@ export function AddNewLayer(): JSX.Element {
       setLayerType(ESRI_IMAGE);
     } else if (layerTokens.indexOf('WFS') !== -1) {
       setLayerType(WFS);
-    } else if (displayURL.toUpperCase().endsWith('.JSON') || displayURL.toUpperCase().endsWith('.GEOJSON')) {
+    } else if (
+      displayURL.toUpperCase().endsWith('.JSON') ||
+      displayURL.toUpperCase().includes('.JSON?') ||
+      displayURL.toUpperCase().endsWith('.GEOJSON') ||
+      displayURL.toUpperCase().includes('.GEOJSON?')
+    ) {
       setLayerType(GEOJSON);
     } else if (displayURL.toUpperCase().indexOf('{Z}/{X}/{Y}') !== -1 || displayURL.toUpperCase().indexOf('{Z}/{Y}/{X}') !== -1) {
       setLayerType(XYZ_TILES);

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -496,7 +496,9 @@ export function AddNewLayer(): JSX.Element {
               new EsriFeatureLayerEntryConfig({
                 geoviewLayerConfig: esriGeoviewLayerConfig,
                 layerId:
-                  layerURL.split('/').pop()?.toLowerCase() !== 'mapserver' && layerURL.split('/').pop()?.toLowerCase() !== 'featureserver'
+                  // Remove trailing slash (/) so pop doesn't return empty string
+                  layerURL.replace(/\/$/, '').split('/').pop()?.toLowerCase() !== 'mapserver' &&
+                  layerURL.replace(/\/$/, '').split('/').pop()?.toLowerCase() !== 'featureserver'
                     ? layerURL.split('/').pop()
                     : (esriMetadata.layers[0].id as string),
                 schemaTag: CONST_LAYER_TYPES.ESRI_FEATURE,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -288,13 +288,12 @@ export function commonProcessFeatureInfoConfig(
       // eslint-disable-next-line no-param-reassign
       layerConfig.source.featureInfo.queryable = queryable;
     }
-    // else The queryable flag comes from the user config and throw an error if it's a group layer with no fields.
-    else if (layerConfig.source.featureInfo.queryable && layerMetadata.type === 'Group Layer') {
-      throw new GeoViewError(
-        layer.mapId,
-        `The config whose layer path is ${layerPath} cannot set a layer as queryable because a group layer does not have field definitions`
-      );
+    // Set queryable to false if there are no fields defined in the service
+    else if (layerConfig.source.featureInfo.queryable && layerMetadata.type !== 'Group Layer' && !layerMetadata.fields.length) {
+      // eslint-disable-next-line no-param-reassign
+      layerConfig.source.featureInfo.queryable = false;
     }
+    // The queryable flag comes from the user config
   } else {
     // eslint-disable-next-line no-param-reassign
     layerConfig.source.featureInfo =

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -288,12 +288,11 @@ export function commonProcessFeatureInfoConfig(
       // eslint-disable-next-line no-param-reassign
       layerConfig.source.featureInfo.queryable = queryable;
     }
-    // else The queryable flag comes from the user config.
-    else if (layerConfig.source.featureInfo.queryable && layerMetadata.type !== 'Group Layer') {
-      // Throw error
+    // else The queryable flag comes from the user config and throw an error if it's a group layer with no fields.
+    else if (layerConfig.source.featureInfo.queryable && layerMetadata.type === 'Group Layer') {
       throw new GeoViewError(
         layer.mapId,
-        `The config whose layer path is ${layerPath} cannot set a layer as queryable because it does not have field definitions`
+        `The config whose layer path is ${layerPath} cannot set a layer as queryable because a group layer does not have field definitions`
       );
     }
   } else {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -37,6 +37,7 @@ import { fetchJson } from '@/core/utils/utilities';
 import { EmptyResponseError } from '@/core/exceptions/core-exceptions';
 import { GeoViewLayerError } from '@/core/exceptions/layer-exceptions';
 import { GeoViewError } from '@/core/exceptions/geoview-exceptions';
+import { logger } from '@/core/utils/logger';
 
 /**
  * Fetches the Esri metadata and sets it for the given layer.
@@ -292,6 +293,7 @@ export function commonProcessFeatureInfoConfig(
     else if (layerConfig.source.featureInfo.queryable && layerMetadata.type !== 'Group Layer' && !layerMetadata.fields.length) {
       // eslint-disable-next-line no-param-reassign
       layerConfig.source.featureInfo.queryable = false;
+      logger.logWarning(`Layer ${layerPath} has no fields defined in the service metadata. Queryable set to false.`);
     }
     // The queryable flag comes from the user config
   } else {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -427,15 +427,12 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
       headers.forEach((header, index) => {
         // If not excluded
         if (!excludedHeaders.includes(header)) {
-          const value = firstRow[index];
-
           // Skip complex fields
-          if (value && typeof value === 'object' && !Array.isArray(value)) {
+          if (firstRow[index] && typeof firstRow[index] === 'object' && !Array.isArray(firstRow[index])) {
             logger.logWarning(`Skipping field '${header}' as it is a complex field`);
             return;
           }
 
-          // Process normally as before
           let type = 'string';
           if (firstRow[index] && firstRow[index] !== '' && Number(firstRow[index])) type = 'number';
 

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -697,11 +697,10 @@ export abstract class AbstractGVLayer extends AbstractBaseLayer {
         const featureFields = feature.getKeys();
         featureFields.forEach((fieldName) => {
           if (fieldName !== 'geometry') {
-            let fieldValue = feature.get(fieldName);
-
+            const fieldValue = feature.get(fieldName);
             // Skip complex fields
             if (fieldValue && typeof fieldValue === 'object' && !Array.isArray(fieldValue)) {
-              fieldValue = JSON.stringify(fieldValue);
+              return;
             }
 
             // Calculate the field domain if not already calculated

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -621,38 +621,6 @@ export abstract class AbstractGVLayer extends AbstractBaseLayer {
   }
 
   /**
-   * Some GeoJSON features may have fields with objects as values, this is a way to flatten those objects so the field can be handled
-   * Recursive so it can handle recursive objects
-   * Example: details = {name: "Test", date: "Today"} => details_name: "Test", details_date: "Today"
-   * @param obj The field object to be flattened
-   * @param prefix The prefix is the name of the field that is an object.
-   * @param result The result object that holds the field names and their values
-   * @returns The final result record
-   */
-  protected flattenFieldObject(obj: unknown, prefix: string = '', result: Record<string, unknown> = {}): Record<string, unknown> {
-    // If not an object or is null/array, return early
-    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
-      return result;
-    }
-
-    // Process each property of the object
-    Object.entries(obj as Record<string, unknown>).forEach(([key, value]) => {
-      const newKey = prefix ? `${prefix}_${key}` : key;
-
-      if (value && typeof value === 'object' && !Array.isArray(value)) {
-        // Recursively flatten nested objects
-        this.flattenFieldObject(value, newKey, result);
-      } else {
-        // Store leaf values
-        // eslint-disable-next-line no-param-reassign
-        result[newKey] = value;
-      }
-    });
-
-    return result;
-  }
-
-  /**
    * Converts the feature information to an array of TypeFeatureInfoEntry[] | undefined | null.
    * @param {Feature[]} features - The array of features to convert.
    * @param {OgcWmsLayerEntryConfig | EsriDynamicLayerEntryConfig | VectorLayerEntryConfig} layerConfig - The layer configuration.
@@ -729,64 +697,45 @@ export abstract class AbstractGVLayer extends AbstractBaseLayer {
         const featureFields = feature.getKeys();
         featureFields.forEach((fieldName) => {
           if (fieldName !== 'geometry') {
-            const fieldValue = feature.get(fieldName);
+            let fieldValue = feature.get(fieldName);
 
+            // Skip complex fields
             if (fieldValue && typeof fieldValue === 'object' && !Array.isArray(fieldValue)) {
-              const flattenedField = this.flattenFieldObject(fieldValue, fieldName);
-              for (const [key, value] of Object.entries(flattenedField)) {
-                const fieldEntry = outfields?.find((outfield) => outfield.name === key || outfield.alias === key);
-                if (fieldEntry) {
-                  featureInfoEntry.fieldInfo[fieldEntry.name] = {
-                    fieldKey: fieldKeyCounter++,
-                    value,
-                    dataType: fieldEntry!.type,
-                    alias: fieldEntry!.alias,
-                    domain: null,
-                  };
-                } else if (!outfields) {
-                  featureInfoEntry.fieldInfo[key] = {
-                    fieldKey: fieldKeyCounter++,
-                    value,
-                    dataType: 'string',
-                    alias: key,
-                    domain: null,
-                  };
-                }
-              }
-            } else {
-              // Calculate the field domain if not already calculated
-              if (!(fieldName in dictFieldDomains)) {
-                // Calculate it
-                dictFieldDomains[fieldName] = this.getFieldDomain(fieldName);
-              }
-              const fieldDomain = dictFieldDomains[fieldName];
+              fieldValue = JSON.stringify(fieldValue);
+            }
 
-              // Calculate the field type if not already calculated
-              if (!(fieldName in dictFieldTypes)) {
-                dictFieldTypes[fieldName] = this.getFieldType(fieldName);
-              }
-              const fieldType = dictFieldTypes[fieldName];
-              const fieldEntry = outfields?.find((outfield) => outfield.name === fieldName || outfield.alias === fieldName);
-              if (fieldEntry) {
-                featureInfoEntry.fieldInfo[fieldEntry.name] = {
-                  fieldKey: fieldKeyCounter++,
-                  value:
-                    // If fieldName is the alias for the entry, we will not get a value, so we try the fieldEntry name.
-                    this.getFieldValue(feature, fieldName, fieldEntry!.type as 'string' | 'number' | 'date') ||
-                    this.getFieldValue(feature, fieldEntry.name, fieldEntry!.type as 'string' | 'number' | 'date'),
-                  dataType: fieldEntry!.type,
-                  alias: fieldEntry!.alias,
-                  domain: fieldDomain,
-                };
-              } else if (!outfields) {
-                featureInfoEntry.fieldInfo[fieldName] = {
-                  fieldKey: fieldKeyCounter++,
-                  value: this.getFieldValue(feature, fieldName, fieldType),
-                  dataType: fieldType,
-                  alias: fieldName,
-                  domain: fieldDomain,
-                };
-              }
+            // Calculate the field domain if not already calculated
+            if (!(fieldName in dictFieldDomains)) {
+              // Calculate it
+              dictFieldDomains[fieldName] = this.getFieldDomain(fieldName);
+            }
+            const fieldDomain = dictFieldDomains[fieldName];
+
+            // Calculate the field type if not already calculated
+            if (!(fieldName in dictFieldTypes)) {
+              dictFieldTypes[fieldName] = this.getFieldType(fieldName);
+            }
+            const fieldType = dictFieldTypes[fieldName];
+            const fieldEntry = outfields?.find((outfield) => outfield.name === fieldName || outfield.alias === fieldName);
+            if (fieldEntry) {
+              featureInfoEntry.fieldInfo[fieldEntry.name] = {
+                fieldKey: fieldKeyCounter++,
+                value:
+                  // If fieldName is the alias for the entry, we will not get a value, so we try the fieldEntry name.
+                  this.getFieldValue(feature, fieldName, fieldEntry!.type as 'string' | 'number' | 'date') ||
+                  this.getFieldValue(feature, fieldEntry.name, fieldEntry!.type as 'string' | 'number' | 'date'),
+                dataType: fieldEntry!.type,
+                alias: fieldEntry!.alias,
+                domain: fieldDomain,
+              };
+            } else if (!outfields) {
+              featureInfoEntry.fieldInfo[fieldName] = {
+                fieldKey: fieldKeyCounter++,
+                value: this.getFieldValue(feature, fieldName, fieldType),
+                dataType: fieldType,
+                alias: fieldName,
+                domain: fieldDomain,
+              };
             }
           }
         });

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
@@ -308,7 +308,7 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
       // Update the layer style
       layer.setStyle({
         ...style,
-        ...{ [geometryType]: { type: 'simple', hasDefault: false, fields: [], info: [theStyle] } },
+        [geometryType]: { type: 'simple', hasDefault: false, fields: [], info: [theStyle] },
       });
     });
   }

--- a/packages/geoview-core/src/geo/layer/layer-sets/legends-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/legends-layer-set.ts
@@ -6,6 +6,9 @@ import { AbstractLayerSet, PropagationType } from '@/geo/layer/layer-sets/abstra
 import { TypeLegend, TypeLegendResultSet, TypeLegendResultSetEntry } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { AbstractGVLayer, LayerStyleChangedEvent } from '@/geo/layer/gv-layers/abstract-gv-layer';
 import { AbstractBaseLayer } from '@/geo/layer/gv-layers/abstract-base-layer';
+import { GVEsriDynamic } from '@/geo/layer/gv-layers/raster/gv-esri-dynamic';
+import { GVEsriFeature } from '@/geo/layer/gv-layers/vector/gv-esri-feature';
+import { GVEsriImage } from '@/geo/layer/gv-layers/raster/gv-esri-image';
 import { LayerApi } from '@/geo/layer/layer';
 
 /**
@@ -139,13 +142,12 @@ export class LegendsLayerSet extends AbstractLayerSet {
     // If the layer legend should be queried (and not already querying).
     // GV Gotta make sure that we're not already querying, because EsriImage layers, for example, adjust the
     // GV style on the fly when querying legend. So, be careful not to loop!
-    if (
-      layer &&
-      layerConfig &&
-      layer instanceof AbstractGVLayer &&
-      this.resultSet[layerPath].legendQueryStatus !== 'querying' &&
-      (this.#legendShouldBeQueried(layerConfig) || forced)
-    ) {
+    const styleLoopingLayerTypes = [GVEsriDynamic, GVEsriFeature, GVEsriImage];
+    if (styleLoopingLayerTypes.some((type) => layer instanceof type) && this.resultSet[layerPath].legendQueryStatus === 'querying') {
+      return;
+    }
+
+    if (layer && layerConfig && layer instanceof AbstractGVLayer && (this.#legendShouldBeQueried(layerConfig) || forced)) {
       // Flag
       this.resultSet[layerPath].legendQueryStatus = 'querying';
 


### PR DESCRIPTION
# Description

1. Ignores fields which have a value of object, which was causing the map to crash. This is probably specific to GeoJSON.
2. The style for GeoJSON objects is now set properly in the legend and layers. This was happening because ( legends-layer-set.ts -> #handleLayerStyleChanged -> #checkQueryLegend ) when setting the style, if the legendQueryStatus was querying, the new legend wouldn't be propagated to the store. This was initially to avoid an infinite loop caused by likely only ESRI layers, but was causing GeoJSON to fail to update the style if a new style was found in the same layer after further processing of the features. Instead, the checkQueryLegend is now only escaped for ESRI layers and others are allowed to continue if the legendQueryStatus = 'querying'.
3. Minor adjustment to add-layer to guess the GeoJSON type when '.geojson?' is in the url.
4. Attempt to assign a name field when no name field is configured / assigned.
5. Small fix for Feature Layers where a trailing slash would cause a blank layerId instead of trying to use the first layer

Fixes # 2584

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
### Host Updated 2025-04-29 12:45

Add the below GeoJSON link as a layer. The style should show all the different types now (Points, Lines, Polygons). Also, when clicking on one of the features, the map does not break. Also, when hovering over a feature or clicking on one, the name field is chosen as the display field and not the first 'cgndbid' field.

https://geogratis.gc.ca/services/geoname/en/geonames.geojson?q=ottawa&category=O,P,M&expand=items.status,items.concise,items.generic,items.province&select=items.status.term,items.concise.term,items.generic.term,items.province.description

[Sandbox](https://matthewmuehlhausernrcan.github.io/geoview/sandbox.html)

All layers still load properly and the set style isn't causing an infinite loop:

[All Layers](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/13-all-layers.json)

Small fix for FeatureServer - Add this layer in the add-layer panel as is. It should add the new layer with layerId=0
https://services.arcgis.com/V6ZHFr6zdgNZuVG0/ArcGIS/rest/services/U2/FeatureServer/

Added additional FeatureServer configs to the ESRI Feature navigator config:
[ESRI Feature Navigator Page](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/17-esri-feature.json)

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2863)
<!-- Reviewable:end -->
