### PR TITLE
fix(legend-image-static) Fix for the legend icon for layers of type image-static

### DIFF
--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -326,6 +326,9 @@ export class LegendEventProcessor extends AbstractEventProcessor {
           bounds = MapEventProcessor.getMapViewerLayerAPI(mapId).calculateBounds(layerConfig.layerPath);
         }
 
+        // Read the icons
+        const icons = LegendEventProcessor.getLayerIconImage(legendResultSetEntry.data!);
+
         const controls: TypeLayerControls = setLayerControls(layerConfig, currentLevel > 2);
         const legendLayerEntry: TypeLegendLayer = {
           bounds,
@@ -344,7 +347,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
           queryable: layerConfig.initialSettings?.states?.queryable,
           items: [] as TypeLegendItem[],
           children: [] as TypeLegendLayer[],
-          icons: LegendEventProcessor.getLayerIconImage(legendResultSetEntry.data!) || [],
+          icons: icons || [],
           url: layerConfig.geoviewLayerConfig.metadataAccessPath,
         };
 
@@ -355,6 +358,16 @@ export class LegendEventProcessor extends AbstractEventProcessor {
               legendLayerEntry.items.push(legendLayerListItem);
             });
         });
+
+        // Also take care of image static by storing the iconImage into the icon property on-the-fly
+        if (isImageStaticLegend(legendResultSetEntry.data!) && icons && icons.length > 0) {
+          legendLayerEntry.items.push({
+            geometryType: 'Point',
+            name: 'image',
+            icon: icons[0].iconImage || null,
+            isVisible: true,
+          });
+        }
 
         // If non existing in the store yet
         if (entryIndex === -1) {


### PR DESCRIPTION
# Description

Fixes #2864

Before:
![image](https://github.com/user-attachments/assets/861ba612-bc00-4402-8671-e5f03bf9ff9d)

After:
![image](https://github.com/user-attachments/assets/20ec4155-20ef-471d-8875-72ca6c831717)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted April 29th 17h: https://alex-nrcan.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2866)
<!-- Reviewable:end -->
