### PR TITLE
fix(class visibility) - Fix class visibility in vector layers and ESRI Dynamic

### DIFF
--- a/packages/geoview-core/public/configs/navigator/07-basic-footer-appbar-combo.json
+++ b/packages/geoview-core/public/configs/navigator/07-basic-footer-appbar-combo.json
@@ -20,9 +20,230 @@
         "metadataAccessPath": "https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/",
         "geoviewLayerType": "esriFeature",
         "listOfLayerEntryConfig": [
-            {
-                "layerId": "1"
+          {
+            "layerId": "1"
+          }
+        ]
+      },
+      {
+        "geoviewLayerId": "wfsLYR1",
+        "geoviewLayerName": "US States",
+        "metadataAccessPath": "https://ahocevar.com/geoserver/wfs?REQUEST=GetCapabilities&VERSION=2.0.0&SERVICE=WFS",
+        "geoviewLayerType": "ogcWfs",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "usa:states",
+            "layerName": "US States",
+            "layerStyle": {
+              "Polygon": {
+                "type": "uniqueValue",
+                "fields": ["STATE_NAME"],
+                "hasDefault": true,
+                "info": [
+                  {
+                    "label": "Alabama",
+                    "visible": true,
+                    "values": ["Alabama"],
+                    "settings": {
+                      "type": "filledPolygon",
+                      "color": "rgba(237,81,81,1)",
+                      "stroke": {
+                        "color": "rgba(153,153,153,0.251)",
+                        "lineStyle": "solid",
+                        "width": 0.75
+                      },
+                      "fillStyle": "solid"
+                    }
+                  },
+                  {
+                    "label": "California",
+                    "visible": true,
+                    "values": ["California"],
+                    "settings": {
+                      "type": "filledPolygon",
+                      "color": "rgba(252,146,31,1)",
+                      "stroke": {
+                        "color": "rgba(153,153,153,0.251)",
+                        "lineStyle": "solid",
+                        "width": 0.75
+                      },
+                      "fillStyle": "solid"
+                    }
+                  },
+                  {
+                    "label": "Other",
+                    "visible": true,
+                    "values": [],
+                    "settings": {
+                      "type": "filledPolygon",
+                      "color": "rgba(170,170,170,1)",
+                      "stroke": {
+                        "color": "rgba(153,153,153,0.251)",
+                        "lineStyle": "solid",
+                        "width": 0.75
+                      },
+                      "fillStyle": "solid"
+                    }
+                  }
+                ]
+              }
             }
+          }
+        ]
+      },
+      {
+        "geoviewLayerId": "geojsonLYR1",
+        "geoviewLayerName": "GeoJSON Sample",
+        "metadataAccessPath": "https://canadian-geospatial-platform.github.io/geoview/public/datasets/geojson/metadata.meta",
+        "geoviewLayerType": "GeoJSON",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "polygons.json",
+            "layerName": "Polygons"
+          }
+        ]
+      },
+      {
+        "geoviewLayerId": "csvLYR1",
+        "geoviewLayerName": "NPRI",
+        "metadataAccessPath": "https://canadian-geospatial-platform.github.io/geoview/public/datasets/csv-files/",
+        "geoviewLayerType": "CSV",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "NPRI-INRP_WaterEau_MediaGroupMilieu_2022",
+            "layerName": "NPRI Water Media Group 2022",
+            "source": {
+              "separator": ","
+            },
+            "layerStyle": {
+              "Point": {
+                "type": "uniqueValue",
+                "fields": ["Province | Province"],
+                "hasDefault": true,
+                "info": [
+                  {
+                    "label": "NL",
+                    "visible": true,
+                    "values": ["NL"],
+                    "settings": {
+                      "type": "simpleSymbol",
+                      "rotation": 0,
+                      "color": "rgba(255,130,0,0.851)",
+                      "stroke": {
+                        "color": "rgba(255,255,255,0.502)",
+                        "lineStyle": "solid",
+                        "width": 0.998
+                      },
+                      "size": 4.002000000000001,
+                      "symbol": "circle",
+                      "offset": [0, 0]
+                    }
+                  },
+                  {
+                    "label": "NB",
+                    "visible": true,
+                    "values": ["NB"],
+                    "settings": {
+                      "type": "simpleSymbol",
+                      "rotation": 0,
+                      "color": "rgba(130,130,0,0.851)",
+                      "stroke": {
+                        "color": "rgba(255,255,255,0.502)",
+                        "lineStyle": "solid",
+                        "width": 0.998
+                      },
+                      "size": 4.002000000000001,
+                      "symbol": "circle",
+                      "offset": [0, 0]
+                    }
+                  },
+                  {
+                    "label": "Other",
+                    "visible": true,
+                    "values": [],
+                    "settings": {
+                      "type": "simpleSymbol",
+                      "rotation": 0,
+                      "color": "rgba(130,130,0,0.851)",
+                      "stroke": {
+                        "color": "rgba(255,255,255,0.502)",
+                        "lineStyle": "solid",
+                        "width": 0.998
+                      },
+                      "size": 4.002000000000001,
+                      "symbol": "circle",
+                      "offset": [0, 0]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {
+        "geoviewLayerId": "ogcFeatureLYR1",
+        "geoviewLayerName": "Large Lakes",
+        "metadataAccessPath": "https://b6ryuvakk5.execute-api.us-east-1.amazonaws.com/dev",
+        "geoviewLayerType": "ogcFeature",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "lakes",
+            "layerStyle": {
+              "Polygon": {
+                "type": "uniqueValue",
+                "fields": ["name"],
+                "hasDefault": true,
+                "info": [
+                  {
+                    "label": "Lake Superior",
+                    "visible": true,
+                    "values": ["Lake Superior"],
+                    "settings": {
+                      "type": "filledPolygon",
+                      "color": "rgba(237,81,81,1)",
+                      "stroke": {
+                        "color": "rgba(153,153,153,0.251)",
+                        "lineStyle": "solid",
+                        "width": 0.75
+                      },
+                      "fillStyle": "solid"
+                    }
+                  },
+                  {
+                    "label": "L. Ontario",
+                    "visible": true,
+                    "values": ["L. Ontario"],
+                    "settings": {
+                      "type": "filledPolygon",
+                      "color": "rgba(252,146,31,1)",
+                      "stroke": {
+                        "color": "rgba(153,153,153,0.251)",
+                        "lineStyle": "solid",
+                        "width": 0.75
+                      },
+                      "fillStyle": "solid"
+                    }
+                  },
+                  {
+                    "label": "Other",
+                    "visible": true,
+                    "values": [],
+                    "settings": {
+                      "type": "filledPolygon",
+                      "color": "rgba(170,170,170,1)",
+                      "stroke": {
+                        "color": "rgba(153,153,153,0.251)",
+                        "lineStyle": "solid",
+                        "width": 0.75
+                      },
+                      "fillStyle": "solid"
+                    }
+                  }
+                ]
+              }
+            }
+          }
         ]
       }
     ]

--- a/packages/geoview-core/public/configs/navigator/07-basic-footer-appbar-combo.json
+++ b/packages/geoview-core/public/configs/navigator/07-basic-footer-appbar-combo.json
@@ -72,7 +72,7 @@
                   },
                   {
                     "label": "Other",
-                    "visible": true,
+                    "visible": false,
                     "values": [],
                     "settings": {
                       "type": "filledPolygon",
@@ -159,7 +159,7 @@
                   },
                   {
                     "label": "Other",
-                    "visible": true,
+                    "visible": false,
                     "values": [],
                     "settings": {
                       "type": "simpleSymbol",
@@ -227,7 +227,7 @@
                   },
                   {
                     "label": "Other",
-                    "visible": true,
+                    "visible": false,
                     "values": [],
                     "settings": {
                       "type": "filledPolygon",

--- a/packages/geoview-core/public/configs/navigator/32-shapefile.json
+++ b/packages/geoview-core/public/configs/navigator/32-shapefile.json
@@ -21,6 +21,80 @@
         "geoviewLayerType": "shapefile",
         "geoviewLayerName": "Sunchild Aquafier",
         "metadataAccessPath": "./datasets/shapefiles/DIG_2012_0028.zip"
+      },
+      {
+        "geoviewLayerId": "shpLYR3",
+        "geoviewLayerName": "Wildfire HotSpots - Symbology Test",
+        "metadataAccessPath": "https://cwfis.cfs.nrcan.gc.ca/downloads/hotspots/hotspots.shp",
+        "geoviewLayerType": "shapefile",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "map1-layers-shpLYR3/undefined",
+            "layerStyle": {
+              "Point": {
+                "type": "uniqueValue",
+                "fields": ["SOURCE"],
+                "hasDefault": true,
+                "info": [
+                  {
+                    "label": "NASA3",
+                    "visible": true,
+                    "values": ["NASA3"],
+                    "settings": {
+                      "type": "simpleSymbol",
+                      "rotation": 0,
+                      "color": "rgba(255,130,0,0.851)",
+                      "stroke": {
+                        "color": "rgba(255,255,255,0.502)",
+                        "lineStyle": "solid",
+                        "width": 0.998
+                      },
+                      "size": 4.002000000000001,
+                      "symbol": "circle",
+                      "offset": [0, 0]
+                    }
+                  },
+                  {
+                    "label": "NASA_Can",
+                    "visible": true,
+                    "values": ["NASA_Can"],
+                    "settings": {
+                      "type": "simpleSymbol",
+                      "rotation": 0,
+                      "color": "rgba(130,130,0,0.851)",
+                      "stroke": {
+                        "color": "rgba(255,255,255,0.502)",
+                        "lineStyle": "solid",
+                        "width": 0.998
+                      },
+                      "size": 4.002000000000001,
+                      "symbol": "circle",
+                      "offset": [0, 0]
+                    }
+                  },
+                  {
+                    "label": "Other",
+                    "visible": true,
+                    "values": [],
+                    "settings": {
+                      "type": "simpleSymbol",
+                      "rotation": 0,
+                      "color": "rgba(130,130,0,0.851)",
+                      "stroke": {
+                        "color": "rgba(255,255,255,0.502)",
+                        "lineStyle": "solid",
+                        "width": 0.998
+                      },
+                      "size": 4.002000000000001,
+                      "symbol": "circle",
+                      "offset": [0, 0]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
       }
     ]
   },

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -1019,8 +1019,9 @@ export class GVEsriDynamic extends AbstractGVRaster {
     styleSettings: TypeLayerStyleSettings,
     sourceFeatureInfo: TypeFeatureInfoLayerConfig
   ): string {
-    // GV The below commented code was previously causing the classes to be reversed by adding a 'not' to the query
-    // GV Need to confirm that the 'not' is no longer needed
+    // TODO The below commented code was previously causing the classes to be reversed by adding a 'not' to the query
+    // TO.DO Need to confirm that the 'not' is no longer needed
+    // TO.DO Changed on 2025-05-29 in PR 2916
     // let queryString = styleSettings.info[styleSettings.info.length - 1].visible !== false && !level ? 'not (' : '(';
     let queryString = '(';
     for (let i = 0; i < queryTree.length; i++) {

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -1019,7 +1019,10 @@ export class GVEsriDynamic extends AbstractGVRaster {
     styleSettings: TypeLayerStyleSettings,
     sourceFeatureInfo: TypeFeatureInfoLayerConfig
   ): string {
-    let queryString = styleSettings.info[styleSettings.info.length - 1].visible !== false && !level ? 'not (' : '(';
+    // GV The below commented code was previously causing the classes to be reversed by adding a 'not' to the query
+    // GV Need to confirm that the 'not' is no longer needed
+    // let queryString = styleSettings.info[styleSettings.info.length - 1].visible !== false && !level ? 'not (' : '(';
+    let queryString = '(';
     for (let i = 0; i < queryTree.length; i++) {
       const value = GVEsriDynamic.#formatFieldValue(styleSettings.fields[fieldOrder[level]], queryTree[i].fieldValue, sourceFeatureInfo);
       // The nextField array is not empty, then it is is not the last field

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -34,7 +34,6 @@ import {
   layerEntryIsGroupLayer,
   TypeLayerStatus,
   GeoCoreLayerConfig,
-  CONST_LAYER_TYPES,
   ShapefileLayerConfig,
 } from '@/api/config/types/map-schema-types';
 import { GeoJSON, layerConfigIsGeoJSON } from '@/geo/layer/geoview-layers/vector/geojson';
@@ -1208,10 +1207,8 @@ export class LayerApi {
         if (toggledStyleInfo) toggledStyleInfo.visible = visibility;
       });
 
-      // Force a re-render of the layer source for ESRI Feature to make visibility changes take effect
-      if (this.#layerEntryConfigs[layerPath].schemaTag === CONST_LAYER_TYPES.ESRI_FEATURE) {
-        layer.getOLLayer().changed();
-      }
+      // Force a re-render of the layer source (this is required if there are classes)
+      layer.getOLLayer().changed();
     }
 
     // Update the legend layers if necessary


### PR DESCRIPTION
# Description

2 bugs:

1. Vector layers with classes weren't properly applying the class visibility. If a class was toggled off, the features in that class would remain visible. Refreshing the ol layer on visibility change seems to fix this: layer.getOLLayer().changed();

2. esriDynamic was not applying class visibility properly when configured in the layerStyle. If a class was configured to not be visible, it would actually be visible in the map, and other classes that were supposed to be visible, would actually be not visible in the map. This was being caused by a 'not' being added in the queryString for the REST service. I'm not 100% sure why the 'not' was required, but removing it fixes the issue.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
### Host Updated 2025-05-29 11:30am

Tested the different types of vector layers in the below navigator page. They all seem to apply the class visibility properly in the map.
[App Bar and Footer Bar Combo](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/07-basic-footer-appbar-combo.json)

In the uniqueValue group, the Water Quantity at monitoring stations (not the one in the Test group layer) has three classes visible and the rest turned off. You can see the visibility is applied correctly. Also, the visibility for other layers is also correct and toggling the class visibilities seem to still work properly.
[ESRI Dynamic Navigator](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/16-esri-dynamic.json)

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2916)
<!-- Reviewable:end -->
