### PR TITLE
Migrated some function in config to static functions for clarity.

### DIFF
--- a/packages/geoview-core/public/configs/OSDP/osdp-health_en.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-health_en.json
@@ -80,7 +80,6 @@
       {
         "geoviewLayerId": "21b821cf-0f1c-40ee-8925-eab12d357668",
         "geoviewLayerName": "The Canadian Radiological Monitoring Network - Airborne Radioactivity",
-        "zIndex": 2,
         "metadataAccessPath": "",
         "geoviewLayerType": "geoCore",
         "initialSettings": {

--- a/packages/geoview-core/public/configs/package-swiper3-config.json
+++ b/packages/geoview-core/public/configs/package-swiper3-config.json
@@ -27,7 +27,7 @@
                     "name": "band-0-pixel-value",
                     "alias": "Pixel value",
                     "type": "number",
-                    "domain": []
+                    "domain": null
                   }
                 ]
               }

--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -355,7 +355,8 @@
       "mapIdAlreadyExists": "Map with ID '__param__' already exists.",
       "geoviewStoreNotFound": "GeoView Store on Map '__param__' not found.",
       "mapDivNotExists": "Div with id ${divId} does not exist",
-      "mapWrongCall": "Div with id __param__ has a class 'geoview-map' and should be initialized via a 'cgpv.init()' call."
+      "mapWrongCall": "Div with id __param__ has a class 'geoview-map' and should be initialized via a 'cgpv.init()' call.",
+      "pluginStateUninitialized": "The Plugin state for '__param__' on Map '__param__' is uninitialized"
     },
     "geocore": {
       "uuidNotFound": "GeoCore layer identifier '__param__' does not exist on the server.",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -355,7 +355,8 @@
       "mapIdAlreadyExists": "La carte avec l'identifiant '__param__' existe déjà.",
       "geoviewStoreNotFound": "Le 'React Store' sur la carte '__param__' est introuvable.",
       "mapDivNotExists": "Div avec identifiant __param__ does not exist.",
-      "mapWrongCall": "Div avec identifiant __param__ a une classe 'geoview-map' et devrait être initialisé via un appel à 'cgpv.init()'."
+      "mapWrongCall": "Div avec identifiant __param__ a une classe 'geoview-map' et devrait être initialisé via un appel à 'cgpv.init()'.",
+      "pluginStateUninitialized": "L'état du Plugin '__param__' sur la carte '__param__' n'est pas initialisé."
     },
     "geocore": {
       "uuidNotFound": "L'identifiant de couche GeoCore '__param__' n'existe pas sur le serveur.",

--- a/packages/geoview-core/public/templates/config-sandbox2.html
+++ b/packages/geoview-core/public/templates/config-sandbox2.html
@@ -223,6 +223,11 @@
         url: 'https://ahocevar.com/geoserver/wfs?REQUEST=GetCapabilities&VERSION=2.0.0&SERVICE=WFS',
         layerIds: ['usa:states']
       },
+      'WKB - Rivers': {
+        type: 'WKB',
+        url: 'https://some-wkb-url/rivers',
+        layerIds: ['rivers']
+      },
       'Geocore - Airborne': {
         type: 'geoCore',
         url: '21b821cf-0f1c-40ee-8925-eab12d357668',
@@ -240,7 +245,8 @@
       },
       'GeoPackage - Rivers': {
         type: 'GeoPackage',
-        url: 'https://canadian-geospatial-platform.github.io/geoview/public/datasets/geopackages/rivers.gpkg'
+        url: 'https://canadian-geospatial-platform.github.io/geoview/public/datasets/geopackages/rivers.gpkg',
+        layerIds: ['rivers']
       }
     };
 
@@ -353,7 +359,7 @@
         showHideLoadingProcess(true);
 
         // If a geocore or shapefile
-        if (layerType === 'geoCore' || layerType === 'shapefile') {
+        if (layerType === 'geoCore' || layerType === 'shapefile' || layerType === 'GeoPackage') {
           // It's a geocore or shapefile, first initialize it and get the layer tree
           const initializedLayerConfig = await cgpv.api.config.createInitConfigFromType(
             layerType,

--- a/packages/geoview-core/src/api/config/config-api.ts
+++ b/packages/geoview-core/src/api/config/config-api.ts
@@ -48,6 +48,7 @@ import { ImageStatic } from '@/geo/layer/geoview-layers/raster/image-static';
 import { OgcFeature } from '@/geo/layer/geoview-layers/vector/ogc-feature';
 import { VectorTiles } from '@/geo/layer/geoview-layers/raster/vector-tiles';
 import { WFS } from '@/geo/layer/geoview-layers/vector/wfs';
+import { WKB } from '@/geo/layer/geoview-layers/vector/wkb';
 import { WMS } from '@/geo/layer/geoview-layers/raster/wms';
 import { XYZTiles } from '@/geo/layer/geoview-layers/raster/xyz-tiles';
 
@@ -167,9 +168,10 @@ export class ConfigApi {
    * Converts the stringMapFeatureConfig to a json object. Comments will be removed from the string.
    * @param {string} stringMapFeatureConfig The map configuration string to convert to JSON format.
    * @returns {MapFeatureConfig | undefined} A JSON map feature configuration object.
+   * @static
    * @private
    */
-  static convertStringToJson(stringMapFeatureConfig: string): MapFeatureConfig | undefined {
+  static #convertStringToJson(stringMapFeatureConfig: string): MapFeatureConfig | undefined {
     // Erase comments in the config file.
     let newStringMapFeatureConfig = removeCommentsFromJSON(stringMapFeatureConfig);
 
@@ -308,14 +310,16 @@ export class ConfigApi {
     // If the user provided a string config, translate it to a json object because the MapFeatureConfig constructor
     // doesn't accept string config. Note that convertStringToJson returns undefined if the string config cannot
     // be translated to a json object.
-    const providedMapFeatureConfig = typeof mapConfig === 'string' ? ConfigApi.convertStringToJson(mapConfig)! : mapConfig;
-
-    // Validate the map config
-    ConfigApi.validateSchema(MAP_CONFIG_SCHEMA_PATH, providedMapFeatureConfig);
-
     try {
-      // If the user provided a valid string config with the mandatory map property, process geocore layers to translate them to their GeoView layers
+      const providedMapFeatureConfig = typeof mapConfig === 'string' ? ConfigApi.#convertStringToJson(mapConfig) : mapConfig;
+
+      // Validate
       if (!providedMapFeatureConfig) throw new MapConfigError('The string configuration provided cannot be translated to a json object');
+
+      // Validate the map config
+      ConfigApi.validateSchema(MAP_CONFIG_SCHEMA_PATH, providedMapFeatureConfig);
+
+      // Validate
       if (!providedMapFeatureConfig.map) throw new MapConfigError('The map property is mandatory');
 
       // Instanciate the mapFeatureConfig. If an error is detected, a workaround procedure
@@ -435,6 +439,8 @@ export class ConfigApi {
         return EsriFeature.initGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL);
       case 'GeoJSON':
         return GeoJSON.initGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL);
+      case 'WKB':
+        return WKB.initGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL);
       case 'ogcFeature':
         return OgcFeature.initGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL);
       case 'ogcWfs':
@@ -491,14 +497,14 @@ export class ConfigApi {
     layerIds: number[] | string[]
   ): Promise<ConfigBaseClass[]> {
     // Depending on the type
-    // TODO: Check - Check, for ALL layers here, if there's a way to better determine the isTimeAware flag, defaults to false, how is it used here?
+    // TODO: Check - Config init - Check, for ALL layers here, if there's a way to better determine the isTimeAware flag, defaults to false, how is it used here?
     switch (layerType) {
       case 'esriDynamic':
         return EsriDynamic.processGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL, layerIds as number[], false);
       case 'esriImage':
         return EsriImage.processGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL, false);
       case 'imageStatic':
-        // TODO: Check - Check if there's a way to better determine the source extent to send, defaults to napl-ring-of-fire's extent
+        // TODO: Check - Config init - Check if there's a way to better determine the source extent to send, defaults to napl-ring-of-fire's extent
         return ImageStatic.processGeoviewLayerConfig(
           geoviewLayerId,
           geoviewLayerName,
@@ -509,10 +515,10 @@ export class ConfigApi {
           4326
         );
       case 'vectorTiles':
-        // TODO: Check - Check if there's a way to better determine the projection to send, defaults to 'EPSG:3978'
+        // TODO: Check - Config init - Check if there's a way to better determine the projection to send, defaults to 'EPSG:3978'
         return VectorTiles.processGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL, layerIds as string[], false, 'EPSG:3978');
       case 'ogcWms':
-        // TODO: Check - Check if there's a way to better determine the typeOfServer to send, defaults to 'mapserver'
+        // TODO: Check - Config init - Check if there's a way to better determine the typeOfServer to send, defaults to 'mapserver'
         return WMS.processGeoviewLayerConfig(
           geoviewLayerId,
           geoviewLayerName,
@@ -530,10 +536,12 @@ export class ConfigApi {
         return EsriFeature.processGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL, layerIds as number[], false);
       case 'GeoJSON':
         return GeoJSON.processGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL, layerIds as string[], false);
+      case 'WKB':
+        return WKB.processGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL, layerIds as string[], false);
       case 'ogcFeature':
         return OgcFeature.processGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL, layerIds as string[], false);
       case 'ogcWfs':
-        // TODO: Check - Check if there's a way to better determine the typeOfServer to send, defaults to 'all'
+        // TODO: Check - Config init - Check if there's a way to better determine the typeOfServer to send, defaults to 'all'
         return WFS.processGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL, layerIds as string[], false, 'all');
       default:
         // Unsupported

--- a/packages/geoview-core/src/api/config/geocore.ts
+++ b/packages/geoview-core/src/api/config/geocore.ts
@@ -14,7 +14,7 @@ import { GeoViewError } from '@/core/exceptions/geoview-exceptions';
  * @exports
  * @class GeoCore
  */
-export abstract class GeoCore {
+export class GeoCore {
   /**
    * Gets GeoView layer configurations list from the UUIDs of the list of layer entry configurations.
    * @param {string} uuid - The UUID of the layer
@@ -75,8 +75,7 @@ export abstract class GeoCore {
       // Use the name from the first layer if none is provided in the config
       if (!tempLayerConfig.geoviewLayerName) tempLayerConfig.geoviewLayerName = response.layers[0].geoviewLayerName;
 
-      const config = new Config(language);
-      const newLayerConfig = config.prevalidateGeoviewLayersConfig([tempLayerConfig], (errorKey: string, params: string[]) => {
+      const newLayerConfig = Config.prevalidateGeoviewLayersConfig([tempLayerConfig], (errorKey: string, params: string[]) => {
         // When an error happens, raise the exception, we handle it higher in this case
         throw new GeoViewError(errorKey, params);
       });

--- a/packages/geoview-core/src/api/config/reader/geopackage-reader.ts
+++ b/packages/geoview-core/src/api/config/reader/geopackage-reader.ts
@@ -64,6 +64,7 @@ export class GeoPackageReader {
       geoviewLayerId: layerConfig.geoviewLayerId,
       geoviewLayerName: layerConfig.geoviewLayerName,
       geoviewLayerType: CONST_LAYER_TYPES.WKB,
+      metadataAccessPath: layerConfig.metadataAccessPath,
       initialSettings: layerConfig.initialSettings,
       listOfLayerEntryConfig: [],
     };
@@ -96,12 +97,12 @@ export class GeoPackageReader {
             // Find layer data for the sublayer
             const matchingLayerData = layersData.find((layerData) => layerData.name === sublayerEntryConfig.layerId);
             if (matchingLayerData) {
-              const { layerId, initialSettings } = sublayerEntryConfig;
+              const { layerId } = sublayerEntryConfig;
               const layerName = ConfigBaseClass.getClassOrTypeLayerName(sublayerEntryConfig);
               listOfSubLayerEntryConfig.push(
                 new WkbLayerEntryConfig({
                   geoviewLayerConfig,
-                  initialSettings,
+                  initialSettings: ConfigBaseClass.getClassOrTypeInitialSettings(sublayerEntryConfig),
                   layerId,
                   layerName: layerName || matchingLayerData.name,
                   layerStyle: matchingLayerData.styleSld ? GeoPackageReader.#processGeopackageStyle(matchingLayerData.styleSld) : undefined,

--- a/packages/geoview-core/src/api/config/reader/shapefile-reader.ts
+++ b/packages/geoview-core/src/api/config/reader/shapefile-reader.ts
@@ -5,8 +5,9 @@ import {
   GeoJSONLayerEntryConfig,
   GeoJSONLayerEntryConfigProps,
 } from '@/api/config/validation-classes/vector-validation-classes/geojson-layer-entry-config';
+import { ConfigBaseClass } from '@/api/config/validation-classes/config-base-class';
+import { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
 import { generateId } from '@/core/utils/utilities';
-import { AbstractBaseLayerEntryConfig } from '../validation-classes/abstract-base-layer-entry-config';
 import { Fetch } from '@/core/utils/fetch-helper';
 
 /**
@@ -77,7 +78,7 @@ export class ShapefileReader {
         layerId: geojson.fileName || filename || generateId(),
         layerName: layerConfig.geoviewLayerName || geojson.fileName,
         layerStyle: AbstractBaseLayerEntryConfig.getClassOrTypeLayerStyle(passedLayerEntryConfig),
-        initialSettings: passedLayerEntryConfig?.initialSettings,
+        initialSettings: ConfigBaseClass.getClassOrTypeInitialSettings(passedLayerEntryConfig),
         source: {
           format: 'GeoJSON',
           geojson: JSON.stringify(geojson),

--- a/packages/geoview-core/src/api/config/reader/uuid-config-reader.ts
+++ b/packages/geoview-core/src/api/config/reader/uuid-config-reader.ts
@@ -148,7 +148,7 @@ export class UUIDmapConfigReader {
             );
           } else if (layerType === CONST_LAYER_TYPES.WFS) {
             // Redirect
-            // TODO: Check - Check if there's a way to better determine the vector strategy to send, defaults to 'all'
+            // TODO: Check - Config init - Check if there's a way to better determine the vector strategy to send, defaults to 'all'
             geoviewLayerConfig = WFS.createGeoviewLayerConfig(idClean, layerName, layerUrl, layerIsTimeAware, 'all', layerEntries);
           } else if (layerType === CONST_LAYER_TYPES.OGC_FEATURE) {
             // Redirect

--- a/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
@@ -1,5 +1,10 @@
 import { TypeLayerStyleConfig, TypeStyleGeometry, TypeLayerStyleSettings } from '@/api/types/map-schema-types';
-import { ConfigAbstractBaseClassOrType, TypeBaseSourceInitialConfig } from '@/api/types/layer-schema-types';
+import {
+  ConfigAbstractBaseClassOrType,
+  TypeBaseSourceInitialConfig,
+  TypeGeoviewLayerType,
+  TypeLayerEntryType,
+} from '@/api/types/layer-schema-types';
 import { ConfigBaseClass, ConfigBaseClassProps } from '@/api/config/validation-classes/config-base-class';
 import { TimeDimension } from '@/core/utils/date-mgt';
 import { FilterNodeType } from '@/geo/utils/renderer/geoview-renderer-types';
@@ -55,8 +60,12 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
    * The class constructor.
    * @param {AbstractBaseLayerEntryConfigProps} layerConfig - The layer configuration we want to instanciate.
    */
-  protected constructor(layerConfig: AbstractBaseLayerEntryConfigProps | AbstractBaseLayerEntryConfig) {
-    super(layerConfig);
+  protected constructor(
+    layerConfig: AbstractBaseLayerEntryConfigProps | AbstractBaseLayerEntryConfig,
+    schemaTag: TypeGeoviewLayerType,
+    entryType: TypeLayerEntryType
+  ) {
+    super(layerConfig, schemaTag, entryType);
 
     // Keep attribute properties
     this.source = layerConfig.source;
@@ -241,7 +250,7 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
     const serialized = super.onToJson<T>() as any;
 
     // Copy values
-    serialized.initialSettings = this.initialSettings;
+    serialized.initialSettings = this.getInitialSettings();
     serialized.attributions = this.getAttributions();
     serialized.source = this.source;
 

--- a/packages/geoview-core/src/api/config/validation-classes/group-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/group-layer-entry-config.ts
@@ -9,22 +9,15 @@ export interface GroupLayerEntryConfigProps extends ConfigBaseClassProps {
  * Type used to define a layer group.
  */
 export class GroupLayerEntryConfig extends ConfigBaseClass {
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.GROUP;
-
   /** The layer entry props that were used in the constructor. */
   declare layerEntryProps: GroupLayerEntryConfigProps;
 
-  /** Tag used to link the entry to a specific schema is not used by groups. */
-  // TODO: Refactor - This attribute should be removed and logic applied using OO pattern once the constructor is cleaned up.
-  declare schemaTag: never;
-
   /** Source settings to apply to the GeoView layer source at creation time is not used by groups. */
-  // TODO: Refactor - This attribute should be removed and logic applied using OO pattern once the constructor is cleaned up.
+  // TODO: Refactor - Config - This attribute should be removed and logic applied using OO pattern once the constructor is cleaned up.
   declare source: never;
 
   /** The list of layer entry configurations to use from the GeoView layer group. */
-  // TODO: Refactor - Try to type this as ConfigBaseClass[] instead of TypeLayerEntryConfig[]
+  // TODO: Refactor - Config - TypeLayerEntryConfig - Try to type this as ConfigBaseClass[] instead of TypeLayerEntryConfig[]
   listOfLayerEntryConfig: TypeLayerEntryConfig[];
 
   /**
@@ -33,7 +26,7 @@ export class GroupLayerEntryConfig extends ConfigBaseClass {
    */
   // TO: Until this is fixed, this constructor supports sending a GroupLayerEntryConfig in its typing, for now (GroupLayerEntryConfigProps | GroupLayerEntryConfig)... though it should only be a GroupLayerEntryConfigProps eventually
   constructor(layerConfig: GroupLayerEntryConfigProps | GroupLayerEntryConfig) {
-    super(layerConfig);
+    super(layerConfig, undefined, CONST_LAYER_ENTRY_TYPES.GROUP);
     this.listOfLayerEntryConfig = layerConfig.listOfLayerEntryConfig || [];
   }
 

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/esri-dynamic-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/esri-dynamic-layer-entry-config.ts
@@ -21,12 +21,6 @@ export interface EsriDynamicLayerEntryConfigProps extends AbstractBaseLayerEntry
  * Type used to define a GeoView image layer to display on the map.
  */
 export class EsriDynamicLayerEntryConfig extends AbstractBaseLayerEntryConfig {
-  /** Tag used to link the entry to a specific schema. */
-  override schemaTag = CONST_LAYER_TYPES.ESRI_DYNAMIC;
-
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.RASTER_IMAGE;
-
   /** The layer entry props that were used in the constructor. */
   declare layerEntryProps: EsriDynamicLayerEntryConfigProps;
 
@@ -41,7 +35,7 @@ export class EsriDynamicLayerEntryConfig extends AbstractBaseLayerEntryConfig {
    * @param {EsriDynamicLayerEntryConfigProps | EsriDynamicLayerEntryConfig} layerConfig - The layer configuration we want to instanciate.
    */
   constructor(layerConfig: EsriDynamicLayerEntryConfigProps | EsriDynamicLayerEntryConfig) {
-    super(layerConfig);
+    super(layerConfig, CONST_LAYER_TYPES.ESRI_DYNAMIC, CONST_LAYER_ENTRY_TYPES.RASTER_IMAGE);
     this.maxRecordCount = layerConfig.maxRecordCount;
 
     // Write the default properties when not specified

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/esri-image-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/esri-image-layer-entry-config.ts
@@ -18,12 +18,6 @@ export interface EsriImageLayerEntryConfigProps extends AbstractBaseLayerEntryCo
  * Type used to define a GeoView image layer to display on the map.
  */
 export class EsriImageLayerEntryConfig extends AbstractBaseLayerEntryConfig {
-  /** Tag used to link the entry to a specific schema. */
-  override schemaTag = CONST_LAYER_TYPES.ESRI_IMAGE;
-
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.RASTER_IMAGE;
-
   /** The layer entry props that were used in the constructor. */
   declare layerEntryProps: EsriImageLayerEntryConfigProps;
 
@@ -35,7 +29,7 @@ export class EsriImageLayerEntryConfig extends AbstractBaseLayerEntryConfig {
    * @param {EsriImageLayerEntryConfigProps | EsriImageLayerEntryConfig} layerConfig - The layer configuration we want to instanciate.
    */
   constructor(layerConfig: EsriImageLayerEntryConfigProps | EsriImageLayerEntryConfig) {
-    super(layerConfig);
+    super(layerConfig, CONST_LAYER_TYPES.ESRI_IMAGE, CONST_LAYER_ENTRY_TYPES.RASTER_IMAGE);
 
     // Write the default properties when not specified
     this.source ??= {};

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/image-static-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/image-static-layer-entry-config.ts
@@ -13,12 +13,6 @@ export interface ImageStaticLayerEntryConfigProps extends AbstractBaseLayerEntry
  * Type used to define a GeoView image layer to display on the map.
  */
 export class ImageStaticLayerEntryConfig extends AbstractBaseLayerEntryConfig {
-  /** Tag used to link the entry to a specific schema. */
-  override schemaTag = CONST_LAYER_TYPES.IMAGE_STATIC;
-
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.RASTER_IMAGE;
-
   /** The layer entry props that were used in the constructor. */
   declare layerEntryProps: ImageStaticLayerEntryConfigProps;
 
@@ -30,7 +24,7 @@ export class ImageStaticLayerEntryConfig extends AbstractBaseLayerEntryConfig {
    * @param {ImageStaticLayerEntryConfigProps | ImageStaticLayerEntryConfig} layerConfig -  The layer configuration we want to instanciate.
    */
   constructor(layerConfig: ImageStaticLayerEntryConfigProps | ImageStaticLayerEntryConfig) {
-    super(layerConfig);
+    super(layerConfig, CONST_LAYER_TYPES.IMAGE_STATIC, CONST_LAYER_ENTRY_TYPES.RASTER_IMAGE);
 
     // Write the default properties when not specified
     this.source.dataAccessPath ??= layerConfig.source.dataAccessPath ?? this.geoviewLayerConfig.metadataAccessPath;

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
@@ -20,12 +20,6 @@ export interface OgcWmsLayerEntryConfigProps extends AbstractBaseLayerEntryConfi
  * Type used to define a GeoView image layer to display on the map.
  */
 export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
-  /** Tag used to link the entry to a specific schema. */
-  override schemaTag = CONST_LAYER_TYPES.WMS;
-
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.RASTER_IMAGE;
-
   /** The layer entry props that were used in the constructor. */
   declare layerEntryProps: OgcWmsLayerEntryConfigProps;
 
@@ -37,7 +31,7 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
    * @param {OgcWmsLayerEntryConfigProps | OgcWmsLayerEntryConfig} layerConfig - The layer configuration we want to instanciate.
    */
   constructor(layerConfig: OgcWmsLayerEntryConfigProps | OgcWmsLayerEntryConfig) {
-    super(layerConfig);
+    super(layerConfig, CONST_LAYER_TYPES.WMS, CONST_LAYER_ENTRY_TYPES.RASTER_IMAGE);
 
     // Write the default properties when not specified
     this.source ??= {};

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/vector-tiles-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/vector-tiles-layer-entry-config.ts
@@ -1,5 +1,6 @@
 import {
   ConfigVectorTilesClassOrType,
+  CONST_LAYER_ENTRY_TYPES,
   CONST_LAYER_TYPES,
   TypeMetadataVectorTiles,
   TypeSourceTileInitialConfig,
@@ -16,9 +17,6 @@ export interface VectorTilesLayerEntryConfigProps extends AbstractBaseLayerEntry
 }
 
 export class VectorTilesLayerEntryConfig extends TileLayerEntryConfig {
-  /** Tag used to link the entry to a specific schema. */
-  override schemaTag = CONST_LAYER_TYPES.VECTOR_TILES;
-
   declare source: TypeSourceTileInitialConfig;
 
   /** The style url */
@@ -29,7 +27,7 @@ export class VectorTilesLayerEntryConfig extends TileLayerEntryConfig {
    * @param {VectorTilesLayerEntryConfigProps | VectorTilesLayerEntryConfig} layerConfig - The layer configuration we want to instanciate.
    */
   constructor(layerConfig: VectorTilesLayerEntryConfigProps | VectorTilesLayerEntryConfig) {
-    super(layerConfig);
+    super(layerConfig, CONST_LAYER_TYPES.VECTOR_TILES, CONST_LAYER_ENTRY_TYPES.RASTER_TILE);
 
     // Keep attributes
     this.#styleUrl = VectorTilesLayerEntryConfig.getClassOrTypeStyleUrl(layerConfig);

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/xyz-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/xyz-layer-entry-config.ts
@@ -13,12 +13,6 @@ export interface XYZTilesLayerEntryConfigProps extends AbstractBaseLayerEntryCon
 }
 
 export class XYZTilesLayerEntryConfig extends TileLayerEntryConfig {
-  /** Tag used to link the entry to a specific schema. */
-  override schemaTag = CONST_LAYER_TYPES.XYZ_TILES;
-
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.RASTER_IMAGE;
-
   /** The layer entry props that were used in the constructor. */
   declare layerEntryProps: XYZTilesLayerEntryConfigProps;
 
@@ -35,7 +29,7 @@ export class XYZTilesLayerEntryConfig extends TileLayerEntryConfig {
    * @param {XYZTilesLayerEntryConfigProps | XYZTilesLayerEntryConfigProps} layerConfig - The layer configuration we want to instanciate.
    */
   constructor(layerConfig: XYZTilesLayerEntryConfigProps | XYZTilesLayerEntryConfigProps) {
-    super(layerConfig);
+    super(layerConfig, CONST_LAYER_TYPES.XYZ_TILES, CONST_LAYER_ENTRY_TYPES.RASTER_IMAGE);
     this.minScaleDenominator = layerConfig.minScaleDenominator || 0;
     this.maxScaleDenominator = layerConfig.maxScaleDenominator || 0;
 

--- a/packages/geoview-core/src/api/config/validation-classes/tile-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/tile-layer-entry-config.ts
@@ -1,13 +1,24 @@
-import { CONST_LAYER_ENTRY_TYPES, TypeSourceTileInitialConfig } from '@/api/types/layer-schema-types';
-import { AbstractBaseLayerEntryConfig } from './abstract-base-layer-entry-config';
+import { TypeGeoviewLayerType, TypeLayerEntryType, TypeSourceTileInitialConfig } from '@/api/types/layer-schema-types';
+import { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
+import { XYZTilesLayerEntryConfigProps } from '@/api/config/validation-classes/raster-validation-classes/xyz-layer-entry-config';
+import { VectorTilesLayerEntryConfigProps } from '@/api/config/validation-classes/raster-validation-classes/vector-tiles-layer-entry-config';
 
 /**
  * Type used to define a GeoView image layer to display on the map.
  */
 export abstract class TileLayerEntryConfig extends AbstractBaseLayerEntryConfig {
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.RASTER_TILE;
-
   /** Initial settings to apply to the GeoView image layer source at creation time. */
   declare source: TypeSourceTileInitialConfig;
+
+  /**
+   * The class constructor.
+   * @param {VectorLayerEntryConfigProps | TileLayerEntryConfig} layerConfig - The layer configuration we want to instanciate.
+   */
+  protected constructor(
+    layerConfig: VectorTilesLayerEntryConfigProps | XYZTilesLayerEntryConfigProps | TileLayerEntryConfig,
+    schemaTag: TypeGeoviewLayerType,
+    entryType: TypeLayerEntryType
+  ) {
+    super(layerConfig, schemaTag, entryType);
+  }
 }

--- a/packages/geoview-core/src/api/config/validation-classes/vector-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/vector-layer-entry-config.ts
@@ -1,4 +1,9 @@
-import { CONST_LAYER_ENTRY_TYPES, TypeLayerMetadataVector, TypeVectorSourceInitialConfig } from '@/api/types/layer-schema-types';
+import {
+  CONST_LAYER_ENTRY_TYPES,
+  TypeGeoviewLayerType,
+  TypeLayerMetadataVector,
+  TypeVectorSourceInitialConfig,
+} from '@/api/types/layer-schema-types';
 import {
   AbstractBaseLayerEntryConfig,
   AbstractBaseLayerEntryConfigProps,
@@ -16,9 +21,6 @@ export interface VectorLayerEntryConfigProps extends AbstractBaseLayerEntryConfi
  */
 // TODO: Refactor - This class should be named 'AbstractVectorLayerEntryConfig' to align with others
 export abstract class VectorLayerEntryConfig extends AbstractBaseLayerEntryConfig {
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.VECTOR;
-
   /** The layer entry props that were used in the constructor. */
   declare layerEntryProps: VectorLayerEntryConfigProps;
 
@@ -32,8 +34,8 @@ export abstract class VectorLayerEntryConfig extends AbstractBaseLayerEntryConfi
    * The class constructor.
    * @param {VectorLayerEntryConfigProps | VectorLayerEntryConfig} layerConfig - The layer configuration we want to instanciate.
    */
-  protected constructor(layerConfig: VectorLayerEntryConfigProps | VectorLayerEntryConfig) {
-    super(layerConfig);
+  protected constructor(layerConfig: VectorLayerEntryConfigProps | VectorLayerEntryConfig, schemaTag: TypeGeoviewLayerType) {
+    super(layerConfig, schemaTag, CONST_LAYER_ENTRY_TYPES.VECTOR);
     this.maxRecordCount = layerConfig.maxRecordCount;
   }
 

--- a/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/csv-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/csv-layer-entry-config.ts
@@ -1,6 +1,6 @@
 import { VectorLayerEntryConfig, VectorLayerEntryConfigProps } from '@/api/config/validation-classes/vector-layer-entry-config';
 import { TypeSourceCSVInitialConfig } from '@/geo/layer/geoview-layers/vector/csv';
-import { CONST_LAYER_ENTRY_TYPES, CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
+import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import { Projection } from '@/geo/utils/projection';
 
 export interface CsvLayerEntryConfigProps extends VectorLayerEntryConfigProps {
@@ -13,12 +13,6 @@ export interface CsvLayerEntryConfigProps extends VectorLayerEntryConfigProps {
 }
 
 export class CsvLayerEntryConfig extends VectorLayerEntryConfig {
-  /** Tag used to link the entry to a specific schema. */
-  override schemaTag = CONST_LAYER_TYPES.CSV;
-
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.VECTOR;
-
   /** The layer entry props that were used in the constructor. */
   declare layerEntryProps: CsvLayerEntryConfigProps;
 
@@ -33,7 +27,7 @@ export class CsvLayerEntryConfig extends VectorLayerEntryConfig {
    * @param {CsvLayerEntryConfigProps | CsvLayerEntryConfig} layerConfig - The layer configuration we want to instanciate.
    */
   constructor(layerConfig: CsvLayerEntryConfigProps | CsvLayerEntryConfig) {
-    super(layerConfig);
+    super(layerConfig, CONST_LAYER_TYPES.CSV);
     this.valueSeparator = layerConfig.valueSeparator;
 
     // Write the default properties when not specified

--- a/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/esri-feature-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/esri-feature-layer-entry-config.ts
@@ -1,4 +1,4 @@
-import { CONST_LAYER_ENTRY_TYPES, CONST_LAYER_TYPES, TypeLayerMetadataEsri } from '@/api/types/layer-schema-types';
+import { CONST_LAYER_TYPES, TypeLayerMetadataEsri } from '@/api/types/layer-schema-types';
 import { VectorLayerEntryConfig, VectorLayerEntryConfigProps } from '@/api/config/validation-classes/vector-layer-entry-config';
 import { TypeSourceEsriFeatureInitialConfig } from '@/geo/layer/geoview-layers/vector/esri-feature';
 
@@ -8,12 +8,6 @@ export interface EsriFeatureLayerEntryConfigProps extends VectorLayerEntryConfig
 }
 
 export class EsriFeatureLayerEntryConfig extends VectorLayerEntryConfig {
-  /** Tag used to link the entry to a specific schema. */
-  override schemaTag = CONST_LAYER_TYPES.ESRI_FEATURE;
-
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.VECTOR;
-
   /** The layer entry props that were used in the constructor. */
   declare layerEntryProps: EsriFeatureLayerEntryConfigProps;
 
@@ -24,7 +18,7 @@ export class EsriFeatureLayerEntryConfig extends VectorLayerEntryConfig {
    * @param {EsriFeatureLayerEntryConfigProps | EsriFeatureLayerEntryConfig} layerConfig - The layer configuration we want to instanciate.
    */
   constructor(layerConfig: EsriFeatureLayerEntryConfigProps | EsriFeatureLayerEntryConfig) {
-    super(layerConfig);
+    super(layerConfig, CONST_LAYER_TYPES.ESRI_FEATURE);
     this.maxRecordCount = layerConfig.maxRecordCount;
 
     // Write the default properties when not specified

--- a/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/geojson-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/geojson-layer-entry-config.ts
@@ -1,5 +1,5 @@
 import { VectorLayerEntryConfig, VectorLayerEntryConfigProps } from '@/api/config/validation-classes/vector-layer-entry-config';
-import { CONST_LAYER_ENTRY_TYPES, CONST_LAYER_TYPES, TypeSourceGeoJSONInitialConfig } from '@/api/types/layer-schema-types';
+import { CONST_LAYER_TYPES, TypeSourceGeoJSONInitialConfig } from '@/api/types/layer-schema-types';
 import { Projection } from '@/geo/utils/projection';
 
 export interface GeoJSONLayerEntryConfigProps extends VectorLayerEntryConfigProps {
@@ -8,12 +8,6 @@ export interface GeoJSONLayerEntryConfigProps extends VectorLayerEntryConfigProp
 }
 
 export class GeoJSONLayerEntryConfig extends VectorLayerEntryConfig {
-  /** Tag used to link the entry to a specific schema. */
-  override schemaTag = CONST_LAYER_TYPES.GEOJSON;
-
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.VECTOR;
-
   /** The layer entry props that were used in the constructor. */
   declare layerEntryProps: GeoJSONLayerEntryConfigProps;
 
@@ -24,7 +18,7 @@ export class GeoJSONLayerEntryConfig extends VectorLayerEntryConfig {
    * @param {GeoJSONLayerEntryConfigProps | GeoJSONLayerEntryConfig} layerConfig - The layer configuration we want to instanciate.
    */
   constructor(layerConfig: GeoJSONLayerEntryConfigProps | GeoJSONLayerEntryConfig) {
-    super(layerConfig);
+    super(layerConfig, CONST_LAYER_TYPES.GEOJSON);
 
     // Value for this.source.format can only be GeoJSON.
     this.source ??= { format: 'GeoJSON' };

--- a/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/ogc-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/ogc-layer-entry-config.ts
@@ -1,9 +1,4 @@
-import {
-  CONST_LAYER_ENTRY_TYPES,
-  CONST_LAYER_TYPES,
-  TypeLayerMetadataOGC,
-  TypeSourceOgcFeatureInitialConfig,
-} from '@/api/types/layer-schema-types';
+import { CONST_LAYER_TYPES, TypeLayerMetadataOGC, TypeSourceOgcFeatureInitialConfig } from '@/api/types/layer-schema-types';
 import { VectorLayerEntryConfig, VectorLayerEntryConfigProps } from '@/api/config/validation-classes/vector-layer-entry-config';
 import { Projection } from '@/geo/utils/projection';
 
@@ -13,12 +8,6 @@ export interface OgcFeatureLayerEntryConfigProps extends VectorLayerEntryConfigP
 }
 
 export class OgcFeatureLayerEntryConfig extends VectorLayerEntryConfig {
-  /** Tag used to link the entry to a specific schema. */
-  override schemaTag = CONST_LAYER_TYPES.OGC_FEATURE;
-
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.VECTOR;
-
   /** The layer entry props that were used in the constructor. */
   declare layerEntryProps: OgcFeatureLayerEntryConfigProps;
 
@@ -29,7 +18,7 @@ export class OgcFeatureLayerEntryConfig extends VectorLayerEntryConfig {
    * @param {OgcFeatureLayerEntryConfigProps | OgcFeatureLayerEntryConfig} layerConfig - The layer configuration we want to instanciate.
    */
   constructor(layerConfig: OgcFeatureLayerEntryConfigProps | OgcFeatureLayerEntryConfig) {
-    super(layerConfig);
+    super(layerConfig, CONST_LAYER_TYPES.OGC_FEATURE);
 
     // Value for this.source.format can only be featureAPI.
     this.source ??= { format: 'featureAPI' };

--- a/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/wfs-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/wfs-layer-entry-config.ts
@@ -1,9 +1,4 @@
-import {
-  CONST_LAYER_ENTRY_TYPES,
-  CONST_LAYER_TYPES,
-  TypeLayerMetadataWfs,
-  TypeSourceWFSVectorInitialConfig,
-} from '@/api/types/layer-schema-types';
+import { CONST_LAYER_TYPES, TypeLayerMetadataWfs, TypeSourceWFSVectorInitialConfig } from '@/api/types/layer-schema-types';
 import { VectorLayerEntryConfig, VectorLayerEntryConfigProps } from '@/api/config/validation-classes/vector-layer-entry-config';
 import { Projection } from '@/geo/utils/projection';
 
@@ -13,12 +8,6 @@ export interface WfsLayerEntryConfigProps extends VectorLayerEntryConfigProps {
 }
 
 export class WfsLayerEntryConfig extends VectorLayerEntryConfig {
-  /** Tag used to link the entry to a specific schema. */
-  override schemaTag = CONST_LAYER_TYPES.WFS;
-
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.VECTOR;
-
   /** The layer entry props that were used in the constructor. */
   declare layerEntryProps: WfsLayerEntryConfigProps;
 
@@ -29,7 +18,7 @@ export class WfsLayerEntryConfig extends VectorLayerEntryConfig {
    * @param {WfsLayerEntryConfigProps | WfsLayerEntryConfig} layerConfig - The layer configuration we want to instanciate.
    */
   constructor(layerConfig: WfsLayerEntryConfigProps | WfsLayerEntryConfig) {
-    super(layerConfig);
+    super(layerConfig, CONST_LAYER_TYPES.WFS);
 
     // Value for this.source.format can only be WFS.
     this.source ??= { format: 'WFS' };

--- a/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/wkb-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/wkb-layer-entry-config.ts
@@ -1,5 +1,5 @@
 import { VectorLayerEntryConfig, VectorLayerEntryConfigProps } from '@/api/config/validation-classes/vector-layer-entry-config';
-import { CONST_LAYER_ENTRY_TYPES, CONST_LAYER_TYPES, TypeSourceWkbVectorInitialConfig } from '@/api/types/layer-schema-types';
+import { CONST_LAYER_TYPES, TypeSourceWkbVectorInitialConfig } from '@/api/types/layer-schema-types';
 import { Projection } from '@/geo/utils/projection';
 
 export interface WkbLayerEntryConfigProps extends VectorLayerEntryConfigProps {
@@ -8,12 +8,6 @@ export interface WkbLayerEntryConfigProps extends VectorLayerEntryConfigProps {
 }
 
 export class WkbLayerEntryConfig extends VectorLayerEntryConfig {
-  /** Tag used to link the entry to a specific schema. */
-  override schemaTag = CONST_LAYER_TYPES.WKB;
-
-  /** Layer entry data type. */
-  override entryType = CONST_LAYER_ENTRY_TYPES.VECTOR;
-
   /** The layer entry props that were used in the constructor. */
   declare layerEntryProps: WkbLayerEntryConfigProps;
 
@@ -24,7 +18,7 @@ export class WkbLayerEntryConfig extends VectorLayerEntryConfig {
    * @param {WkbLayerEntryConfigProps | WkbLayerEntryConfig} layerConfig - The layer configuration we want to instanciate.
    */
   constructor(layerConfig: WkbLayerEntryConfigProps | WkbLayerEntryConfig) {
-    super(layerConfig);
+    super(layerConfig, CONST_LAYER_TYPES.WKB);
 
     // Value for this.source.format can only be WKB.
     this.source ??= { format: 'WKB' };

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/geochart-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/geochart-event-processor.ts
@@ -5,6 +5,7 @@ import {
   TypeGeochartResultSetEntry,
 } from '@/core/stores/store-interface-and-intial-values/geochart-state';
 import { GeoViewGeoChartConfig } from '@/api/config/reader/uuid-config-reader';
+import { PluginStateUninitializedError } from '@/core/exceptions/geoview-exceptions';
 import { logger } from '@/core/utils/logger';
 
 import { AbstractEventProcessor, BatchedPropagationLayerDataArrayByMap } from '@/api/event-processors/abstract-event-processor';
@@ -63,6 +64,7 @@ export class GeochartEventProcessor extends AbstractEventProcessor {
   // GV ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
 
   // #region
+
   // Holds the list of layer data arrays being buffered in the propagation process for the batch
   static #batchedPropagationLayerDataArray: BatchedPropagationLayerDataArrayByMap<TypeGeochartResultSetEntry> = {};
 
@@ -72,29 +74,53 @@ export class GeochartEventProcessor extends AbstractEventProcessor {
   static #timeDelayBetweenPropagationsForBatch = 2000;
 
   /**
-   * Shortcut to get the Geochart state for a given map id
-   * @param {string} mapId The mapId
-   * @returns {IGeochartState | undefined} The Geochart state. Forcing the return to also be 'undefined', because
-   *                                       there will be no geochartState if the Geochart plugin isn't active.
-   *                                       This helps the developers making sure the existence is checked.
+   * Checks if the Geochart plugin is iniitialized for the given map.
+   * @param {string} mapId - The map id
+   * @returns {boolean} True when the Geochart plugin is initialized.
    */
-  protected static getGeochartState(mapId: string): IGeochartState | undefined {
-    // Return the geochart state when it exists
-    return super.getState(mapId).geochartState;
+  static isGeochartInitialized(mapId: string): boolean {
+    try {
+      // Get its state, this will throw PluginStateUninitializedError if uninitialized
+      this.getGeochartState(mapId);
+      return true;
+    } catch {
+      // Uninitialized
+      return false;
+    }
+  }
+
+  /**
+   * Shortcut to get the Geochart state for a given map id
+   * @param {string} mapId - The mapId
+   * @returns {IGeochartState} The Geochart state.
+   * @throws {PluginStateUninitializedError} When the Geochart plugin is uninitialized.
+   */
+  protected static getGeochartState(mapId: string): IGeochartState {
+    // Get the geochart state
+    const { geochartState } = super.getState(mapId);
+
+    // If not found
+    if (!geochartState) throw new PluginStateUninitializedError('Geochart', mapId);
+
+    // Return it
+    return geochartState;
   }
 
   /**
    * Get a specific state.
    * @param {string} mapId - The mapId
    * @param {'geochartChartsConfig' | 'layerDataArray' | 'layerDataArrayBatchLayerPathBypass' | 'selectedLayerPath'} state - The state to get
-   * @returns {string | TypeGeochartResultSetEntry[] | GeoChartStoreByLayerPath | undefined} The requested state
+   * @returns {string | TypeGeochartResultSetEntry[] | GeoChartStoreByLayerPath} The requested state
    */
   static getSingleGeochartState(
     mapId: string,
     state: 'geochartChartsConfig' | 'layerDataArray' | 'layerDataArrayBatchLayerPathBypass' | 'selectedLayerPath'
-  ): string | TypeGeochartResultSetEntry[] | GeoChartStoreByLayerPath | undefined {
-    if (this.getGeochartState(mapId)) return this.getGeochartState(mapId)![state];
-    return undefined;
+  ): string | TypeGeochartResultSetEntry[] | GeoChartStoreByLayerPath {
+    // Get the geochart state which is only initialized if the Geochart Plugin exists.
+    const geochartState = this.getGeochartState(mapId);
+
+    // Return the state
+    return geochartState[state];
   }
 
   /**
@@ -104,8 +130,12 @@ export class GeochartEventProcessor extends AbstractEventProcessor {
    *
    * @param {string} mapId the map id
    * @param {GeoViewGeoChartConfig[]} charts The array of JSON configuration for GeoChart
+   * @throws {PluginStateUninitializedError} When the Geochart plugin is uninitialized.
    */
   static setGeochartCharts(mapId: string, charts: GeoViewGeoChartConfig[]): void {
+    // Get the geochart state which is only initialized if the Geochart Plugin exists.
+    const geochartState = this.getGeochartState(mapId);
+
     // The store object representation
     const chartData: GeoChartStoreByLayerPath = {};
 
@@ -122,7 +152,7 @@ export class GeochartEventProcessor extends AbstractEventProcessor {
     });
 
     // Set store charts config
-    this.getGeochartState(mapId)?.setterActions.setGeochartCharts(chartData);
+    geochartState.setterActions.setGeochartCharts(chartData);
 
     // If there is chart data, tab should not be hidden
     if (Object.keys(chartData).length) UIEventProcessor.showTab(mapId, 'geochart');
@@ -136,18 +166,18 @@ export class GeochartEventProcessor extends AbstractEventProcessor {
    * @param {string} mapId The map ID
    * @param {string} layerPath The layer path
    * @param {GeoViewGeoChartConfig} chartConfig The Geochart Configuration
+   * @throws {PluginStateUninitializedError} When the Geochart plugin is uninitialized.
    */
   static addGeochartChart(mapId: string, layerPath: string, chartConfig: GeoViewGeoChartConfig): void {
-    // The processor needs an initialized chart store which is only initialized if the Geochart plugin exists.
-    // Therefore, we validate its existence first.
-    if (!this.getGeochartState(mapId)) return;
+    // Get the geochart state which is only initialized if the Geochart Plugin exists.
+    const geochartState = this.getGeochartState(mapId);
 
     // Config to add
     const toAdd: GeoChartStoreByLayerPath = {};
     toAdd[layerPath] = chartConfig;
 
     // Update the layer data array in the store
-    this.getGeochartState(mapId)!.setterActions.setGeochartCharts({ ...this.getGeochartState(mapId)?.geochartChartsConfig, ...toAdd });
+    geochartState.setterActions.setGeochartCharts({ ...geochartState.geochartChartsConfig, ...toAdd });
 
     // Make sure tab is not hidden
     UIEventProcessor.showTab(mapId, 'geochart');
@@ -160,26 +190,28 @@ export class GeochartEventProcessor extends AbstractEventProcessor {
    * Removes a GeoChart Configuration at the specified map id and layer path
    * @param {string} mapId The map ID
    * @param {string} layerPath The layer path
+   * @throws {PluginStateUninitializedError} When the Geochart plugin is uninitialized.
    */
   static removeGeochartChart(mapId: string, layerPath: string): void {
-    // The processor needs an initialized chart store which is only initialized if the Geochart plugin exists.
-    // Therefore, we validate its existence first.
-    if (!this.getGeochartState(mapId)) return;
-    if (!this.getGeochartState(mapId)?.geochartChartsConfig) return;
+    // Get the geochart state which is only initialized if the Geochart Plugin exists.
+    const geochartState = this.getGeochartState(mapId);
+
+    // If no geochartChartsConfig, return
+    if (!geochartState.geochartChartsConfig) return;
 
     // Config to remove
-    if (Object.keys(this.getGeochartState(mapId)!.geochartChartsConfig).includes(layerPath)) {
+    if (Object.keys(geochartState.geochartChartsConfig).includes(layerPath)) {
       // Grab the config
-      const chartConfigs = this.getGeochartState(mapId)!.geochartChartsConfig;
+      const chartConfigs = geochartState.geochartChartsConfig;
 
       // Delete the config
       delete chartConfigs[layerPath];
 
       // Update the layer data array in the store
-      this.getGeochartState(mapId)!.setterActions.setGeochartCharts({ ...chartConfigs });
+      geochartState.setterActions.setGeochartCharts({ ...chartConfigs });
 
       // If there are no more geochart layers, hide tab
-      if (!Object.keys(this.getGeochartState(mapId)!.geochartChartsConfig).length) UIEventProcessor.hideTab(mapId, 'geochart');
+      if (!Object.keys(geochartState.geochartChartsConfig).length) UIEventProcessor.hideTab(mapId, 'geochart');
 
       // Log
       logger.logInfo('Removed GeoChart configs for layer path:', layerPath);
@@ -191,15 +223,15 @@ export class GeochartEventProcessor extends AbstractEventProcessor {
    * @param {string} mapId The map id
    * @param {TypeGeochartResultSetEntry[]} layerDataArray The layer data array to propagate in the store
    * @returns {Promise<void>}
+   * @throws {PluginStateUninitializedError} When the Geochart plugin is uninitialized.
    * @private
    */
   static #propagateArrayDataToStore(mapId: string, layerDataArray: TypeGeochartResultSetEntry[]): void {
-    // To propagate in the store, the processor needs an initialized chart store which is only initialized if the Geochart plugin exists.
-    // Therefore, we validate its existence first.
-    if (!this.getGeochartState(mapId)) return;
+    // Get the geochart state which is only initialized if the Geochart Plugin exists.
+    const geochartState = this.getGeochartState(mapId);
 
     // Update the layer data array in the store
-    this.getGeochartState(mapId)!.setterActions.setLayerDataArray(layerDataArray);
+    geochartState.setterActions.setLayerDataArray(layerDataArray);
   }
 
   /**
@@ -211,15 +243,12 @@ export class GeochartEventProcessor extends AbstractEventProcessor {
    * @param {string} mapId - The map id
    * @param {TypeGeochartResultSetEntry[]} layerDataArray - The layer data array to batch on
    * @returns {Promise<void>} Promise upon completion
+   * @throws {PluginStateUninitializedError} When the Geochart plugin is uninitialized.
    * @private
    */
   static #propagateFeatureInfoToStoreBatch(mapId: string, layerDataArray: TypeGeochartResultSetEntry[]): Promise<void> {
-    // To propagate in the store, the processor needs an initialized chart store which is only initialized if the Geochart plugin exists.
-    // Therefore, we validate its existence first.
-    if (!this.getGeochartState(mapId)) return Promise.resolve();
-
-    // The geochart state as validated
-    const geochartState = this.getGeochartState(mapId)!;
+    // Get the geochart state which is only initialized if the Geochart Plugin exists.
+    const geochartState = this.getGeochartState(mapId);
 
     // Redirect to batch propagate
     return this.helperPropagateArrayStoreBatch(

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -1,6 +1,6 @@
 import { Extent, TypeLayerStyleSettings, TypeFeatureInfoEntry, TypeStyleGeometry } from '@/api/types/map-schema-types';
 import { TimeDimension } from '@/core/utils/date-mgt';
-import { CONST_LAYER_TYPES, TypeGeoviewLayerType, TypeLayerControls } from '@/api/types/layer-schema-types';
+import { CONST_LAYER_TYPES, TypeLayerControls } from '@/api/types/layer-schema-types';
 import { TypeLegendLayer, TypeLegendLayerItem, TypeLegendItem } from '@/core/components/layers/types';
 import { TypeWmsLegend, isImageStaticLegend, isVectorLegend, isWmsLegend } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { ConfigBaseClass } from '@/api/config/validation-classes/config-base-class';
@@ -314,18 +314,20 @@ export class LegendEventProcessor extends AbstractEventProcessor {
     const setLayerControls = (layerConfig: ConfigBaseClass, isChild: boolean = false): TypeLayerControls => {
       const removeDefault = isChild ? MapEventProcessor.getGeoViewMapConfig(mapId)?.globalSettings?.canRemoveSublayers !== false : true;
 
-      const controls: TypeLayerControls = {
-        highlight: layerConfig.initialSettings?.controls?.highlight !== undefined ? layerConfig.initialSettings?.controls?.highlight : true,
-        hover: layerConfig.initialSettings?.controls?.hover !== undefined ? layerConfig.initialSettings?.controls?.hover : false,
-        opacity: layerConfig.initialSettings?.controls?.opacity !== undefined ? layerConfig.initialSettings?.controls?.opacity : true,
-        query: layerConfig.initialSettings?.controls?.query !== undefined ? layerConfig.initialSettings?.controls?.query : false,
-        remove: layerConfig.initialSettings?.controls?.remove !== undefined ? layerConfig.initialSettings?.controls?.remove : removeDefault,
-        table: layerConfig.initialSettings?.controls?.table !== undefined ? layerConfig.initialSettings?.controls?.table : true,
-        visibility:
-          layerConfig.initialSettings?.controls?.visibility !== undefined ? layerConfig.initialSettings?.controls?.visibility : true,
-        zoom: layerConfig.initialSettings?.controls?.zoom !== undefined ? layerConfig.initialSettings?.controls?.zoom : true,
+      // Get the initial settings
+      const initialSettings = layerConfig.getInitialSettings();
+
+      // Get the layer controls using default values when needed
+      return {
+        highlight: initialSettings?.controls?.highlight ?? true, // default: true
+        hover: initialSettings?.controls?.hover ?? false, // default: false
+        opacity: initialSettings?.controls?.opacity ?? true, // default: true
+        query: initialSettings?.controls?.query ?? false, // default: false
+        remove: initialSettings?.controls?.remove ?? removeDefault, // default: removeDefault
+        table: initialSettings?.controls?.table ?? true, // default: true
+        visibility: initialSettings?.controls?.visibility ?? true, // default: true
+        zoom: initialSettings?.controls?.zoom ?? true, // default: true
       };
-      return controls;
     };
 
     // TODO: refactor - avoid nested function relying on outside parameter like layerPathNodes
@@ -368,9 +370,9 @@ export class LegendEventProcessor extends AbstractEventProcessor {
             layerName,
             layerStatus: legendResultSetEntry.layerStatus,
             legendQueryStatus: legendResultSetEntry.legendQueryStatus,
-            type: layerConfig.entryType as TypeGeoviewLayerType,
+            type: layerConfig.getSchemaTag(),
             canToggle: legendResultSetEntry.data?.type !== CONST_LAYER_TYPES.ESRI_IMAGE,
-            opacity: layerConfig.initialSettings?.states?.opacity ? layerConfig.initialSettings.states.opacity : 1,
+            opacity: layerConfig.getInitialSettings()?.states?.opacity ?? 1, // default: 1
             icons: [] as TypeLegendLayerItem[],
             items: [] as TypeLegendItem[],
             children: [] as TypeLegendLayer[],
@@ -414,11 +416,11 @@ export class LegendEventProcessor extends AbstractEventProcessor {
           layerStatus: legendResultSetEntry.layerStatus,
           legendQueryStatus: legendResultSetEntry.legendQueryStatus,
           styleConfig: legendResultSetEntry.data?.styleConfig,
-          type: legendResultSetEntry.data?.type || (layerConfig.entryType as TypeGeoviewLayerType),
+          type: legendResultSetEntry.data?.type || layerConfig.getSchemaTag(),
           canToggle: legendResultSetEntry.data?.type !== CONST_LAYER_TYPES.ESRI_IMAGE,
-          opacity: layerConfig.initialSettings?.states?.opacity || 1,
-          hoverable: layerConfig.initialSettings?.states?.hoverable,
-          queryable: layerConfig.initialSettings?.states?.queryable,
+          opacity: layerConfig.getInitialSettings()?.states?.opacity ?? 1,
+          hoverable: layerConfig.getInitialSettings()?.states?.hoverable,
+          queryable: layerConfig.getInitialSettings()?.states?.queryable,
           items: [] as TypeLegendItem[],
           children: [] as TypeLegendLayer[],
           icons: icons || [],
@@ -591,13 +593,9 @@ export class LegendEventProcessor extends AbstractEventProcessor {
     // TODO Update after refactor, layerEntryConfig will not know initial settings
     const layerEntryConfig = MapEventProcessor.getMapViewerLayerAPI(mapId).getLayerEntryConfig(layerPath);
 
-    // Set the layer status to loading
-    // TODO: Cleanup - Don't do this anymore, the loading status is handled automatically via the enhanced onLoading/onLoaded functions (2025-06-17)
-    // layerEntryConfig?.setLayerStatusLoading();
-
     // Reset layer states to original values
-    const opacity = layerEntryConfig?.initialSettings.states?.opacity || 1;
-    const visibility = layerEntryConfig?.initialSettings.states?.visible || true;
+    const opacity = layerEntryConfig?.getInitialSettings().states?.opacity ?? 1; // default: 1
+    const visibility = layerEntryConfig?.getInitialSettings().states?.visible ?? true; // default: true
     LegendEventProcessor.setLayerOpacity(mapId, layerPath, opacity);
     MapEventProcessor.setOrToggleMapLayerVisibility(mapId, layerPath, visibility);
 

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -1208,7 +1208,13 @@ export class MapEventProcessor extends AbstractEventProcessor {
     if (geoviewLayer) {
       const initialFilter = this.getInitialFilter(mapId, layerPath);
       const tableFilter = DataTableEventProcessor.getTableFilter(mapId, layerPath);
-      const sliderFilter = TimeSliderEventProcessor.getTimeSliderFilter(mapId, layerPath);
+
+      // If the TimeSlider is initialized
+      let sliderFilter;
+      if (TimeSliderEventProcessor.isTimeSliderInitialized(mapId)) {
+        // Assign it for the return
+        sliderFilter = TimeSliderEventProcessor.getTimeSliderFilter(mapId, layerPath);
+      }
       return [initialFilter, tableFilter, sliderFilter].filter((filter) => filter);
     }
     return undefined;
@@ -1234,11 +1240,14 @@ export class MapEventProcessor extends AbstractEventProcessor {
     ) {
       // Depending on the instance
       if (geoviewLayer instanceof GVWMS || geoviewLayer instanceof GVEsriImage) {
-        // Read filter information
-        const filter = TimeSliderEventProcessor.getTimeSliderFilter(mapId, layerPath);
+        // If the Time Slider is initialized
+        if (TimeSliderEventProcessor.isTimeSliderInitialized(mapId)) {
+          // Read filter information
+          const filter = TimeSliderEventProcessor.getTimeSliderFilter(mapId, layerPath);
 
-        // If filter was defined
-        if (filter) geoviewLayer.applyViewFilter(filter);
+          // If filter was defined
+          if (filter) geoviewLayer.applyViewFilter(filter);
+        }
       } else {
         // Read filter information
         const filters = this.getActiveVectorFilters(mapId, layerPath) || [''];
@@ -1285,11 +1294,11 @@ export class MapEventProcessor extends AbstractEventProcessor {
         hoverable: orderedLayerInfo.hoverable,
       },
       controls: legendLayerInfo.controls,
-      bounds: layerEntryConfig.initialSettings.bounds,
-      className: layerEntryConfig.initialSettings.className,
-      extent: layerEntryConfig.initialSettings.extent,
-      minZoom: layerEntryConfig.initialSettings.minZoom,
-      maxZoom: layerEntryConfig.initialSettings.maxZoom,
+      bounds: layerEntryConfig.getInitialSettings().bounds,
+      className: layerEntryConfig.getInitialSettings().className,
+      extent: layerEntryConfig.getInitialSettings().extent,
+      minZoom: layerEntryConfig.getInitialSettings().minZoom,
+      maxZoom: layerEntryConfig.getInitialSettings().maxZoom,
     };
   }
 
@@ -1542,8 +1551,12 @@ export class MapEventProcessor extends AbstractEventProcessor {
         if (selectedDataTableLayerPath) newMapConfig.footerBar.selectedDataTableLayerPath = selectedDataTableLayerPath as string;
         const selectedLayerLayerPath = LegendEventProcessor.getLayerPanelState(mapId, 'selectedLayerPath');
         if (selectedLayerLayerPath) newMapConfig.footerBar.selectedLayersLayerPath = selectedLayerLayerPath as string;
-        const selectedTimeSliderLayerPath = TimeSliderEventProcessor.getTimeSliderSelectedLayer(mapId);
-        if (selectedTimeSliderLayerPath) newMapConfig.footerBar.selectedTimeSliderLayerPath = selectedTimeSliderLayerPath;
+
+        // If the TimeSlider plugin is initialized
+        if (TimeSliderEventProcessor.isTimeSliderInitialized(mapId)) {
+          // Store it
+          newMapConfig.footerBar.selectedTimeSliderLayerPath = TimeSliderEventProcessor.getTimeSliderSelectedLayer(mapId);
+        }
       }
 
       return newMapConfig;

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/time-slider-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/time-slider-event-processor.ts
@@ -16,6 +16,7 @@ import { AbstractGVLayer } from '@/geo/layer/gv-layers/abstract-gv-layer';
 import { DateMgt } from '@/core/utils/date-mgt';
 import { logger } from '@/core/utils/logger';
 import { LayerNotFoundError, LayerWrongTypeError } from '@/core/exceptions/layer-exceptions';
+import { PluginStateUninitializedError } from '@/core/exceptions/geoview-exceptions';
 
 // GV Important: See notes in header of MapEventProcessor file for information on the paradigm to apply when working with UIEventProcessor vs UIState
 
@@ -28,44 +29,79 @@ export class TimeSliderEventProcessor extends AbstractEventProcessor {
   // GV ALWAYS use map event processor when an action modify store and IS NOT trap by map state event handler
 
   // #region
+
+  /**
+   * Checks if the Time Slider plugin is iniitialized for the given map.
+   * @param {string} mapId - The map id
+   * @returns {boolean} True when the Time lider plugin is initialized.
+   */
+  static isTimeSliderInitialized(mapId: string): boolean {
+    try {
+      // Get its state, this will throw PluginStateUninitializedError if uninitialized
+      this.getTimeSliderState(mapId);
+      return true;
+    } catch {
+      // Uninitialized
+      return false;
+    }
+  }
+
   /**
    * Shortcut to get the TimeSlider state for a given map id
    * @param {string} mapId - The mapId
-   * @returns {ITimeSliderState | undefined} The Time Slider state. Forcing the return to also be 'undefined', because
-   *                                         there will be no timeSliderState if the TimeSlider plugin isn't active.
-   *                                         This helps the developers making sure the existence is checked.
+   * @returns {ITimeSliderState} The Time Slider state.
+   * @throws {PluginStateUninitializedError} When the Time Slider plugin is uninitialized.
    */
-  protected static getTimesliderState(mapId: string): ITimeSliderState | undefined {
-    // Return the time slider state
-    return super.getState(mapId).timeSliderState;
+  protected static getTimeSliderState(mapId: string): ITimeSliderState {
+    // Get the time slider state
+    const { timeSliderState } = super.getState(mapId);
+
+    // If not found
+    if (!timeSliderState) throw new PluginStateUninitializedError('TimeSlider', mapId);
+
+    // Return it
+    return timeSliderState;
   }
 
   /**
    * Gets time slider layers.
    * @param {string} mapId - The map id of the state to act on
-   * @returns {TimeSliderLayerSet | undefined} The time slider layer set or undefined
+   * @returns {TimeSliderLayerSet} The time slider layer set or undefined
+   * @throws {PluginStateUninitializedError} When the Time Slider plugin is uninitialized.
    */
-  static getTimeSliderLayers(mapId: string): TimeSliderLayerSet | undefined {
-    return this.getTimesliderState(mapId)?.timeSliderLayers;
+  static getTimeSliderLayers(mapId: string): TimeSliderLayerSet {
+    return this.getTimeSliderState(mapId).timeSliderLayers;
   }
 
   /**
    * Gets time slider selected layer path.
    * @param {string} mapId - The map id of the state to act on
-   * @returns {string} The selected time slider layer path or undefined
+   * @returns {string} The selected time slider layer path
+   * @throws {PluginStateUninitializedError} When the Time Slider plugin is uninitialized.
    */
-  static getTimeSliderSelectedLayer(mapId: string): string | undefined {
-    return this.getTimesliderState(mapId)?.selectedLayerPath;
+  static getTimeSliderSelectedLayer(mapId: string): string {
+    return this.getTimeSliderState(mapId).selectedLayerPath;
   }
 
   /**
-   * Gets filter(s) for a layer.
+   * Gets filter(s) for all layers.
+   * @param {string} mapId - The map id of the state to act on
+   * @returns {string} The time slider filter(s) for the layer
+   * @throws {PluginStateUninitializedError} When the Time Slider plugin is uninitialized.
+   */
+  static getTimeSliderFilters(mapId: string): Record<string, string> {
+    return this.getTimeSliderState(mapId).sliderFilters;
+  }
+
+  /**
+   * Gets filter(s) for a specific layer path.
    * @param {string} mapId - The map id of the state to act on
    * @param {string} layerPath - The path of the layer
-   * @returns {string | undefined} The time slider filter(s) for the layer
+   * @returns {string} The time slider filter(s) for the layer
+   * @throws {PluginStateUninitializedError} When the Time Slider plugin is uninitialized.
    */
-  static getTimeSliderFilter(mapId: string, layerPath: string): string | undefined {
-    return this.getTimesliderState(mapId)?.sliderFilters[layerPath];
+  static getTimeSliderFilter(mapId: string, layerPath: string): string {
+    return this.getTimeSliderFilters(mapId)[layerPath];
   }
 
   /**
@@ -75,8 +111,8 @@ export class TimeSliderEventProcessor extends AbstractEventProcessor {
    * @param {TypeTimeSliderProps?} timesliderConfig - Optional time slider configuration
    */
   static checkInitTimeSliderLayerAndApplyFilters(mapId: string, layer: AbstractGVLayer, timesliderConfig?: TypeTimeSliderProps): void {
-    // If there is no TimeSlider
-    if (!this.getTimesliderState(mapId)) return;
+    // If there is no Time Slider, ignore
+    if (!this.isTimeSliderInitialized(mapId)) return;
 
     // Get the temporal dimension, if any
     const tempDimension = layer.getTimeDimension();
@@ -99,16 +135,17 @@ export class TimeSliderEventProcessor extends AbstractEventProcessor {
    * @param {string} mapId - The map id of the state to act on
    * @param {string} layerPath - The layer path of the layer to add to the state
    * @param {TypeTimeSliderValues} timeSliderValues - The time slider values to add and apply filters
+   * @throws {PluginStateUninitializedError} When the Time Slider plugin is uninitialized.
    */
   static #addTimeSliderLayerAndApplyFilters(mapId: string, layerPath: string, timeSliderValues: TypeTimeSliderValues): void {
-    // If there is no TimeSlider
-    if (!this.getTimesliderState(mapId)) return; // Skip
+    // Get the timeslider state which is only initialized if the TimeSlider Plugin exists.
+    const timeSliderState = this.getTimeSliderState(mapId);
 
     // Create set part (because that's how it works for now)
     const timeSliderLayer = { [layerPath]: timeSliderValues };
 
     // Add it
-    this.getTimesliderState(mapId)?.setterActions.addTimeSliderLayer(timeSliderLayer);
+    timeSliderState.setterActions.addTimeSliderLayer(timeSliderLayer);
 
     const { defaultValue, field, filtering, minAndMax, values } = timeSliderLayer[layerPath];
     this.updateFilters(mapId, layerPath, defaultValue, field, filtering, minAndMax, values);
@@ -121,16 +158,17 @@ export class TimeSliderEventProcessor extends AbstractEventProcessor {
    * Removes a time slider layer from the state
    * @param {string} mapId - The map id of the state to act on
    * @param {string} layerPath - The layer path of the layer to remove from the state
+   * @throws {PluginStateUninitializedError} When the TimeSlider plugin is uninitialized.
    */
   static removeTimeSliderLayer(mapId: string, layerPath: string): void {
-    // Get the timeslider state
-    const timeSliderState = this.getTimesliderState(mapId);
+    // Get the timeslider state which is only initialized if the TimeSlider Plugin exists.
+    const timeSliderState = this.getTimeSliderState(mapId);
 
     // Redirect
-    timeSliderState?.setterActions.removeTimeSliderLayer(layerPath);
+    timeSliderState.setterActions.removeTimeSliderLayer(layerPath);
 
-    // If there are no layers with time dimension
-    if (!timeSliderState || !Object.keys(timeSliderState.timeSliderLayers).length) {
+    // If there are no more layers with time dimension
+    if (!Object.keys(timeSliderState.timeSliderLayers).length) {
       // Hide tab
       UIEventProcessor.hideTab(mapId, 'time-slider');
     }
@@ -250,10 +288,11 @@ export class TimeSliderEventProcessor extends AbstractEventProcessor {
    * Sets the selected layer path
    * @param {string} mapId - The map id of the state to act on
    * @param {string} layerPath - The layer path to use
+   * @throws {PluginStateUninitializedError} When the TimeSlider plugin is uninitialized.
    */
   static setSelectedLayerPath(mapId: string, layerPath: string): void {
     // Redirect
-    this.getTimesliderState(mapId)?.setterActions.setSelectedLayerPath(layerPath);
+    this.getTimeSliderState(mapId).setterActions.setSelectedLayerPath(layerPath);
   }
 
   /**
@@ -261,10 +300,11 @@ export class TimeSliderEventProcessor extends AbstractEventProcessor {
    * @param {string} mapId - The map id of the state to act on
    * @param {string} layerPath - The layer path to use
    * @param {string} filter - The filter
+   * @throws {PluginStateUninitializedError} When the TimeSlider plugin is uninitialized.
    */
   static addOrUpdateSliderFilter(mapId: string, layerPath: string, filter: string): void {
-    const curSliderFilters = this.getTimesliderState(mapId)?.sliderFilters;
-    this.getTimesliderState(mapId)?.setterActions.setSliderFilters({ ...curSliderFilters, [layerPath]: filter });
+    const curSliderFilters = this.getTimeSliderFilters(mapId);
+    this.getTimeSliderState(mapId).setterActions.setSliderFilters({ ...curSliderFilters, [layerPath]: filter });
   }
 
   // #endregion
@@ -287,6 +327,7 @@ export class TimeSliderEventProcessor extends AbstractEventProcessor {
    * @param {number[]} minAndMax - Minimum and maximum values of slider
    * @param {number[]} values - Filter values to apply
    * @returns {void}
+   * @throws {PluginStateUninitializedError} When the TimeSlider plugin is uninitialized.
    */
   static updateFilters(
     mapId: string,
@@ -327,8 +368,8 @@ export class TimeSliderEventProcessor extends AbstractEventProcessor {
       }
     }
 
-    this.getTimesliderState(mapId)?.setterActions.setFiltering(layerPath, filtering);
-    this.getTimesliderState(mapId)?.setterActions.setValues(layerPath, values);
+    this.getTimeSliderState(mapId).setterActions.setFiltering(layerPath, filtering);
+    this.getTimeSliderState(mapId).setterActions.setValues(layerPath, values);
     this.addOrUpdateSliderFilter(mapId, layerPath, filter);
     MapEventProcessor.applyLayerFilters(mapId, layerPath);
 

--- a/packages/geoview-core/src/api/types/layer-schema-types.ts
+++ b/packages/geoview-core/src/api/types/layer-schema-types.ts
@@ -622,10 +622,7 @@ export interface TypeSourceImageEsriInitialConfig extends TypeBaseSourceInitialC
   transparent?: boolean;
 }
 
-export const layerEntryIsGroupLayer = (verifyIfLayer: ConfigClassOrType): verifyIfLayer is GroupLayerEntryConfig => {
-  return verifyIfLayer?.entryType === CONST_LAYER_ENTRY_TYPES.GROUP;
-};
-
+// TODO: ALEX - MOVE THOSE OVER TO CONFIGBASECLASS
 export const layerConfigIsEsriDynamicFromType = (verifyIfLayer: TypeGeoviewLayerConfig): verifyIfLayer is TypeEsriDynamicLayerConfig => {
   return verifyIfLayer?.geoviewLayerType === CONST_LAYER_TYPES.ESRI_DYNAMIC;
 };

--- a/packages/geoview-core/src/app.tsx
+++ b/packages/geoview-core/src/app.tsx
@@ -165,8 +165,7 @@ async function renderMap(mapElement: HTMLElement): Promise<MapViewer> {
   // create a new config for this map element
   const lang = mapElement.hasAttribute('data-lang') ? (mapElement.getAttribute('data-lang')! as TypeDisplayLanguage) : 'en';
 
-  const config = new Config(lang);
-  const configObj = config.initializeMapConfig(mapId, configuration.map.listOfGeoviewLayerConfig, (errorKey: string, params: string[]) => {
+  const configObj = Config.initializeMapConfig(mapId, configuration.map.listOfGeoviewLayerConfig, (errorKey: string, params: string[]) => {
     // Wait for the map viewer to get loaded in the api
     api
       .getMapViewerAsync(mapId)

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -84,8 +84,7 @@ export function Datapanel({ fullWidth = false, containerType = CONTAINER_TYPE.FO
       setSelectedLayerPath(_layer.layerPath);
       setIsLoading(true);
 
-      // TODO: Check - Why would we trigger when the layer status is in error!? Removed the OR condition for now
-      // trigger the fetching of the features when not available OR when layer status is in error
+      // If the features weren't fetched yet for the layer, trigger it now
       if (!orderedLayerData.filter((layers) => layers.layerPath === _layer.layerPath && !!layers?.features?.length).length) {
         triggerGetAllFeatureInfo(_layer.layerPath).catch((error: unknown) => {
           // Log

--- a/packages/geoview-core/src/core/components/data-table/json-export-button.tsx
+++ b/packages/geoview-core/src/core/components/data-table/json-export-button.tsx
@@ -10,6 +10,7 @@ import { useLayerStoreActions } from '@/core/stores/store-interface-and-intial-v
 import { useAppStoreActions } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { useMapProjection } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { GeometryApi } from '@/geo/layer/geometry/geometry';
+import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 
 interface JSONExportButtonProps {
   rows: unknown[];
@@ -203,7 +204,7 @@ function JSONExportButton({ rows, features, layerPath }: JSONExportButtonProps):
     setIsExporting(true);
     try {
       const layer = getLayer(layerPath);
-      const layerIsEsriDynamic = layer?.type === 'esriDynamic';
+      const layerIsEsriDynamic = layer?.type === CONST_LAYER_TYPES.ESRI_DYNAMIC;
 
       const jsonGenerator = getJson(layerIsEsriDynamic);
       const chunks = [];

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -121,7 +121,10 @@ export function FeatureInfo({ feature }: FeatureInfoProps): JSX.Element | null {
     return {
       uid: feature.uid,
       iconSrc: feature.featureIcon,
-      name: feature.nameField ? (feature.fieldInfo?.[feature.nameField]?.value as string) || '' : 'No name / Sans nom',
+      name:
+        feature.nameField && feature.fieldInfo?.[feature.nameField]?.value
+          ? (feature.fieldInfo?.[feature.nameField]?.value as string)
+          : 'No name / Sans nom',
       extent: feature.extent,
       geometry: feature.geometry,
       geoviewLayerType: feature.geoviewLayerType,

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -152,8 +152,7 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
 
     const allTabs = { ...tabsList, ...memoTabs };
 
-    // TODO: Use the indexValue coming from the tab to order so custom tab can be placed anywhere
-    // inject guide tab at last position of tabs.
+    // Inject guide tab at last position of tabs.
     return Object.keys({ ...tabsList, ...{ guide: {} } }).map((tab, index) => {
       return {
         id: tab,

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -530,8 +530,7 @@ export function AddNewLayer(): JSX.Element {
       newGeoViewLayer = await GeoPackageReader.createLayerConfigFromGeoPackage(newGeoViewLayer as GeoPackageLayerConfig);
 
     // Use the config to convert simplified layer config into proper layer config
-    const config = new Config(language);
-    const configObj = config.initializeMapConfig(mapId, [newGeoViewLayer], (errorKey: string, params: string[]) => {
+    const configObj = Config.initializeMapConfig(mapId, [newGeoViewLayer], (errorKey: string, params: string[]) => {
       // Get the message for the logger
       const message = getLocalizedMessage(language, errorKey, params);
 

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -101,7 +101,6 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   const sxClasses = getSxClasses(theme);
   const hiddenStyle = { color: theme.palette.grey[600], fontStyle: 'italic' };
 
-  const [isDataTableVisible, setIsDataTableVisible] = useState(false);
   const [isInfoCollapse, setIsInfoCollapse] = useState(false);
   const [allSublayersVisible, setAllSublayersVisible] = useState(true);
 
@@ -128,7 +127,6 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   const layersData = useDataTableAllFeaturesDataArray();
   const language = useAppDisplayLanguage();
   const metadataUrl = useAppMetadataServiceURL();
-  const selectedLayer = layersData.find((_layer) => _layer.layerPath === layerDetails?.layerPath);
   const layerFilter = getLayerDefaultFilter(layerDetails.layerPath);
   const layerTimeDimension = getLayerTimeDimension(layerDetails.layerPath);
   const layerNativeProjection = getLayerServiceProjection(layerDetails.layerPath);
@@ -148,27 +146,6 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
 
   // Get the localized layer type
   const memoLocalizedLayerType = useMemo(() => UtilAddLayer.getLocalizeLayerType(language, true), [language]);
-
-  useEffect(() => {
-    // Log
-    logger.logTraceUseEffect('LAYER DETAILS', selectedLayer, layerDetails);
-    // TODO: refactor - remove timer!
-    // Reason for timer:- when layer detail component is loaded, behind the scene we send query to fetch the features.
-    // After component is rendered and fetching features is done, eventhough store is update, it never re rendered this component
-    // thats why we need to update the state so that layers data is fetched again from store.
-    let timer: NodeJS.Timeout;
-    if (!selectedLayer) {
-      setIsDataTableVisible(true);
-    } else {
-      timer = setTimeout(() => {
-        setIsDataTableVisible(true);
-      }, 100);
-    }
-    return () => {
-      setIsDataTableVisible(false);
-      if (timer) clearTimeout(timer);
-    };
-  }, [layersData, layerDetails, selectedLayer]);
 
   // GV Wrapped in useEffect since it was throwing a warning otherwise
   useEffect(() => {
@@ -404,7 +381,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   function renderLayerButtons(): JSX.Element {
     return (
       <Box sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '15px', marginLeft: 'auto' }}>
-        {isDataTableVisible && datatableSettings[layerDetails.layerPath] && renderDetailsButton()}
+        {datatableSettings[layerDetails.layerPath] && renderDetailsButton()}
         <IconButton tooltip={t('legend.refreshLayer')!} className="buttonOutline" onClick={handleRefreshLayer}>
           <RestartAltIcon />
         </IconButton>
@@ -431,7 +408,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
 
   const renderWMSImage = (): JSX.Element | null => {
     if (
-      layerDetails.type === 'ogcWms' &&
+      layerDetails.type === CONST_LAYER_TYPES.WMS &&
       layerDetails.icons.length &&
       layerDetails.icons[0].iconImage &&
       layerDetails.icons[0].iconImage !== 'no data'

--- a/packages/geoview-core/src/core/exceptions/geoview-exceptions.ts
+++ b/packages/geoview-core/src/core/exceptions/geoview-exceptions.ts
@@ -330,7 +330,7 @@ export class NoExtentError extends GeoViewError {
 export class InitDivNotExistError extends GeoViewError {
   /**
    * Creates an instance of InitDivNotExistError.
-   * @param {string} mapId - The map id for which a wront function call was made.
+   * @param {string} mapId - The map id for which a wrong function call was made.
    */
   constructor(mapId: string) {
     super('error.map.mapDivNotExists', [mapId]);
@@ -350,7 +350,7 @@ export class InitDivNotExistError extends GeoViewError {
 export class InitMapWrongCallError extends GeoViewError {
   /**
    * Creates an instance of InitMapWrongCallError.
-   * @param {string} mapId - The map id for which a wront function call was made.
+   * @param {string} mapId - The map id for which a wrong function call was made.
    */
   constructor(mapId: string) {
     super('error.map.mapWrongCall', [mapId]);
@@ -360,5 +360,25 @@ export class InitMapWrongCallError extends GeoViewError {
 
     // Ensure correct inheritance (important for transpilation targets)
     Object.setPrototypeOf(this, InitMapWrongCallError.prototype);
+  }
+}
+
+/**
+ * Error thrown when a plugin state hasn't been initialized and we're trying to access it.
+ */
+export class PluginStateUninitializedError extends GeoViewError {
+  /**
+   * Creates an instance of PluginStateUninitializedError.
+   * @param {string} pluginId - The plugin id for which the state was uninitialized.
+   * @param {string} mapId - The map id
+   */
+  constructor(pluginId: string, mapId: string) {
+    super('error.map.pluginStateUninitialized', [pluginId, mapId]);
+
+    // Set a custom name for the error type to differentiate it from other error types
+    this.name = 'PluginStateUninitializedError';
+
+    // Ensure correct inheritance (important for transpilation targets)
+    Object.setPrototypeOf(this, PluginStateUninitializedError.prototype);
   }
 }

--- a/packages/geoview-core/src/core/utils/fetch-helper.ts
+++ b/packages/geoview-core/src/core/utils/fetch-helper.ts
@@ -132,7 +132,10 @@ export class Fetch {
    * @param {RequestInit?} init - The optional initialization parameters for the fetch.
    * @param {number?} timeoutMs - The optional maximum timeout period to wait for an answer before throwing a RequestTimeoutError.
    * @returns {Promise<string>} The fetched text response.
+   * @throws {ResponseError} If the response is not OK (non-2xx).
    * @throws {ResponseEmptyError} If the JSON response is empty.
+   * @throws {RequestAbortedError | RequestTimeoutError} If the request was cancelled or timed out.
+   * @throws {Error} For any other unexpected failures.
    */
   static async fetchText(url: string, init?: RequestInit, timeoutMs?: number): Promise<string> {
     // Get the buffer array of the response

--- a/packages/geoview-core/src/core/utils/utilities.ts
+++ b/packages/geoview-core/src/core/utils/utilities.ts
@@ -345,15 +345,13 @@ export function removeCommentsFromJSON(config: string): string {
 }
 
 /**
- * Parses JSON config
- *
- * @param {string} configObjStr - Map config to parse
- * @returns {unknown} Cleaned and parsed config object
+ * Parses JSON config string into a JSON object of type T.
+ * @param {string} configStr - Map config to parse
+ * @returns {T} Cleaned and parsed config object
  */
-// TODO: refactor - yves, move this function to config class
-export function parseJSONConfig(configObjStr: string): unknown {
+export function parseJSONConfig<T>(configStr: string): T {
   // remove CR and LF from the map config
-  let jsonString = configObjStr.replace(/(\r\n|\n|\r)/gm, '');
+  let jsonString = configStr.replace(/(\r\n|\n|\r)/gm, '');
   // replace apostrophes not preceded by a backslash with quotes
   jsonString = jsonString.replace(/(?<!\\)'/gm, '"');
   // replace apostrophes preceded by a backslash with a single apostrophe

--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -579,63 +579,6 @@ export class BasemapApi {
     throw new CoreBasemapCreationError();
   }
 
-  // TODO: Cleanup - Not used anymore? (Code doesn't seem very good anyways with the bilingual things? Commenting out for now 2025-07-30)
-  // /**
-  //  * Create a custom basemap.
-  //  * @param {TypeBasemapProps} basemapProps - Basemap properties.
-  //  * @param {TypeValidMapProjectionCodes} projection - Projection code.
-  //  * @param {TypeDisplayLanguage} language - Optional language.
-  //  * @returns {TypeBasemapProps} The created custom basemap.
-  //  */
-  // createCustomBasemap(
-  //   basemapProps: TypeBasemapProps,
-  //   projection: TypeValidMapProjectionCodes,
-  //   language?: TypeDisplayLanguage
-  // ): TypeBasemapProps {
-  //   interface bilingual {
-  //     en: string;
-  //     fr: string;
-  //   }
-
-  //   // Extract bilangual sections
-  //   const name: bilingual = basemapProps.name as unknown as bilingual;
-  //   const description: bilingual = basemapProps.description as unknown as bilingual;
-  //   const thumbnailUrl: bilingual = basemapProps.thumbnailUrl as unknown as bilingual;
-  //   const attribution: bilingual = basemapProps.attribution as unknown as bilingual;
-
-  //   // Check if language is provided for the basemap creation
-  //   const languageCode = language === undefined ? AppEventProcessor.getDisplayLanguage(this.mapViewer.mapId) : language;
-
-  //   // Create the basemap properties
-  //   const formatProps: TypeBasemapProps = { ...basemapProps };
-  //   formatProps.name = languageCode === 'en' ? name.en : name.fr;
-  //   formatProps.layers = basemapProps.layers.map((layer) => {
-  //     return {
-  //       ...layer,
-  //       url: languageCode === 'en' ? (layer.url as unknown as bilingual).en : (layer.url as unknown as bilingual).fr,
-  //       // TODO: Handle custom vector tile basemaps too
-  //       source: new XYZ({
-  //         attributions: attribution[languageCode],
-  //         projection: Projection.PROJECTIONS[projection],
-  //         url: languageCode === 'en' ? (layer.url as unknown as bilingual).en : (layer.url as unknown as bilingual).fr,
-  //         crossOrigin: 'Anonymous',
-  //         tileGrid: new TileGrid({
-  //           extent: this.defaultExtent,
-  //           origin: this.defaultOrigin,
-  //           resolutions: this.defaultResolutions!,
-  //         }),
-  //       }),
-  //     };
-  //   });
-  //   formatProps.type = 'test';
-  //   formatProps.description = languageCode === 'en' ? description.en : description.fr;
-  //   formatProps.altText = languageCode === 'en' ? description.en : description.fr;
-  //   formatProps.thumbnailUrl = languageCode === 'en' ? thumbnailUrl.en : thumbnailUrl.fr;
-  //   formatProps.attribution = languageCode === 'en' ? [attribution.en] : [attribution.fr];
-
-  //   return formatProps;
-  // }
-
   // #endregion
 
   /**

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -606,7 +606,7 @@ export abstract class AbstractGeoViewLayer {
 
         // If working on a group layer
         if (layerConfig.getEntryTypeIsGroup()) {
-          const newLayerGroup = this.createLayerGroup(layerConfig, layerConfig.initialSettings);
+          const newLayerGroup = this.createLayerGroup(layerConfig, layerConfig.getInitialSettings());
           const groupReturned = await this.#processListOfLayerEntryConfig(layerConfig.listOfLayerEntryConfig, newLayerGroup);
           if (groupReturned) {
             if (layerGroup) layerGroup.addLayer(groupReturned);
@@ -635,14 +635,14 @@ export abstract class AbstractGeoViewLayer {
       if (!layerGroup) {
         // All children of this level in the tree have the same parent, so we use the first element of the array to retrieve the parent node.
         // eslint-disable-next-line no-param-reassign
-        layerGroup = this.createLayerGroup(listOfLayerEntryConfig[0].parentLayerConfig!, listOfLayerEntryConfig[0].initialSettings);
+        layerGroup = this.createLayerGroup(listOfLayerEntryConfig[0].parentLayerConfig!, listOfLayerEntryConfig[0].getInitialSettings());
       }
 
       // TODO: Refactor - Rework this Promise to be "Promise<AbstractBaseLayer>"
       const promiseOfLayerCreated: Promise<AbstractBaseLayer | undefined>[] = [];
       listOfLayerEntryConfig.forEach((layerConfig) => {
         if (layerConfig.getEntryTypeIsGroup()) {
-          const newLayerGroup = this.createLayerGroup(layerConfig, layerConfig.initialSettings);
+          const newLayerGroup = this.createLayerGroup(layerConfig, layerConfig.getInitialSettings());
           promiseOfLayerCreated.push(this.#processListOfLayerEntryConfig(layerConfig.listOfLayerEntryConfig, newLayerGroup));
         } else if (layerConfig.layerStatus === 'error') {
           // This layer was already detected as in error, don't make the layer, don't add to the list

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -86,7 +86,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
     const entriesTree = EsriDynamic.buildLayerEntriesTree(entries);
 
     // Redirect
-    // TODO: Check - Check if there's a way to better determine the isTimeAware flag, defaults to false, how is it used here?
+    // TODO: Check - Config init - Check if there's a way to better determine the isTimeAware flag, defaults to false, how is it used here?
     return EsriDynamic.createGeoviewLayerConfig(this.geoviewLayerId, this.geoviewLayerName, this.metadataAccessPath, false, entriesTree);
   }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
@@ -40,7 +40,7 @@ export class EsriImage extends AbstractGeoViewRaster {
    */
   protected override onInitLayerEntries(): Promise<TypeGeoviewLayerConfig> {
     // Redirect
-    // TODO: Check - Check if there's a way to better determine the isTimeAware flag, defaults to false, how is it used here?
+    // TODO: Check - Config init -Check if there's a way to better determine the isTimeAware flag, defaults to false, how is it used here?
     return Promise.resolve(EsriImage.createGeoviewLayerConfig(this.geoviewLayerId, this.geoviewLayerName, this.metadataAccessPath, false));
   }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/image-static.ts
@@ -57,7 +57,7 @@ export class ImageStatic extends AbstractGeoViewRaster {
   protected override onInitLayerEntries(): Promise<TypeGeoviewLayerConfig> {
     // Redirect
     return Promise.resolve(
-      // TODO: Check - Check if there's a way to better determine the isTimeAware flag, defaults to false, how is it used here?
+      // TODO: Check - Config init - Check if there's a way to better determine the isTimeAware flag, defaults to false, how is it used here?
       ImageStatic.createGeoviewLayerConfig(this.geoviewLayerId, this.geoviewLayerName, this.metadataAccessPath, false, [])
     );
   }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -117,7 +117,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
         // Resolve the url
         const url = AbstractGeoViewVector.#resolveUrl(layerConfig, vectorSource, extent, resolution, projection);
 
-        if (layerConfig.schemaTag !== 'WKB') {
+        if (layerConfig.getSchemaTag() !== CONST_LAYER_TYPES.WKB) {
           // Fetch the data, or use passed geoJSON if present
           responseText =
             layerEntryIsGeoJSONFromConfig(layerConfig) && layerConfig.source?.geojson
@@ -219,7 +219,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
   ): Promise<Feature[] | undefined> {
     // TODO: Refactor - Consider changing the return type to Promise<Feature[]>
 
-    switch (layerConfig.schemaTag) {
+    switch (layerConfig.getSchemaTag()) {
       case CONST_LAYER_TYPES.CSV:
         // Attempt to convert CSV text to OpenLayers features
         return AbstractGeoViewVector.#convertCsv(responseText, layerConfig, Projection.getProjectionFromString(projection));
@@ -325,7 +325,6 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    */
   // GV: featureLimit ideal amount varies with the service and with maxAllowableOffset.
   // TODO: Add options for featureLimit to config
-  // TODO: Will need to move with onCreateVectorSource
   static #getEsriFeatures(url: string, featureCount: number, maxRecordCount?: number, featureLimit: number = 1000): Promise<unknown[]> {
     // Update url
     const baseUrl = url.replace('&returnCountOnly=true', `&outfields=*&geometryPrecision=1&maxAllowableOffset=5`);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -104,7 +104,7 @@ export class EsriFeature extends AbstractGeoViewVector {
     }
 
     // Redirect
-    // TODO: Check - Check if there's a way to better determine the isTimeAware flag, defaults to false, how is it used here?
+    // TODO: Check - Config init -  a way to better determine the isTimeAware flag, defaults to false, how is it used here?
     return EsriFeature.createGeoviewLayerConfig(this.geoviewLayerId, this.geoviewLayerName, rootUrl, false, entries);
   }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -13,7 +13,6 @@ import {
   CONST_LAYER_TYPES,
   TypeMetadataGeoJSON,
 } from '@/api/types/layer-schema-types';
-import { validateExtentWhenDefined } from '@/geo/utils/utilities';
 import { GeoJSONLayerEntryConfig } from '@/api/config/validation-classes/vector-validation-classes/geojson-layer-entry-config';
 import { VectorLayerEntryConfig, VectorLayerEntryConfigProps } from '@/api/config/validation-classes/vector-layer-entry-config';
 import { Fetch } from '@/core/utils/fetch-helper';
@@ -92,7 +91,7 @@ export class GeoJSON extends AbstractGeoViewVector {
     const id = this.metadataAccessPath.substring(idx + 1);
 
     // Redirect
-    // TODO: Check - Check if there's a way to better determine the isTimeAware flag, defaults to false, how is it used here?
+    // TODO: Check - Config init - Check if there's a way to better determine the isTimeAware flag, defaults to false, how is it used here?
     return Promise.resolve(GeoJSON.createGeoviewLayerConfig(this.geoviewLayerId, this.geoviewLayerName, rootUrl, false, [{ id }]));
   }
 
@@ -134,13 +133,13 @@ export class GeoJSON extends AbstractGeoViewVector {
       // If the layer metadata was found
       if (layerMetadataFound) {
         // If no name
-        if (!layerConfig.getLayerName()) layerConfig.setLayerName(layerMetadataFound.layerName || 'No name / Sans nom');
+        if (!layerConfig.getLayerName()) layerConfig.setLayerName(layerMetadataFound.layerName || layerConfig.getLayerNameCascade());
 
         // eslint-disable-next-line no-param-reassign
         layerConfig.source = defaultsDeep(layerConfig.source, layerMetadataFound.source);
 
-        // eslint-disable-next-line no-param-reassign
-        layerConfig.initialSettings = defaultsDeep(layerConfig.initialSettings, layerMetadataFound.initialSettings);
+        // Set the initial settings
+        layerConfig.setInitialSettings(defaultsDeep(layerConfig.getInitialSettings(), layerMetadataFound.initialSettings));
 
         // Set the layer style
         layerConfig.setLayerStyle(defaultsDeep(layerConfig.getLayerStyle(), layerMetadataFound.layerStyle));
@@ -171,8 +170,8 @@ export class GeoJSON extends AbstractGeoViewVector {
         }
       }
 
-      // eslint-disable-next-line no-param-reassign
-      layerConfig.initialSettings.extent = validateExtentWhenDefined(layerConfig.initialSettings.extent);
+      // Validate and update the extent initial settings
+      layerConfig.validateUpdateInitialSettingsExtent();
     }
 
     // Setting the layer metadata now with the updated config values. Setting the layer metadata with the config, directly, like it's done in CSV

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -305,7 +305,7 @@ export abstract class AbstractGVLayer extends AbstractBaseLayer {
     // If first time
     if (!this.loadedOnce) {
       // Now that the layer is loaded, set its visibility correctly (had to be done in the loaded event, not before, per prior note in pre-refactor)
-      this.setVisible(layerConfig.initialSettings?.states?.visible !== false);
+      this.setVisible(layerConfig.getInitialSettings()?.states?.visible ?? true); // default: true
 
       // Emit event for the first time the layer got loaded
       this.#emitLayerFirstLoaded();
@@ -959,12 +959,19 @@ export abstract class AbstractGVLayer extends AbstractBaseLayer {
 
     // Set the layer options as read from the initialSettings
     // GV We disable the warnings, because this function purpose is to actually initialize the given parameter
+
+    // If a className is defined in the initial settings, set it in the layer options
     // eslint-disable-next-line no-param-reassign
-    if (layerConfig.initialSettings?.className !== undefined) layerOptions.className = layerConfig.initialSettings.className;
+    if (layerConfig.getInitialSettings()?.className !== undefined) layerOptions.className = layerConfig.getInitialSettings().className;
+
+    // If an extent is defined in the initial settings, set it in the layer options
     // eslint-disable-next-line no-param-reassign
-    if (layerConfig.initialSettings?.extent !== undefined) layerOptions.extent = layerConfig.initialSettings.extent;
-    // eslint-disable-next-line no-param-reassign
-    if (layerConfig.initialSettings?.states?.opacity !== undefined) layerOptions.opacity = layerConfig.initialSettings.states.opacity;
+    if (layerConfig.getInitialSettings()?.extent !== undefined) layerOptions.extent = layerConfig.getInitialSettings().extent;
+
+    // If an opacity is defined in the initial settings, set it in the layer options
+    if (layerConfig.getInitialSettings()?.states?.opacity !== undefined)
+      // eslint-disable-next-line no-param-reassign
+      layerOptions.opacity = layerConfig.getInitialSettings().states!.opacity;
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/gv-group-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/gv-group-layer.ts
@@ -28,7 +28,7 @@ export class GVGroupLayer extends AbstractBaseLayer {
     layerConfig.onLayerStatusChanged((config) => {
       if (config.layerStatus === 'loaded' && !this.loadedOnce) {
         this.loadedOnce = true;
-        this.setVisible(layerConfig.initialSettings?.states?.visible !== false);
+        this.setVisible(layerConfig.getInitialSettings()?.states?.visible ?? true); // default: true
       }
     });
   }

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -131,7 +131,7 @@ export class GVEsriDynamic extends AbstractGVRaster {
       legendInfo.forEach((info) => {
         const styleInfo: TypeLayerStyleConfigInfo = {
           label: info.label,
-          visible: layerConfig.initialSettings.states?.visible || true,
+          visible: layerConfig.getInitialSettings().states?.visible ?? true, // default: true,
           values: info.label.split(','),
           settings: {
             type: 'iconSymbol',

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
@@ -110,7 +110,7 @@ export class GVEsriImage extends AbstractGVRaster {
       legendInfo.forEach((info) => {
         const styleInfo: TypeLayerStyleConfigInfo = {
           label: info.label,
-          visible: layerConfig.initialSettings.states?.visible || true,
+          visible: layerConfig.getInitialSettings().states?.visible ?? true, // default: true
           values: info.label.split(','),
           settings: {
             type: 'iconSymbol',

--- a/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
@@ -69,7 +69,7 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
 
     // Update the resultSet data
     const layerPath = layer.getLayerPath();
-    this.resultSet[layerPath].eventListenerEnabled = layer.getLayerConfig().initialSettings.states?.queryable ?? true;
+    this.resultSet[layerPath].eventListenerEnabled = layer.getLayerConfig().getInitialSettings().states?.queryable ?? true; // default: true
     this.resultSet[layerPath].queryStatus = 'processed';
     this.resultSet[layerPath].features = [];
   }

--- a/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
@@ -67,7 +67,7 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
 
     // Update the resultSet data
     const layerPath = layer.getLayerPath();
-    this.resultSet[layerPath].eventListenerEnabled = layer.getLayerConfig().initialSettings.states?.hoverable ?? true;
+    this.resultSet[layerPath].eventListenerEnabled = layer.getLayerConfig().getInitialSettings().states?.hoverable ?? true;
     this.resultSet[layerPath].queryStatus = 'processed';
     this.resultSet[layerPath].feature = undefined;
   }

--- a/packages/geoview-core/src/geo/layer/layer-sets/legends-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/legends-layer-set.ts
@@ -224,7 +224,7 @@ export class LegendsLayerSet extends AbstractLayerSet {
           // If there's no determined layer style in the layer config
           if (!layerConfig.getLayerStyle()) {
             // If the layer visible state is invisible upon load or the style has been applied, we should query legend
-            shouldQueryLegend = !layerConfig.initialSettings?.states?.visible || layer.styleApplied;
+            shouldQueryLegend = !layerConfig.getInitialSettings()?.states?.visible || layer.styleApplied;
           }
         }
       }

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -1276,7 +1276,6 @@ export class MapViewer {
     return extent;
   }
 
-  // TODO: Move to config API after refactor?
   /**
    * Creates a map config based on current map state.
    * @param {BooleanExpression} overrideGeocoreServiceNames - Indicates if geocore layer names should be kept as is or returned to defaults.
@@ -1287,10 +1286,8 @@ export class MapViewer {
     return MapEventProcessor.createMapConfigFromMapState(this.mapId, overrideGeocoreServiceNames);
   }
 
-  // TODO: Move to config API after refactor?
   /**
    * Searches through a map config and replaces any matching layer names with their provided partner.
-   *
    * @param {string[][]} namePairs -  The array of name pairs. Presumably one english and one french name in each pair.
    * @param {TypeMapFeaturesInstance} mapConfig - The config to modify, or one created using the current map state if not provided.
    * @param {boolean} removeUnlisted - Whether or not names not provided should be removed from config.

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -25,13 +25,6 @@ import { TypeBasemapLayer } from '@/geo/layer/basemap/basemap-types';
 import { TypeMapMouseInfo } from '@/geo/map/map-viewer';
 import { NetworkError } from '@/core/exceptions/core-exceptions';
 
-/**
- * Interface used for css style declarations
- */
-interface TypeCSSStyleDeclaration extends CSSStyleDeclaration {
-  mozTransform: string;
-}
-
 // available layer types
 export const layerTypes = CONST_LAYER_TYPES;
 
@@ -238,54 +231,6 @@ export function getLegendStylesFromConfig(styleConfig: TypeLayerStyleConfig): Pr
 }
 
 /**
- * Gets computed translate values
- * https://zellwk.com/blog/css-translate-values-in-javascript/
- * @param {HTMLElement} element the HTML element to get value for
- * @returns {Object} the x, y and z translation values
- */
-// TODO: clean - not use anywhere
-export function getTranslateValues(element: HTMLElement): {
-  x: number;
-  y: number;
-  z: number;
-} {
-  const style = window.getComputedStyle(element) as TypeCSSStyleDeclaration;
-  const matrix = style.transform || style.webkitTransform || style.mozTransform;
-  const values = { x: 0, y: 0, z: 0 };
-
-  // No transform property. Simply return 0 values.
-  if (matrix === 'none' || matrix === undefined) return values;
-
-  // Can either be 2d or 3d transform
-  const matrixType = matrix.includes('3d') ? '3d' : '2d';
-  const matrixMatch = matrix.match(/matrix.*\((.+)\)/);
-  const matrixValues = matrixMatch && matrixMatch[1].split(', ');
-
-  // 2d matrices have 6 values
-  // Last 2 values are X and Y.
-  // 2d matrices does not have Z value.
-  if (matrixType === '2d') {
-    return {
-      x: Number(matrixValues && matrixValues[4]),
-      y: Number(matrixValues && matrixValues[5]),
-      z: 0,
-    };
-  }
-
-  // 3d matrices have 16 values
-  // The 13th, 14th, and 15th values are X, Y, and Z
-  if (matrixType === '3d') {
-    return {
-      x: Number(matrixValues && matrixValues[12]),
-      y: Number(matrixValues && matrixValues[13]),
-      z: Number(matrixValues && matrixValues[14]),
-    };
-  }
-
-  return values;
-}
-
-/**
  * Format the coordinates for degrees - minutes - seconds (lat, long)
  * @param {number} value the value to format
  * @returns {string} the formatted value
@@ -437,6 +382,18 @@ export function validateExtent(extent: Extent, code: string = 'EPSG:4326'): Exte
 }
 
 /**
+ * Validates lat long, LCC, or Web Mercator extent if it is defined.
+ * @param {Extent} extent - The extent to validate.
+ * @param {string} code - The projection code of the extent. Default EPSG:4326.
+ * @returns {Extent | undefined} The validated extent if it was defined.
+ */
+export function validateExtentWhenDefined(extent: Extent | undefined, code: string = 'EPSG:4326'): Extent | undefined {
+  // Validate extent if it is defined
+  if (extent) return validateExtent(extent, code);
+  return undefined;
+}
+
+/**
  * Checks if a given extent is long/lat.
  * @param {Extent} extent - The extent to check.
  * @returns {boolean} Whether or not the extent is long/lat
@@ -457,17 +414,6 @@ export function isExtentLonLat(extent: Extent): boolean {
   return false;
 }
 
-/**
- * Validates lat long, LCC, or Web Mercator extent if it is defined.
- * @param {Extent} extent - The extent to validate.
- * @param {string} code - The projection code of the extent. Default EPSG:4326.
- * @returns {Extent | undefined} The validated extent if it was defined.
- */
-export function validateExtentWhenDefined(extent: Extent | undefined, code: string = 'EPSG:4326'): Extent | undefined {
-  // Validate extent if it is defined
-  if (extent) return validateExtent(extent, code);
-  return undefined;
-}
 // #endregion EXTENT
 
 /**

--- a/packages/geoview-core/src/ui/drawer/drawer.tsx
+++ b/packages/geoview-core/src/ui/drawer/drawer.tsx
@@ -63,7 +63,6 @@ function DrawerUI(props: DrawerPropsExtend): JSX.Element {
   const { variant, status, className, style, children, ...rest } = props;
 
   // Hooks
-  // TODO: refactor - language values should be pass as props
   const { t } = useTranslation<string>();
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);

--- a/packages/geoview-core/src/ui/modal/modal.tsx
+++ b/packages/geoview-core/src/ui/modal/modal.tsx
@@ -187,8 +187,6 @@ function ModalUI(props: DialogPropsExtend): JSX.Element {
   } = props;
 
   // Hooks
-  // TODO: remove coupling with translation, pass as props
-  // TODO: refactor - language values should be pass as props
   const { t } = useTranslation();
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);

--- a/packages/geoview-core/src/ui/panel/panel.tsx
+++ b/packages/geoview-core/src/ui/panel/panel.tsx
@@ -16,6 +16,7 @@ import { getSxClasses } from '@/ui/panel/panel-style';
 import { useMapSize } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { DEFAULT_APPBAR_CORE } from '@/api/types/map-schema-types';
 import { FocusTrapContainer } from '@/core/components/common';
+import { delay } from '@/core/utils/utilities';
 import { logger } from '@/core/utils/logger';
 
 /**
@@ -49,7 +50,6 @@ function PanelUI(props: TypePanelAppProps): JSX.Element {
   const { status: open = false, isFocusTrapped = false, panelStyles, panelGroupName } = panel;
 
   // Hooks
-  // TODO: refactor - language values should be pass as props
   const { t } = useTranslation<string>();
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
@@ -90,14 +90,22 @@ function PanelUI(props: TypePanelAppProps): JSX.Element {
       }
 
       // Wait the transition period (+50 ms just to be sure of shenanigans)
-      setTimeout(() => {
-        onOpen?.();
-      }, theme.transitions.duration.standard + 50);
+      delay(theme.transitions.duration.standard + 50)
+        .then(() => {
+          onOpen?.();
+        })
+        .catch(() => {
+          logger.logPromiseFailed('in delay in UI.PANEL - open');
+        });
     } else {
       // Wait the transition period (+50 ms just to be sure of shenanigans)
-      setTimeout(() => {
-        onClose?.();
-      }, theme.transitions.duration.standard + 50);
+      delay(theme.transitions.duration.standard + 50)
+        .then(() => {
+          onClose?.();
+        })
+        .catch(() => {
+          logger.logPromiseFailed('in delay in UI.PANEL - open');
+        });
     }
   }, [open, theme.transitions.duration.standard, onOpen, onClose]);
 

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -113,7 +113,6 @@ function TabsUI(props: TypeTabsProps): JSX.Element {
   } = props;
 
   // Hooks
-  // TODO: refactor - language values should be pass as props
   const { t } = useTranslation<string>();
   const theme = useTheme();
 


### PR DESCRIPTION
# Description

- entryType also privatized to get/setEntryType
- schemaTag also privatized to get/setSchemaTag
- Added back the @throws jsdoc for fetch-helper.ts
- Added support for WKB in config-sandbox2.html for future OSDP Health demo cleanup of json
- Old code cleanup
- Moved the check if layers are loaded and updating of the store logic Fixed schema for package-swiper3-config.json
- Creation of a new exception 'PluginStateUninitializedError' and solidified the usage of the time-slider/geochart/swiper states
- Explicit no-param-reassign in config-validation
- TODO comments cleanup
- Removed an unnecessary useEffect in layer-details concerning the data-table button visibility
- The type property in TypeLegendLayer now using the getSchemaTag() instead of the getEntryType() as that seems to have been the intent all along when checking the types and the 'as TypeGeoviewLayerType' casting that seemed misleading
- Now throwing an LayerServiceMetadataEmptyError when trying to process an Esri layer without metadata (it shouldn't be happening anyways as it would have bugged before, so might as well throw a clear message now)
- initialSettings also privatized with get/set and immutable states management
- Many other small fixes and cleanup

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted Sept 16th 16h30: https://alex-nrcan.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~
