### PR TITLE
feat(initialView): allow for map projection extent initial/home view

### DIFF
--- a/packages/geoview-core/public/configs/navigator/01-basemap-LCC-TLS.json
+++ b/packages/geoview-core/public/configs/navigator/01-basemap-LCC-TLS.json
@@ -3,7 +3,20 @@
     "interaction": "dynamic",
     "viewSettings": {
       "projection": 3978,
-      "maxExtent": [-125, 30, -60, 89]
+      "maxExtent": [
+        -125,
+        30,
+        -60,
+        89
+      ],
+      "initialView": {
+        "extent": [
+          618157.4086582607,
+          -950073.2626501226,
+          2039609.776216048,
+          476729.6157014831
+        ]
+      }
     },
     "basemapOptions": {
       "basemapId": "transport",
@@ -11,7 +24,10 @@
       "labeled": true
     }
   },
-  "components": ["overview-map", "north-arrow"],
+  "components": [
+    "overview-map",
+    "north-arrow"
+  ],
   "overviewMap": {
     "hideOnZoom": 6
   },

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -32,7 +32,7 @@ import { LayerApi } from '@/geo/layer/layer';
 import { MapViewer, TypeMapState, TypeMapMouseInfo } from '@/geo/map/map-viewer';
 import { TypeRecordOfPlugin } from '@/api/plugin/plugin-types';
 import { Projection } from '@/geo/utils/projection';
-import { isPointInExtent } from '@/geo/utils/utilities';
+import { isPointInExtent, isExtentLngLat } from '@/geo/utils/utilities';
 import { getGeoViewStore } from '@/core/stores/stores-managers';
 import { NORTH_POLE_POSITION, OL_ZOOM_DURATION, OL_ZOOM_MAXZOOM, OL_ZOOM_PADDING } from '@/core/utils/constant';
 import { logger } from '@/core/utils/logger';
@@ -994,11 +994,15 @@ export class MapEventProcessor extends AbstractEventProcessor {
     // If extent is in config, use it
     if (homeView!.extent) {
       const lnglatExtent = homeView!.extent as Extent;
-      extent = Projection.transformExtentFromProj(
-        lnglatExtent,
-        Projection.getProjectionLngLat(),
-        Projection.getProjectionFromString(`EPSG:${currProjection}`)
-      );
+      // If extent is not lon/lat, we assume it is in the map projection and use it as is.
+      extent = isExtentLngLat(extent)
+        ? Projection.transformExtentFromProj(
+            lnglatExtent,
+            Projection.getProjectionLngLat(),
+            Projection.getProjectionFromString(`EPSG:${currProjection}`)
+          )
+        : lnglatExtent;
+
       options.padding = [0, 0, 0, 0];
     }
 

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -56,7 +56,7 @@ import { Translate } from '@/geo/interaction/translate';
 import EventHelper, { EventDelegateBase } from '@/api/events/event-helper';
 import { ModalApi } from '@/ui';
 import { delay, generateId, getLocalizedMessage } from '@/core/utils/utilities';
-import { createEmptyBasemap, getPointerPositionFromMapEvent } from '@/geo/utils/utilities';
+import { createEmptyBasemap, getPointerPositionFromMapEvent, isExtentLngLat } from '@/geo/utils/utilities';
 import { logger } from '@/core/utils/logger';
 import { NORTH_POLE_POSITION } from '@/core/utils/constant';
 import { TypeMapFeaturesConfig, TypeHTMLElement } from '@/core/types/global-types';
@@ -665,8 +665,12 @@ export class MapViewer {
 
     // Zoom to extent provided in config, if provided.
     if (this.mapFeaturesConfig.map.viewSettings.initialView?.extent) {
+      // If extent is not lon/lat, we assume it is in the map projection and use it as is.
+      const extent = isExtentLngLat(this.mapFeaturesConfig.map.viewSettings.initialView!.extent)
+        ? this.convertExtentLngLatToMapProj(this.mapFeaturesConfig.map.viewSettings.initialView!.extent as Extent)
+        : this.mapFeaturesConfig.map.viewSettings.initialView!.extent;
       // Zoom to extent
-      this.zoomToExtent(this.convertExtentLngLatToMapProj(this.mapFeaturesConfig.map.viewSettings.initialView!.extent as Extent), {
+      this.zoomToExtent(extent, {
         padding: [0, 0, 0, 0],
       }).catch((error: unknown) => {
         // Log

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -415,6 +415,27 @@ export function validateExtent(extent: Extent, code: string = 'EPSG:4326'): Exte
 }
 
 /**
+ * Checks if a given extent is long/lat.
+ * @param {Extent} extent - The extent to check.
+ * @returns {boolean} Whether or not the extent is long/lat
+ */
+export function isExtentLngLat(extent: Extent): boolean {
+  if (
+    extent.length === 4 &&
+    extent[0] >= -180 &&
+    extent[0] <= 180 &&
+    extent[1] >= -90 &&
+    extent[1] <= 90 &&
+    extent[2] >= -180 &&
+    extent[2] <= 180 &&
+    extent[3] >= -90 &&
+    extent[3] <= 90
+  )
+    return true;
+  return false;
+}
+
+/**
  * Validates lat long, LCC, or Web Mercator extent if it is defined.
  * @param {Extent} extent - The extent to validate.
  * @param {string} code - The projection code of the extent. Default EPSG:4326.


### PR DESCRIPTION
Closes #2881

# Description

Adds check for lng/lat extent to home view and initial view, and assumes it is map projection otherwise and does not alter it

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/01-basemap-LCC-TLS.json

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2888)
<!-- Reviewable:end -->
