### PR TITLE
fix(schema): Schema update for disabledLayerTypes config properties

### DIFF
--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -2213,7 +2213,7 @@
           "description": "Disabled layer types are not allowed in the add layers component",
           "type": "array",
           "items": {
-            "enum": [
+            "anyOf": [
               {
                 "$ref": "#/definitions/TypeGeoviewLayerType"
               },

--- a/packages/geoview-core/src/api/config/types/config-validation-schema.json
+++ b/packages/geoview-core/src/api/config/types/config-validation-schema.json
@@ -437,11 +437,14 @@
           "description": "List of layer types that are disabled in the viewer.",
           "type": "array",
           "items": {
-            "enum": [
+            "anyOf": [
               {
                 "$ref": "#/definitions/TypeGeoviewLayerType"
               },
-              "geoCore"
+              {
+                "type": "string",
+                "enum": ["geoCore"]
+              }
             ]
           }
         }


### PR DESCRIPTION
# Description

Small fix for the validation schemas for the disabledLayerTypes config property.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Notice in the console that the validation warnings don't show up in the global-settings page.

[Global Serttings](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/31-global-settings.json)

If you go into the sandbox and add the following to the config, then it will throw a validation errors for 'geocore' and ogcwfs' because they don't match, but the other two are fine.

'globalSettings': {
    'disabledLayerTypes': [
      'geoCore',
      'geocore',
      'ogcWfs',
      'ogcwfs'
    ]
  }

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2873)
<!-- Reviewable:end -->
