### PR TITLE
fix(wcag ui): Add, remove, edit alt/aria-label text to improve A11Y

### DIFF
--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -106,6 +106,7 @@
     "hidden": "Layer is hidden",
     "parentHidden": "Parent layer is hidden",
     "stepOne": "Upload data",
+    "stepOneLoading": "Uploading data...",
     "stepTwo": "Select format",
     "stepThree": "Configure layer",
     "stepFour": "Enter name",
@@ -167,6 +168,7 @@
     "instructionsNoLayersTitle": "No layers visible",
     "instructionsNoLayersBody": "Add visible layers on the map.",
     "moreInfo": "More Information",
+    "lessInfo": "Less Information",
     "layerType": "Type: ",
     "layerResource": "Resource: ",
     "layerMetadata": "Metadata: ",
@@ -183,7 +185,8 @@
     "hideLayer": "Hide {{name}} layer",
     "tableViewNone": "Table (unavailable)",
     "moveLayerUp": "Move layer up",
-    "moveLayerDown": "Move layer down"
+    "moveLayerDown": "Move layer down",
+    "layerControls": "Layers controls"
   },
   "details": {
     "title": "Details",
@@ -215,7 +218,8 @@
     "easting": "Easting",
     "northing": "Northing",
     "ntsMapsheet": "NTS Mapsheet",
-    "elevation": "Elevation"
+    "elevation": "Elevation",
+    "guideControls": "Guide controls"
   },
   "lightbox": {
     "next": "Next",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -106,6 +106,7 @@
     "hidden": "La couche est cachée",
     "parentHidden": "La couche parent est cachée",
     "stepOne": "Télécharger des données",
+    "stepOneLoading": "Téléchargement des données...",
     "stepTwo": "Sélectionner le format",
     "stepThree": "Configurer la couche",
     "stepFour": "Entrer le nom",
@@ -167,6 +168,7 @@
     "instructionsNoLayersTitle": "Aucune couche visible",
     "instructionsNoLayersBody": "Ajoutez des couches visibles sur la carte.",
     "moreInfo": "Plus d'informations",
+    "lessInfo": "Moins d'informations",
     "layerType": "Type : ",
     "layerResource": "Ressource : ",
     "layerMetadata": "Métadonnées : ",
@@ -183,7 +185,8 @@
     "hideLayer": "Masquer la couche {{name}}",
     "tableViewNone": "Tableau (indisponible)",
     "moveLayerUp": "Déplacer la couche vers le haut",
-    "moveLayerDown": "Déplacer la couche vers le bas"
+    "moveLayerDown": "Déplacer la couche vers le bas",
+    "layerControls": "Commandes des couches"
   },
   "details": {
     "title": "Détails",
@@ -215,7 +218,8 @@
     "easting": "Easting",
     "northing": "Northing",
     "ntsMapsheet": "Carte SNRC",
-    "elevation": "Élévation"
+    "elevation": "Élévation",
+    "guideControls": "Commandes du guide"
   },
   "lightbox": {
     "next": "Prochaine",

--- a/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
@@ -42,7 +42,7 @@ import { CONTAINER_TYPE } from '@/core/utils/constant';
 import type { TypeValidAppBarCoreProps } from '@/api/types/map-schema-types';
 import { DEFAULT_APPBAR_CORE, DEFAULT_APPBAR_TABS_ORDER } from '@/api/types/map-schema-types';
 import { handleEscapeKey } from '@/core/utils/utilities';
-import { Button } from '@/ui/button/button';
+import { IconButton } from '@/ui/icon-button/icon-button';
 
 interface GroupPanelType {
   icon: ReactNode;
@@ -355,17 +355,16 @@ export function AppBar(props: AppBarProps): JSX.Element {
               {buttonPanel?.button.visible !== undefined && buttonPanel?.button.visible ? (
                 <Fragment key={buttonPanel.button.id}>
                   <ListItem>
-                    <Button
+                    <IconButton
                       id={buttonPanel.button.id}
-                      aria-label={t(buttonPanel.button.tooltip!)!}
-                      tooltip={t(buttonPanel.button.tooltip!)!}
+                      aria-label={t(buttonPanel.button['aria-label'])}
                       tooltipPlacement="right"
                       className={`buttonFilled ${tabId === buttonPanel.button.id && isOpen ? 'active' : ''}`}
                       size="small"
                       onClick={() => handleButtonClicked(buttonPanel.button.id!)}
-                      startIcon={buttonPanel.button.children}
-                      type="icon"
-                    />
+                    >
+                      {buttonPanel.button.children}
+                    </IconButton>
                   </ListItem>
                 </Fragment>
               ) : null}

--- a/packages/geoview-core/src/core/components/common/layer-icon.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-icon.tsx
@@ -55,6 +55,7 @@ function IconStack({ layerPath }: TypeIconStackProps): JSX.Element | null {
     [iconData]
   );
 
+  // TODO: WCAG Issue #3109 - Add meaningful alt text to image icons if needed
   const renderSingleIcon = useCallback((): JSX.Element => {
     // Log
     logger.logTraceUseCallback('LAYER-ICON - renderSingleIcon');
@@ -65,7 +66,7 @@ function IconStack({ layerPath }: TypeIconStackProps): JSX.Element | null {
           <BrowserNotSupportedIcon />
         ) : (
           <Box sx={sxClasses.legendIcon}>
-            <Box component="img" alt="icon" src={iconImage} sx={sxClasses.maxIconImg} />
+            <Box component="img" alt="" src={iconImage} sx={sxClasses.maxIconImg} />
           </Box>
         )}
       </Icon>
@@ -80,11 +81,11 @@ function IconStack({ layerPath }: TypeIconStackProps): JSX.Element | null {
       <Box sx={sxClasses.stackIconsBox} aria-hidden="true">
         <Icon {...ICON_BUTTON_BASE_PROPS} sx={sxClasses.iconPreviewStacked}>
           <Box sx={sxClasses.legendIconTransparent}>
-            {iconImageStacked && <Box component="img" alt="icon" src={iconImageStacked} sx={sxClasses.maxIconImg} />}
+            {iconImageStacked && <Box component="img" alt="" src={iconImageStacked} sx={sxClasses.maxIconImg} />}
           </Box>
         </Icon>
         <Icon {...ICON_BUTTON_BASE_PROPS} sx={sxClasses.iconPreviewHoverable}>
-          <Box sx={sxClasses.legendIcon}>{iconImage && <Box component="img" alt="icon" src={iconImage} sx={sxClasses.maxIconImg} />}</Box>
+          <Box sx={sxClasses.legendIcon}>{iconImage && <Box component="img" alt="" src={iconImage} sx={sxClasses.maxIconImg} />}</Box>
         </Icon>
       </Box>
     );

--- a/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
@@ -1,7 +1,7 @@
-import type { ReactNode, Ref} from 'react';
+import type { ReactNode, Ref } from 'react';
 import { useState, useCallback, forwardRef, useImperativeHandle, useEffect, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { SxProps} from '@mui/material/styles';
+import type { SxProps } from '@mui/material/styles';
 import { useTheme } from '@mui/material/styles';
 import Markdown from 'markdown-to-jsx';
 import { Box, FullscreenIcon, ButtonGroup, Button, Typography, IconButton } from '@/ui';
@@ -323,7 +323,7 @@ const ResponsiveGridLayout = forwardRef(
         <Box ref={guideContainerRef} tabIndex={0} sx={{ padding: '20px', overflow: 'auto' }}>
           <Box className="guideBox">
             {/* Close button, only shown WCAG is enabled and not fullScreen */}
-            {(isFocusTrap && !isFullScreen) && (
+            {isFocusTrap && !isFullScreen && (
               <IconButton
                 id={`layout-close-guide-${mapId}`}
                 onClick={handleCloseGuide}
@@ -413,7 +413,7 @@ const ResponsiveGridLayout = forwardRef(
               {rightTop ?? <Box />}
 
               <Box sx={sxClasses.rightButtonsContainer}>
-                <ButtonGroup size="small" variant="outlined" aria-label="outlined button group">
+                <ButtonGroup size="small" variant="outlined" aria-label={t('details.guideControls')!}>
                   {!fullWidth && !hideEnlargeBtn && renderEnlargeButton()}
                   {!!guideContentIds?.length && renderGuideButton()}
                   {!isMapFullScreen && renderFullScreenButton()}

--- a/packages/geoview-core/src/core/components/export/export-modal.tsx
+++ b/packages/geoview-core/src/core/components/export/export-modal.tsx
@@ -313,7 +313,7 @@ export default function ExportModal(): JSX.Element {
           <MenuItem onClick={() => handleSelectFormat('jpeg')}>JPEG</MenuItem>
         </Menu>
         <Button type="text" onClick={handleFormatMenuClick} variant="outlined" size="small" sx={sxClasses.buttonOutlined}>
-          Format: {exportFormat.toUpperCase()}
+          {t('exportModal.formatBtn')} {exportFormat.toUpperCase()}
         </Button>
 
         {/* DPI Selection - Only show for PNG and JPEG */}

--- a/packages/geoview-core/src/core/components/layers/layers-toolbar.tsx
+++ b/packages/geoview-core/src/core/components/layers/layers-toolbar.tsx
@@ -95,7 +95,7 @@ export function LayersToolbar(): JSX.Element {
 
   return (
     <Box id="layers-toolbar" sx={layerToolbarStyle}>
-      <ButtonGroup size="small" variant="outlined" aria-label="outlined button group">
+      <ButtonGroup size="small" variant="outlined" aria-label={t('layers.layerControls')!}>
         <Button
           makeResponsive
           type="text"

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { SelectChangeEvent } from '@mui/material';
 import type { ButtonPropsLayerPanel } from '@/ui';
-import { Box, Button, ButtonGroup, CircularProgressBase, FileUploadIcon, Paper, Select, Stepper, TextField } from '@/ui';
+import { Box, Button, IconButton, ButtonGroup, CircularProgressBase, FileUploadIcon, Paper, Select, Stepper, TextField } from '@/ui';
 import { useGeoViewMapId } from '@/core/stores/geoview-store';
 import { useLayerStoreActions } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { useAppDisabledLayerTypes, useAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
@@ -139,6 +139,7 @@ function FileUploadSection({ onFileSelected, onUrlChanged, displayURL, disabledL
    * @param {React.DragEvent<HTMLDivElement>} event - The drag event containing dropped files
    * @returns {void}
    */
+
   const handleDrop = (event: React.DragEvent<HTMLDivElement>): void => {
     event.preventDefault();
     event.stopPropagation();
@@ -147,7 +148,8 @@ function FileUploadSection({ onFileSelected, onUrlChanged, displayURL, disabledL
       processFile(event.dataTransfer.files[0]);
     }
   };
-
+  // TODO: WCAG Issue #3117 -  aria-label(layers.fileTypes) needs to include button text (layers.upload)...
+  // TODO: WCAG Issue #3117 -  ... button text (Choose a file) does not begin with sane word aria-label (Upload a...)
   return (
     <Box
       className="dropzone"
@@ -209,6 +211,7 @@ function FileUploadSection({ onFileSelected, onUrlChanged, displayURL, disabledL
           }
         }}
         className="buttonOutlineFilled"
+        aria-label={t('layers.fileTypes')!}
         tooltip={t('layers.fileTypes')!}
       >
         <FileUploadIcon />
@@ -742,9 +745,9 @@ export function AddNewLayer(): JSX.Element {
     return (
       <ButtonGroup sx={sxClasses.buttonGroup}>
         {isLoading ? (
-          <Button sx={{ width: '80px' }} type="icon" size="small" variant="contained" className="buttonOutlineFilled" disabled>
+          <IconButton sx={{ width: '80px' }} size="small" className="buttonOutlineFilled" disabled aria-label={t('layers.stepOneLoading')}>
             <CircularProgressBase size="20px" />
-          </Button>
+          </IconButton>
         ) : (
           <Button
             variant="contained"

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -453,7 +453,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
       return (
         <Grid sx={sxClasses.itemsGrid}>
           <Grid container pt={6} pb={6}>
-            <Box component="img" alt="icon" src={layerDetails.icons[0].iconImage} sx={sxClasses.wmsImage} />
+            <Box component="img" alt="" src={layerDetails.icons[0].iconImage} sx={sxClasses.wmsImage} />
           </Grid>
         </Grid>
       );
@@ -520,11 +520,13 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
 
     return (
       <Box>
-        <Button type="text" sx={{ fontSize: theme.palette.geoViewFontSize.sm }} onClick={() => setIsInfoCollapse(!isInfoCollapse)}>
-          {`${t('layers.moreInfo')}`}
-          <IconButton className="buttonOutline" edge="end" size="small" aria-label={t('layers.toggleCollapse')}>
-            {isInfoCollapse ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-          </IconButton>
+        <Button
+          type="text"
+          sx={{ fontSize: theme.palette.geoViewFontSize.sm }}
+          onClick={() => setIsInfoCollapse(!isInfoCollapse)}
+          endIcon={isInfoCollapse ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+        >
+          {isInfoCollapse ? `${t('layers.lessInfo')}` : `${t('layers.moreInfo')}`}
         </Button>
         <Collapse in={isInfoCollapse} sx={sxClasses.layerInfo}>
           <Box>{`${t('layers.layerType')}${localizedTypeName}`}</Box>

--- a/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
@@ -15,6 +15,8 @@ interface ItemsListProps {
 
 // Extracted ListItem Component
 // Apply style to increase left/right tooltip area (padding: '0 18px 0 18px', margin: '0 -18px 0 -18px')
+// TODO: WCAG Issue #3121 - List items aren't focusable using keyboard navigation...
+// TODO: WCAG Issue #3121 - ... rework so to use buttons/checkboxes or similar component that is keyboard accessible for toggling
 const LegendListItem = memo(
   ({
     item: { icon, name, isVisible },
@@ -31,7 +33,7 @@ const LegendListItem = memo(
       <ListItemIcon>
         <Tooltip title={show ? value : ''} key={`Tooltip-${name}-${icon}1`} placement="left" disableHoverListener={!show}>
           <Box sx={{ padding: '0 18px 0 18px', margin: '0 -18px 0 -18px' }}>
-            {icon ? <Box component="img" alt={name} src={icon} /> : <BrowserNotSupportedIcon />}
+            {icon ? <Box component="img" alt="" src={icon} /> : <BrowserNotSupportedIcon />}
           </Box>
         </Tooltip>
       </ListItemIcon>

--- a/packages/geoview-core/src/core/components/mouse-position/mouse-position.tsx
+++ b/packages/geoview-core/src/core/components/mouse-position/mouse-position.tsx
@@ -130,6 +130,9 @@ export const MousePosition = memo(function MousePosition({ expanded }: MousePosi
     [positions, positionMode, expanded, sxClasses, theme.palette.geoViewFontSize.lg]
   );
 
+  // TODO: WCAG Issue #2390 - Ensure that mouse position button updates are announced by screen readers
+  // TODO: WCAG Issue #2390 - Rethink this to use mutliple buttons or select element for better accessibility?
+
   const collapsedContent = useMemo(
     () => (
       <Box

--- a/packages/geoview-core/src/core/components/scale/scale.tsx
+++ b/packages/geoview-core/src/core/components/scale/scale.tsx
@@ -139,7 +139,8 @@ export const Scale = memo(function Scale({ expanded }: ScaleProps): JSX.Element 
     ),
     [interaction, scaleValues, scaleMode, sxClasses.scaleText, getScaleWidth]
   );
-
+  // TODO: WCAG Issue #2390 - Ensure that scale button updates are announced by screen readers
+  // TODO: WCAG Issue #2390 - Rethink this to use mutliple buttons or select element for better accessibility?
   return (
     <Tooltip title={t('mapnav.scale')} placement="top">
       <Box sx={BOX_STYLES}>

--- a/packages/geoview-core/src/core/containers/focus-trap.tsx
+++ b/packages/geoview-core/src/core/containers/focus-trap.tsx
@@ -259,21 +259,11 @@ export function FocusTrapDialog(props: FocusTrapProps): JSX.Element {
       contentModal={<UseHtmlToReact htmlContent={t('keyboardnav.focusdialog.main')} />}
       actions={
         <>
-          <Button
-            id="enable-focus"
-            tooltip={t('keyboardnav.focusdialog.button.enable')!}
-            tooltipPlacement="top-end"
-            autoFocus
-            onClick={handleEnable}
-            type="text"
-            sx={MODAL_BUTTON_STYLES}
-          >
+          <Button id="enable-focus" autoFocus onClick={handleEnable} type="text" sx={MODAL_BUTTON_STYLES}>
             {t('keyboardnav.focusdialog.button.enable')}
           </Button>
           <Button
             id="skip-focus"
-            tooltip={t('keyboardnav.focusdialog.button.skip')!}
-            tooltipPlacement="top-end"
             onClick={handleSkip}
             type="text"
             sx={{

--- a/packages/geoview-core/src/ui/button/button.tsx
+++ b/packages/geoview-core/src/ui/button/button.tsx
@@ -14,6 +14,9 @@ export type ButtonProps = {
  * A customized Material-UI Button component with tooltip and responsive support.
  *
  * @component
+ * @param {ButtonProps} props - The properties for the Button component
+ * @param {Ref<HTMLButtonElement>} ref - The ref forwarded to the underlying MaterialButton
+ * @returns {JSX.Element} A rendered Button component
  * @example
  * ```tsx
  * // Basic usage
@@ -45,9 +48,6 @@ export type ButtonProps = {
  * </Button>
  * ```
  *
- * @param {ButtonProps} props - The properties for the Button component
- * @param {Ref<HTMLButtonElement>} ref - The ref forwarded to the underlying MaterialButton
- * @returns {JSX.Element} A rendered Button component
  *
  * @note For performance optimization in cases of frequent parent re-renders,
  * consider wrapping this component with React.memo at the consumption level.
@@ -130,5 +130,8 @@ function ButtonUI(props: ButtonProps, ref: Ref<HTMLButtonElement>): JSX.Element 
   );
 }
 
-// Export the Button  using forwardRef so that passing ref is permitted and functional in the react standards
+// Export the Button using forwardRef so that passing ref is permitted and functional in the react standards
+// TODO: WCAG Issue #2390 - This (forwardRef) prevents TypeDoc from documenting the 'Button' component as expected...
+// TODO: WCAG Issue #2390 - IconButton uses a custom prop ('iconRef') to work around this issue...
+// TODO: WCAG Issue #2390 - Investigate if similar approach could work here.
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(ButtonUI);

--- a/packages/geoview-core/src/ui/panel/panel-types.ts
+++ b/packages/geoview-core/src/ui/panel/panel-types.ts
@@ -65,6 +65,9 @@ export interface PanelStyles {
 /**
  * Interface for the button properties used when creating a new button.
  */
+
+// TODO: WCAG Issue #2390 - type prop appears to be unused in codebase. Remove from interface (and all references) once confirmed.
+
 export interface TypeButtonProps extends Omit<ButtonProps, 'type'> {
   /** Button id */
   id?: string;


### PR DESCRIPTION
* Add TODOs for a11y button usage related to other issues
* Replace Button with IconButton where icon-only usage is appropriate
* Update translations for new aria-label strings
* Remove redundant tooltips that duplicate button text
* Remove redundant alt text from decorative images (use alt="" instead)

# Description

Fixes to help improve A11Y through the correct implementation of alt and aria-label text. Closes issue #3108.

Fixes #3108

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

__[Add the URL for your deploy!](https://kenchase.github.io/geoview/)__

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3146)
<!-- Reviewable:end -->
