### PR TITLE
(fix) Fixes the guide inner-panel which wasn't staying open for Details and Geochart

### DIFF
--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -56,7 +56,7 @@ export function DetailsPanel({ fullWidth = false }: DetailsPanelType): JSX.Eleme
 
   // States
   const [currentFeatureIndex, setCurrentFeatureIndex] = useState<number>(0);
-  const [selectedLayerPathLocal, setselectedLayerPathLocal] = useState<string>(selectedLayerPath);
+  const [selectedLayerPathLocal, setSelectedLayerPathLocal] = useState<string>(selectedLayerPath);
   const [arrayOfLayerListLocal, setArrayOfLayerListLocal] = useState<LayerListEntry[]>([]);
   const prevLayerSelected = useRef<TypeLayerData>();
   const prevLayerFeatures = useRef<TypeFeatureInfoEntry[] | undefined | null>();
@@ -270,11 +270,14 @@ export function DetailsPanel({ fullWidth = false }: DetailsPanelType): JSX.Eleme
    */
   useEffect(() => {
     // Log
-    logger.logTraceUseEffect('DETAILS-PANEL - check selection', memoLayerSelectedItem);
+    logger.logTraceUseEffect('DETAILS-PANEL - check selection', memoLayerSelectedItem, selectedLayerPath);
 
-    // Redirect to the keep selected layer path logic
-    checkSelectedLayerPathList(setLayerDataArrayBatchLayerPathBypass, setSelectedLayerPath, memoLayerSelectedItem, memoLayersList);
-  }, [memoLayerSelectedItem, memoLayersList, setLayerDataArrayBatchLayerPathBypass, setSelectedLayerPath]);
+    // If selected layer path is not empty, launch the checker to try to maintain the selection on the correct selected layer
+    if (selectedLayerPath) {
+      // Redirect to the keep selected layer path logic
+      checkSelectedLayerPathList(setLayerDataArrayBatchLayerPathBypass, setSelectedLayerPath, memoLayerSelectedItem, memoLayersList);
+    }
+  }, [memoLayerSelectedItem, memoLayersList, selectedLayerPath, setLayerDataArrayBatchLayerPathBypass, setSelectedLayerPath]);
 
   // #endregion
 
@@ -355,7 +358,7 @@ export function DetailsPanel({ fullWidth = false }: DetailsPanelType): JSX.Eleme
   // If the layer path has changed since last render
   if (selectedLayerPathLocal !== selectedLayerPath) {
     // Selected layer path changed
-    setselectedLayerPathLocal(selectedLayerPath);
+    setSelectedLayerPathLocal(selectedLayerPath);
     // Reset the feature index, because it's a whole different selected layer with different features
     resetCurrentIndex();
   }
@@ -375,18 +378,20 @@ export function DetailsPanel({ fullWidth = false }: DetailsPanelType): JSX.Eleme
   );
 
   /**
-   * Select the layer after layer is selected from map.
+   * Select a layer after a map click happened on the map.
    */
   useEffect(() => {
     // Log
     logger.logTraceUseEffect('DETAILS-PANEL- mapClickCoordinates', mapClickCoordinates);
 
+    // If nothing was previously selected at all
     if (mapClickCoordinates && memoLayersList?.length && !selectedLayerPath.length) {
       const selectedLayer = memoLayersList.find((layer) => !!layer.numOffeatures);
+      // Select the first layer that has features
       setSelectedLayerPath(selectedLayer?.layerPath ?? '');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapClickCoordinates, memoLayersList]);
+  }, [mapClickCoordinates, memoLayersList, setSelectedLayerPath]);
 
   /**
    * Check all layers status is processed while querying


### PR DESCRIPTION
# Description

Fixes #2851 
Also, bonus, when clicking a layer with a chart associated on the map, the layer is selected immediately on the Chart panel (same behavior as Details panel).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted April 29th @ 13h : https://alex-nrcan.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2865)
<!-- Reviewable:end -->
