### PR TITLE
fix(legend): forces style creation for hidden vector layers

### DIFF
--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
@@ -76,6 +76,14 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
     // Apply the layer filter right away if any
     AbstractGVVector.applyViewFilterOnConfig(layerConfig, layerConfig.getExternalFragmentsOrder(), undefined, layerConfig.layerFilter);
 
+    // If the layer is initially not visible, make it visible until the style is set so we have a style for the legend
+    this.onLayerFirstLoaded(() => {
+      if (!this.getStyle() && !this.getVisible()) {
+        this.onLayerStyleChanged(() => this.setVisible(false));
+        this.setVisible(true);
+      }
+    });
+
     // Create and set the OpenLayer layer
     this.olLayer = new VectorLayer<VectorSource<Feature<Geometry>>>(layerOptions);
   }


### PR DESCRIPTION
Closes #2919

# Description

Forces style creation for initially hidden vector layers, so the icon is available in the legend.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/outlier-style.html - point and polygon layer
https://damonu2.github.io/geoview/outlier-geometry.html - multi polygon layer

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/2925)
<!-- Reviewable:end -->
