### PR TITLE
fix(ui): Sets footerbar tab/dropdown to adjust using the same breakpoints as the panels

### DIFF
--- a/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
@@ -47,17 +47,17 @@ const getSxClasses = (theme: Theme): SxStyles => ({
   versionHeading: {
     display: 'flex',
     alignItems: 'center',
-    borderBottom: `1px solid ${theme.palette.geoViewColor.bgColor.dark[100]}}`,
+    borderBottom: `1px solid ${theme.palette.geoViewColor.bgColor.dark[100]}`,
+    padding: '10px',
+    justifyContent: 'space-between',
   },
   versionsInfoTitle: {
     fontSize: theme.palette.geoViewFontSize.default,
     fontWeight: '700',
-    padding: '20px',
     color: theme.palette.geoViewColor.textColor.main,
-    marginBottom: '10px',
   },
   versionInfoContent: {
-    padding: '20px',
+    padding: '10px',
     gap: '5px',
     display: 'flex',
     flexDirection: 'column',
@@ -137,7 +137,7 @@ export default function Version(): JSX.Element {
                 <Typography sx={sxClasses.versionsInfoTitle} component="h3">
                   {t('appbar.version')}
                 </Typography>
-                <IconButton onClick={handleClickAway} aria-label={t('general.close')} tooltipPlacement="right">
+                <IconButton onClick={handleClickAway} size="small" aria-label={t('general.close')} tooltipPlacement="right">
                   <CloseIcon />
                 </IconButton>
               </Box>

--- a/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode, Ref } from 'react';
 import { useState, useCallback, forwardRef, useImperativeHandle, useEffect, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useMediaQuery } from '@mui/material';
 import type { SxProps } from '@mui/material/styles';
 import { useTheme } from '@mui/material/styles';
 import Markdown from 'markdown-to-jsx';
@@ -62,6 +63,7 @@ const ResponsiveGridLayout = forwardRef(
     const { t } = useTranslation<string>();
     const theme = useTheme();
     const isMapFullScreen = useAppFullscreenActive();
+    const isMobile = useMediaQuery( theme.breakpoints.down('sm') );
 
     // Ref for right panel
     const rightMainRef = useRef<HTMLDivElement>();
@@ -216,7 +218,7 @@ const ResponsiveGridLayout = forwardRef(
     }
 
     const renderEnlargeButton = (): JSX.Element | null => {
-      if (window.innerWidth <= theme.breakpoints.values.md) {
+      if (isMobile) {
         return null; // Return null if on small screens (down to md)
       }
 
@@ -238,7 +240,7 @@ const ResponsiveGridLayout = forwardRef(
 
     const renderCloseButton = (): JSX.Element | null => {
       // Check conditions for hiding the button
-      if (!toggleMode && (window.innerWidth >= theme.breakpoints.values.sm || !isRightPanelVisible)) {
+      if (!toggleMode && (!isMobile || !isRightPanelVisible)) {
         return null;
       }
 

--- a/packages/geoview-core/src/core/components/common/responsive-grid.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid.tsx
@@ -38,11 +38,11 @@ const PANEL_SIZES = {
   default: { xs: 12 } as PanelSize,
   left: {
     normal: { sm: 5, md: 4, lg: 4 },
-    enlarged: { sm: 5, md: 2, lg: 1.25 }
+    enlarged: { sm: 3, md: 2, lg: 1.25 }
   } as PanelConfig,
   right: {
     normal: { sm: 7, md: 8, lg: 8 },
-    enlarged: { sm: 7, md: 10, lg: 10.75 },
+    enlarged: { sm: 9, md: 10, lg: 10.75 },
   } as PanelConfig,
 } as const;
 

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -574,19 +574,16 @@ export function DetailsPanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: Deta
 
     // Show the details for a feature on map click
     if (mapClickCoordinates && memoLayersList?.length) {
-      // Select the first layer that has features and isn't the coordinate info
-      const selectedLayer = memoLayersList.find((layer) => !!layer.numOffeatures && layer.layerPath !== 'coordinate-info');
-      let newSelectedLayerPath = selectedLayer?.layerPath ?? '';
-
-      // Fallback to the coordinate info if it's enabled and no features are available
-      if (!selectedLayer && coordinateInfoEnabled) {
-        newSelectedLayerPath = 'coordinate-info';
+      // if we don't have a selected layer path with features select the first layer path with features
+      if (!selectedLayerPath.length) {
+        const selectedLayer = memoLayersList.find((layer) => !!layer.numOffeatures);
+        setSelectedLayerPath(selectedLayer?.layerPath ?? '');
       }
 
-      setSelectedLayerPath(newSelectedLayerPath);
-
       // make sure the right panel is visible
-      layoutRef.current?.showRightPanel(true);
+      if (!isRightPanelVisible) {
+        layoutRef.current?.showRightPanel(true);
+      }
     }
 
     // On new map click (coordinates changed), clear all highlights, checked features, and layer features

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar-style.ts
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar-style.ts
@@ -17,9 +17,6 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
     boxShadow: 2,
     width: '100%',
     transition: 'height 0.2s ease-out',
-    '& .MuiGrid-container': {
-      background: theme.palette.geoViewColor.bgColor.main,
-    },
     '& .MuiTab-root': {
       minHeight: '40px',
     },

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -17,7 +17,6 @@ import {
   useUIFooterBarIsCollapsed,
   useUIHiddenTabs,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import { useMapSize } from '@/core/stores/store-interface-and-intial-values/map-state';
 import type { FooterBarApi, FooterTabCreatedEvent, FooterTabRemovedEvent } from '@/core/components';
 import { DEFAULT_FOOTER_TABS_ORDER } from '@/api/types/map-schema-types';
 import { useGeoViewConfig, useGeoViewMapId } from '@/core/stores/geoview-store';
@@ -75,7 +74,6 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
   const isCollapsed = useUIFooterBarIsCollapsed();
   const shellContainer = useAppShellContainer();
   const { setActiveFooterBarTab, enableFocusTrap, disableFocusTrap, setFooterBarIsCollapsed } = useUIStoreActions();
-  const mapSize = useMapSize() || [200, 200]; // Default in case the map isn't rendered yet and the Footer tries to render
   const appHeight: number = useAppHeight();
   const hiddenTabs: string[] = useUIHiddenTabs();
 
@@ -435,7 +433,6 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
         TabContentVisibilty={!isCollapsed ? 'visible' : 'hidden'}
         containerType={CONTAINER_TYPE.FOOTER_BAR}
         rightButtons={!isCollapsed && isMapFullScreen && <ResizeFooterPanel />}
-        sideAppSize={mapSize}
         appHeight={appHeight}
         hiddenTabs={hiddenTabs}
         isFullScreen={isMapFullScreen}

--- a/packages/geoview-core/src/core/components/guide/guide-search.tsx
+++ b/packages/geoview-core/src/core/components/guide/guide-search.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -7,6 +7,7 @@ import { Box, TextField, InputAdornment, IconButton } from '@/ui';
 import { SearchIcon, CloseIcon, KeyboardArrowUpIcon, KeyboardArrowDownIcon } from '@/ui/icons';
 import type { TypeGuideObject } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { logger } from '@/core/utils/logger';
+import { getSxClasses } from './guide-style';
 
 interface GuideSearchProps {
   guide: TypeGuideObject | undefined;
@@ -24,6 +25,7 @@ export function GuideSearch({ guide, onSectionChange, onSearchStateChange }: Gui
   // Hooks
   const { t } = useTranslation();
   const theme = useTheme();
+  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // State
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -464,7 +466,7 @@ export function GuideSearch({ guide, onSectionChange, onSearchStateChange }: Gui
   );
 
   return (
-    <Box sx={{ p: 2, borderBottom: '1px solid', borderColor: 'divider', width: '400px', maxWidth: '100%' }}>
+    <Box sx={sxClasses.guideSearch}>
       <TextField
         fullWidth
         size="small"

--- a/packages/geoview-core/src/core/components/guide/guide-style.ts
+++ b/packages/geoview-core/src/core/components/guide/guide-style.ts
@@ -126,4 +126,10 @@ export const getSxClasses = (theme: Theme): SxStyles =>
       marginTop: '30px',
       marginBottom: '12px',
     },
+    guideSearch: {
+      backgroundColor: theme.palette.geoViewColor.bgColor.light[600],
+      marginBottom: '10px',
+      width: '400px',
+      maxWidth: '100%',
+    },
   }) as const;

--- a/packages/geoview-core/src/core/components/guide/guide.tsx
+++ b/packages/geoview-core/src/core/components/guide/guide.tsx
@@ -222,11 +222,11 @@ export const Guide = memo(function GuidePanel({ containerType = CONTAINER_TYPE.F
   const ariaLabel = t('guide.title');
   return (
     <Box sx={sxClasses.guideContainer}>
-      <GuideSearch guide={guide} onSectionChange={handleSectionChange} onSearchStateChange={handleSearchStateChange} />
       <Box sx={{ flex: 1, minHeight: 0 }}>
         <Layout
           containerType={containerType}
           selectedLayerPath={selectedLayerPath}
+          layoutSwitch={<GuideSearch guide={guide} onSectionChange={handleSectionChange} onSearchStateChange={handleSearchStateChange} />}
           layerList={layersList}
           onLayerListClicked={handleGuideItemClick}
           aria-label={ariaLabel}

--- a/packages/geoview-core/src/core/components/layers/layers-panel.tsx
+++ b/packages/geoview-core/src/core/components/layers/layers-panel.tsx
@@ -84,7 +84,7 @@ export function LayersPanel({ containerType }: TypeLayersPanel): JSX.Element {
           fontWeight: '600',
           overflow: 'hidden',
           textOverflow: 'ellipsis',
-          [theme.breakpoints.up('md')]: { display: 'none' },
+          [theme.breakpoints.up('sm')]: { display: 'none' },
         }}
         component="div"
       >

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details-style.ts
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details-style.ts
@@ -51,7 +51,6 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
     fontSize: theme.palette.geoViewFontSize.default,
     marginLeft: '20px',
     alignSelf: 'center',
-    whiteSpace: 'nowrap',
   },
   wmsImage: {
     maxWidth: '100%',

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -5,21 +5,22 @@ import type { TypeLegendLayer, TypeLegendItem } from '@/core/components/layers/t
 import { getSxClasses } from './layer-details-style';
 import {
   Box,
+  BrowserNotSupportedIcon,
   CheckBoxIcon,
   CheckBoxOutlineBlankIcon,
-  IconButton,
-  Paper,
-  Typography,
-  ZoomInSearchIcon,
+  Divider,
   Grid,
-  RestartAltIcon,
+  HighlightIcon,
   HighlightOutlinedIcon,
+  IconButton,
+  List,
+  ListItem,
+  Paper,
+  RestartAltIcon,
   TableViewIcon,
   TimeSliderIcon,
-  BrowserNotSupportedIcon,
-  Divider,
-  ListItem,
-  List,
+  Typography,
+  ZoomInSearchIcon,
 } from '@/ui';
 import { useLayerHighlightedLayer, useLayerStoreActions } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { useUIStoreActions } from '@/core/stores/store-interface-and-intial-values/ui-state';
@@ -349,10 +350,10 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
             key={`${item.name}/${layerDetails.items.indexOf(item)}`}
             alignItems="center"
             justifyItems="stretch"
-            sx={{ display: 'flex', flexWrap: 'nowrap' }}
+            sx={{ display: 'flex', flexWrap: 'nowrap', marginBottom: '5px' }}
           >
             <Grid size={{ xs: 'auto' }}>{renderItemCheckbox(item)}</Grid>
-            <Grid size={{ xs: 'auto' }} sx={{ display: 'flex' }}>
+            <Grid size={{ xs: 'grow' }} sx={{ display: 'flex' }}>
               {item.icon ? (
                 <Box component="img" sx={{ alignSelf: 'center', maxHeight: '26px', maxWidth: '26px' }} alt={item.name} src={item.icon} />
               ) : (
@@ -423,13 +424,8 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   function renderHighlightButton(): JSX.Element {
     if (isLayerHighlightCapable)
       return (
-        <IconButton
-          aria-label={t('legend.highlightLayer')}
-          onClick={handleHighlightLayer}
-          className={highlightedLayer === layerDetails.layerPath ? 'buttonOutline active' : 'buttonOutline'}
-          disabled={layerHidden}
-        >
-          <HighlightOutlinedIcon />
+        <IconButton aria-label={t('legend.highlightLayer')} onClick={handleHighlightLayer} className="buttonOutline" disabled={layerHidden}>
+          {highlightedLayer === layerDetails.layerPath ? <HighlightIcon /> : <HighlightOutlinedIcon />}
         </IconButton>
       );
     return <Box />;
@@ -625,10 +621,9 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
               justifyContent: 'space-between',
               width: '100%',
               alignItems: 'center',
-              paddingTop: '10px',
             }}
           >
-            <Box sx={{ textAlign: 'left', maxWidth: '70%', [theme.breakpoints.down('md')]: { display: 'none' } }}>
+            <Box sx={{ textAlign: 'left', maxWidth: '70%', [theme.breakpoints.down('sm')]: { display: 'none' } }}>
               <Typography sx={{ ...sxClasses.categoryTitle, ...(layerHidden && hiddenStyle) }} title={layerDetails.layerName}>
                 {layerDetails.layerName}
               </Typography>

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/map-rotation.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/map-rotation.tsx
@@ -159,7 +159,6 @@ export default function MapRotation(): JSX.Element {
         justifyContent: 'center',
         transform: `rotate(${mapRotation}rad)`,
         transition: 'transform 0.3s ease-in-out',
-        color: '#000000',
       },
       children: createElement(ThreeSixtyIcon),
     }),

--- a/packages/geoview-core/src/core/components/nav-bar/nav-bar-style.ts
+++ b/packages/geoview-core/src/core/components/nav-bar/nav-bar-style.ts
@@ -38,7 +38,7 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
   navBtnGroup: {
     borderRadius: theme.spacing(5),
     backgroundColor: theme.palette.geoViewColor.bgColor.light[500],
-
+    overflow: 'hidden',
     '& .MuiButtonGroup-grouped:not(:last-child)': {
       borderColor: theme.palette.geoViewColor.bgColor.light[900],
     },
@@ -46,7 +46,7 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
   navButton: {
     backgroundColor: theme.palette.geoViewColor.bgColor.light[500],
     color: theme.palette.geoViewColor.bgColor.dark[900],
-    borderRadius: theme.spacing(5),
+    borderRadius: 0,
     width: '44px',
     height: '44px',
     maxWidth: '44px',
@@ -79,6 +79,6 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
     fontSize: theme.palette.geoViewFontSize.default,
     fontWeight: '700',
     color: theme.palette.geoViewColor.textColor.main,
-    borderBottom: `1px solid ${theme.palette.geoViewColor.bgColor.dark[100]}}`,
+    borderBottom: `1px solid ${theme.palette.geoViewColor.bgColor.dark[100]}`,
   },
 });

--- a/packages/geoview-core/src/core/components/notifications/notifications-style.ts
+++ b/packages/geoview-core/src/core/components/notifications/notifications-style.ts
@@ -14,8 +14,7 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
     width: '350px',
     maxHeight: '500px',
     overflowY: 'hidden',
-    gap: '8px',
-    marginLeft: '18px',
+    marginLeft: '15px',
     backgroundColor: theme.palette.geoViewColor.bgColor.light[200],
     borderRadius: '5px',
     boxShadow: 2,
@@ -25,8 +24,8 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    padding: '1.25rem 0.25rem 1.25rem 1.25rem',
-    borderBottom: `1px solid ${theme.palette.geoViewColor.bgColor.dark[100]}}`,
+    padding: '10px',
+    borderBottom: `1px solid ${theme.palette.geoViewColor.bgColor.dark[100]}`,
   },
   notificationsTitle: {
     fontSize: theme.palette.geoViewFontSize.default,
@@ -35,14 +34,14 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
   },
   notificationsList: {
     overflowY: 'auto',
-    padding: '0px 0px 20px 0px',
+    padding: '0 10px',
   },
   notificationItem: {
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
     gap: '8px',
-    padding: '10px 15px',
+    padding: '10px 0',
 
     '&:not(:last-child)': {
       borderBottom: `1px solid ${theme.palette.geoViewColor.bgColor.dark[300]}`,

--- a/packages/geoview-core/src/core/components/notifications/notifications.tsx
+++ b/packages/geoview-core/src/core/components/notifications/notifications.tsx
@@ -89,7 +89,7 @@ const NotificationItem = memo(function NotificationItem({
           <Box sx={sxClasses.notificationsCount}>{notification.count}</Box>
         </Box>
       )}
-      <IconButton aria-label={t('general.close')} onClick={handleRemove}>
+      <IconButton aria-label={t('general.close')} size="small" onClick={handleRemove}>
         <CloseIcon />
       </IconButton>
     </Box>
@@ -127,7 +127,7 @@ const NotificationHeader = memo(function NotificationHeader({
         >
           {t('appbar.removeAllNotifications')}
         </Button>
-        <IconButton aria-label={t('general.close')} sx={{ ml: '0.25rem' }} onClick={onClose}>
+        <IconButton aria-label={t('general.close')} size="small" sx={{ ml: '0.25rem' }} onClick={onClose}>
           <CloseIcon />
         </IconButton>
       </Box>
@@ -298,7 +298,7 @@ export default memo(function Notifications(): JSX.Element {
               {notifications.length > 0 ? (
                 notificationsList
               ) : (
-                <Typography component="div" sx={{ padding: '10px 15px' }}>
+                <Typography component="div" sx={{ padding: '10px 0' }}>
                   {t('appbar.noNotificationsAvailable')}
                 </Typography>
               )}

--- a/packages/geoview-core/src/core/containers/shell.tsx
+++ b/packages/geoview-core/src/core/containers/shell.tsx
@@ -325,6 +325,8 @@ export function Shell(props: ShellProps): JSX.Element {
       </Link>
       <FocusTrap open={activeTrapGeoView}>
         <Box ref={shellRef} id={`shell-${mapViewer.mapId}`} sx={sxClasses.shell} className="geoview-shell" tabIndex={-1}>
+          <CircularProgress isLoaded={mapLoaded} />
+          <CircularProgress isLoaded={!circularProgressActive} />
           {interaction === 'dynamic' && (
             <Link
               id={`main-map-${mapViewer.mapId}`}
@@ -341,8 +343,6 @@ export function Shell(props: ShellProps): JSX.Element {
           )}
 
           <Box id={`map-${mapViewer.mapId}`} sx={sxClasses.mapShellContainer} className="mapContainer" ref={mapShellContainerRef}>
-            <CircularProgress isLoaded={mapLoaded} />
-            <CircularProgress isLoaded={!circularProgressActive} />
             <AppBar api={mapViewer.appBarApi} onScrollShellIntoView={handleScrollShellIntoView} />
             <Box sx={sxClasses.mapContainer}>
               <Map viewer={mapViewer} />

--- a/packages/geoview-core/src/ui/tabs/tabs-style.ts
+++ b/packages/geoview-core/src/ui/tabs/tabs-style.ts
@@ -48,8 +48,9 @@ export const getSxClasses = (theme: Theme, isMapFullScreen: boolean, appHeight: 
     },
   },
   mobileDropdown: {
+    marginLeft: '41px',
     maxWidth: '200px',
-    p: 6,
+    padding: '8px 0',
     '& .MuiInputBase-root': {
       borderRadius: '4px',
     },

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -1,10 +1,9 @@
 import type { SyntheticEvent, ReactNode, MouseEvent } from 'react';
 import { useState, useEffect, useMemo, useCallback, useRef, memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { Size } from 'ol/size';
 
 import type { TabsProps, TabProps, BoxProps, SelectChangeEvent, TabScrollButtonProps } from '@mui/material';
-import { Grid, Tab as MaterialTab, Tabs as MaterialTabs, Box, TabScrollButton } from '@mui/material';
+import { Grid, Tab as MaterialTab, Tabs as MaterialTabs, Box, TabScrollButton, useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { UseHtmlToReact } from '@/core/components/common/hooks/use-html-to-react';
 import { logger } from '@/core/utils/logger';
@@ -38,7 +37,6 @@ type FocusItemProps = {
 /**
  * Tabs ui properties
  */
-
 export interface TypeTabsProps {
   shellContainer?: HTMLElement;
   tabs: TypeTabs[];
@@ -55,7 +53,6 @@ export interface TypeTabsProps {
   onOpenKeyboard?: (uiFocus: FocusItemProps) => void;
   onCloseKeyboard?: () => void;
   containerType?: TypeContainerBox;
-  sideAppSize: Size;
   appHeight: number;
   hiddenTabs: string[];
   isFullScreen: boolean;
@@ -98,7 +95,6 @@ function TabsUI(props: TypeTabsProps): JSX.Element {
     tabProps = {},
     containerType,
     isCollapsed,
-    sideAppSize,
     appHeight,
     hiddenTabs,
     isFullScreen,
@@ -107,18 +103,14 @@ function TabsUI(props: TypeTabsProps): JSX.Element {
   // Hooks
   const { t } = useTranslation<string>();
   const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   // State
   // boolean value in state reflects when tabs will be collapsed state, then value needs to false.
   const [value, setValue] = useState<number | boolean>(0);
   const [tabPanels, setTabPanels] = useState([tabs[0]]);
   const tabPanelRef = useRef<HTMLDivElement | null>(null);
-
   const sxClasses = useMemo(() => getSxClasses(theme, isFullScreen, appHeight), [theme, isFullScreen, appHeight]);
-
-  // show/hide dropdown based on map size
-  const initMobileDropdown = sideAppSize[0] !== 0 ? sideAppSize[0] < theme.breakpoints.values.sm : false;
-  const [showMobileDropdown, setShowMobileDropdown] = useState(initMobileDropdown);
 
   /**
    * Update Tab panel when value change from tabs and dropdown.
@@ -218,17 +210,6 @@ function TabsUI(props: TypeTabsProps): JSX.Element {
   }, [tabs, t]);
 
   useEffect(() => {
-    logger.logTraceUseEffect('UI.TABS - mapSize', sideAppSize);
-
-    // show/hide mobile dropdown when screen size change.
-    if (sideAppSize[0] < theme.breakpoints.values.sm) {
-      setShowMobileDropdown(true);
-    } else {
-      setShowMobileDropdown(false);
-    }
-  }, [sideAppSize, theme.breakpoints.values.sm]);
-
-  useEffect(() => {
     logger.logTraceUseEffect('UI.TABS - isCollapsed', isCollapsed);
 
     const tabPanel = tabPanelRef?.current;
@@ -276,7 +257,7 @@ function TabsUI(props: TypeTabsProps): JSX.Element {
         }}
       >
         <Grid size={{ xs: 7, sm: 10 }}>
-          {!showMobileDropdown ? (
+          {!isMobile ? (
             <MaterialTabs
               variant="scrollable"
               scrollButtons


### PR DESCRIPTION
# Description

Includes minor ui changes and bug fix for the details panel. UI changes tracked in #3069

- Footerbar shows tabs above sm breakpoint(640px) and dropdown below sm breakpoint
- Fixes incorrect background colour in footer panels on MuiGrid-containers
- Fixes layerName display in layers panels between sm and md breakpoints(640px - 960px)
- Move the guide search box into the left panel top for better alignment
- Fix ResponsiveGridLayout buttons to hide/show properly on resize (now uses a media query instead of initial window width)
- Fix active color for map rotation icon (white foreground on purple background)
- Fix corner rounding on navbar buttons (top rounding on first button and bottom rounding on last button only)
- Adjust the app loading element to cover the map and footer
- Use HighlightIcon for active highlight in layers panel to match legend panel
- Fix bug with details panel not retaining a previous selected layer if it still has features on a new map click
- Wrap long legend item labels in layer details panel

Closes # (issue)
- #3161 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- With the footerbar available resize the window to see the tabs change to a dropdown below 640 and vice versa
- Open the layers panel in the footer, "Toggle classes visibility" control and the classes should have the same background color as the parent panel
- Open the layers panel in the footer, resize screen width to between 640px-960px, the layer title should only be displayed within the panel and not adjacent to the englarge/guide/fullscreen controls
- Open the guide panel in the footer, the guide search should not be stacked and aligned above the guide sections on the left
- Open the layers panel in the footer, resize the window from 1200px down to below 640px. Guide and fullscreen buttons should always be available, enlarge/reduce buttons will show any size above 640px and close button will only show below 640px
- Click on the map rotation button in the navbar, the foreground color will now be white when the background is purple
- Click on the map rotation button and basemap select buttons in the navbar, the top corners of these buttons wont be rounded
- When loading the page, view that the loader extends over the footerbar 
- Open the layers panel and click on the highlight icon, once active the filled highlight icon will be shown
- Click on a feature to open the details, click on another feature from the same layer. The same layer should remain selected even if it isn't the first layer in the list
- Add layer e2424b6c-db0c-4996-9bc0-2ca2e6714d71 and view the layer, the long labels for the items in the layer should wrap and no longer overflow the panel

https://jaredkinger.github.io/geoview/demos-navigator.html?config=./configs/navigator/demos/09-basic-footer-layers-tab.json

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3195)
<!-- Reviewable:end -->
