### PR TITLE
fix(data-table): Filter unsymbolized features

### DIFF
--- a/packages/geoview-core/public/configs/navigator/31-global-settings.json
+++ b/packages/geoview-core/public/configs/navigator/31-global-settings.json
@@ -11,6 +11,10 @@
     },
     "listOfGeoviewLayerConfig": [
       {
+        "geoviewLayerId": "4baa66ad-aa29-4233-a6a8-7f5cbefb5ea8",
+        "geoviewLayerType": "geoCore"
+      },
+      {
         "geoviewLayerId": "geojsonLYR1",
         "geoviewLayerName": "GeoJSON Sample",
         "metadataAccessPath": "./datasets/geojson/metadata.meta",
@@ -88,6 +92,7 @@
       "ogcWms",
       "imageStatic",
       "vectorTiles"
-    ]
+    ],
+    "showUnsymbolizedFeatures": true
   }
 }

--- a/packages/geoview-core/public/templates/demos/demo-cgdi.html
+++ b/packages/geoview-core/public/templates/demos/demo-cgdi.html
@@ -63,13 +63,12 @@
             {
               'geoviewLayerId': 'HMS',
               'geoviewLayerName': 'Hydrometric Monitoring Stations',
-              'metadataAccessPath': 'https://api.weather.gc.ca/collections/hydrometric-stations/',
               'geoviewLayerType': 'GeoJSON',
               'listOfLayerEntryConfig': [
                 {
                   'layerId': 'hydrometric-stations',
-                  'layerName': 'Hydrometric Stations',
                   'source': {
+                    'format': 'GeoJSON',
                     'dataAccessPath': 'https://api.weather.gc.ca/collections/hydrometric-stations/items?f=json'
                   }
                 }
@@ -94,13 +93,13 @@
                   }
                 },
                 {
-                  'layerId': 'HRDPA.6F_PR',
+                  'layerId': 'RDPA.6F_PR',
                   'source': {
                     'style': 'CAPA24-LINEAR'
                   }
                 },
                 {
-                  'layerId': 'HRDPA.6P_PR',
+                  'layerId': 'RDPA.6P_PR',
                   'source': {
                     'style': 'CAPA24-LINEAR'
                   }
@@ -118,13 +117,13 @@
                   }
                 },
                 {
-                  'layerId': 'HRDPA.24F_PR',
+                  'layerId': 'RDPA.24F_PR',
                   'source': {
                     'style': 'CAPA24-LINEAR'
                   }
                 },
                 {
-                  'layerId': 'HRDPA.24P_PR',
+                  'layerId': 'RDPA.24P_PR',
                   'source': {
                     'style': 'CAPA24-LINEAR'
                   }
@@ -171,7 +170,7 @@
             {
               'geoviewLayerId': 'Active_Inactive_Disposal_at_Sea_Sites',
               'geoviewLayerName': 'Active Inactive Disposal at Sea Sites',
-              'metadataAccessPath': 'https://maps-cartes.ec.gc.ca/arcgis/services/Active_Inactive_Disposal_at_Sea_Sites/MapServer/WMSServer',
+              'metadataAccessPath': 'https://maps-cartes.ec.gc.ca/arcgis/services/DMS/ActiveDisposalSites_SitesImmersionActifs/MapServer/WMSServer',
               'geoviewLayerType': 'ogcWms',
               'listOfLayerEntryConfig': [
                 { 'layerId': '0' }
@@ -180,14 +179,13 @@
             {
               'geoviewLayerId': 'ShorelineSegmentationWithSCATClassification',
               'geoviewLayerName': 'Shoreline Segmentation With SCAT Classification',
-              'metadataAccessPath': 'https://maps-cartes.ec.gc.ca/arcgis/services/EPB_EPO/ShorelineSegmentationWithSCATClassification/MapServer/WMSServer',
+              'metadataAccessPath': 'https://maps-cartes.ec.gc.ca/arcgis/services/DMS/Shoreline_Mapping_Vector_Data/MapServer/WMSServer',
               'geoviewLayerType': 'ogcWms',
               'listOfLayerEntryConfig': [
                 { 'layerId': '0' },
                 { 'layerId': '1' },
                 { 'layerId': '2' },
-                { 'layerId': '3' },
-                { 'layerId': '4' }
+                { 'layerId': '3' }
               ]
             },
             {

--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -2251,6 +2251,10 @@
               }
             ]
           }
+        },
+        "showUnsymbolizedFeatures": {
+          "type": "boolean",
+          "description": "Whether or not to show unsymbolized features. Default = false."
         }
       }
     },

--- a/packages/geoview-core/src/api/config/types/config-constants.ts
+++ b/packages/geoview-core/src/api/config/types/config-constants.ts
@@ -206,7 +206,11 @@ export const CV_DEFAULT_MAP_FEATURE_CONFIG = Cast<MapFeatureConfig>({
     proxyUrl: CV_CONFIG_PROXY_URL,
     metadataUrl: CV_CONFIG_METADATA_RECORDS_URL,
   },
-  globalSettings: { canRemoveSublayers: true, disabledLayerTypes: [] },
+  globalSettings: {
+    canRemoveSublayers: true,
+    disabledLayerTypes: [],
+    showUnsymbolizedFeatures: false,
+  },
   schemaVersionUsed: '1.0',
 });
 

--- a/packages/geoview-core/src/api/config/types/config-validation-schema.json
+++ b/packages/geoview-core/src/api/config/types/config-validation-schema.json
@@ -449,6 +449,11 @@
               }
             ]
           }
+        },
+        "showUnsymbolizedFeatures": {
+          "description": "Whether or not to show unsymbolized features.",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/packages/geoview-core/src/api/config/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/config/types/map-schema-types.ts
@@ -203,6 +203,8 @@ export type TypeGlobalSettings = {
   canRemoveSublayers?: boolean;
   /** Whether a certain layer type should be disabled */
   disabledLayerTypes?: TypeGeoviewLayerType[];
+  /** Whether to display unsymbolized features in the datatable and other components */
+  showUnsymbolizedFeatures?: boolean;
 };
 
 /** Definition of the map configuration settings. */

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/app-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/app-event-processor.ts
@@ -59,6 +59,15 @@ export class AppEventProcessor extends AbstractEventProcessor {
   }
 
   /**
+   * Shortcut to get the display theme for a given map id
+   * @param {string} mapId - The mapId
+   * @returns {TypeDisplayTheme} The display theme.
+   */
+  static getShowUnsymbolizedFeatures(mapId: string): boolean {
+    return this.getAppState(mapId).showUnsymbolizedFeatures;
+  }
+
+  /**
    * Adds a snackbar message (optional add to notification).
    * @param {SnackbarType} type - The type of message.
    * @param {string} message - The message.

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -363,8 +363,6 @@ function DataTable({ data, layerPath }: DataTableProps): JSX.Element {
     // get filtered feature for unique value info style so non visible class is not in the table
     const filterArray = getFilteredDataFromLegendVisibility(data.layerPath, data?.features ?? []);
 
-    // TODO Filter features based on current map extent olLayer.getSource().getFeaturesInExtent(extent, projection)
-
     return (filterArray ?? []).map((feature) => {
       const icon = feature.featureIcon ? (
         <Box component="img" alt={feature?.nameField ?? ''} src={feature.featureIcon} className="layer-icon" />

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -363,6 +363,8 @@ function DataTable({ data, layerPath }: DataTableProps): JSX.Element {
     // get filtered feature for unique value info style so non visible class is not in the table
     const filterArray = getFilteredDataFromLegendVisibility(data.layerPath, data?.features ?? []);
 
+    // TODO Filter features based on current map extent olLayer.getSource().getFeaturesInExtent(extent, projection)
+
     return (filterArray ?? []).map((feature) => {
       const icon = feature.featureIcon ? (
         <Box component="img" alt={feature?.nameField ?? ''} src={feature.featureIcon} className="layer-icon" />

--- a/packages/geoview-core/src/core/components/data-table/export-button.tsx
+++ b/packages/geoview-core/src/core/components/data-table/export-button.tsx
@@ -37,6 +37,8 @@ function ExportButton({ layerPath, rows, columns, children }: ExportButtonProps)
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
+  const COLUMNS_TO_REMOVE = ['ICON', 'ZOOM', 'DETAILS', 'geoviewID'];
+
   /**
    * Shows export menu.
    */
@@ -65,7 +67,7 @@ function ExportButton({ layerPath, rows, columns, children }: ExportButtonProps)
     logger.logTraceUseMemo('DATA-TABLE - EXPORT BUTTON - getCsvOptions', columns);
 
     // Remove the utility columns
-    const filteredColumns = columns.filter((col) => !['ICON', 'ZOOM', 'DETAILS', 'geoviewID'].includes(col.id as string));
+    const filteredColumns = columns.filter((col) => !COLUMNS_TO_REMOVE.includes(col.id as string));
 
     return (): Options => ({
       filename: `table-${getLayer(layerPath)?.layerName.replaceAll(' ', '-')}`,
@@ -90,7 +92,10 @@ function ExportButton({ layerPath, rows, columns, children }: ExportButtonProps)
     const csvRows = rows.map((row) => {
       const mappedRow = Object.keys(row).reduce(
         (acc, curr) => {
-          acc[curr] = row[curr]?.value ?? '';
+          // Only add the field if it's not a utility column
+          if (!COLUMNS_TO_REMOVE.includes(curr)) {
+            acc[curr] = row[curr]?.value ?? '';
+          }
           return acc;
         },
         {} as Record<string, unknown>

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/app-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/app-state.ts
@@ -30,6 +30,7 @@ export interface IAppState {
   isCrosshairsActive: boolean;
   isFullscreenActive: boolean;
   notifications: Array<NotificationDetailsType>;
+  showUnsymbolizedFeatures: boolean;
 
   setDefaultConfigValues: (geoviewConfig: TypeMapFeaturesConfig) => void;
 
@@ -77,6 +78,7 @@ export function initializeAppState(set: TypeSetStore, get: TypeGetStore): IAppSt
     isCrosshairsActive: false,
     isFullscreenActive: false,
     notifications: [],
+    showUnsymbolizedFeatures: false,
 
     // initialize default stores section from config information when store receive configuration file
     setDefaultConfigValues: (geoviewConfig: TypeMapFeaturesConfig) => {
@@ -92,6 +94,7 @@ export function initializeAppState(set: TypeSetStore, get: TypeGetStore): IAppSt
           geolocatorServiceURL: geoviewConfig.serviceUrls?.geolocatorUrl,
           metadataServiceURL: geoviewConfig.serviceUrls?.metadataUrl,
           geoviewHTMLElement: document.getElementById(get().mapId)!,
+          showUnsymbolizedFeatures: geoviewConfig.globalSettings?.showUnsymbolizedFeatures || false,
         },
       });
     },

--- a/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
@@ -1,3 +1,4 @@
+import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 import { DataTableEventProcessor } from '@/api/event-processors/event-processor-children/data-table-event-processor';
 import { QueryType, TypeLayerEntryConfig } from '@/api/config/types/map-schema-types';
 import { AbstractGVLayer } from '@/geo/layer/gv-layers/abstract-gv-layer';
@@ -141,6 +142,11 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
                 this.layerApi.getLayerEntryConfig(layerPath) as TypeLayerEntryConfig,
                 arrayOfRecords
               );
+            }
+
+            if (!AppEventProcessor.getShowUnsymbolizedFeatures(this.getMapId())) {
+              // eslint-disable-next-line no-param-reassign
+              arrayOfRecords = arrayOfRecords.filter((record) => record.featureIcon);
             }
 
             // Keep the features retrieved

--- a/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
@@ -144,6 +144,7 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
               );
             }
 
+            // Filter out unsymbolized features if the showUnsymbolizedFeatures config is false
             if (!AppEventProcessor.getShowUnsymbolizedFeatures(this.getMapId())) {
               // eslint-disable-next-line no-param-reassign
               arrayOfRecords = arrayOfRecords.filter((record) => record.featureIcon);

--- a/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
@@ -12,6 +12,7 @@ import {
   TypeFeatureInfoResultSetEntry,
 } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import { AbortError } from '@/core/exceptions/core-exceptions';
+import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 
 /**
  * A Layer-set working with the LayerApi at handling a result set of registered layers and synchronizing
@@ -174,6 +175,11 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
 
             // Use the response to possibly patch the layer config metadata
             if (arrayOfRecords.length) this.#patchMissingMetadataIfNecessary(layerPath, arrayOfRecords[0]);
+
+            if (!AppEventProcessor.getShowUnsymbolizedFeatures(this.getMapId())) {
+              // eslint-disable-next-line no-param-reassign
+              arrayOfRecords = arrayOfRecords.filter((record) => record.featureIcon);
+            }
 
             // Keep the features retrieved
             this.resultSet[layerPath].features = arrayOfRecords;

--- a/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
@@ -1,7 +1,7 @@
 import { Coordinate } from 'ol/coordinate';
+import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 import { FeatureInfoEventProcessor } from '@/api/event-processors/event-processor-children/feature-info-event-processor';
 import EventHelper, { EventDelegateBase } from '@/api/events/event-helper';
-import { logger } from '@/core/utils/logger';
 import { TypeFeatureInfoEntry, TypeFeatureInfoLayerConfig, TypeLayerEntryConfig, TypeResultSet } from '@/api/config/types/map-schema-types';
 import { AbstractGVLayer } from '@/geo/layer/gv-layers/abstract-gv-layer';
 import { AbstractBaseLayer } from '@/geo/layer/gv-layers/abstract-base-layer';
@@ -12,7 +12,7 @@ import {
   TypeFeatureInfoResultSetEntry,
 } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import { AbortError } from '@/core/exceptions/core-exceptions';
-import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
+import { logger } from '@/core/utils/logger';
 
 /**
  * A Layer-set working with the LayerApi at handling a result set of registered layers and synchronizing
@@ -176,6 +176,7 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
             // Use the response to possibly patch the layer config metadata
             if (arrayOfRecords.length) this.#patchMissingMetadataIfNecessary(layerPath, arrayOfRecords[0]);
 
+            // Filter out unsymbolized features if the showUnsymbolizedFeatures config is false
             if (!AppEventProcessor.getShowUnsymbolizedFeatures(this.getMapId())) {
               // eslint-disable-next-line no-param-reassign
               arrayOfRecords = arrayOfRecords.filter((record) => record.featureIcon);


### PR DESCRIPTION
# Description

Added a global setting called showUnsymbolizedFeatures (default=false).

Made it so that un-symbolized features are filtered out of the data table. This also fixes an issue for the data table not reflecting the current features displayed by the time-slider filter. Also filtered out results for the details tab on map click as well.

Fixes # 2179, 2654

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
### Host updated 2025-05-13 1:05pm

If you load the Global Settings navigator page, you can see how to set the showUnsymbolizedFeatures is set. The default is false, so this page has it set to true so you can see how when you load the data table, or click on the map, you will see all the features, and not just the symbolized ones. If you go to any other page and add the below geoCore id, you will see how the data-table is filtered and only the symbolized features show when you click on the map.

Feature for testing the details tab:  4baa66ad-aa29-4233-a6a8-7f5cbefb5ea8

[Global Settings Navigator](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/31-global-settings.json)

Also, on the time slider page, you can see how the data table is filtered based on the current filter from the time slider. You can set the time slider to "play" and then switch to the data-table and watch as the features update.

[Time Slider Navigator Page](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/10-package-time-slider.json)

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2884)
<!-- Reviewable:end -->
