### PR TITLE
fix(state config): check for time slider imitialization

### DIFF
--- a/packages/geoview-core/public/templates/sandbox.html
+++ b/packages/geoview-core/public/templates/sandbox.html
@@ -57,7 +57,7 @@
       }
 
       textarea {
-        height: 9999px;
+        height: 99999px;
         line-height: 21px;
         overflow-y: hidden;
         padding: 0;

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -1572,14 +1572,16 @@ export class MapEventProcessor extends AbstractEventProcessor {
         viewSettings,
       };
 
-      // Create time slider config and add to core package configs
       let { corePackagesConfig } = config;
-      const sliders = this.#createTimeSliderConfigs(mapId);
-      if (corePackagesConfig && sliders) {
-        const configObj = corePackagesConfig?.find((packageConfig) => Object.keys(packageConfig).includes('time-slider'));
-        if (configObj) configObj['time-slider'] = { sliders };
-        else corePackagesConfig.push({ 'time-slider': { sliders } });
-      } else if (sliders) corePackagesConfig = [{ 'time-slider': { sliders } }];
+      // Create time slider config and add to core package configs
+      if (TimeSliderEventProcessor.isTimeSliderInitialized(mapId)) {
+        const sliders = this.#createTimeSliderConfigs(mapId);
+        if (corePackagesConfig && sliders) {
+          const configObj = corePackagesConfig?.find((packageConfig) => Object.keys(packageConfig).includes('time-slider'));
+          if (configObj) configObj['time-slider'] = { sliders };
+          else corePackagesConfig.push({ 'time-slider': { sliders } });
+        } else if (sliders) corePackagesConfig = [{ 'time-slider': { sliders } }];
+      }
 
       // Construct map config
       const newMapConfig: TypeMapFeaturesInstance = {


### PR DESCRIPTION
Checks if time slider is initialized before trying to access state in createConfigFromMapState. Also extends length of sandbox text area.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?



# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3055)
<!-- Reviewable:end -->
