### PR TITLE
fix(basemap): shaded basemap appears over transport

### DIFF
--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -411,23 +411,15 @@ export class BasemapApi {
     this.#startBasemapCreationWatcher();
 
     if (coreBasemapOptions) {
-      // Create shaded layer
-      if (coreBasemapOptions.shaded && this.basemapsList[projectionCode].shaded) {
-        const shadedLayer = await this.#createBasemapLayer('shaded', this.basemapsList[projectionCode].shaded, defaultOpacity, true);
-        if (shadedLayer) {
-          basemapLayers.push(shadedLayer);
-          basemaplayerTypes.push('shaded');
-        }
-      }
-
       // Create transport layer
       if (coreBasemapOptions.basemapId === 'transport' && this.basemapsList[projectionCode].transport) {
         const transportLayer = await this.#createBasemapLayer(
           'transport',
           this.basemapsList[projectionCode].transport,
-          coreBasemapOptions.shaded ? 0.75 : defaultOpacity,
+          defaultOpacity,
           true
         );
+
         if (transportLayer) {
           basemapLayers.push(transportLayer);
           basemaplayerTypes.push('transport');
@@ -438,6 +430,20 @@ export class BasemapApi {
           defaultResolutions = transportLayer.resolutions;
           minZoom = transportLayer.minScale;
           maxZoom = transportLayer.maxScale;
+        }
+      }
+
+      // Create shaded layer
+      if (coreBasemapOptions.shaded && this.basemapsList[projectionCode].shaded) {
+        const shadedLayer = await this.#createBasemapLayer(
+          'shaded',
+          this.basemapsList[projectionCode].shaded,
+          coreBasemapOptions.basemapId === 'transport' ? 0.3 : defaultOpacity,
+          true
+        );
+        if (shadedLayer) {
+          basemapLayers.push(shadedLayer);
+          basemaplayerTypes.push('shaded');
         }
       }
 

--- a/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
@@ -78,7 +78,7 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
    */
   protected override onPropagateToStore(resultSetEntry: TypeFeatureInfoResultSetEntry, type: PropagationType): void {
     // Redirect - Add layer to the list after registration
-    this.#propagateToStore(resultSetEntry, type === 'layer-registration' ? 'name' : 'click');
+    this.#propagateToStore(resultSetEntry, type !== 'layerStatus' ? 'name' : 'click');
   }
 
   /**


### PR DESCRIPTION
Closes #2938

Also prevents switching to details panel on name change.
Closes #2930

# Description

Reorders basemap layers putting transport on the bottom as it does not become transparent with reduced opacity, allowing shaded to be visible.

Prevents changing a layer name from switching tabs to the details panel.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?



# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
