### PR TITLE
refactor(schema): remove layerIdExtension

### DIFF
--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -223,6 +223,7 @@
       "emptyLayerGroup": "Empty layer group for layer '__param__'.",
       "unableToCreateGroupLayer": "Unable to create group layer '__param__'.",
       "vectorSourceUrlNotDefined": "Vector source URL is not defined for layer '__param__'.",
+      "tooManyEsriFeatures": "Layer '__param__' has too many features to function properly. Consider loading as ESRI Dynamic if possible",
       "vectorTileLayerProjectionMismatch": "Vector tile layer '__param__' projection does not match the map projection.",
       "extentParameterNotDefined": "Parameter extent is not defined in source element for layer '__param__'.",
       "projectionParameterNotDefined": "Parameter projection is not defined in source element for layer '__param__'."

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -223,6 +223,7 @@
       "emptyLayerGroup": "Groupe de couches vide pour la couche '__param__'.",
       "unableToCreateGroupLayer": "Impossible de créer le groupe de couches '__param__'.",
       "vectorSourceUrlNotDefined": "L'URL de la source vectorielle n'est pas définie pour la couche '__param__'.",
+      "tooManyEsriFeatures": "La couche '__param__' a trop de caractéristiques pour fonctionner correctement. Envisager le chargement en tant que ESRI Dynamic si possible",
       "vectorTileLayerProjectionMismatch": "La projection de la couche vectorielle tuilée '__param__' ne correspond pas à celle de la carte.",
       "extentParameterNotDefined": "Le paramètre extent n'est pas défini dans l'élément source pour la couche '__param__'.",
       "projectionParameterNotDefined": "Le paramètre projection n'est pas défini dans l'élément source pour la couche '__param__'."

--- a/packages/geoview-core/src/api/config/types/classes/geoview-config/abstract-geoview-layer-config.ts
+++ b/packages/geoview-core/src/api/config/types/classes/geoview-config/abstract-geoview-layer-config.ts
@@ -404,8 +404,6 @@ export abstract class AbstractGeoviewLayerConfig {
    * The resulting config will then be overwritten by the values provided in the user config.
    */
   applyDefaultValues(): void {
-    this.serviceDateFormat = this.serviceDateFormat || 'DD/MM/YYYY HH:MM:SSZ';
-    this.externalDateFormat = this.externalDateFormat || 'DD/MM/YYYY HH:MM:SSZ';
     this.isTimeAware = this.isTimeAware !== undefined ? this.isTimeAware : true;
   }
 

--- a/packages/geoview-core/src/core/components/layers/left-panel/delete-undo-button.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/delete-undo-button.tsx
@@ -64,13 +64,13 @@ export function DeleteUndoButton(props: DeleteUndoButtonProps): JSX.Element {
     if (isVisible) setOrToggleLayerVisibility(layerPath);
     removeLayerHighlights(layerPath);
     setInUndoState(true);
-    setLayerDeleteInProgress(true);
+    setLayerDeleteInProgress(layerPath);
   };
 
   const handleUndoClick = (): void => {
     setOrToggleLayerVisibility(layerPath);
     setInUndoState(false);
-    setLayerDeleteInProgress(false);
+    setLayerDeleteInProgress('');
   };
 
   const handleDeleteKeyDown = (event: KeyboardEvent): void => {
@@ -94,7 +94,7 @@ export function DeleteUndoButton(props: DeleteUndoButtonProps): JSX.Element {
   useEffect(() => {
     return () => {
       setInUndoState(false);
-      setLayerDeleteInProgress(false);
+      setLayerDeleteInProgress('');
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/geoview-core/src/core/components/layers/left-panel/left-panel.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/left-panel.tsx
@@ -1,4 +1,10 @@
-import { useLayerDisplayState, useLayerLegendLayers } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useEffect } from 'react';
+import {
+  useLayerDeleteInProgress,
+  useLayerDisplayState,
+  useLayerLegendLayers,
+  useLayerStoreActions,
+} from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { LayersList } from './layers-list';
 import { AddNewLayer } from './add-new-layer/add-new-layer';
 import { logger } from '@/core/utils/logger';
@@ -15,6 +21,16 @@ export function LeftPanel({ showLayerDetailsPanel, isLayoutEnlarged }: LeftPanel
   // get from the store
   const legendLayers = useLayerLegendLayers();
   const displayState = useLayerDisplayState();
+  const layerDeleteInProgress = useLayerDeleteInProgress();
+  const { deleteLayer } = useLayerStoreActions();
+
+  useEffect(() => {
+    // Log
+    logger.logTraceUseEffect('LEFT-PANEL - deleteLayer, displayState, layerDeleteInProgress');
+
+    // Delete layer if layerDeleteInProgress is active and user clicks to a different tab.
+    if (displayState !== 'remove' && layerDeleteInProgress) deleteLayer(layerDeleteInProgress);
+  }, [deleteLayer, displayState, layerDeleteInProgress]);
 
   if (displayState === 'add') {
     return <AddNewLayer />;

--- a/packages/geoview-core/src/core/exceptions/layer-exceptions.ts
+++ b/packages/geoview-core/src/core/exceptions/layer-exceptions.ts
@@ -187,6 +187,25 @@ export class LayerEntryConfigLayerIdEsriMustBeNumberError extends LayerError {
 }
 
 /**
+ * Custom error class thrown when the ESRI feature layer has too many features.
+ * @extends {LayerError}
+ */
+export class LayerTooManyEsriFeatures extends LayerError {
+  /**
+   * Constructor to initialize the LayerTooManyEsriFeatures.
+   * This error is thrown when the ESRI feature layer has more than 200 000 features.
+   * @param {string} geoviewLayerId - The ID of the GeoView layer with invalid layer type.
+   * @param {string | undefined} layerName - The layer name.
+   */
+  constructor(geoviewLayerId: string, layerName: string | undefined) {
+    super(geoviewLayerId, 'validation.layer.tooManyEsriFeatures', [layerName || geoviewLayerId]);
+
+    // Ensure correct inheritance (important for transpilation targets)
+    Object.setPrototypeOf(this, LayerTooManyEsriFeatures.prototype);
+  }
+}
+
+/**
  * Custom error class thrown when the MetadataAccessPath is missing for a layer configuration.
  * @extends {LayerError}
  */

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -39,7 +39,7 @@ export interface ILayerState {
   selectedLayerPath: string | undefined | null;
   legendLayers: TypeLegendLayer[];
   displayState: TypeLayersViewDisplayState;
-  layerDeleteInProgress: boolean;
+  layerDeleteInProgress: string;
   selectedLayerSortingArrowId: string;
   layersAreLoading: boolean;
   setDefaultConfigValues: (geoviewConfig: TypeMapFeaturesConfig) => void;
@@ -51,14 +51,14 @@ export interface ILayerState {
     getLayer: (layerPath: string) => TypeLegendLayer | undefined;
     getLayerBounds: (layerPath: string) => number[] | undefined;
     getLayerDefaultFilter: (layerPath: string) => string | undefined;
-    getLayerDeleteInProgress: () => boolean;
+    getLayerDeleteInProgress: () => string;
     getLayerServiceProjection: (layerPath: string) => string | undefined;
     getLayerTemporalDimension: (layerPath: string) => TypeTemporalDimension | undefined;
     refreshLayer: (layerPath: string) => void;
     setAllItemsVisibility: (layerPath: string, visibility: boolean) => void;
     setDisplayState: (newDisplayState: TypeLayersViewDisplayState) => void;
     setHighlightLayer: (layerPath: string) => void;
-    setLayerDeleteInProgress: (newVal: boolean) => void;
+    setLayerDeleteInProgress: (newVal: string) => void;
     setLayerOpacity: (layerPath: string, opacity: number) => void;
     setLayerHoverable: (layerPath: string, enable: boolean) => void;
     setLayerQueryable: (layerPath: string, enable: boolean) => void;
@@ -72,7 +72,7 @@ export interface ILayerState {
   setterActions: {
     setDisplayState: (newDisplayState: TypeLayersViewDisplayState) => void;
     setHighlightLayer: (layerPath: string) => void;
-    setLayerDeleteInProgress: (newVal: boolean) => void;
+    setLayerDeleteInProgress: (newVal: string) => void;
     setLegendLayers: (legendLayers: TypeLegendLayer[]) => void;
     setSelectedLayerPath: (layerPath: string) => void;
     setSelectedLayerSortingArrowId: (arrowId: string) => void;
@@ -92,7 +92,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
     legendLayers: [] as TypeLegendLayer[],
     selectedLayerPath: null,
     displayState: 'view',
-    layerDeleteInProgress: false,
+    layerDeleteInProgress: '',
     selectedLayerSortingArrowId: '',
 
     // Initialize default
@@ -113,7 +113,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
        */
       deleteLayer: (layerPath: string): void => {
         LegendEventProcessor.deleteLayer(get().mapId, layerPath);
-        get().layerState.setterActions.setLayerDeleteInProgress(false);
+        get().layerState.setterActions.setLayerDeleteInProgress('');
       },
 
       /**
@@ -256,9 +256,9 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Sets the layer delete in progress state.
-       * @param {boolean} newVal - The new value.
+       * @param {string} newVal - The new value (the layerPath waiting to be deleted or '').
        */
-      setLayerDeleteInProgress: (newVal: boolean): void => {
+      setLayerDeleteInProgress: (newVal: string): void => {
         // Redirect to setter
         get().layerState.setterActions.setLayerDeleteInProgress(newVal);
       },
@@ -375,9 +375,9 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Sets the layer delete in progress state.
-       * @param {boolean} newVal - The new value.
+       * @param {string} newVal - The new value (the layerPath waiting to be deleted or '').
        */
-      setLayerDeleteInProgress: (newVal: boolean): void => {
+      setLayerDeleteInProgress: (newVal: string): void => {
         set({
           layerState: {
             ...get().layerState,
@@ -468,6 +468,7 @@ export const useLayerSelectedLayer = (): TypeLegendLayer => useStore(useGeoViewS
 export const useLayerSelectedLayerPath = (): string | null | undefined =>
   useStore(useGeoViewStore(), (state) => state.layerState.selectedLayerPath);
 export const useLayerDisplayState = (): TypeLayersViewDisplayState => useStore(useGeoViewStore(), (state) => state.layerState.displayState);
+export const useLayerDeleteInProgress = (): string => useStore(useGeoViewStore(), (state) => state.layerState.layerDeleteInProgress);
 export const useSelectedLayerSortingArrowId = (): string =>
   useStore(useGeoViewStore(), (state) => state.layerState.selectedLayerSortingArrowId);
 export const useLayersAreLoading = (): boolean => useStore(useGeoViewStore(), (state) => state.layerState.layersAreLoading);

--- a/packages/geoview-core/src/core/utils/config/validation-classes/abstract-base-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/abstract-base-layer-entry-config.ts
@@ -23,9 +23,6 @@ import { TimeDimension } from '@/app';
  * Base type used to define a GeoView layer to display on the map.
  */
 export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
-  /** The ending element of the layer configuration path. */
-  override layerIdExtension?: string | undefined = undefined;
-
   /** The metadata associated with the service */
   #serviceMetadata?: TypeJsonObject;
 

--- a/packages/geoview-core/src/core/utils/config/validation-classes/config-base-class.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/config-base-class.ts
@@ -33,9 +33,6 @@ export abstract class ConfigBaseClass {
   // eslint-disable-next-line no-restricted-syntax
   private _layerStatus: TypeLayerStatus = 'newInstance';
 
-  /** The ending extension (element) of the layer identifier. This element is part of the schema. */
-  layerIdExtension?: string;
-
   /** The display name of the layer (English/French). */
   layerName?: string;
 
@@ -347,9 +344,7 @@ export abstract class ConfigBaseClass {
    */
   static #evaluateLayerPath(layerConfig: ConfigBaseClass, layerPath?: string): string {
     let pathEnding = layerPath;
-    if (pathEnding === undefined)
-      pathEnding =
-        layerConfig.layerIdExtension === undefined ? layerConfig.layerId : `${layerConfig.layerId}.${layerConfig.layerIdExtension}`;
+    if (pathEnding === undefined) pathEnding = layerConfig.layerId;
     if (!layerConfig.parentLayerConfig) return `${layerConfig.geoviewLayerConfig.geoviewLayerId}/${pathEnding}`;
     return this.#evaluateLayerPath(
       layerConfig.parentLayerConfig as GroupLayerEntryConfig,
@@ -386,7 +381,6 @@ export abstract class ConfigBaseClass {
     return {
       layerName: this.layerName,
       layerId: this.layerId,
-      layerIdExtension: this.layerIdExtension,
       schemaTag: this.schemaTag,
       entryType: this.entryType,
       layerStatus: this.layerStatus,

--- a/packages/geoview-core/src/core/utils/config/validation-classes/group-layer-entry-config.ts
+++ b/packages/geoview-core/src/core/utils/config/validation-classes/group-layer-entry-config.ts
@@ -12,9 +12,6 @@ export class GroupLayerEntryConfig extends ConfigBaseClass {
   /** Layer entry data type. */
   override entryType = CONST_LAYER_ENTRY_TYPES.GROUP;
 
-  /** The ending element of the layer configuration path is not used on groups. */
-  declare layerIdExtension: never;
-
   /** Source settings to apply to the GeoView layer source at creation time is not used by groups. */
   declare source: never;
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -24,7 +24,11 @@ import { AbstractBaseLayerEntryConfig } from '@/core/utils/config/validation-cla
 import { Projection } from '@/geo/utils/projection';
 import { Fetch } from '@/core/utils/fetch-helper';
 import { TypeJsonObject } from '@/api/config/types/config-types';
-import { LayerDataAccessPathMandatoryError, LayerNoGeographicDataInCSVError } from '@/core/exceptions/layer-exceptions';
+import {
+  LayerDataAccessPathMandatoryError,
+  LayerNoGeographicDataInCSVError,
+  LayerTooManyEsriFeatures,
+} from '@/core/exceptions/layer-exceptions';
 import { LayerEntryConfigVectorSourceURLNotDefinedError } from '@/core/exceptions/layer-entry-config-exceptions';
 import { doUntilPromises } from '@/core/utils/utilities';
 
@@ -113,6 +117,8 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
           // Check and throw exception if the content actually contains an embedded error
           // (EsriFeature type of response might return an embedded error inside a 200 HTTP OK)
           Fetch.throwIfResponseHasEmbeddedError(responseText);
+          // Check if feature count is too large
+          if (JSON.parse(responseText).count > 200000) throw new LayerTooManyEsriFeatures(layerConfig.layerId, layerConfig.getLayerName());
         }
 
         // Parse the result of the fetch to read the features

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -82,10 +82,7 @@ export class GeoJSON extends AbstractGeoViewVector {
    */
   protected override onValidateLayerEntryConfig(layerConfig: TypeLayerEntryConfig): void {
     if (Array.isArray(this.metadata?.listOfLayerEntryConfig)) {
-      const foundEntry = this.#recursiveSearch(
-        `${layerConfig.layerId}${layerConfig.layerIdExtension ? `.${layerConfig.layerIdExtension}` : ''}`,
-        Cast<TypeLayerEntryConfig[]>(this.metadata?.listOfLayerEntryConfig)
-      );
+      const foundEntry = this.#recursiveSearch(layerConfig.layerId, Cast<TypeLayerEntryConfig[]>(this.metadata?.listOfLayerEntryConfig));
       if (!foundEntry) {
         // Add a layer load error
         this.addLayerLoadError(new LayerEntryConfigLayerIdNotFoundError(layerConfig), layerConfig);
@@ -107,7 +104,7 @@ export class GeoJSON extends AbstractGeoViewVector {
     if (this.metadata) {
       // Search for the layer metadata
       const layerMetadataFound = this.#recursiveSearch(
-        `${layerConfig.layerId}${layerConfig.layerIdExtension ? `.${layerConfig.layerIdExtension}` : ''}`,
+        layerConfig.layerId,
         Cast<TypeLayerEntryConfig[]>(this.metadata?.listOfLayerEntryConfig)
       ) as VectorLayerEntryConfig;
 
@@ -204,8 +201,7 @@ export class GeoJSON extends AbstractGeoViewVector {
    */
   #recursiveSearch(searchKey: string, metadataLayerList: TypeLayerEntryConfig[]): TypeLayerEntryConfig | undefined {
     for (const layerMetadata of metadataLayerList) {
-      if (searchKey === `${layerMetadata.layerId}${layerMetadata.layerIdExtension ? `.${layerMetadata.layerIdExtension}` : ''}`)
-        return layerMetadata;
+      if (searchKey === layerMetadata.layerId) return layerMetadata;
       if ('isLayerGroup' in layerMetadata && (layerMetadata.isLayerGroup as boolean)) {
         const foundLayer = this.#recursiveSearch(searchKey, layerMetadata.listOfLayerEntryConfig);
         if (foundLayer) return foundLayer;


### PR DESCRIPTION
# Description

Removes layerIdExtension from code. Also removes some defaults preventing dates being read properly, and adds an error if an ESRI feature layer has more than 200 000 features. Deletes layer if delete is started and user navigates to another layers tab.

Closes #1013
Closes #744
Closes #2877

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
https://damonu2.github.io/geoview/add-layers.html
Add: https://egisp.dfo-mpo.gc.ca/arcgis/rest/services/open_data_donnees_ouvertes/msdi_dynamic_current_layer_couche_dynamique_de_courant_idsm/MapServer/0 - no longer has date errors and loads properly.

Add: https://services.arcgis.com/V6ZHFr6zdgNZuVG0/ArcGIS/rest/services/U2/FeatureServer/0 - Too many features error, will abort load.

https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/06-basic-footer-layers-tab.json - Play around with deleting layers and navigating away from remove tab.

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
