### PR TITLE
fix(hover): hover tooltip alignment fixed

### DIFF
--- a/packages/geoview-core/src/api/config/map-feature-config.ts
+++ b/packages/geoview-core/src/api/config/map-feature-config.ts
@@ -15,7 +15,13 @@ import type {
   TypeExternalPackagesProps,
   TypeValidVersions,
 } from '@/api/types/map-schema-types';
-import { DEFAULT_MAP_FEATURE_CONFIG, MAP_EXTENTS, VALID_PROJECTION_CODES, MAP_CENTER, MAP_ZOOM_LEVEL } from '@/api/types/map-schema-types';
+import {
+  DEFAULT_MAP_FEATURE_CONFIG,
+  VALID_PROJECTION_CODES,
+  MAP_CENTER,
+  MAP_ZOOM_LEVEL,
+  MAX_EXTENTS_RESTRICTION,
+} from '@/api/types/map-schema-types';
 import { deepMerge } from '@/core/utils/utilities';
 
 /**
@@ -121,7 +127,7 @@ export class MapFeatureConfig {
       projection && VALID_PROJECTION_CODES.includes(projection) ? projection : DEFAULT_MAP_FEATURE_CONFIG.map.viewSettings.projection;
 
     // Set values specific to projection
-    mapConfig.viewSettings.maxExtent = [...MAP_EXTENTS[proj]];
+    mapConfig.viewSettings.maxExtent = MAX_EXTENTS_RESTRICTION[proj];
     mapConfig.viewSettings.initialView = { zoomAndCenter: [MAP_ZOOM_LEVEL[proj], MAP_CENTER[proj]] };
 
     // Return it

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -23,7 +23,7 @@ import type {
   TypeMapConfig,
   TypeMapFeaturesInstance,
 } from '@/api/types/map-schema-types';
-import { MAP_EXTENTS } from '@/api/types/map-schema-types';
+import { MAP_EXTENTS, MAX_EXTENTS_RESTRICTION } from '@/api/types/map-schema-types';
 import type {
   MapConfigLayerEntry,
   TypeLayerInitialSettings,
@@ -484,7 +484,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
       ];
       const newProjection = projectionCode;
 
-      // If maxExtent was provided and un the native projection, apply
+      // If maxExtent was provided and in the native projection, apply
       // GV The extent is different between LCC and WM and switching from one to the other may introduce weird constraint.
       // GV We may have to keep extent as array for configuration file but, technically, user does not change projection often.
       // GV A wider LCC extent like [-125, 30, -60, 89] (minus -125) will introduce distortion on larger screen...
@@ -493,7 +493,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
       const mapMaxExtent =
         viewSettings!.maxExtent && Number(newProjection) === Number(viewSettings!.projection)
           ? viewSettings?.maxExtent
-          : MAP_EXTENTS[newProjection];
+          : MAX_EXTENTS_RESTRICTION[newProjection];
 
       // create new view settings
       const newView: TypeViewSettings = {
@@ -1596,7 +1596,7 @@ export class MapEventProcessor extends AbstractEventProcessor {
         rotation: this.getMapStateProtected(mapId).rotation,
         minZoom: currentView.getMinZoom(),
         maxZoom: currentView.getMaxZoom(),
-        maxExtent: this.getGeoViewMapConfig(mapId)?.map.viewSettings.maxExtent ? MAP_EXTENTS[projection] : undefined,
+        maxExtent: this.getGeoViewMapConfig(mapId)?.map.viewSettings.maxExtent,
         projection,
       };
 

--- a/packages/geoview-core/src/api/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/types/map-schema-types.ts
@@ -344,9 +344,16 @@ export const VALID_MAP_CENTER: Record<TypeValidMapProjectionCodes, Record<string
   3978: { lat: [40, 90], long: [-140, -60] },
 };
 
-// extents and center for each projection
+// Map view extents for each projection
 export const MAP_EXTENTS: Record<TypeValidMapProjectionCodes, number[]> = {
   3857: [-180, 0, 80, 84],
+  // TODO: tighten these up for initial view now that we have a separate MAX_EXTENTS_RESTRICTION
+  3978: [-150, -10, -30, 90],
+};
+
+// Extent restrictions for each projection
+export const MAX_EXTENTS_RESTRICTION: Record<TypeValidMapProjectionCodes, number[]> = {
+  3857: [-180, -85.05112877980659, 180, 85.05112877980659],
   3978: [-150, -10, -30, 90],
 };
 

--- a/packages/geoview-core/src/core/components/hover-tooltip/hover-tooltip.tsx
+++ b/packages/geoview-core/src/core/components/hover-tooltip/hover-tooltip.tsx
@@ -52,7 +52,10 @@ export const HoverTooltip = memo(function HoverTooltip(): JSX.Element | null {
 
     // Approximate width calculation (50px for empty tooltip)
     // Assuming average character width of 10px and adding padding/margins
-    const approximateWidth = 50 + String(hoverFeatureInfo.fieldInfo?.value).length * 10;
+    let approximateWidth = 25 + String(hoverFeatureInfo.fieldInfo?.value).length * 10;
+
+    // After a certain length, the string is cut off with ellipsis in the tooltip, so we have a max width.
+    if (approximateWidth > 370) approximateWidth = 370; // Cap to max width
 
     // Only get getBoundingClientRect if we don't have it stored
     if (!mapRectRef.current) mapRectRef.current = mapElem.getBoundingClientRect();


### PR DESCRIPTION
Closes #3202

# Description

Fixes alignment of hover tooltips when moved to the left side of feature.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/outlier-ESRI-maxRecordCount.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3203)
<!-- Reviewable:end -->
