### PR TITLE
feat(outfields): New function to expand ability to replace outfields

### DIFF
--- a/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
@@ -271,7 +271,9 @@ const ResponsiveGridLayout = forwardRef(
           return customGet(guide?.footerPanel?.children, `${key}.content`);
         })
         .filter((item) => item !== undefined)
-        .join('\n');
+        .join('\n')
+        // Remove links
+        .replaceAll(/\[Top\]\(#.*?\)/g, '');
 
       if (!content) return null;
 


### PR DESCRIPTION
Closes #2966
Also removes links from individual guide pages fixing some of #2941

# Description

New method in layers (replaceFeatureOutfields) to completely replace outfields. Also removes "Top" link from guides when split into subsections.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demos-navigator.html?config=./configs/navigator/06-basic-footer-layers-tab.json
In console: cgpv.api.getMapViewer('map1').layer.replaceFeatureOutfields('esriFeatureLYR5/0', 'string,string,oid', 'project_name,province_en,OBJECTID', 'Project Name,Province,Unique ID')

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
