### PR TITLE
[HOTFIX] (datatable) Fix the datatable panel and the layers list turning disabled after map projection change

### DIFF
--- a/packages/geoview-core/src/api/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/types/map-schema-types.ts
@@ -827,7 +827,7 @@ export type TypeLayerData = {
   // when Array.isArray(features) is true, the features property contains the query result.
   // when property features is null, the query ended with an error.
   queryStatus: TypeQueryStatus;
-  features: TypeFeatureInfoEntry[] | undefined | null;
+  features?: TypeFeatureInfoEntry[];
   isDisabled?: boolean;
 };
 

--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -21,7 +21,7 @@ export interface LayerListEntry {
   mapFilteredIcon?: ReactNode;
   tooltip?: JSX.Element | string;
   numOffeatures?: number;
-  features?: TypeFeatureInfoEntry[] | undefined | null;
+  features?: TypeFeatureInfoEntry[] | undefined;
   layerUniqueId?: string;
   isDisabled?: boolean;
 }
@@ -62,10 +62,9 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
     .trim();
 
   // Constant for state
-  const isDisabled = layer?.numOffeatures === 0 || layer?.features === null || layer?.isDisabled;
+  const isDisabled = layer?.numOffeatures === 0 || layer?.queryStatus === 'error' || layer?.isDisabled;
   const isLoading =
     layer?.numOffeatures === 0 ||
-    layer?.features === null ||
     layer.queryStatus === 'processing' ||
     layer.layerStatus === 'loading' ||
     layer.layerStatus === 'processing';
@@ -77,7 +76,7 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
     if (layer.layerStatus === 'error' || layer?.queryStatus === 'error') {
       return `${t('legend.layerError')}`;
     }
-    if (['init', 'processing'].includes(layer.queryStatus)) {
+    if (['processing'].includes(layer.queryStatus)) {
       return `${t('layers.querying')}...`;
     }
     return (

--- a/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
@@ -160,7 +160,7 @@ export default function DataTableModal(): JSX.Element {
     // Get feature info result for selected layer to check if it is loading
     const selectedLayerData = layersData.find((_layer) => _layer.layerPath === selectedLayer);
 
-    if (selectedLayerData?.queryStatus !== 'error' && selectedLayerData?.queryStatus !== 'processed') {
+    if (selectedLayerData?.queryStatus === 'processing') {
       setIsLoading(true);
     } else setIsLoading(false);
   }, [layersData, selectedLayer]);

--- a/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
@@ -58,8 +58,8 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
 
     // Update the resultSet data
     const layerPath = layer.getLayerPath();
+    this.resultSet[layerPath].queryStatus = 'init';
     this.resultSet[layerPath].eventListenerEnabled = true;
-    this.resultSet[layerPath].queryStatus = 'processed';
     this.resultSet[layerPath].features = undefined;
 
     // Extra initialization of settings
@@ -149,8 +149,6 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
 
             // Keep the features retrieved
             this.resultSet[layerPath].features = arrayOfRecords;
-
-            // Query was processed
             this.resultSet[layerPath].queryStatus = 'processed';
           })
           .catch((error: unknown) => {
@@ -160,7 +158,7 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
               logger.logDebug('Query aborted and replaced by another one.. keep spinning..');
             } else {
               // Error
-              this.resultSet[layerPath].features = null;
+              this.resultSet[layerPath].features = undefined;
               this.resultSet[layerPath].queryStatus = 'error';
 
               // Log
@@ -182,7 +180,7 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
       }
 
       // Error
-      this.resultSet[layerPath].features = null;
+      this.resultSet[layerPath].features = undefined;
       this.resultSet[layerPath].queryStatus = 'error';
 
       // Propagate to the store
@@ -207,7 +205,8 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
     if (!this.resultSet[layerPath]) return;
 
     // Clear features
-    this.resultSet[layerPath].features = null;
+    this.resultSet[layerPath].features = undefined;
+    this.resultSet[layerPath].queryStatus = 'init';
 
     // Propagate to the store
     this.#propagateToStore(this.resultSet[layerPath]);


### PR DESCRIPTION
# Description

Fixes an issue with the layers list in the data table panel turning disabled after switching the map projection.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted: Jan 8th: 13h15

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3230)
<!-- Reviewable:end -->
