### PR TITLE
Fixes regression preventing an array of geocore ids from being used in a map config

### DIFF
--- a/packages/geoview-core/src/api/config/config-api.ts
+++ b/packages/geoview-core/src/api/config/config-api.ts
@@ -332,8 +332,22 @@ export class ConfigApi {
         let newListOfGeoviewLayerConfig = listOfGeoviewLayerConfig.map((layerConfig) => {
           if (layerConfig.geoviewLayerType === CV_CONFIG_GEOCORE_TYPE) {
             const jsonConfigFound = arrayOfJsonConfig.find((jsonConfig) => {
-              // Remove the duplicate tag from the ID so it will match
-              const geocoreId = (layerConfig.geoviewLayerId as string).split(':')[0];
+              // For single ids, remove the duplicate tag from the ID so it will match.
+              // For arrays of ids, do the same for each id in the array.
+              let geocoreId;
+
+              if (Array.isArray(layerConfig.geoviewLayerId)) {
+                let geoviewLayerId;
+                geocoreId = [];
+
+                for (const id of layerConfig.geoviewLayerId) {
+                  [geoviewLayerId] = (id as string).split(':');
+                  geocoreId.push(geoviewLayerId);
+                }
+              } else {
+                [geocoreId] = (layerConfig.geoviewLayerId as string).split(':');
+              }
+
               return jsonConfig.geoviewLayerId === `rcs.${geocoreId}.${language}`;
             });
             if (jsonConfigFound) {

--- a/packages/geoview-core/src/geo/layer/other/geocore.ts
+++ b/packages/geoview-core/src/geo/layer/other/geocore.ts
@@ -48,8 +48,21 @@ export class GeoCore {
     const url = `${mapConfig!.serviceUrls.geocoreUrl}`;
 
     try {
+      // For single ids, remove any tags following the uuid.
+      // For arrays of ids, do the same for each id in the array.
+      const splitUuidArr = [];
+      if (Array.isArray(uuid)) {
+        let splitUuid;
+        for (const id of uuid) {
+          [splitUuid] = id.split(':');
+          splitUuidArr.push(splitUuid);
+        }
+      } else {
+        splitUuidArr.push(uuid.split(':')[0]);
+      }
+
       // Get the GV config from UUID and await
-      const response = await UUIDmapConfigReader.getGVConfigFromUUIDs(url, this.#displayLanguage, [uuid.split(':')[0]]);
+      const response = await UUIDmapConfigReader.getGVConfigFromUUIDs(url, this.#displayLanguage, splitUuidArr);
 
       // Validate the generated Geoview Layer Config
       ConfigValidation.validateListOfGeoviewLayerConfig(this.#displayLanguage, response.layers);


### PR DESCRIPTION
# Description

In commit [30e9fca](https://github.com/Canadian-Geospatial-Platform/geoview/commit/30e9fcae717a9cc53b68185951ffca79408c4e68) a regression was introduced that broke any map that included an array of geocore ids for the 'geoviewLayerId' key in the map config. This is because the String.split() method is used in the code, throwing the following error with arrays:

```
undefined TypeError: e.geoviewLayerId.split is not a function
    at config-api.ts:336:72
    at Array.find (<anonymous>)
    at config-api.ts:334:55
    at Array.map (<anonymous>)
    at config-api.ts:332:68
```

To fix this, whenever an array is used, the String.split() method is applied to each id individually instead of the whole array.

Fixes # N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Go to the sandbox.
- From the sandbox, edit the map configuration so that you are adding an array of geocore ids instead of the default for the 'listOfGeoviewLayerConfig' key.
- Validate and create the map.
- The map should build without errors.
- Repeat the steps above for a single id to make sure no additional regressions were introduced.

Here is a sample config you can use for testing. Feel free to try different geocore ids for the 'geoviewLayerId' key:

```
{
  'map': {
    'interaction': 'dynamic',
    'viewSettings': {
      'projection': 3978
    },
    'basemapOptions': {
      'basemapId': 'transport',
      'shaded': false,
      'labeled': true
    },
    'listOfGeoviewLayerConfig': [{
      'geoviewLayerType': 'geoCore',
      'geoviewLayerId': ['8e98d369-18bd-47ee-8bfd-e75577eb4119', 'c9ab948f-5009-4dbc-9129-2f6e373f17f6', 'd2af02fe-9e12-413d-8959-06be963bde52']
    }]
  },
  'components': ['overview-map'],
  'footerBar': {
    'tabs': {
      'core': ['legend', 'layers', 'details', 'data-table']
    }
  },
  'corePackages': [],
  'theme': 'geo.ca'
}
```

__[https://lbercovitch.github.io/geoview-leah/](https://lbercovitch.github.io/geoview-leah/)__

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2869)
<!-- Reviewable:end -->
