### PR TITLE
fix(ui) Fix translation for appbar panel titles

### DIFF
--- a/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
@@ -317,7 +317,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
           panelId: `Appbar${capitalize(tab)}PanelId`,
           panelGroupName: tab,
           type: CONTAINER_TYPE.APP_BAR,
-          title: capitalize(tab),
+          title: `${camelCase(tab)}.title`,
           icon: memoPanels[tab].icon,
           content: memoPanels[tab].content,
           width: getPanelWidth(tab),


### PR DESCRIPTION
# Description
App bar panel titles now show the correct title for the current language.

Fixes #2908 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Go to demo in hosted version, change language to French and view appbar panel titles. They should now be properly translated in French.

https://jaredkinger.github.io/geoview/demos-navigator.html?config=./configs/navigator/07-basic-appbar-layers-tab.json

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
