### PR TITLE
fix(class visibility): hides unnecessary toggle class visibility

### DIFF
--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -281,7 +281,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
     // No checkbox for simple style layers
     if (layerDetails.styleConfig[item.geometryType]?.type === 'simple') return null;
 
-    // GV: Some esri layer has uniqueValue renderer but there is no field define in their metadata (i.e. e2424b6c-db0c-4996-9bc0-2ca2e6714d71).
+    // GV: Some esri layer has uniqueValue renderer but there is no field defined in their metadata (i.e. e2424b6c-db0c-4996-9bc0-2ca2e6714d71).
     // For these layers, we need to disable checkboxes
     if (layerDetails.styleConfig[item.geometryType]?.fields[0] === undefined) return null;
 
@@ -642,16 +642,17 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
             {renderLayerButtons()}
           </Box>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap-reverse' }}>
-            {layerDetails.items.length > 1 && (
-              <Grid container direction="row" alignItems="center" justifyItems="stretch">
-                <Grid size={{ xs: 'auto' }}>{renderHeaderCheckbox()}</Grid>
-                <Grid size={{ xs: 'auto' }}>
-                  <Box component="span" sx={{ fontWeight: 'bold', ...(layerHidden && hiddenStyle) }}>
-                    {t('layers.toggleItemsVisibility')}
-                  </Box>
+            {layerDetails.items.length > 1 &&
+              layerDetails.items.some((item) => layerDetails.styleConfig?.[item.geometryType]?.fields[0] !== undefined) && (
+                <Grid container direction="row" alignItems="center" justifyItems="stretch">
+                  <Grid size={{ xs: 'auto' }}>{renderHeaderCheckbox()}</Grid>
+                  <Grid size={{ xs: 'auto' }}>
+                    <Box component="span" sx={{ fontWeight: 'bold', ...(layerHidden && hiddenStyle) }}>
+                      {t('layers.toggleItemsVisibility')}
+                    </Box>
+                  </Grid>
                 </Grid>
-              </Grid>
-            )}
+              )}
             {layerDetails.children.length > 0 && (
               <Grid container direction="row" alignItems="center" justifyItems="stretch">
                 <Grid size={{ xs: 'auto' }}>

--- a/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
@@ -29,7 +29,8 @@ const LegendListItem = memo(
     showVisibilityTooltip: { show: boolean; value: string };
     showNameTooltip: boolean;
   }): JSX.Element => (
-    <ListItem className={!isVisible || !layerVisible ? 'unchecked' : 'checked'}>
+    // eslint-disable-next-line no-nested-ternary
+    <ListItem className={!show ? undefined : !isVisible || !layerVisible ? 'unchecked' : 'checked'}>
       <ListItemIcon>
         <Tooltip title={show ? value : ''} key={`Tooltip-${name}-${icon}1`} placement="left" disableHoverListener={!show}>
           <Box sx={{ display: 'flex', padding: '0 18px 0 18px', margin: '0 -18px 0 -18px' }}>
@@ -60,7 +61,8 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
   const { toggleItemVisibility, getLayer } = useLayerStoreActions();
   const layerControls = useLayerSelectorControls(layerPath);
   const layerHidden = useMapSelectorIsLayerHiddenOnMap(layerPath);
-  const canToggleItemVisibility = getLayer(layerPath)?.canToggle && layerControls?.visibility !== false;
+  const legendLayer = getLayer(layerPath);
+  const canToggleItemVisibility = legendLayer?.canToggle && layerControls?.visibility !== false;
 
   /**
    * Handles toggling of class visibility when the legend item is clicked.
@@ -88,7 +90,7 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
           item,
           layerVisible: !layerHidden,
           showVisibilityTooltip: {
-            show: Boolean(canToggleItemVisibility && !layerHidden),
+            show: Boolean(canToggleItemVisibility && !layerHidden && legendLayer.styleConfig?.[item.geometryType]?.fields[0] !== undefined),
             value: t('layers.toggleItemVisibility'),
           },
           showNameTooltip: item.name.length > CONST_NAME_LENGTH_TOOLTIP,
@@ -96,7 +98,7 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
 
         // If classes can be toggled, wrap the component in a Box to handle click events
         const listItem = <LegendListItem key={`${item.name}-${item.isVisible}-${item.icon}`} {...commonProps} />;
-        return canToggleItemVisibility && !layerHidden ? (
+        return commonProps.showVisibilityTooltip.show ? (
           <Box key={`Box-${item.name}-${item.icon}`} onClick={() => handleToggleItemVisibility(item)} sx={sxClasses.toggleableItem}>
             {listItem}
           </Box>


### PR DESCRIPTION
Closes #3196

# Description

Hides the class visibility toggle if none of the classes are toggleable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/add-layers.html - add: https://egisp.dfo-mpo.gc.ca/arcgis/rest/services/open_data_donnees_ouvertes/canada_nature_fund_cnfasar_priority_places_priority_marine_threats/MapServer

Check other layers in: https://damonu2.github.io/geoview/layers-navigator.html?config=./configs/navigator/layers/esri-dynamic.json

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3208)
<!-- Reviewable:end -->
