### PR TITLE
feat(initialView): allow for map projection extent in itial/home view

### DIFF
--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -995,7 +995,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
     if (homeView!.extent) {
       const lnglatExtent = homeView!.extent as Extent;
       // If extent is not lon/lat, we assume it is in the map projection and use it as is.
-      extent = isExtentLngLat(extent)
+      extent = isExtentLngLat(lnglatExtent)
         ? Projection.transformExtentFromProj(
             lnglatExtent,
             Projection.getProjectionLngLat(),
@@ -1016,6 +1016,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
         Projection.getProjectionLngLat(),
         Projection.getProjectionFromString(`EPSG:${currProjection}`)
       );
+
     return this.zoomToExtent(mapId, extent, options);
   }
 


### PR DESCRIPTION
Closes #2881

# Description

Quick fix for wrong extent being checked in homeView extent


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/01-basemap-LCC-TLS.json

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2894)
<!-- Reviewable:end -->
