### PR TITLE
fix(wcag): Use semantic HTML, and ARIA roles/tags (sidebar)

### DIFF
--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -70,7 +70,8 @@
     "share": "Share",
     "version": "About GeoView",
     "repoLink": "Github",
-    "removeAllNotifications": "Remove all"
+    "removeAllNotifications": "Remove all",
+    "navLabel": "Main map controls"
   },
   "legend": {
     "title": "Legend",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -70,7 +70,8 @@
     "share": "Partager",
     "version": "À propos de GéoView",
     "repoLink": "Github",
-    "removeAllNotifications": "Effacer tout"
+    "removeAllNotifications": "Effacer tout",
+    "navLabel": "Contrôles principaux de la carte"
   },
   "legend": {
     "title": "Légende",

--- a/packages/geoview-core/src/core/components/app-bar/app-bar-style.ts
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar-style.ts
@@ -35,12 +35,9 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
       backgroundColor: 'transparent',
       justifyContent: 'center',
     },
-    '& hr': {
-      width: '80%',
-      marginLeft: '5px',
-    },
   },
   appBarButtons: {
+    position: 'relative',
     paddingTop: '16px',
     borderRightColor: theme.palette.geoViewColor.primary.light[100],
     borderRightWidth: 1,
@@ -68,9 +65,25 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
       },
     },
   },
+  appBarSeparator: {
+    '&::before': {
+      content: '""',
+      display: 'block',
+      borderTop: `1px solid ${theme.palette.geoViewColor.grey.light[100]}`,
+      width: '40px',
+      margin: 'auto 5px',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+    },
+    marginTop: '0.5em',
+    padding: '0.5em 0 0 0',
+    position: 'relative',
+  },
   versionButtonDiv: {
     position: 'absolute',
     bottom: 0,
+    width: '100%',
   },
   appBarPanels: {},
 });

--- a/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
@@ -94,12 +94,14 @@ export default function Version(): JSX.Element {
     if (open) setOpen(false);
   }, [open]);
 
+  // TODO: WCAG Issue #3154 - add aria-controls to <IconButton>. Needs id on the popper container to work correctly.
   return (
     <ClickAwayListener mouseEvent="onMouseDown" touchEvent="onTouchStart" onClickAway={handleClickAway}>
       <Box sx={{ padding: interaction === 'dynamic' ? 'none' : '5px' }}>
         <IconButton
           id="version-button"
           aria-label={t('appbar.version')}
+          aria-expanded={open ? 'true' : 'false'}
           tooltipPlacement="right"
           onClick={handleOpenPopover}
           className={`${interaction === 'dynamic' ? 'buttonFilled' : 'style4'} ${open ? 'active' : ''}`}

--- a/packages/geoview-core/src/core/components/export/export-modal-button.tsx
+++ b/packages/geoview-core/src/core/components/export/export-modal-button.tsx
@@ -13,6 +13,7 @@ import { useGeoViewMapId } from '@/core/stores/geoview-store';
 interface ExportProps {
   className?: string;
   sxDetails?: object;
+  ariaExpanded?: boolean;
 }
 
 /**
@@ -20,7 +21,9 @@ interface ExportProps {
  *
  * @returns {JSX.Element} the export button
  */
-export default function ExportButton({ className = '', sxDetails }: ExportProps): JSX.Element {
+
+// TODO: WCAG Issue #3154 - add aria-controls to <IconButton>. Needs id of the modal to be passed as a prop.
+export default function ExportButton({ className = '', sxDetails, ariaExpanded = false }: ExportProps): JSX.Element {
   // Hooks
   const theme = useTheme();
   const { t } = useTranslation<string>();
@@ -33,6 +36,7 @@ export default function ExportButton({ className = '', sxDetails }: ExportProps)
     <IconButton
       id={`${mapId}-export-btn`}
       aria-label={t('appbar.export')}
+      aria-expanded={ariaExpanded}
       tooltipPlacement="right"
       onClick={() => enableFocusTrap({ activeElementId: 'export', callbackElementId: `${mapId}-export-btn` })}
       sx={{ [theme.breakpoints.down('md')]: { display: 'none' }, ...sxDetails }}

--- a/packages/geoview-core/src/core/components/notifications/notifications.tsx
+++ b/packages/geoview-core/src/core/components/notifications/notifications.tsx
@@ -168,7 +168,7 @@ export default memo(function Notifications(): JSX.Element {
   // Animation
   const shakeAnimation = useShake();
   const timerRef = useRef<ReturnType<typeof setTimeout>>();
-  const AnimatedBox = animated(Box);
+  const AnimatedSpan = animated('span');
 
   // Handlers
   const handleOpenPopover = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
@@ -240,21 +240,29 @@ export default memo(function Notifications(): JSX.Element {
     [notifications, handleRemoveNotification, theme, sxClasses, t]
   );
 
+  // TODO: WCAG Issue #3154 - add aria-controls to notifications <IconButton>. Needs id of the modal to be passed as a prop.
   return (
     <ClickAwayListener mouseEvent="onMouseDown" touchEvent="onTouchStart" onClickAway={handleClickAway}>
       <Box sx={{ padding: interaction === 'dynamic' ? 'none' : '5px' }}>
         <IconButton
           id="notification"
           aria-label={t('appbar.notifications')}
+          aria-expanded={open}
           tooltipPlacement="right"
           onClick={handleOpenPopover}
           className={`${interaction === 'dynamic' ? 'buttonFilled' : 'style4'} ${open ? 'active' : ''}`}
           color="primary"
         >
           <Badge badgeContent={notificationsCount > 99 ? '99+' : notificationsCount} color="error">
-            <AnimatedBox sx={{ display: 'inline-flex', alignItems: 'center' }} style={hasNewNotification ? shakeAnimation : undefined}>
+            <AnimatedSpan
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                ...(hasNewNotification ? shakeAnimation : {}),
+              }}
+            >
               {hasNewNotification ? <NotificationsActiveIcon /> : <NotificationsIcon />}
-            </AnimatedBox>
+            </AnimatedSpan>
           </Badge>
         </IconButton>
 


### PR DESCRIPTION
* Render AppBar buttons within a <nav> element
* Add AppBar aria-label and related translations
* Add aria-expanded to AppBar Buttons
* Minimize number of generated lists in button panel (renderButtonPanel)
* Prevent empty lists/list in button panel (renderButtonPanel)
* Remove invalid hr from button panel and replace with css (app-bar-style.ts)
* Update <AnimatedBox> to <AnimatedSpan> (for valid HTML)

# Description

Update AppBar to use semantic HTML, and ARIA roles/tags (sidebar)

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested manually using Chrome dev tools. All AppBar buttons now have the elements described above.

__[Add the URL for your deploy!](https://kenchase.github.io/geoview/)__

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3159)
<!-- Reviewable:end -->
