### PR TITLE
feat(drawer): Rotate Text Drawings

### DIFF
--- a/packages/geoview-core/src/api/event-processors/event-processor-children/drawer-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/drawer-event-processor.ts
@@ -571,6 +571,15 @@ export class DrawerEventProcessor extends AbstractEventProcessor {
       viewer.unregisterMapPointerHandlers(viewer.map);
     }
 
+    // If editing already, stop it
+    // GV Moved the stop editing up so the rotation is set properly for any active text drawing
+    if (state.actions.getIsEditing()) {
+      this.stopEditing(mapId);
+    }
+
+    // Clear the text rotation for new features
+    state.actions.setTextRotation(0);
+
     // Get current state values if not provided
     const currentGeomType = geomType || state.actions.getActiveGeom();
     const currentStyle = styleInput || state.actions.getStyle();
@@ -607,11 +616,6 @@ export class DrawerEventProcessor extends AbstractEventProcessor {
     state.actions.setDrawInstance(draw);
     if (geomType) {
       state.actions.setActiveGeom(geomType);
-    }
-
-    // If editing already, stop it
-    if (state.actions.getIsEditing()) {
-      this.stopEditing(mapId);
     }
   }
 

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/drawer-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/drawer-event-processor.ts
@@ -49,6 +49,7 @@ interface TypeGeoJSONStyleProps {
   textHaloWidth?: number;
   textBold?: boolean;
   textItalic?: boolean;
+  textRotation?: number;
 }
 
 const DEFAULT_ICON_SOURCE =
@@ -507,6 +508,7 @@ export class DrawerEventProcessor extends AbstractEventProcessor {
       feature.set('textHaloWidth', style.textHaloWidth);
       feature.set('textBold', style.textBold);
       feature.set('textItalic', style.textItalic);
+      feature.set('textRotation', style.textRotation);
     }
   }
 
@@ -529,6 +531,7 @@ export class DrawerEventProcessor extends AbstractEventProcessor {
       style.textHaloWidth = feature.get('textHaloWidth');
       style.textBold = feature.get('textBold');
       style.textItalic = feature.get('textItalic');
+      style.textRotation = feature.get('textRotation');
     }
 
     // Extract stroke/fill properties from the feature's style
@@ -651,6 +654,7 @@ export class DrawerEventProcessor extends AbstractEventProcessor {
             fill: new Fill({ color: currentStyle.textColor }),
             stroke: new Stroke({ color: currentStyle.textHaloColor, width: currentStyle.textHaloWidth }),
             font: `${currentStyle.textItalic ? 'italic ' : ''}${currentStyle.textBold ? 'bold ' : ''}${currentStyle.textSize}px ${currentStyle.textFont}`,
+            rotation: 0,
           }),
         });
       } else {
@@ -797,6 +801,7 @@ export class DrawerEventProcessor extends AbstractEventProcessor {
         const finalSize = feature.get('textSize') as number;
         const isBold = feature.get('textBold') as boolean;
         const isItalic = feature.get('textItalic') as boolean;
+        const rotation = feature.get('textRotation') as number;
 
         const state = this.getDrawerState(mapId);
         if (!state) return;
@@ -804,6 +809,7 @@ export class DrawerEventProcessor extends AbstractEventProcessor {
         state.actions.setTextSize(finalSize);
         state.actions.setTextBold(isBold);
         state.actions.setTextItalic(isItalic);
+        state.actions.setTextRotation(rotation);
       }
 
       const geom = feature.getGeometry();
@@ -1018,6 +1024,7 @@ export class DrawerEventProcessor extends AbstractEventProcessor {
             fill: new Fill({ color: newStyle.textColor }),
             stroke: new Stroke({ color: newStyle.textHaloColor, width: newStyle.textHaloWidth }),
             font: `${newStyle.textItalic ? 'italic ' : ''}${newStyle.textBold ? 'bold ' : ''}${newStyle.textSize}px ${newStyle.textFont}`,
+            rotation: newStyle.textRotation,
           }),
         });
       } else {
@@ -1175,6 +1182,7 @@ export class DrawerEventProcessor extends AbstractEventProcessor {
                   textHaloWidth: feature.get('textHaloWidth'),
                   textBold: feature.get('textBold'),
                   textItalic: feature.get('textItalic'),
+                  textRotation: feature.get('textRotation'),
                 };
               } else {
                 // point style icon
@@ -1262,6 +1270,7 @@ export class DrawerEventProcessor extends AbstractEventProcessor {
                     width: styleProps.textHaloWidth,
                   }),
                   font: `${styleProps.textItalic ? 'italic ' : ''}${styleProps.textBold ? 'bold ' : ''}${styleProps.textSize}px ${styleProps.textFont}`,
+                  rotation: styleProps.textRotation,
                 }),
               });
             } else {

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/drawer-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/drawer-event-processor.ts
@@ -577,12 +577,13 @@ export class DrawerEventProcessor extends AbstractEventProcessor {
       this.stopEditing(mapId);
     }
 
-    // Clear the text rotation for new features
-    state.actions.setTextRotation(0);
-
     // Get current state values if not provided
     const currentGeomType = geomType || state.actions.getActiveGeom();
     const currentStyle = styleInput || state.actions.getStyle();
+
+    // Make new text horizontal, regardless of what the state rotation was
+    // GV If a style input is added for the rotation, then this can be removed
+    currentStyle.textRotation = 0;
 
     // If drawing already, stop and restart as it's likely a style change
     if (this.getDrawerState(mapId)?.drawInstance) {

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/drawer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/drawer-state.ts
@@ -27,6 +27,7 @@ export type StyleProps = {
   textHaloWidth?: number;
   textBold?: boolean;
   textItalic?: boolean;
+  textRotation?: number;
 };
 
 export type TypeDrawerConfig = {
@@ -86,6 +87,7 @@ export interface IDrawerState {
     setTextHaloWidth: (textHaloWidth: number) => void;
     setTextBold: (textBold: boolean) => void;
     setTextItalic: (textItalic: boolean) => void;
+    setTextRotation: (textRotation: number) => void;
     setDrawInstance(drawInstance: Draw): void;
     removeDrawInstance(): void;
     setTransformInstance(transformInstance: Transform): void;
@@ -122,6 +124,7 @@ export interface IDrawerState {
     setTextHaloWidth: (textHaloWidth: number) => void;
     setTextBold: (textBold: boolean) => void;
     setTextItalic: (textItalic: boolean) => void;
+    setTextRotation: (textRotation: number) => void;
     setDrawInstance: (drawInstance: Draw) => void;
     removeDrawInstance: () => void;
     setIsEditing: (isEditing: boolean) => void;
@@ -160,6 +163,9 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
       textColor: '#000000',
       textHaloColor: 'rgba(255,255,255,0.7)',
       textHaloWidth: 3,
+      textBold: false,
+      textItalic: false,
+      textRotation: 0,
     },
     drawInstance: undefined,
     isEditing: false,
@@ -311,6 +317,10 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         // Redirect to setter
         get().drawerState.setterActions.setTextItalic(textItalic);
       },
+      setTextRotation: (textRotation: number) => {
+        // Redirect to setter
+        get().drawerState.setterActions.setTextRotation(textRotation);
+      },
       setDrawInstance: (drawInstance: Draw) => {
         // Redirect to setter
         get().drawerState.setterActions.setDrawInstance(drawInstance);
@@ -364,6 +374,7 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         DrawerEventProcessor.uploadDrawings(get().mapId, file);
       },
       updateFeatureStyle() {
+        // Refresh the draw instance with the new style
         if (get().drawerState.drawInstance !== undefined) {
           DrawerEventProcessor.startDrawing(get().mapId);
         }
@@ -562,6 +573,19 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
             style: {
               ...get().drawerState.style,
               textItalic,
+            },
+          },
+        });
+        get().drawerState.actions.updateFeatureStyle();
+      },
+
+      setTextRotation: (textRotation: number) => {
+        set({
+          drawerState: {
+            ...get().drawerState,
+            style: {
+              ...get().drawerState.style,
+              textRotation,
             },
           },
         });

--- a/packages/geoview-core/src/geo/interaction/transform/transform-base.ts
+++ b/packages/geoview-core/src/geo/interaction/transform/transform-base.ts
@@ -1929,6 +1929,16 @@ export class OLTransform extends OLPointer {
       // Create rotate handle at end of rotated line
       this.createHandle(rotatedLineEnd, HandleType.ROTATE);
     }
+
+    // Add delete handle if enabled
+    if (this.options.enableDelete) {
+      const offset = this.#getMapBasedPadding() * 1.3;
+      const deletePos: Coordinate = [maxX + offset, minY - offset];
+
+      // Rotate the delete handle position
+      const rotatedDeletePos = OLTransform.rotateCoordinate(deletePos, this.center, -textRotation);
+      this.createHandle(rotatedDeletePos, HandleType.DELETE);
+    }
   }
 
   /**

--- a/packages/geoview-core/src/geo/interaction/transform/transform-base.ts
+++ b/packages/geoview-core/src/geo/interaction/transform/transform-base.ts
@@ -610,7 +610,7 @@ export class OLTransform extends OLPointer {
     handle.set('feature', this.selectedFeature);
 
     // Update Rotate Icon Rotation
-    if (type === HandleType.ROTATE && this.angle !== 0) {
+    if (type === HandleType.ROTATE) {
       const text = ROTATE_STYLE.getText();
       if (text) {
         text.setRotation(this.angle);

--- a/packages/geoview-drawer/src/buttons/style.tsx
+++ b/packages/geoview-drawer/src/buttons/style.tsx
@@ -252,6 +252,15 @@ export function StylePanel(): JSX.Element {
     return () => observer.disconnect();
   }, [displayLanguage]);
 
+  // Preload all Google Fonts
+  useEffect(() => {
+    FONT_OPTIONS.forEach((font) => {
+      if (font.isGoogleFont) {
+        loadGoogleFont(font.name);
+      }
+    });
+  }, []);
+
   /**
    * Render style controls in navbar panel
    * @returns ReactNode
@@ -276,7 +285,12 @@ export function StylePanel(): JSX.Element {
               select
               value={style.textFont || DEFAULT_FONT}
               onChange={handleFontChange}
-              sx={sxClasses.input}
+              sx={{
+                ...sxClasses.input,
+                '& .MuiNativeSelect-select': {
+                  fontFamily: style.textFont || DEFAULT_FONT,
+                },
+              }}
               slotProps={{
                 select: {
                   native: true,
@@ -284,7 +298,7 @@ export function StylePanel(): JSX.Element {
               }}
             >
               {FONT_OPTIONS.map((font) => (
-                <option key={font.value} value={font.value}>
+                <option key={font.value} value={font.value} style={{ fontFamily: font.value }}>
                   {font.name}
                 </option>
               ))}


### PR DESCRIPTION
# Description

Add the extent box and the rotate handle to text when transforming / editing. Can manually turn the text to rotate it.

Fixes #3004 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
### Host Updated 2025-08-22 10:00am

Place text and edit/rotate it. Place other features, click between them. Download and Re-Upload the drawings. Draw new text after rotating.

[Drawer Navigator Page](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/12-package-drawer.json)

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3007)
<!-- Reviewable:end -->
