### PR TITLE
fix(config): geocore datatAccessPath set to undefined from createMapC…

### DIFF
--- a/packages/geoview-core/schema.json
+++ b/packages/geoview-core/schema.json
@@ -202,6 +202,7 @@
         "selectedTab": {
           "type": "string",
           "enum": [
+            "",
             "legend",
             "layers",
             "details",
@@ -274,6 +275,7 @@
         "selectedTab": {
           "type": "string",
           "enum": [
+            "",
             "geolocator",
             "geochart",
             "details",
@@ -791,7 +793,10 @@
           }
         }
       },
-      "required": ["type", "codedValues"]
+      "required": [
+        "type",
+        "codedValues"
+      ]
     },
     "codeValueEntryType": {
       "description": "The structure of a code value.",

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -400,10 +400,10 @@ export function AddNewLayer(): JSX.Element {
         );
 
         // Set the layer type as it may have changed in the case of GeoCore for example
-        setLayerType(curlayerType);
+        setLayerType(geoviewLayerConfig.geoviewLayerType);
 
         // Update UI
-        setLayerURL(layerURL);
+        setLayerURL(layerURL.startsWith('blob') ? layerURL : geoviewLayerConfig.metadataAccessPath || layerURL);
 
         // Get the name and ID of the first entry before deleting the listOfLayerEntryConfig
         const idOfFirstLayerEntryConfig = geoviewLayerConfig.listOfLayerEntryConfig[0]?.layerId;


### PR DESCRIPTION
…onfigFromMapState

Closes #3008
Closes #3010 

# Description

Fixes issue with geocore layers not loading from config made with createMapConfigFromMapState. Changes dataAccessPath being set to empty string to undefined.

Also fixes some minor issues in add layers causing ESRI feature, geoJSON and geocore to fail to load

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/demo-osdp-integration.html
Add layers, update config with current map state, refresh map.

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3009)
<!-- Reviewable:end -->
