### PR TITLE
fix(wcag ui): Add required a11y props to icon button components

### DIFF
--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -132,6 +132,7 @@
     "name": "Name",
     "layerSelect": "Select layer(s)",
     "deleteLayer": "Delete layer",
+    "undoLayer": "Undo layer",
     "errorDisabled": "The layer type '__param__' is disabled in this map.",
     "errorEmpty": "__param__ cannot be empty.",
     "errorNone": "No file or source added.",
@@ -175,7 +176,14 @@
     "layerServiceProjection": "Service projection: ",
     "layerHoverable": "Info on mouse over",
     "layerQueryable": "Info on mouse click",
-    "noSelection": "No selection"
+    "noSelection": "No selection",
+    "showAllLayers": "Show all layers",
+    "hideAllLayers": "Hide all layers",
+    "showLayer": "Show {{name}} layer",
+    "hideLayer": "Hide {{name}} layer",
+    "tableViewNone": "Table (unavailable)",
+    "moveLayerUp": "Move layer up",
+    "moveLayerDown": "Move layer down"
   },
   "details": {
     "title": "Details",
@@ -330,7 +338,9 @@
   "guide": {
     "title": "Guide",
     "search": "Search guide...",
-    "errorMessage": "Sorry, unable to find the help document!"
+    "errorMessage": "Sorry, unable to find the help document!",
+    "arrowUp": "Previous match",
+    "arrowDown": "Next match"
   },
   "footerBar": {
     "resizeTooltip": "Resize",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -132,6 +132,7 @@
     "name": "Nom",
     "layerSelect": "Sélectionner couche(s)",
     "deleteLayer": "Supprimer la couche",
+    "undoLayer": "Annuler la suppression de la couche",
     "errorDisabled": "Le type de couche « __param__ » est désactivé dans cette carte.",
     "errorEmpty": "__param__ ne peut être vide.",
     "errorNone": "Pas de fichier ou de source ajouté.",
@@ -175,7 +176,14 @@
     "layerServiceProjection": "Projection du service : ",
     "layerHoverable": "Info au passage de la souris",
     "layerQueryable": "Info au click de la souris",
-    "noSelection": "Aucune sélection"
+    "noSelection": "Aucune sélection",
+    "showAllLayers": "Afficher toutes les couches",
+    "hideAllLayers": "Masquer toutes les couches",
+    "showLayer": "Afficher la couche {{name}}",
+    "hideLayer": "Masquer la couche {{name}}",
+    "tableViewNone": "Tableau (indisponible)",
+    "moveLayerUp": "Déplacer la couche vers le haut",
+    "moveLayerDown": "Déplacer la couche vers le bas"
   },
   "details": {
     "title": "Détails",
@@ -330,7 +338,9 @@
   "guide": {
     "title": "Guide",
     "search": "Rechercher dans le guide...",
-    "errorMessage": "Désolé, impossible de trouver le document d'aide!"
+    "errorMessage": "Désolé, impossible de trouver le document d'aide!",
+    "arrowUp": "Correspondance précédente",
+    "arrowDown": "Correspondance suivante"
   },
   "footerBar": {
     "resizeTooltip": "Redimensionner",

--- a/packages/geoview-core/src/api/plugin/appbar-plugin.ts
+++ b/packages/geoview-core/src/api/plugin/appbar-plugin.ts
@@ -39,6 +39,7 @@ export abstract class AppBarPlugin extends AbstractPlugin {
     // Return dummy plugin button
     return {
       id: 'somePluginButton',
+      'aria-label': 'Some aria label',
       tooltip: 'Some tooltip',
       tooltipPlacement: 'right',
       children: this.react.createElement(MapIcon),

--- a/packages/geoview-core/src/api/plugin/navbar-plugin.ts
+++ b/packages/geoview-core/src/api/plugin/navbar-plugin.ts
@@ -34,6 +34,7 @@ export abstract class NavBarPlugin extends AbstractPlugin {
       main: {
         buttonProps: {
           id: 'someNavBarPluginButton',
+          'aria-label': 'Some aria label',
           tooltip: 'Some tooltip',
           tooltipPlacement: 'right',
           children: this.react.createElement(MapIcon),

--- a/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
@@ -299,6 +299,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
       .map((tab): [IconButtonPropsExtend, TypePanelProps, string] => {
         const button: IconButtonPropsExtend = {
           id: tab,
+          'aria-label': t(`${camelCase(tab)}.title`),
           tooltip: t(`${camelCase(tab)}.title`)!,
           tooltipPlacement: 'bottom',
           children: memoPanels[tab].icon,

--- a/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
@@ -99,8 +99,7 @@ export default function Version(): JSX.Element {
       <Box sx={{ padding: interaction === 'dynamic' ? 'none' : '5px' }}>
         <IconButton
           id="version-button"
-          tooltip={t('appbar.version')!}
-          aria-label={t('appbar.version')!}
+          aria-label={t('appbar.version')}
           tooltipPlacement="right"
           onClick={handleOpenPopover}
           className={`${interaction === 'dynamic' ? 'buttonFilled' : 'style4'} ${open ? 'active' : ''}`}
@@ -136,7 +135,7 @@ export default function Version(): JSX.Element {
                 <Typography sx={sxClasses.versionsInfoTitle} component="h3">
                   {t('appbar.version')}
                 </Typography>
-                <IconButton onClick={handleClickAway}>
+                <IconButton onClick={handleClickAway} aria-label={t('general.close')} tooltipPlacement="right">
                   <CloseIcon />
                 </IconButton>
               </Box>

--- a/packages/geoview-core/src/core/components/attribution/attribution.tsx
+++ b/packages/geoview-core/src/core/components/attribution/attribution.tsx
@@ -80,9 +80,8 @@ export const Attribution = memo(function Attribution(): JSX.Element {
         id="attribution"
         onClick={handleOpenPopover}
         className={open ? 'active' : ''}
+        aria-label={t('mapctrl.attribution.tooltip')}
         tooltipPlacement="top"
-        tooltip={t('mapctrl.attribution.tooltip')!}
-        aria-label={t('mapctrl.attribution.tooltip')!}
         sx={buttonStyles}
       >
         <MoreHorizIcon />

--- a/packages/geoview-core/src/core/components/common/full-screen-dialog.tsx
+++ b/packages/geoview-core/src/core/components/common/full-screen-dialog.tsx
@@ -1,5 +1,6 @@
-import type { ReactNode} from 'react';
+import type { ReactNode } from 'react';
 import { memo, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { DialogProps } from '@mui/material';
 import { CloseIcon, Dialog, DialogContent, IconButton } from '@/ui';
 import { logger } from '@/core/utils/logger';
@@ -31,6 +32,9 @@ export const FullScreenDialog = memo(function FullScreenDialog({
 }: FullScreenDialogProps): JSX.Element {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
+  // Hooks
+  const { t } = useTranslation<string>();
+
   useEffect(() => {
     // Log
     logger.logTraceUseEffect('FULL SCREEN DIALOG - open with focus on close', open);
@@ -59,7 +63,14 @@ export const FullScreenDialog = memo(function FullScreenDialog({
       sx={{ maxHeight: '100% !important' }}
     >
       <DialogContent sx={DIALOG_CONTENT_STYLES}>
-        <IconButton ref={closeButtonRef} onClick={onClose} color="primary" className="buttonFilledOutline" sx={CLOSE_BUTTON_STYLES}>
+        <IconButton
+          ref={closeButtonRef}
+          onClick={onClose}
+          aria-label={t('general.close')}
+          color="primary"
+          className="buttonFilledOutline"
+          sx={CLOSE_BUTTON_STYLES}
+        >
           <CloseIcon />
         </IconButton>
         {children}

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -389,6 +389,8 @@ function DataTable({ data, layerPath }: DataTableProps): JSX.Element {
         ZOOM: (
           <IconButton
             color="primary"
+            aria-label={t('dataTable.zoom')}
+            tooltipPlacement="top"
             // Function returns void promise instead of void, other work arounds led to more eslint issues
             onClick={() => {
               handleZoomIn(feature).catch((error) => logger.logError('Zoom failed:', error));
@@ -402,6 +404,8 @@ function DataTable({ data, layerPath }: DataTableProps): JSX.Element {
           <Box marginLeft="0.3rem">
             <IconButton
               color="primary"
+              aria-label={t('dataTable.details')}
+              tooltipPlacement="top"
               onClick={() => {
                 setSelectedFeature(feature);
                 enableFocusTrap({ activeElementId: 'featureDetailDataTable', callbackElementId: 'table-details' });

--- a/packages/geoview-core/src/core/components/data-table/export-button.tsx
+++ b/packages/geoview-core/src/core/components/data-table/export-button.tsx
@@ -113,7 +113,7 @@ function ExportButton({ layerPath, rows, columns, children }: ExportButtonProps)
 
   return (
     <>
-      <IconButton onClick={handleClick} tooltip={t('dataTable.exportBtn')!} className="buttonOutline">
+      <IconButton onClick={handleClick} aria-label={t('dataTable.exportBtn')} className="buttonOutline">
         <DownloadIcon />
       </IconButton>
       <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>

--- a/packages/geoview-core/src/core/components/data-table/top-toolbar.tsx
+++ b/packages/geoview-core/src/core/components/data-table/top-toolbar.tsx
@@ -88,7 +88,6 @@ function TopToolbar(props: TopToolbarProps<ColumnsType>): JSX.Element {
 
           <IconButton
             className="buttonOutline"
-            tooltip={t('dataTable.clearFilters')}
             aria-label={t('dataTable.clearFilters')}
             color="primary"
             onClick={() => useTable?.resetColumnFilters()}

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -448,8 +448,7 @@ export function DetailsPanel({ fullWidth = false, containerType = CONTAINER_TYPE
                   .replace('{total}', `${memoSelectedLayerDataFeatures?.length}`)}
                 <IconButton
                   sx={{ marginLeft: '1.25rem', [theme.breakpoints.down('sm')]: { display: 'none' } }}
-                  aria-label={t('details.clearAllfeatures')!}
-                  tooltip={t('details.clearAllfeatures')!}
+                  aria-label={t('details.clearAllfeatures')}
                   tooltipPlacement="top"
                   onClick={() => handleClearAllHighlights()}
                   className="buttonOutline"
@@ -462,8 +461,7 @@ export function DetailsPanel({ fullWidth = false, containerType = CONTAINER_TYPE
             <Grid size={{ xs: 6 }}>
               <Box sx={{ textAlign: 'right', marginRight: '1.625rem' }}>
                 <IconButton
-                  aria-label={t('details.previousFeatureBtn')!}
-                  tooltip={t('details.previousFeatureBtn')!}
+                  aria-label={t('details.previousFeatureBtn')}
                   tooltipPlacement="top"
                   onClick={() => handleFeatureNavigateChange(-1)}
                   disabled={currentFeatureIndex <= 0}
@@ -473,8 +471,7 @@ export function DetailsPanel({ fullWidth = false, containerType = CONTAINER_TYPE
                 </IconButton>
                 <IconButton
                   sx={{ marginLeft: '1.25rem' }}
-                  aria-label={t('details.nextFeatureBtn')!}
-                  tooltip={t('details.nextFeatureBtn')!}
+                  aria-label={t('details.nextFeatureBtn')}
                   tooltipPlacement="top"
                   onClick={() => handleFeatureNavigateChange(1)}
                   disabled={!memoSelectedLayerData?.features || currentFeatureIndex + 1 >= memoSelectedLayerData.features.length}

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -86,7 +86,7 @@ const FeatureHeader = memo(function FeatureHeader({ iconSrc, name, hasGeometry, 
         </Tooltip>
         <IconButton
           color="primary"
-          tooltip={t('details.zoomTo')!}
+          aria-label={t('details.zoomTo')}
           tooltipPlacement="top"
           disabled={!hasGeometry}
           onClick={onZoomIn}

--- a/packages/geoview-core/src/core/components/export/export-modal-button.tsx
+++ b/packages/geoview-core/src/core/components/export/export-modal-button.tsx
@@ -32,8 +32,7 @@ export default function ExportButton({ className = '', sxDetails }: ExportProps)
   return (
     <IconButton
       id={`${mapId}-export-btn`}
-      tooltip={t('appbar.export')!}
-      aria-label={t('appbar.export')!}
+      aria-label={t('appbar.export')}
       tooltipPlacement="right"
       onClick={() => enableFocusTrap({ activeElementId: 'export', callbackElementId: `${mapId}-export-btn` })}
       sx={{ [theme.breakpoints.down('md')]: { display: 'none' }, ...sxDetails }}

--- a/packages/geoview-core/src/core/components/footer-bar/hooks/resize-footer-panel.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/hooks/resize-footer-panel.tsx
@@ -73,7 +73,7 @@ export const ResizeFooterPanel = memo(function ResizeFooterPanel(): JSX.Element 
   const open = Boolean(anchorEl);
   return (
     <>
-      <IconButton onClick={(e) => handleClick(e)} tooltip={t('footerBar.resizeTooltip')!}>
+      <IconButton onClick={(e) => handleClick(e)} aria-label={t('footerBar.resizeTooltip')}>
         <HeightIcon />
       </IconButton>
       <Popover

--- a/packages/geoview-core/src/core/components/geolocator/geolocator-bar.tsx
+++ b/packages/geoview-core/src/core/components/geolocator/geolocator-bar.tsx
@@ -36,11 +36,19 @@ export function GeolocatorBar({ searchValue, onChange, onSearch, onReset, isLoad
         >
           <StyledInputField placeholder={t('geolocator.search')!} autoFocus onChange={onChange} value={searchValue} />
           <Box sx={{ display: 'flex', marginLeft: 'auto', alignItems: 'center' }}>
-            <IconButton size="small" edge="end" color="inherit" sx={{ mr: 4 }} disabled={!searchValue.length} onClick={onSearch}>
+            <IconButton
+              size="small"
+              edge="end"
+              color="inherit"
+              aria-label={t('geolocator.search')}
+              sx={{ mr: 4 }}
+              disabled={!searchValue.length}
+              onClick={onSearch}
+            >
               <SearchIcon sx={{ fontSize: theme.palette.geoViewFontSize.sm }} />
             </IconButton>
             <Divider orientation="vertical" variant="middle" flexItem />
-            <IconButton size="small" edge="end" color="inherit" sx={{ mr: 2, ml: 4 }} onClick={onReset}>
+            <IconButton size="small" edge="end" color="inherit" aria-label={t('general.close')} sx={{ mr: 2, ml: 4 }} onClick={onReset}>
               <CloseIcon sx={{ fontSize: theme.palette.geoViewFontSize.sm }} />
             </IconButton>
           </Box>

--- a/packages/geoview-core/src/core/components/geolocator/geolocator-result.tsx
+++ b/packages/geoview-core/src/core/components/geolocator/geolocator-result.tsx
@@ -119,7 +119,7 @@ export function GeolocatorResult({ geoLocationData, searchValue, error }: Geoloc
               size="small"
               edge="end"
               color="inherit"
-              tooltip={t('geolocator.clearFilters')!}
+              aria-label={t('geolocator.clearFilters')}
               onClick={handleClearFilters}
               disabled={!geoLocationData.length}
             >

--- a/packages/geoview-core/src/core/components/guide/guide-search.tsx
+++ b/packages/geoview-core/src/core/components/guide/guide-search.tsx
@@ -401,10 +401,10 @@ export function GuideSearch({ guide, onSectionChange, onSearchStateChange }: Gui
                       <Box sx={{ fontSize: '0.75rem', color: 'text.secondary', whiteSpace: 'nowrap' }}>
                         {currentMatchIndex + 1} of {allMatches.length}
                       </Box>
-                      <IconButton size="small" onClick={handlePrevious} disabled={allMatches.length === 0}>
+                      <IconButton size="small" aria-label={t('guide.arrowUp')} onClick={handlePrevious} disabled={allMatches.length === 0}>
                         <KeyboardArrowUpIcon sx={{ fontSize: theme.palette.geoViewFontSize.sm }} />
                       </IconButton>
-                      <IconButton size="small" onClick={handleNext} disabled={allMatches.length === 0}>
+                      <IconButton size="small" aria-label={t('guide.arrowDown')} onClick={handleNext} disabled={allMatches.length === 0}>
                         <KeyboardArrowDownIcon sx={{ fontSize: theme.palette.geoViewFontSize.sm }} />
                       </IconButton>
                     </>
@@ -413,6 +413,7 @@ export function GuideSearch({ guide, onSectionChange, onSearchStateChange }: Gui
                     size="small"
                     edge="end"
                     color="inherit"
+                    aria-label={t('general.close')}
                     onClick={handleClear}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') {

--- a/packages/geoview-core/src/core/components/layers/left-panel/delete-undo-button.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/delete-undo-button.tsx
@@ -23,6 +23,8 @@ function UndoButtonWithProgress(props: UndoButtonProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/left-panel/delete-undo-button/UndoButtonWithProgress');
 
+  const { t } = useTranslation<string>();
+
   const { progressValue, onUndo, handleKeyDown } = props;
   return (
     <Box sx={{ position: 'relative', display: 'inline-flex' }} onClick={onUndo}>
@@ -39,7 +41,7 @@ function UndoButtonWithProgress(props: UndoButtonProps): JSX.Element {
           justifyContent: 'center',
         }}
       >
-        <IconButton edge="end" size="small" onKeyDown={(e) => handleKeyDown(e)}>
+        <IconButton aria-label={t('layers.undoLayer')} edge="end" size="small" onKeyDown={(e) => handleKeyDown(e)}>
           <UndoIcon />
         </IconButton>
       </Box>
@@ -133,7 +135,7 @@ export function DeleteUndoButton(props: DeleteUndoButtonProps): JSX.Element {
         edge="end"
         size="small"
         onKeyDown={(e) => handleDeleteKeyDown(e)}
-        tooltip={t('layers.deleteLayer')!}
+        aria-label={t('layers.deleteLayer')}
       >
         <DeleteOutlineIcon color="error" />
       </IconButton>
@@ -141,7 +143,7 @@ export function DeleteUndoButton(props: DeleteUndoButtonProps): JSX.Element {
   }
   if (!inUndoState) {
     return (
-      <IconButton onClick={handleDeleteClick} edge="end" size="small" disabled>
+      <IconButton aria-label={t('layers.deleteLayer')} onClick={handleDeleteClick} edge="end" size="small" disabled>
         <DeleteOutlineIcon color="disabled" />
       </IconButton>
     );

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -53,6 +53,9 @@ import { useGeoViewMapId } from '@/core/stores/geoview-store';
 import { useUISelectedFooterLayerListItemId } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import type { TypeLayerControls } from '@/api/types/layer-schema-types';
 
+// TODO: WCAG Issue #3108 - Check all disabled buttons. They may need special treatment. Need to find instance in UI first)
+// TODO: WCAG Issue #3108 - Check all icon buttons for "state related" aria values (i.e aria-checked, aria-disabled, etc.)
+
 interface SingleLayerProps {
   layerPath: string;
   depth: number;
@@ -280,6 +283,7 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
   }, [layerPath, layerStatus, parentHidden, t, layerChildren, layerItems, datatableSettings]);
 
   // Memoize the EditModeButtons component section
+
   const memoEditModeButtons = useMemo((): JSX.Element | null => {
     // Log
     logger.logTraceUseMemo('SINGLE-LAYER - memoEditModeButtons', layerPath);
@@ -304,6 +308,7 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
           )}
           <IconButton
             id={`${mapId}-${layerPath}-up-order`}
+            aria-label={t('layers.moveLayerUp')}
             disabled={isFirst}
             edge="end"
             size="small"
@@ -314,6 +319,7 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
           </IconButton>
           <IconButton
             id={`${mapId}-${layerPath}-down-order`}
+            aria-label={t('layers.moveLayerDown')}
             disabled={isLast}
             edge="end"
             size="small"
@@ -338,6 +344,7 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
     layerPath,
     mapId,
     reorderLayer,
+    t,
     theme.palette.geoViewColor.bgColor.dark,
   ]);
 
@@ -355,7 +362,7 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
           <IconButton
             edge="end"
             size="small"
-            tooltip={layerChildren && layerChildren.length > 0 ? t('layers.reloadSublayers')! : t('layers.reloadLayer')!}
+            aria-label={layerChildren && layerChildren.length > 0 ? t('layers.reloadSublayers') : t('layers.reloadLayer')}
             className="buttonOutline"
             onClick={handleReload}
           >
@@ -372,7 +379,7 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
           <IconButton
             edge="end"
             size="small"
-            tooltip={t('layers.visibilityIsAlways')!}
+            aria-label={t('layers.visibilityIsAlways')}
             className="buttonOutline"
             disabled={!inVisibleRange}
           >
@@ -391,7 +398,7 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
         <IconButton
           edge="end"
           size="small"
-          tooltip={t('layers.zoomVisibleScale')!}
+          aria-label={t('layers.zoomVisibleScale')}
           sx={{ display: isZoomToVisibleScaleCapable ? 'block' : 'none' }}
           onClick={handleZoomToLayerVisibleScale}
         >
@@ -402,7 +409,7 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
             edge={inVisibleRange ? false : 'end'}
             size="small"
             onClick={handleToggleVisibility}
-            tooltip={t('layers.toggleVisibility')!}
+            aria-label={t('layers.toggleVisibility')}
             className="buttonOutline"
             disabled={!inVisibleRange || parentHidden}
           >
@@ -442,7 +449,7 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
           edge="end"
           size="small"
           onClick={handleExpandGroupClick}
-          tooltip={t('layers.toggleCollapse')!}
+          aria-label={t('layers.toggleCollapse')}
           className="buttonOutline"
         >
           {legendExpanded ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -48,6 +48,10 @@ import {
   useMapSelectorLayerParentHidden,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 
+// TODO: WCAG Issue #3108 - Fix layers.moreInfo button (button nested within a button)
+// TODO: WCAG Issue #3108 - Check all disabled buttons. They may need special treatment. Need to find instance in UI first)
+// TODO: WCAG Issue #3108 - Check all icon buttons for "state related" aria values (i.e aria-checked, aria-disabled, etc.)
+
 interface LayerDetailsProps {
   layerDetails: TypeLegendLayer;
 }
@@ -63,6 +67,7 @@ const Sublayer = memo(({ layer }: SubLayerProps): JSX.Element => {
 
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
+  const { t } = useTranslation<string>();
 
   // Hooks
   const layerHidden = useMapSelectorIsLayerHiddenOnMap(layer.layerPath);
@@ -73,7 +78,15 @@ const Sublayer = memo(({ layer }: SubLayerProps): JSX.Element => {
   // Return the ui
   return (
     <ListItem>
-      <IconButton color="primary" onClick={() => setOrToggleLayerVisibility(layer.layerPath)} disabled={parentHidden}>
+      <IconButton
+        color="primary"
+        role="checkbox"
+        onClick={() => setOrToggleLayerVisibility(layer.layerPath)}
+        disabled={parentHidden}
+        aria-checked={layerVisible === true}
+        aria-label={layerVisible ? t('layers.hideLayer', { name: layer.layerName }) : t('layers.showLayer', { name: layer.layerName })}
+        tooltipPlacement="left"
+      >
         {layerVisible ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
       </IconButton>
       <LayerIcon layerPath={layer.layerPath} />
@@ -263,14 +276,22 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
 
     if (!layerDetails.canToggle) {
       return (
-        <IconButton disabled tooltip={t('layers.visibilityIsAlways')!}>
+        <IconButton disabled role="checkbox" aria-label={t('layers.visibilityIsAlways')} aria-checked={false} tooltipPlacement="left">
           <CheckBoxIcon color="disabled" />
         </IconButton>
       );
     }
 
     return (
-      <IconButton color="primary" onClick={() => toggleItemVisibility(layerDetails.layerPath, item)} disabled={layerHidden}>
+      <IconButton
+        role="checkbox"
+        color="primary"
+        aria-label={item.isVisible ? t('layers.hideLayer', { name: item.name }) : t('layers.showLayer', { name: item.name })}
+        aria-checked={item.isVisible === true}
+        tooltipPlacement="left"
+        onClick={() => toggleItemVisibility(layerDetails.layerPath, item)}
+        disabled={layerHidden}
+      >
         {item.isVisible === true ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
       </IconButton>
     );
@@ -279,14 +300,22 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   function renderHeaderCheckbox(): JSX.Element {
     if (!layerDetails.canToggle) {
       return (
-        <IconButton disabled>
+        <IconButton disabled role="checkbox" aria-label={t('layers.visibilityIsAlways')} aria-checked={false} tooltipPlacement="left">
           <CheckBoxIcon color="disabled" />
         </IconButton>
       );
     }
 
     return (
-      <IconButton color="primary" onClick={() => setAllItemsVisibility(layerDetails.layerPath, !allItemsChecked())} disabled={layerHidden}>
+      <IconButton
+        color="primary"
+        role="checkbox"
+        aria-label={allItemsChecked() ? t('layers.hideAllLayers') : t('layers.showAllLayers')}
+        aria-checked={allItemsChecked() === true}
+        tooltipPlacement="left"
+        onClick={() => setAllItemsVisibility(layerDetails.layerPath, !allItemsChecked())}
+        disabled={layerHidden}
+      >
         {allItemsChecked() ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
       </IconButton>
     );
@@ -345,12 +374,12 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   function renderDetailsButton(): JSX.Element {
     if (layerDetails.controls?.table !== false)
       return (
-        <IconButton id="table-details" tooltip={t('legend.tableDetails')!} className="buttonOutline" onClick={handleOpenTable}>
+        <IconButton id="table-details" aria-label={t('legend.tableDetails')} className="buttonOutline" onClick={handleOpenTable}>
           <TableViewIcon />
         </IconButton>
       );
     return (
-      <IconButton id="table-details" className="buttonOutline" disabled>
+      <IconButton aria-label={t('layers.tableViewNone')} id="table-details" className="buttonOutline" disabled>
         <TableViewIcon color="disabled" />
       </IconButton>
     );
@@ -360,7 +389,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
     if (isLayerHighlightCapable)
       return (
         <IconButton
-          tooltip={t('legend.highlightLayer')!}
+          aria-label={t('legend.highlightLayer')}
           onClick={handleHighlightLayer}
           className={highlightedLayer === layerDetails.layerPath ? 'buttonOutline active' : 'buttonOutline'}
           disabled={layerHidden}
@@ -375,7 +404,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
     if (isLayerZoomToExtentCapable)
       return (
         <IconButton
-          tooltip={t('legend.zoomTo')!}
+          aria-label={t('legend.zoomTo')}
           onClick={handleZoomTo}
           className="buttonOutline"
           disabled={layerDetails.bounds === undefined || layerHidden}
@@ -390,7 +419,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
     return (
       <Box sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '15px', marginLeft: 'auto' }}>
         {datatableSettings[layerDetails.layerPath] && renderDetailsButton()}
-        <IconButton tooltip={t('legend.refreshLayer')!} className="buttonOutline" onClick={handleRefreshLayer}>
+        <IconButton aria-label={t('legend.refreshLayer')} className="buttonOutline" onClick={handleRefreshLayer}>
           <RestartAltIcon />
         </IconButton>
         {renderHighlightButton()}
@@ -493,7 +522,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
       <Box>
         <Button type="text" sx={{ fontSize: theme.palette.geoViewFontSize.sm }} onClick={() => setIsInfoCollapse(!isInfoCollapse)}>
           {`${t('layers.moreInfo')}`}
-          <IconButton className="buttonOutline" edge="end" size="small" tooltip={t('layers.toggleCollapse')!}>
+          <IconButton className="buttonOutline" edge="end" size="small" aria-label={t('layers.toggleCollapse')}>
             {isInfoCollapse ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
           </IconButton>
         </Button>
@@ -588,7 +617,15 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
             {layerDetails.children.length > 0 && (
               <Grid container direction="row" alignItems="center" justifyItems="stretch">
                 <Grid size={{ xs: 'auto' }}>
-                  <IconButton color="primary" onClick={handleToggleAllVisibility} disabled={layerHidden}>
+                  <IconButton
+                    role="checkbox"
+                    aria-label={allSublayersVisible ? t('layers.hideAllLayers') : t('layers.showAllLayers')}
+                    aria-checked={allSublayersVisible === true}
+                    tooltipPlacement="left"
+                    color="primary"
+                    onClick={handleToggleAllVisibility}
+                    disabled={layerHidden}
+                  >
                     {allSublayersVisible ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
                   </IconButton>
                 </Grid>

--- a/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
@@ -32,6 +32,9 @@ import {
 import { getSxClasses } from './legend-styles';
 import { logger } from '@/core/utils/logger';
 
+// TODO: WCAG Issue #3108 - Check all icon buttons for aria-label clarity and translations
+// TODO: WCAG Issue #3108 - Check all icon buttons for "state related" aria values (i.e aria-checked, aria-disabled, etc.)
+
 interface SecondaryControlsProps {
   layerPath: string;
 }
@@ -141,7 +144,7 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
       <Box sx={sxClasses.subtitle}>
         <IconButton
           edge="end"
-          tooltip={t('layers.zoomVisibleScale')!}
+          aria-label={t('layers.zoomVisibleScale')}
           className={`buttonOutline ${isZoomToVisibleScaleCapable ? '' : 'outOfRangeButton'}`}
           onClick={controls.handleZoomToLayerVisibleScale}
         >
@@ -150,7 +153,7 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
         {isLayerVisibleCapable && (
           <IconButton
             edge={isInVisibleRange ? false : 'end'}
-            tooltip={t('layers.toggleVisibility')!}
+            aria-label={t('layers.toggleVisibility')}
             className="buttonOutline"
             onClick={controls.handleToggleVisibility}
             disabled={!isInVisibleRange || parentHidden || layerStatus === 'error'}
@@ -160,7 +163,7 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
         )}
         {isLayerHighlightCapable && (
           <IconButton
-            tooltip={t('legend.highlightLayer')!}
+            aria-label={t('legend.highlightLayer')}
             sx={styles.btnMargin}
             className="buttonOutline"
             onClick={controls.handleHighlightLayer}
@@ -171,7 +174,7 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
         )}
         {isLayerZoomToExtentCapable && (
           <IconButton
-            tooltip={t('legend.zoomTo')!}
+            aria-label={t('legend.zoomTo')}
             className="buttonOutline"
             onClick={controls.handleZoomTo}
             disabled={!isInVisibleRange || parentHidden || !isVisible || layerStatus === 'error'}

--- a/packages/geoview-core/src/core/components/legend/legend-layer.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer.tsx
@@ -22,6 +22,9 @@ import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import { getSxClasses } from './legend-styles';
 import { logger } from '@/core/utils/logger';
 
+// TODO: WCAG Issue #3108 - Check all icon buttons for aria-label clarity and translations
+// TODO: WCAG Issue #3108 - Check all icon buttons for "state related" aria values (i.e aria-checked, aria-disabled, etc.)
+
 interface LegendLayerProps {
   layerPath: string;
 }
@@ -67,7 +70,7 @@ const LegendLayerHeader = memo(({ layerPath, tooltip, onExpandClick }: LegendLay
         secondary={<SecondaryControls layerPath={layerPath} />}
       />
       {((layerChildren && layerChildren.length > 0) || (layerItems && layerItems.length > 1) || layerType === CONST_LAYER_TYPES.WMS) && (
-        <IconButton className="buttonOutline" onClick={onExpandClick} edge="end" size="small" tooltip={tooltip}>
+        <IconButton className="buttonOutline" onClick={onExpandClick} edge="end" size="small" aria-label={tooltip}>
           {!isCollapsed ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
         </IconButton>
       )}

--- a/packages/geoview-core/src/core/components/map-info/map-info-expand-button.tsx
+++ b/packages/geoview-core/src/core/components/map-info/map-info-expand-button.tsx
@@ -53,7 +53,7 @@ export const MapInfoExpandButton = memo(function MapInfoExpandButton({ onExpand,
 
   return (
     <Box sx={BOX_STYLES}>
-      <IconButton aria-label={t(TOOLTIP_KEY)!} tooltip={t(TOOLTIP_KEY)!} tooltipPlacement="top" onClick={handleClick} sx={buttonStyles}>
+      <IconButton aria-label={t(TOOLTIP_KEY)} tooltipPlacement="top" onClick={handleClick} sx={buttonStyles}>
         <ExpandIcon expanded={expanded} />
       </IconButton>
     </Box>

--- a/packages/geoview-core/src/core/components/map-info/map-info-rotation-button.tsx
+++ b/packages/geoview-core/src/core/components/map-info/map-info-rotation-button.tsx
@@ -48,13 +48,7 @@ export const MapInfoRotationButton = memo(function MapInfoRotationButton(): JSX.
   );
 
   return (
-    <IconButton
-      tooltipPlacement="top"
-      tooltip={t('mapctrl.rotation.resetRotation')!}
-      aria-label={t('mapctrl.rotation.resetRotation')!}
-      onClick={handleRotationReset}
-      sx={buttonStyles}
-    >
+    <IconButton aria-label={t('mapctrl.rotation.resetRotation')} tooltipPlacement="top" onClick={handleRotationReset} sx={buttonStyles}>
       <ArrowUpIcon ref={iconRef} style={iconStyles} />
     </IconButton>
   );

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/basemap-select.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/basemap-select.tsx
@@ -76,8 +76,7 @@ export default function BasemapSelect(): JSX.Element {
           <ListItem>
             <IconButton
               id="button-default"
-              aria-label={t('basemaps.default')!}
-              tooltip={t('basemaps.default')!}
+              aria-label={t('basemaps.default')}
               tooltipPlacement="left"
               size="small"
               onClick={() => handleChoice('default')}
@@ -91,8 +90,7 @@ export default function BasemapSelect(): JSX.Element {
         <ListItem>
           <IconButton
             id="button-transport"
-            aria-label={t('basemaps.transport')!}
-            tooltip={t('basemaps.transport')!}
+            aria-label={t('basemaps.transport')}
             tooltipPlacement="left"
             size="small"
             onClick={() => handleChoice('transport')}
@@ -105,8 +103,7 @@ export default function BasemapSelect(): JSX.Element {
         <ListItem>
           <IconButton
             id="button-imagery"
-            aria-label={t('basemaps.imagery')!}
-            tooltip={t('basemaps.imagery')!}
+            aria-label={t('basemaps.imagery')}
             tooltipPlacement="left"
             size="small"
             onClick={() => handleChoice('imagery')}
@@ -119,8 +116,7 @@ export default function BasemapSelect(): JSX.Element {
         <ListItem>
           <IconButton
             id="button-simple"
-            aria-label={t('basemaps.simple')!}
-            tooltip={t('basemaps.simple')!}
+            aria-label={t('basemaps.simple')}
             tooltipPlacement="left"
             size="small"
             onClick={() => handleChoice('simple')}
@@ -133,8 +129,7 @@ export default function BasemapSelect(): JSX.Element {
         <ListItem>
           <IconButton
             id="button-nogeom"
-            aria-label={t('basemaps.nogeom')!}
-            tooltip={t('basemaps.nogeom')!}
+            aria-label={t('basemaps.nogeom')}
             tooltipPlacement="left"
             size="small"
             onClick={() => handleChoice('nogeom')}
@@ -150,7 +145,7 @@ export default function BasemapSelect(): JSX.Element {
 
   // Set up props for nav bar panel button
   const button: IconButtonPropsExtend = {
-    tooltip: 'mapnav.basemap',
+    'aria-label': t('mapnav.basemap'),
     children: createElement(MapIcon),
     tooltipPlacement: 'left',
   };

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/fullscreen.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/fullscreen.tsx
@@ -67,7 +67,7 @@ export default function Fullscreen(): JSX.Element {
   return (
     <IconButton
       id="fullscreen"
-      tooltip={t('mapnav.fullscreen')!}
+      aria-label={t('mapnav.fullscreen')}
       tooltipPlacement="left"
       onClick={() => setFullscreen()}
       sx={sxClasses.navButton}

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/home.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/home.tsx
@@ -34,7 +34,7 @@ export default function Home(): JSX.Element {
   };
 
   return (
-    <IconButton id="home" tooltip={t('mapnav.home')!} tooltipPlacement="left" onClick={handleZoom} sx={sxClasses.navButton}>
+    <IconButton id="home" aria-label={t('mapnav.home')} tooltipPlacement="left" onClick={handleZoom} sx={sxClasses.navButton}>
       <HomeIcon />
     </IconButton>
   );

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/location.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/location.tsx
@@ -49,7 +49,7 @@ export default function Location(): JSX.Element {
   };
 
   return (
-    <IconButton id="location" tooltip={t('mapnav.location')!} tooltipPlacement="left" onClick={handleZoomToMe} sx={sxClasses.navButton}>
+    <IconButton id="location" aria-label={t('mapnav.location')} tooltipPlacement="left" onClick={handleZoomToMe} sx={sxClasses.navButton}>
       <EmojiPeopleIcon />
     </IconButton>
   );

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/projection.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/projection.tsx
@@ -9,6 +9,7 @@ import type { IconButtonPropsExtend } from '@/ui/icon-button/icon-button';
 import { IconButton } from '@/ui/icon-button/icon-button';
 import { List, ListItem } from '@/ui/list';
 import { ProjectionIcon, PublicIcon } from '@/ui/icons';
+import { useTranslation } from 'react-i18next';
 
 const projectionChoiceOptions: {
   [key: string]: {
@@ -27,6 +28,8 @@ const projectionChoiceOptions: {
 export default function Projection(): JSX.Element {
   // Log
   logger.logTraceRender('components/nav-bar/buttons/projection');
+
+  const { t } = useTranslation<string>();
 
   // Store
   const projection = useMapProjection();
@@ -54,7 +57,6 @@ export default function Projection(): JSX.Element {
           <IconButton
             id="button-wm"
             aria-label={projectionChoiceOptions['3857'].name}
-            tooltip={projectionChoiceOptions['3857'].name}
             tooltipPlacement="left"
             size="small"
             onClick={() => handleChoice(projectionChoiceOptions['3857'].code)}
@@ -68,7 +70,6 @@ export default function Projection(): JSX.Element {
           <IconButton
             id="button-lcc"
             aria-label={projectionChoiceOptions['3978'].name}
-            tooltip={projectionChoiceOptions['3978'].name}
             tooltipPlacement="left"
             size="small"
             onClick={() => handleChoice(projectionChoiceOptions['3978'].code)}
@@ -84,7 +85,7 @@ export default function Projection(): JSX.Element {
 
   // Set up props for nav bar panel button
   const button: IconButtonPropsExtend = {
-    tooltip: 'mapnav.projection',
+    'aria-label': t('mapnav.projection'),
     children: createElement(ProjectionIcon),
     tooltipPlacement: 'left',
   };

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/zoom-in.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/zoom-in.tsx
@@ -25,7 +25,7 @@ export default function ZoomIn(): JSX.Element {
   return (
     <IconButton
       id="zoomIn"
-      tooltip={t('mapnav.zoomIn')!}
+      aria-label={t('mapnav.zoomIn')}
       tooltipPlacement="left"
       onClick={() => setZoom(zoom + 0.5)}
       sx={sxClasses.navButton}

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/zoom-out.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/zoom-out.tsx
@@ -25,7 +25,7 @@ export default function ZoomOut(): JSX.Element {
   return (
     <IconButton
       id="zoomOut"
-      tooltip={t('mapnav.zoomOut')!}
+      aria-label={t('mapnav.zoomOut')}
       tooltipPlacement="left"
       onClick={() => setZoom(zoom - 0.5)}
       sx={sxClasses.navButton}

--- a/packages/geoview-core/src/core/components/nav-bar/nav-bar-panel-button.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/nav-bar-panel-button.tsx
@@ -83,7 +83,8 @@ export default function NavbarPanelButton({ buttonPanel }: NavbarPanelButtonType
         <IconButton
           key={buttonPanel.button.id}
           id={buttonPanel.button.id}
-          tooltip={t(buttonPanel.button.tooltip!)!}
+          aria-label={buttonPanel.button['aria-label']}
+          tooltip={buttonPanel.button.tooltip}
           tooltipPlacement={buttonPanel.button.tooltipPlacement}
           sx={sxClasses.navButton}
           onClick={(e) => handleClick(e)}
@@ -107,7 +108,12 @@ export default function NavbarPanelButton({ buttonPanel }: NavbarPanelButtonType
             <DialogTitle sx={sxClasses.popoverTitle}>
               <span style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%' }}>
                 {t(buttonPanel.panel?.title as string) ?? ''}
-                <IconButton size="small" onClick={closePanel} sx={{ padding: 0.5, color: 'inherit', position: 'relative', left: '16px' }}>
+                <IconButton
+                  size="small"
+                  aria-label={t('general.close')}
+                  onClick={closePanel}
+                  sx={{ padding: 0.5, color: 'inherit', position: 'relative', left: '16px' }}
+                >
                   <CloseIcon fontSize="small" />
                 </IconButton>
               </span>

--- a/packages/geoview-core/src/core/components/nav-bar/nav-bar.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/nav-bar.tsx
@@ -202,7 +202,8 @@ export function NavBar(props: NavBarProps): JSX.Element {
           <IconButton
             key={buttonPanel.button.id}
             id={buttonPanel.button.id}
-            tooltip={t(buttonPanel.button.tooltip!)!}
+            aria-label={buttonPanel.button['aria-label']}
+            tooltip={buttonPanel.button.tooltip}
             tooltipPlacement={buttonPanel.button.tooltipPlacement}
             sx={sxClasses.navButton}
             onClick={buttonPanel.button.onClick}
@@ -274,7 +275,7 @@ export function NavBar(props: NavBarProps): JSX.Element {
           {needsExpansion && (
             <IconButton
               key={`expand-${groupName}`}
-              tooltip={isExpanded ? 'Show less' : 'Show more'}
+              aria-label={isExpanded ? t('general.close') : t('general.open')}
               tooltipPlacement="left"
               sx={sxClasses.navButton}
               onClick={toggleExpansion}

--- a/packages/geoview-core/src/core/components/notifications/notifications.tsx
+++ b/packages/geoview-core/src/core/components/notifications/notifications.tsx
@@ -47,11 +47,13 @@ const NotificationItem = memo(function NotificationItem({
   onRemove,
   theme,
   sxClasses,
+  t,
 }: {
   notification: NotificationDetailsType;
   onRemove: (key: string) => void;
   theme: Theme;
   sxClasses: SxStyles;
+  t: (key: string) => string;
 }) {
   const handleRemove = useCallback(() => {
     logger.logTraceUseCallback('NOTIFICATION - remove', notification.key);
@@ -88,7 +90,7 @@ const NotificationItem = memo(function NotificationItem({
           <Box sx={sxClasses.notificationsCount}>{notification.count}</Box>
         </Box>
       )}
-      <IconButton onClick={handleRemove}>
+      <IconButton aria-label={t('general.close')} onClick={handleRemove}>
         <CloseIcon />
       </IconButton>
     </Box>
@@ -106,6 +108,7 @@ const NotificationHeader = memo(function NotificationHeader({
   onClose: () => void;
   onRemoveAll: () => void;
   hasNotifications: boolean;
+
   t: (key: string) => string;
   sxClasses: SxStyles;
 }) {
@@ -125,7 +128,7 @@ const NotificationHeader = memo(function NotificationHeader({
         >
           {t('appbar.removeAllNotifications')}
         </Button>
-        <IconButton sx={{ ml: '0.25rem' }} onClick={onClose}>
+        <IconButton aria-label={t('general.close')} sx={{ ml: '0.25rem' }} onClick={onClose}>
           <CloseIcon />
         </IconButton>
       </Box>
@@ -231,9 +234,10 @@ export default memo(function Notifications(): JSX.Element {
           onRemove={handleRemoveNotification}
           theme={theme}
           sxClasses={sxClasses}
+          t={t}
         />
       )),
-    [notifications, handleRemoveNotification, theme, sxClasses]
+    [notifications, handleRemoveNotification, theme, sxClasses, t]
   );
 
   return (
@@ -241,8 +245,7 @@ export default memo(function Notifications(): JSX.Element {
       <Box sx={{ padding: interaction === 'dynamic' ? 'none' : '5px' }}>
         <IconButton
           id="notification"
-          tooltip={t('appbar.notifications')!}
-          aria-label={t('appbar.notifications')!}
+          aria-label={t('appbar.notifications')}
           tooltipPlacement="right"
           onClick={handleOpenPopover}
           className={`${interaction === 'dynamic' ? 'buttonFilled' : 'style4'} ${open ? 'active' : ''}`}

--- a/packages/geoview-core/src/ui/drawer/drawer.tsx
+++ b/packages/geoview-core/src/ui/drawer/drawer.tsx
@@ -100,7 +100,7 @@ function DrawerUI(props: DrawerPropsExtend): JSX.Element {
     >
       <Box sx={sxClasses.toolbar}>
         <IconButton
-          tooltip={open ? t('general.close')! : t('general.open')!}
+          aria-label={open ? t('general.close') : t('general.open')}
           tooltipPlacement="right"
           onClick={() => {
             handleDrawerToggle(!open);

--- a/packages/geoview-core/src/ui/modal/modal.tsx
+++ b/packages/geoview-core/src/ui/modal/modal.tsx
@@ -241,7 +241,7 @@ function ModalUI(props: DialogPropsExtend): JSX.Element {
             ) : null}
             <IconButton
               id={`${modalId}-close-button`}
-              tooltip={t('close')!}
+              aria-label={t('close')}
               tooltipPlacement="right"
               onClick={modal.close}
               className="headerActionsContainer"

--- a/packages/geoview-core/src/ui/panel/panel.tsx
+++ b/packages/geoview-core/src/ui/panel/panel.tsx
@@ -154,9 +154,8 @@ function PanelUI(props: TypePanelAppProps): JSX.Element {
             action={
               open ? (
                 <IconButton
-                  tooltip={t('general.close')!}
+                  aria-label={t('general.close')}
                   tooltipPlacement="right"
-                  aria-label={t('general.close')!}
                   size="small"
                   onClick={() => onGeneralClose?.()}
                   iconRef={closeBtnRef}


### PR DESCRIPTION
# Description

Updated IconButton component:

* fix icon-button: aria-label required
* fix icon-button: children required
* fix icon-button: tooltip uses aria-label if not provided
* update all icon buttons to include aria-label
* update "checkbox" icon buttons to include aria-checked
* Add conditional aria labelling to match state (e.g. show/hide)
* update translations

Addresses #3108

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested manually by looking at the accessibility tree in Chrome's dev console (all IconButton instances should have a "Name" value.) 

__[Add the URL for your deploy!](https://kenchase.github.io/geoview/)__

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3133)
<!-- Reviewable:end -->
