### PR TITLE
fix(legend-spinner) Fixes when the legend isn't fully queried and the layer should still be showing the spinner on the icon

### DIFF
--- a/packages/geoview-core/src/api/config/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/config/types/map-schema-types.ts
@@ -956,20 +956,22 @@ export const layerEntryIsImageStatic = (verifyIfLayer: TypeLayerEntryConfig): ve
 };
 
 /**
- * Returns true if the layer entry from the map configuration represents a GeoCore layer type.
- * @param {MapConfigLayerEntry} layerConfigEntryOption The layer entry config to check
- * @returns {boolean} True if the layer type if GeoCore
+ * Type guard that checks if a given map layer configuration entry is of type GeoCore.
+ * @param {MapConfigLayerEntry} layerConfigEntryOption - The layer entry config to check
+ * @returns {layerConfigEntryOption is GeoCoreLayerConfig} True if the layer is a GeoCore layer, narrowing the type to GeoCoreLayerConfig.
  */
-export const mapConfigLayerEntryIsGeoCore = (layerConfigEntryOption: MapConfigLayerEntry): boolean => {
+export const mapConfigLayerEntryIsGeoCore = (layerConfigEntryOption: MapConfigLayerEntry): layerConfigEntryOption is GeoCoreLayerConfig => {
   return layerConfigEntryOption.geoviewLayerType === CONST_LAYER_ENTRY_TYPES.GEOCORE;
 };
 
 /**
- * Returns true if the layer entry from the map configuration represents a shapefile layer type.
- * @param {MapConfigLayerEntry} layerConfigEntryOption The layer entry config to check
- * @returns {boolean} True if the layer type if GeoCore
+ * Type guard that checks if a given map layer configuration entry is of type Shapefile.
+ * @param {MapConfigLayerEntry} layerConfigEntryOption - The layer entry config to check
+ * @returns {layerConfigEntryOption is ShapefileLayerConfig} True if the layer is a Shapefile layer, narrowing the type to ShapefileLayerConfig.
  */
-export const mapConfigLayerEntryIsShapefile = (layerConfigEntryOption: MapConfigLayerEntry): boolean => {
+export const mapConfigLayerEntryIsShapefile = (
+  layerConfigEntryOption: MapConfigLayerEntry
+): layerConfigEntryOption is ShapefileLayerConfig => {
   return layerConfigEntryOption.geoviewLayerType === CONST_LAYER_ENTRY_TYPES.SHAPEFILE;
 };
 

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -203,6 +203,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
    * @returns {TypeRecordOfPlugin} The map plugins record
    */
   static async getMapViewerPlugins(mapId: string): Promise<TypeRecordOfPlugin> {
+    // TODO: Check - Remove the try/catch here to force explicit case-by-case handling instead of via shared function.
     try {
       // Check if the plugins exist
       // TODO: if you run the code fast enough (only happened to me in the TimeSliderEventProcessor),

--- a/packages/geoview-core/src/core/components/common/layer-icon.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-icon.tsx
@@ -140,16 +140,12 @@ export const LayerIcon = memo(function LayerIcon({ layerPath }: LayerIconProps):
 
   // If there is an error in layer or query status, flag it and show icon error
   const isError = layerStatus === 'error' || (layerQueryStatus && layerQueryStatus === 'error');
-
-  // We show the is loading spinner only for first load, once loaded/loading we show icon.
-  // We show a progress bar to notify flip between loading and loaded
-  const isLoading = layerStatus !== 'loaded' && layerStatus !== 'loading' && layerQueryStatus !== 'queried';
-
-  const hasChildren = layerChildren && layerChildren.length;
-
   if (isError) return <ErrorIcon color="error" />;
 
-  if (isLoading) {
+  // If the layer isn't 'loaded' and isn't 'loading', or the legend is still being queried, the icon should show the spinner
+  const showSpinner = (layerStatus !== 'loaded' && layerStatus !== 'loading') || layerQueryStatus === 'querying';
+
+  if (showSpinner) {
     return (
       <Box sx={LOADING_BOX_STYLES}>
         <CircularProgressBase size={20} />
@@ -157,6 +153,7 @@ export const LayerIcon = memo(function LayerIcon({ layerPath }: LayerIconProps):
     );
   }
 
+  const hasChildren = layerChildren && layerChildren.length;
   if (hasChildren) return <GroupWorkOutlinedIcon color="primary" />;
 
   return <IconStack layerPath={layerPath} />;

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -34,7 +34,6 @@ import {
   layerEntryIsGroupLayer,
   TypeLayerStatus,
   GeoCoreLayerConfig,
-  ShapefileLayerConfig,
 } from '@/api/config/types/map-schema-types';
 import { GeoJSON, layerConfigIsGeoJSON } from '@/geo/layer/geoview-layers/vector/geojson';
 import { GeoPackage, layerConfigIsGeoPackage } from '@/geo/layer/geoview-layers/vector/geopackage';
@@ -364,7 +363,7 @@ export class LayerApi {
         const geoCore = new GeoCore(this.getMapId(), this.mapViewer.getDisplayLanguage());
 
         // Create a promise to fetch from UUID
-        const promise = geoCore.createLayersFromUUID(geoviewLayerConfig.geoviewLayerId, geoviewLayerConfig as GeoCoreLayerConfig);
+        const promise = geoCore.createLayersFromUUID(geoviewLayerConfig.geoviewLayerId, geoviewLayerConfig);
 
         // Catch failed promises here. The filled promises will be taken care of with the others below.
         promise.catch((error: unknown) => {
@@ -375,9 +374,7 @@ export class LayerApi {
         // Add the promise to the array
         promisesOfGeoCoreGeoviewLayers.push(promise);
       } else if (mapConfigLayerEntryIsShapefile(geoviewLayerConfig)) {
-        const promise = ShapefileReader.convertShapefileConfigToGeoJson(geoviewLayerConfig as ShapefileLayerConfig) as Promise<
-          TypeGeoviewLayerConfig[]
-        >;
+        const promise = ShapefileReader.convertShapefileConfigToGeoJson(geoviewLayerConfig);
 
         // Catch failed promises here. The filled promises will be taken care of with the others below.
         promise.catch((error: unknown) => {
@@ -389,7 +386,7 @@ export class LayerApi {
         promisesOfGeoCoreGeoviewLayers.push(promise);
       } else {
         // Add a resolved promise for a regular Geoview Layer Config
-        promisesOfGeoCoreGeoviewLayers.push(Promise.resolve([geoviewLayerConfig as TypeGeoviewLayerConfig]));
+        promisesOfGeoCoreGeoviewLayers.push(Promise.resolve([geoviewLayerConfig]));
       }
     }
 

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -678,11 +678,11 @@ export class MapViewer {
 
   /**
    * Set map extent.
-   *
    * @param {Extent} extent - New extent to zoom to.
+   * @returns {Promise<void>} A promise that resolves when the zoom operation completes.
    */
-  async setExtent(extent: Extent): Promise<void> {
-    await MapEventProcessor.zoomToExtent(this.mapId, extent);
+  setExtent(extent: Extent): Promise<void> {
+    return MapEventProcessor.zoomToExtent(this.mapId, extent);
   }
 
   /**
@@ -875,6 +875,7 @@ export class MapViewer {
    *
    * @param {Extent} extent - The extent to zoom to.
    * @param {FitOptions} options - The options to configure the zoomToExtent (default: { padding: [100, 100, 100, 100], maxZoom: 11 }).
+   * @returns {Promise<void>} A promise that resolves when the zoom operation completes.
    */
   zoomToExtent(extent: Extent, options?: FitOptions): Promise<void> {
     // TODO: Discussion - Where is the line between a function using MapEventProcessor in MapViewer vs in MapState action?
@@ -898,6 +899,7 @@ export class MapViewer {
    *
    * @param {Extent | Coordinate} extent - The extent or coordinate to zoom to.
    * @param {FitOptions} options - The options to configure the zoomToExtent (default: { padding: [100, 100, 100, 100], maxZoom: 11 }).
+   * @returns {Promise<void>} A promise that resolves when the zoom operation completes.
    */
   zoomToLonLatExtentOrCoordinate(extent: Extent | Coordinate, options?: FitOptions): Promise<void> {
     const fullExtent = extent.length === 2 ? [extent[0], extent[1], extent[0], extent[1]] : extent;


### PR DESCRIPTION
# Description

Fixes when the legend isn't fully queried and the layer should still be showing the spinner on the icon

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted June 2nd @ 16h00: https://alex-nrcan.github.io/geoview/ **INVALID HOST RIGHT NOW**

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2922)
<!-- Reviewable:end -->
