### PR TITLE
fix(wcag): accessible keyboard navigation

### DIFF
--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -186,7 +186,6 @@
     "toggleVisibility": "Toggle visibility",
     "toggleItemsVisibility": "Toggle classes visibility",
     "toggleSublayersVisibility": "Toggle sublayers visibility",
-    "toggleItemVisibility": "Click to show/hide item",
     "toggleCollapse": "Toggle collapse",
     "zoomVisibleScale": "Zoom to visible scale",
     "querying": "Querying",
@@ -215,7 +214,8 @@
     "moveLayerUp": "Move layer up",
     "moveLayerDown": "Move layer down",
     "layerControls": "Layers controls",
-    "selectLayerAndScrollTimeSlider": "Show in Time Slider panel"
+    "selectLayerAndScrollTimeSlider": "Show in Time Slider panel",
+    "selectLayer": "Select {{layerName}}"
   },
   "details": {
     "title": "Details",
@@ -391,7 +391,8 @@
     "searchInputLabel": "Search keyword(s)",
     "errorMessage": "Sorry, unable to find the help document!",
     "arrowUp": "Previous match",
-    "arrowDown": "Next match"
+    "arrowDown": "Next match",
+    "closeGuide": "Close guide"
   },
   "footerBar": {
     "resizeTooltip": "Resize",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -186,7 +186,6 @@
     "toggleVisibility": "Basculer la visibilité",
     "toggleItemsVisibility": "Basculer la visibilité des classes",
     "toggleSublayersVisibility": "Basculer la visibilité des sous-couches",
-    "toggleItemVisibility": "Cliquer pour afficher/masquer l'élément",
     "toggleCollapse": "Basculer la fermeture",
     "zoomVisibleScale": "Zoom à l'échelle visible",
     "querying": "Requête en cours",
@@ -215,7 +214,8 @@
     "moveLayerUp": "Déplacer la couche vers le haut",
     "moveLayerDown": "Déplacer la couche vers le bas",
     "layerControls": "Commandes des couches",
-    "selectLayerAndScrollTimeSlider": "Voir dans le panneau Curseur Temporel"
+    "selectLayerAndScrollTimeSlider": "Voir dans le panneau Curseur Temporel",
+    "selectLayer": "Sélectionner {{layerName}}"
   },
   "details": {
     "title": "Détails",
@@ -391,7 +391,8 @@
     "searchInputLabel": "Entrer le(s) mot(s)-clé(s)",
     "errorMessage": "Désolé, impossible de trouver le document d'aide!",
     "arrowUp": "Correspondance précédente",
-    "arrowDown": "Correspondance suivante"
+    "arrowDown": "Correspondance suivante",
+    "closeGuide": "Fermer le guide"
   },
   "footerBar": {
     "resizeTooltip": "Redimensionner",

--- a/packages/geoview-core/src/core/components/common/focus-trap-container.tsx
+++ b/packages/geoview-core/src/core/components/common/focus-trap-container.tsx
@@ -71,6 +71,11 @@ export const FocusTrapContainer = memo(function FocusTrapContainer({
     // Log
     logger.logTraceUseMemo('FOCUS-TRAP-ELEMENT - isActive');
 
+    // Don't activate if a modal is currently open (prevents competing FocusTraps)
+    if (focusItem.activeElementId && focusItem.activeElementId !== id) {
+      return false;
+    }
+
     // For footer bar containers, activate focus trap when WCAG is enabled and this container is active
     if (containerType === CONTAINER_TYPE.FOOTER_BAR) {
       return activeTrapGeoView && id === focusItem.activeElementId;

--- a/packages/geoview-core/src/core/components/common/layer-list-style.ts
+++ b/packages/geoview-core/src/core/components/common/layer-list-style.ts
@@ -43,7 +43,6 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
   listItemButton: {
     width: '100%',
     borderRadius: '5px',
-    marginBottom: '10px',
     '&.Mui-selected:hover': {
       backgroundColor: 'inherit',
     },

--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -103,15 +103,18 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
     [isDisabled, isLoading, onListItemClick]
   );
 
-  // TODO: WCAG Issue #3116 Finish implementing button styles to be consistent with rest of the app (keyboard focus))
-
   return (
-    <Tooltip title={layer.tooltip} placement="top" arrow>
-      <ListItem id={id} disablePadding>
+    <Tooltip
+      title={layer.tooltip}
+      placement="top"
+      arrow
+      enterDelay={theme.transitions.duration.tooltipDelay}
+      enterNextDelay={theme.transitions.duration.tooltipDelay}
+    >
+      <ListItem id={id} disablePadding className={containerClass}>
         <ListItemButton
           component="button"
           sx={sxClasses.listItemButton}
-          className={containerClass}
           onKeyDown={(e) => handleLayerKeyDown(e, layer)}
           onClick={() => onListItemClick(layer)}
           selected={isSelected}

--- a/packages/geoview-core/src/core/components/common/responsive-grid-layout-style.ts
+++ b/packages/geoview-core/src/core/components/common/responsive-grid-layout-style.ts
@@ -13,6 +13,7 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
     flexDirection: 'column',
     height: '100%',
     padding: '16px 0',
+    gap: '10px',
   },
   topRow: {
     '& .responsive-layout-left-top': {
@@ -63,21 +64,19 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
     },
   },
   rightMainContent: {
-    border: `2px solid ${theme.palette.geoViewColor.primary.main}`,
-    borderRadius: '5px 0 5px 5px',
-    backgroundColor: theme.palette.geoViewColor.bgColor.light[300],
-    overflowY: 'auto',
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    width: '100%',
     '&:focus-visible': {
       border: '2px solid inherit',
     },
-    '&.guide-container': {
-      backgroundColor: theme.palette.geoViewColor.white,
-    },
-    width: '100%',
+
     '& .MuiPaper-root': {
       border: 'none',
     },
     '& .guideBox': {
+      position: 'relative',
       color: `${theme.palette.geoViewColor.grey.dark[800]}  !important`,
       padding: '16px',
       img: {
@@ -107,6 +106,24 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
       fontSize: theme.palette.geoViewFontSize.md,
       fontWeight: '500',
       padding: 10,
+    },
+    '& .guide-button-container': {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      border: 'none',
+      borderRadius: '0',
+    },
+    '& .guide-button-group': {
+      border: `2px solid ${theme.palette.geoViewColor.primary.main}`,
+      borderBottom: 'none',
+      borderRadius: '8px 8px 0 0',
+    },
+    '& .panel-content-container': {
+      backgroundColor: theme.palette.geoViewColor.white,
+      minHeight: '0',
+      border: `2px solid ${theme.palette.geoViewColor.primary.main}`,
+      borderRadius: '5px 0 5px 5px',
+      overflow: 'auto',
     },
   },
   gridRightMain: {

--- a/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
@@ -14,10 +14,15 @@ import { logger } from '@/core/utils/logger';
 import { ArrowBackIcon, ArrowForwardIcon, CloseIcon, QuestionMarkIcon } from '@/ui/icons';
 import { useGeoViewMapId } from '@/core/stores/geoview-store';
 import { useAppGuide, useAppFullscreenActive } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { useUIActiveTrapGeoView, useUISelectedFooterLayerListItemId } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import {
+  useUIActiveTrapGeoView,
+  useUISelectedFooterLayerListItemId,
+  useUIActiveFocusItem,
+} from '@/core/stores/store-interface-and-intial-values/ui-state';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { CONTAINER_TYPE } from '@/core/utils/constant';
 import { handleEscapeKey } from '@/core/utils/utilities';
+import { FocusTrap } from '@/ui';
 
 interface ResponsiveGridLayoutProps {
   leftTop?: ReactNode;
@@ -37,6 +42,7 @@ interface ResponsiveGridLayoutProps {
 interface ResponsiveGridLayoutExposedMethods {
   setIsRightPanelVisible: (isVisible: boolean) => void;
   setRightPanelFocus: () => void;
+  closeBtnRef?: React.RefObject<HTMLButtonElement>;
 }
 
 const ResponsiveGridLayout = forwardRef(
@@ -64,6 +70,8 @@ const ResponsiveGridLayout = forwardRef(
     const theme = useTheme();
     const isMapFullScreen = useAppFullscreenActive();
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    // Derive whether we have content (vs guide-only) from rightMain prop
+    const hasContent = !!rightMain;
 
     // Ref for right panel
     const rightMainRef = useRef<HTMLDivElement>();
@@ -72,12 +80,14 @@ const ResponsiveGridLayout = forwardRef(
     const guideContainerRef = useRef<HTMLDivElement>(null);
     const guideToggleBtnRef = useRef<HTMLButtonElement>(null);
     const fullScreenBtnRef = useRef<HTMLButtonElement>(null);
+    const closeBtnRef = useRef<HTMLButtonElement>(null);
 
     // Store
     const mapId = useGeoViewMapId();
     const guide = useAppGuide();
     const selectedFooterLayerListItemId = useUISelectedFooterLayerListItemId();
     const isFocusTrap = useUIActiveTrapGeoView();
+    const focusItem = useUIActiveFocusItem();
 
     // States
     const [isRightPanelVisible, setIsRightPanelVisible] = useState(false);
@@ -101,13 +111,24 @@ const ResponsiveGridLayout = forwardRef(
         return {
           setIsRightPanelVisible: (isVisible: boolean) => setIsRightPanelVisible(isVisible),
           setRightPanelFocus: () => {
-            if (rightMainRef.current && !isGuideOpen) {
-              setTimeout(() => {
-                if (rightMainRef.current) rightMainRef.current.tabIndex = 0;
-                rightMainRef.current?.focus();
-              }, 0);
+            if (isGuideOpen) return;
+
+            // Focus close button if available, otherwise focus main content
+            if (closeBtnRef.current) {
+              // Use  requestAnimationFrame to ensure DOM is fully painted
+              requestAnimationFrame(() => {
+                closeBtnRef.current?.focus();
+              });
+            } else if (rightMainRef.current) {
+              requestAnimationFrame(() => {
+                if (rightMainRef.current) {
+                  rightMainRef.current.tabIndex = 0;
+                  rightMainRef.current.focus();
+                }
+              });
             }
           },
+          closeBtnRef,
         };
       },
       [isGuideOpen]
@@ -127,6 +148,22 @@ const ResponsiveGridLayout = forwardRef(
       onGuideIsOpen?.(isGuideOpen);
     }, [isGuideOpen, onGuideIsOpen]);
 
+    // Auto-focus Close selection button when panel opens with content
+    useEffect(() => {
+      // Don't auto-focus on Close selection button if a modal is open (prevents stealing focus from modal restoration)
+      // activeElementId is truthy (non-empty string) when a modal is active
+      if (focusItem.activeElementId && focusItem.activeElementId !== '') {
+        return;
+      }
+
+      // Only focus when: panel visible, has content, not showing guide, and close button exists
+      if (isRightPanelVisible && hasContent && !isGuideOpen && closeBtnRef.current) {
+        requestAnimationFrame(() => {
+          closeBtnRef.current?.focus();
+        });
+      }
+    }, [isRightPanelVisible, hasContent, isGuideOpen, focusItem.activeElementId]);
+
     useEffect(() => {
       // if hideEnlargeBtn changes to true and isEnlarged is true, set isEnlarged to false
       if (hideEnlargeBtn && isEnlarged) {
@@ -135,15 +172,43 @@ const ResponsiveGridLayout = forwardRef(
     }, [hideEnlargeBtn, isEnlarged]);
 
     // Callback to be executed after escape key is pressed.
+    // When the right sub-panel is open, escape triggers the sub-panel close button.
+    // When the right sub-panel is not open, escape closes the main panel.
     const handleEscapeKeyCallback = useCallback((): void => {
-      if (rightMainRef.current && selectedFooterLayerListItemId.length) {
+      // Don't close sub panel if guide is open - let the guide handle its own ESC
+      if (isGuideOpen) {
+        return;
+      }
+
+      // Check if the sub-panel close button is available (indicating the right panel is open and can be closed)
+      // Close button is visible when there's feature content, the right panel is visible, and WCAG mode is on
+      const shouldCloseSubPanel = hasContent && isRightPanelVisible && isFocusTrap;
+
+      if (shouldCloseSubPanel) {
+        // Trigger the sub-panel close button click if it exists
+        if (closeBtnRef.current) {
+          closeBtnRef.current.click();
+        } else {
+          // Fallback to direct close if button ref not available
+          setIsRightPanelVisible(false);
+          onRightPanelClosed?.();
+        }
+      } else if (rightMainRef.current && selectedFooterLayerListItemId.length) {
+        // Fall back to original focus management behavior (allows parent to handle closing the main panel)
         rightMainRef.current.tabIndex = -1;
       }
-    }, [selectedFooterLayerListItemId]);
+    }, [isGuideOpen, hasContent, isRightPanelVisible, isFocusTrap, closeBtnRef, selectedFooterLayerListItemId, onRightPanelClosed]);
 
     const handleKeyDown = useCallback(
-      (event: KeyboardEvent): void => handleEscapeKey(event.key, selectedFooterLayerListItemId, true, handleEscapeKeyCallback),
-      [handleEscapeKeyCallback, selectedFooterLayerListItemId]
+      (event: KeyboardEvent): void => {
+        // Check if we're in fullscreen mode - if so, don't handle escape here
+        // The fullscreen dialog will handle it
+        if (isFullScreen) {
+          return;
+        }
+        handleEscapeKey(event.key, selectedFooterLayerListItemId, true, handleEscapeKeyCallback);
+      },
+      [handleEscapeKeyCallback, selectedFooterLayerListItemId, isFullScreen]
     );
 
     // return back the focus to layeritem for which right panel was opened.
@@ -210,6 +275,23 @@ const ResponsiveGridLayout = forwardRef(
       }, 200);
     }, []);
 
+    // Add keyboard handler for guide
+    const handleGuideKeyDown = useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>): void => {
+        // Only handle ESC when not in fullscreen (fullscreen dialog handles its own ESC)
+        if (event.key === 'Escape' && !isFullScreen) {
+          // Only close if the close button would be visible
+          if (isFocusTrap && hasContent) {
+            // IMPORTANT: Stop propagation to prevent parent handlers from closing the sub panel
+            event.stopPropagation();
+            event.preventDefault();
+            handleCloseGuide();
+          }
+        }
+      },
+      [isFullScreen, isFocusTrap, hasContent, handleCloseGuide]
+    );
+
     // If we're on mobile
     if (theme.breakpoints.down('md')) {
       if (!(leftMain || leftTop) && !isRightPanelVisible) {
@@ -240,12 +322,23 @@ const ResponsiveGridLayout = forwardRef(
 
     const renderCloseButton = (): JSX.Element | null => {
       // Check conditions for hiding the button
-      if (!toggleMode && (!isMobile || !isRightPanelVisible)) {
+
+      // Default condition for mobile or toggle mode
+      let shouldShowCloseButton = (toggleMode && hasContent) || (isMobile && isRightPanelVisible);
+
+      // In WCAG mode, show close button when there is content
+      if (isFocusTrap) {
+        shouldShowCloseButton = hasContent && isRightPanelVisible;
+      } else if (isMobile) {
+        shouldShowCloseButton = isRightPanelVisible;
+      }
+      if (!shouldShowCloseButton) {
         return null;
       }
 
       return (
         <Button
+          ref={closeBtnRef}
           makeResponsive
           type="text"
           size="small"
@@ -275,6 +368,7 @@ const ResponsiveGridLayout = forwardRef(
           tooltip={t('general.openGuide')!}
           startIcon={<QuestionMarkIcon />}
           className={`guideButton ${isGuideOpen ? 'active' : ''}`}
+          disabled={isGuideOpen && !hasContent}
         >
           {t('general.guide')}
         </Button>
@@ -332,7 +426,13 @@ const ResponsiveGridLayout = forwardRef(
       if (!content) return null;
 
       return (
-        <Box ref={guideContainerRef} tabIndex={0}>
+        <Box
+          ref={guideContainerRef}
+          tabIndex={0}
+          className="panel-content-container"
+          sx={guideSxClasses.guideContainer}
+          onKeyDown={handleGuideKeyDown}
+        >
           <Box
             className="guideBox"
             sx={{
@@ -340,19 +440,20 @@ const ResponsiveGridLayout = forwardRef(
               ...(guideSxClasses.guideContainer as any)?.['& .guideBox'],
             }}
           >
-            {/* Close button, only shown WCAG is enabled and not fullScreen */}
-            {isFocusTrap && !isFullScreen && (
+            {/* Close button inside guide - shown when WCAG is enabled, not fullscreen, and no feature content is selected */}
+
+            {isFocusTrap && !isFullScreen && hasContent && (
               <IconButton
                 id={`layout-close-guide-${mapId}`}
                 onClick={handleCloseGuide}
                 sx={{
                   position: 'absolute',
                   top: 15,
-                  right: 15,
+                  right: 0,
                   zIndex: 1000,
                 }}
                 tabIndex={0}
-                aria-label={t('general.closeGuide') || 'Close guide'}
+                aria-label={t('guide.closeGuide') || 'Close guide'}
               >
                 <CloseIcon />
               </IconButton>
@@ -366,12 +467,52 @@ const ResponsiveGridLayout = forwardRef(
     const renderRightContent = (): JSX.Element => {
       const content = !isGuideOpen ? rightMain : renderGuide();
 
+      // Only trap focus when: WCAG mode on, right panel is visible, not fullscreen, has feature content, AND no modal is open
+      const shouldTrapFocus = isFocusTrap && isRightPanelVisible && !isFullScreen && hasContent && !focusItem.activeElementId;
+
+      // Build the main content box
+      const mainContentBox = (
+        <Box
+          ref={isGuideOpen ? undefined : rightMainRef}
+          tabIndex={shouldTrapFocus ? -1 : undefined} // MUI will throw an error and automatically set this to -1 when box is focused
+          sx={sxClasses.rightMainContent}
+          className={`responsive-layout-right-main-content ${isGuideOpen ? 'guide-container' : ''}`}
+        >
+          <Box sx={sxClasses.rightButtonsContainer} className="guide-button-container">
+            <ButtonGroup size="small" variant="outlined" aria-label={t('details.guideControls')!} className="guide-button-group">
+              {!toggleMode && !hideEnlargeBtn && renderEnlargeButton()}
+              {!!guideContentIds?.length && renderGuideButton()}
+              {!isMapFullScreen && renderFullScreenButton()}
+              {!!(leftMain || leftTop) && renderCloseButton()}
+            </ButtonGroup>
+          </Box>
+          {!isGuideOpen && (
+            <Box className="panel-content-container">
+              {content || <Typography className="noSelection">{t('layers.noSelection')}</Typography>}
+            </Box>
+          )}
+          {isGuideOpen && (content || <Typography className="noSelection">{t('layers.noSelection')}</Typography>)}
+        </Box>
+      );
+
+      // Wrap the content box in FocusTrap if conditions are met
+      const wrappedMainContent = shouldTrapFocus ? (
+        <FocusTrap open={true} disableAutoFocus>
+          {mainContentBox}
+        </FocusTrap>
+      ) : (
+        mainContentBox
+      );
+
       return (
         <>
           <FullScreenDialog
             open={isFullScreen}
             onClose={() => {
               setIsFullScreen(false);
+            }}
+            onExited={() => {
+              // Use onExited callback to restore focus to the fullscreen button after the dialog exit animation completes
               fullScreenBtnRef.current?.focus();
             }}
           >
@@ -380,13 +521,7 @@ const ResponsiveGridLayout = forwardRef(
             </Box>
           </FullScreenDialog>
 
-          <Box
-            ref={isGuideOpen ? undefined : rightMainRef}
-            sx={sxClasses.rightMainContent}
-            className={`responsive-layout-right-main-content ${isGuideOpen ? 'guide-container' : ''}`}
-          >
-            {content || <Typography className="noSelection">{t('layers.noSelection')}</Typography>}
-          </Box>
+          {wrappedMainContent}
         </>
       );
     };
@@ -428,15 +563,6 @@ const ResponsiveGridLayout = forwardRef(
               }}
             >
               {rightTop ?? <Box />}
-
-              <Box sx={sxClasses.rightButtonsContainer}>
-                <ButtonGroup size="small" variant="outlined" aria-label={t('details.guideControls')!}>
-                  {!toggleMode && !hideEnlargeBtn && renderEnlargeButton()}
-                  {!!guideContentIds?.length && renderGuideButton()}
-                  {!isMapFullScreen && renderFullScreenButton()}
-                  {!!(leftMain || leftTop) && renderCloseButton()}
-                </ButtonGroup>
-              </Box>
             </Box>
           </ResponsiveGrid.Right>
         </ResponsiveGrid.Root>
@@ -472,8 +598,6 @@ const ResponsiveGridLayout = forwardRef(
     );
   }
 );
-
 ResponsiveGridLayout.displayName = 'ResponsiveGridLayout';
-
 export { ResponsiveGridLayout };
 export type { ResponsiveGridLayoutExposedMethods };

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -50,6 +50,7 @@ import { getSxClasses } from './data-table-style';
 import { useLightBox } from '@/core/components/common';
 import { NUMBER_FILTER, DATE_FILTER, STRING_FILTER } from '@/core/utils/constant';
 import type { DataTableProps, ColumnsType } from './data-table-types';
+import { useGeoViewMapId } from '@/core/stores/geoview-store';
 
 /**
  * Build Data table from map.
@@ -59,7 +60,7 @@ import type { DataTableProps, ColumnsType } from './data-table-types';
  * @returns {JSX.Element} Data table as react element.
  */
 
-function DataTable({ data, layerPath }: DataTableProps): JSX.Element {
+function DataTable({ data, layerPath, containerType }: DataTableProps): JSX.Element {
   const { t } = useTranslation();
 
   const sxtheme = useTheme();
@@ -97,6 +98,9 @@ function DataTable({ data, layerPath }: DataTableProps): JSX.Element {
   // #endregion
 
   const { enableFocusTrap } = useUIStoreActions();
+
+  const mapId = useGeoViewMapId();
+  const tableDetailsButtonId = `table-details-${containerType}-${mapId}`;
 
   const handleDensityChange = (updaterOrValue: MRTDensityState | ((prevState: MRTDensityState) => MRTDensityState)): void => {
     setDensity(updaterOrValue);
@@ -424,7 +428,7 @@ function DataTable({ data, layerPath }: DataTableProps): JSX.Element {
             tooltipPlacement="top"
             onClick={() => {
               setSelectedFeature(feature);
-              enableFocusTrap({ activeElementId: 'featureDetailDataTable', callbackElementId: 'table-details' });
+              enableFocusTrap({ activeElementId: 'featureDetailDataTable', callbackElementId: tableDetailsButtonId });
             }}
           >
             <InfoOutlinedIcon />

--- a/packages/geoview-core/src/core/components/details/coordinate-info.tsx
+++ b/packages/geoview-core/src/core/components/details/coordinate-info.tsx
@@ -22,7 +22,11 @@ type CoordinateData = {
   elevation?: string;
 };
 
-export function CoordinateInfoSwitch(): JSX.Element {
+interface CoordinateInfoSwitchProps {
+  disabled?: boolean;
+}
+
+export function CoordinateInfoSwitch({ disabled }: CoordinateInfoSwitchProps): JSX.Element {
   // Log
   logger.logTraceRender('components/toggle-all/toggle');
 
@@ -49,6 +53,7 @@ export function CoordinateInfoSwitch(): JSX.Element {
           checked={coordinateInfoEnabled}
           onChange={handleCoordinateInfoToggle}
           label={t('details.showCoordinateInfo') || undefined}
+          disabled={disabled}
         />
       </span>
     </Tooltip>
@@ -92,7 +97,7 @@ export function CoordinateInfo(): JSX.Element {
   const { lat, lng, utmZone, easting, northing, ntsMapsheet, elevation } = coordinateData;
 
   return (
-    <Box sx={sxClasses.rightPanelContainer}>
+    <Box sx={sxClasses.rightPanelContainer} className="guide-content-container">
       <Box sx={sxClasses.coordinateInfoContainer}>
         <Typography variant="h6" sx={sxClasses.coordinateInfoTitle}>
           {t('details.coordinateInfoTitle')}

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -85,6 +85,8 @@ export function DetailsPanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: Deta
   const prevFeatureIndex = useRef<number>(0); // 0 because that's the default index for the features
   const prevMapClickCoordinates = useRef<TypeMapMouseInfo | undefined>(mapClickCoordinates);
   const layoutRef = useRef<LayoutExposedMethods>(null);
+  const prevButtonRef = useRef<HTMLButtonElement>(null);
+  const nextButtonRef = useRef<HTMLButtonElement>(null);
 
   // #region MAIN HOOKS SECTION ***************************************************************************************
 
@@ -187,8 +189,8 @@ export function DetailsPanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: Deta
             queryStatus: layer!.queryStatus,
             numOffeatures: layer!.features?.length ?? 0,
             layerFeatures: getNumFeaturesLabel(layer!),
-            tooltip: `${layer!.layerName}, ${getNumFeaturesLabel(layer!)}`,
-            layerUniqueId: `${mapId}-${TABS.DETAILS}-${layer?.layerPath}`,
+            tooltip: t('layers.selectLayer', { layerName: layer!.layerName }) ?? '',
+            layerUniqueId: `${mapId}-${TABS.DETAILS}-${layer?.layerPath ?? ''}`,
           }) as LayerListEntry
       );
 
@@ -210,7 +212,7 @@ export function DetailsPanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: Deta
           queryStatus: layer.queryStatus,
           numOffeatures: layer.features?.length ?? 0,
           layerFeatures: getNumFeaturesLabel(layer),
-          tooltip: `${layer.layerName}, ${getNumFeaturesLabel(layer)}`,
+          tooltip: t('layers.selectLayer', { layerName: layer.layerName }) ?? '',
           layerUniqueId: `${mapId}-${TABS.DETAILS}-${layer.layerPath}`,
         });
       }
@@ -245,7 +247,7 @@ export function DetailsPanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: Deta
         queryStatus: coordinateInfoLayer.queryStatus,
         numOffeatures: coordinateInfoLayer.features?.length ?? 0,
         layerFeatures: getNumFeaturesLabel(coordinateInfoLayer),
-        tooltip: `${coordinateInfoLayer.layerName}, ${getNumFeaturesLabel(coordinateInfoLayer)}`,
+        tooltip: t('layers.selectLayer', { layerName: coordinateInfoLayer.layerName ?? '' }) ?? '',
         layerUniqueId: `${mapId}-${TABS.DETAILS}-${coordinateInfoLayer.layerPath}`,
       });
     }
@@ -261,6 +263,7 @@ export function DetailsPanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: Deta
     mapId,
     getMapLayerParentHidden,
     orderedLayers,
+    t,
   ]);
 
   /**
@@ -491,11 +494,28 @@ export function DetailsPanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: Deta
       // Log
       logger.logTraceUseCallback('DETAILS-PANEL - handleFeatureNavigateChange', currentFeatureIndex);
 
+      const newIndex = currentFeatureIndex + change;
+      const maxIndex = (memoSelectedLayerData?.features?.length ?? 0) - 1;
+
+      // Don't navigate if out of bounds
+      if (newIndex < 0 || newIndex > maxIndex) {
+        return;
+      }
+
       // Keep previous index for navigation
       prevFeatureIndex.current = currentFeatureIndex;
 
       // Update current index
-      updateFeatureSelected(currentFeatureIndex + change, memoSelectedLayerData);
+      updateFeatureSelected(newIndex, memoSelectedLayerData);
+
+      // Restore focus to the navigation button after React completes the state update and re-render
+      requestAnimationFrame(() => {
+        if (change === -1) {
+          prevButtonRef.current?.focus();
+        } else {
+          nextButtonRef.current?.focus();
+        }
+      });
     },
     [currentFeatureIndex, memoSelectedLayerData, updateFeatureSelected]
   );
@@ -710,9 +730,11 @@ export function DetailsPanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: Deta
     if (memoSelectedLayerDataFeatures && memoSelectedLayerDataFeatures.length > 0) {
       // Get only the current feature
       const currentFeature = memoSelectedLayerDataFeatures[currentFeatureIndex];
+      const isPrevDisabled = currentFeatureIndex <= 0;
+      const isNextDisabled = !memoSelectedLayerData?.features || currentFeatureIndex + 1 >= memoSelectedLayerData.features.length;
 
       return (
-        <Box sx={sxClasses.rightPanelContainer}>
+        <Box sx={sxClasses.rightPanelContainer} className="guide-content-container">
           <Grid container sx={sxClasses.rightPanelBtnHolder}>
             <Grid size={{ xs: 6 }} sx={{ alignSelf: 'center' }}>
               <Box>
@@ -723,22 +745,43 @@ export function DetailsPanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: Deta
             </Grid>
             {memoSelectedLayerData?.features && memoSelectedLayerData.features.length > 1 && (
               <Grid size={{ xs: 6 }} className="buttonGroup">
+                {/* Navigation buttons use aria-disabled with manual styling to preserve keyboard focus when users reach first/last items */}
                 <Box sx={{ textAlign: 'right' }}>
                   <IconButton
+                    iconRef={prevButtonRef}
                     aria-label={t('details.previousFeatureBtn')}
                     tooltipPlacement="top"
-                    onClick={() => handleFeatureNavigateChange(-1)}
-                    disabled={currentFeatureIndex <= 0}
+                    onClick={() => {
+                      if (!isPrevDisabled) {
+                        handleFeatureNavigateChange(-1);
+                      }
+                    }}
+                    aria-disabled={isPrevDisabled}
+                    sx={{
+                      opacity: isPrevDisabled ? 0.5 : 1,
+                      cursor: isPrevDisabled ? 'not-allowed' : 'pointer',
+                      pointerEvents: isPrevDisabled ? 'none' : 'auto',
+                    }}
                     className="buttonOutline"
                   >
                     <ArrowBackIosOutlinedIcon />
                   </IconButton>
                   <IconButton
-                    sx={{ marginLeft: '16px' }}
+                    iconRef={nextButtonRef}
+                    sx={{
+                      marginLeft: '16px',
+                      opacity: isNextDisabled ? 0.5 : 1,
+                      cursor: isNextDisabled ? 'not-allowed' : 'pointer',
+                      pointerEvents: isNextDisabled ? 'none' : 'auto',
+                    }}
                     aria-label={t('details.nextFeatureBtn')}
                     tooltipPlacement="top"
-                    onClick={() => handleFeatureNavigateChange(1)}
-                    disabled={!memoSelectedLayerData?.features || currentFeatureIndex + 1 >= memoSelectedLayerData.features.length}
+                    onClick={() => {
+                      if (!isNextDisabled) {
+                        handleFeatureNavigateChange(1);
+                      }
+                    }}
+                    aria-disabled={isNextDisabled}
                     className="buttonOutline"
                   >
                     <ArrowForwardIosOutlinedIcon />
@@ -763,7 +806,7 @@ export function DetailsPanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: Deta
       containerType={containerType}
       layoutSwitch={
         <Box sx={sxClasses.layoutSwitch}>
-          {!hideCoordinateInfoSwitch && <CoordinateInfoSwitch />}
+          {!hideCoordinateInfoSwitch && <CoordinateInfoSwitch disabled={!mapClickCoordinates} />}
           <IconButton
             aria-label={t('details.clearAllfeatures')}
             tooltipPlacement="top"

--- a/packages/geoview-core/src/core/components/guide/guide-style.ts
+++ b/packages/geoview-core/src/core/components/guide/guide-style.ts
@@ -14,7 +14,6 @@ export const getSxClasses = (theme: Theme): SxStyles =>
       display: 'flex',
       flexDirection: 'column',
       '& .responsive-layout-right-main-content': {
-        backgroundColor: theme.palette.geoViewColor.white,
         '&:focus-visible': {
           border: '2px solid inherit',
         },

--- a/packages/geoview-core/src/core/components/layers/layers-panel.tsx
+++ b/packages/geoview-core/src/core/components/layers/layers-panel.tsx
@@ -34,10 +34,9 @@ export function LayersPanel({ containerType }: TypeLayersPanel): JSX.Element {
       // Log
       logger.logTraceUseCallback('LAYERS-PANEL - showLayerDetailsPanel');
 
-      // Set the visibility and focus
+      // Just set visibility - focus will be handled automatically by useEffect
       responsiveLayoutRef.current?.setIsRightPanelVisible(true);
       responsiveLayoutRef.current?.setRightPanelFocus();
-      // set the focus item when layer item clicked.
       setSelectedFooterLayerListItemId(`${layerId}`);
     },
     [setSelectedFooterLayerListItemId]
@@ -70,9 +69,8 @@ export function LayersPanel({ containerType }: TypeLayersPanel): JSX.Element {
 
   const rightPanel = (): JSX.Element | null => {
     if (selectedLayer && displayState === 'view') {
-      return <LayerDetails layerDetails={selectedLayer} />;
+      return <LayerDetails layerDetails={selectedLayer} containerType={containerType} />;
     }
-
     return null;
   };
 

--- a/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useTheme } from '@mui/material/styles';
-import { Box } from '@/ui';
+import { List } from '@/ui';
 import { useGeoViewMapId, useMapOrderedLayers } from '@/core/stores';
 import { logger } from '@/core/utils/logger';
 import type { TypeLegendLayer } from '@/core/components/layers/types';
@@ -67,5 +67,5 @@ export function LayersList({ layersList, showLayerDetailsPanel, isLayoutEnlarged
     });
   }, [depth, isLayoutEnlarged, mapId, showLayerDetailsPanel, layersList, layerPathOrder]);
 
-  return <Box sx={getListClass()}>{memoLegendItems}</Box>;
+  return <List sx={getListClass()}>{memoLegendItems}</List>;
 }

--- a/packages/geoview-core/src/core/components/layers/left-panel/left-panel-styles.ts
+++ b/packages/geoview-core/src/core/components/layers/left-panel/left-panel-styles.ts
@@ -13,6 +13,40 @@ export const getSxClasses = (theme: Theme): SxClasses => ({
     color: 'text.primary',
     width: '100%',
     overflowY: 'auto',
+
+    // list item
+    '& .MuiListItem-root': {
+      height: '100%',
+      flexDirection: 'column',
+      alignItems: 'stretch',
+      '& > .MuiBox-root': {
+        height: '100%',
+        position: 'relative',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        borderBottom: `1px solid ${theme.palette.geoViewColor.grey.darken(1, 0.12)}`,
+      },
+    },
+
+    // TODO: WCAG Issue #3236 -  Overly complex. Consider using a CSS class name to identify the deepest nested list items
+    // list item boxes - remove border from sub-level list box if the list does not contain sub-items
+    '& > .MuiListItem-root:has(ul) ul:not(:has(ul)):last-of-type > li:last-child > .MuiBox-root': {
+      borderBottom: 'none',
+    },
+
+    // list item button
+    '& .MuiListItemButton-root': {
+      padding: '0 2px 0 16px',
+      height: '100%',
+      '&:hover': {
+        backgroundColor: 'transparent',
+      },
+      '&.Mui-selected:not(.Mui-focusVisible)': {
+        backgroundColor: 'transparent',
+      },
+    },
+
     // layer title
     '& .MuiListItemText-primary': {
       fontWeight: '600',
@@ -38,23 +72,6 @@ export const getSxClasses = (theme: Theme): SxClasses => ({
         '& .MuiIconButton-root': {
           margin: '0px 1px',
         },
-      },
-    },
-
-    '& .MuiListItem-root': {
-      height: '100%',
-      '& .MuiListItemButton-root': {
-        padding: '0 2px 0 16px',
-        height: '100%',
-      },
-      '& .MuiBox-root': {
-        height: '100%',
-        borderTopRightRadius: '4px',
-        borderBottomRightRadius: '4px',
-        position: 'relative',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
       },
     },
 

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { animated } from '@react-spring/web';
 import { useTheme } from '@mui/material/styles';
 import { getSxClasses } from '@/core/components/common/layer-list-style';
 import {
@@ -11,13 +10,11 @@ import {
   KeyboardArrowUpIcon,
   ListItem,
   ListItemButton,
-  ListItemIcon,
   ListItemText,
   ProgressBar,
   Tooltip,
   VisibilityOffOutlinedIcon,
   VisibilityOutlinedIcon,
-  Paper,
 } from '@/ui';
 import type { TypeLegendLayer } from '@/core/components/layers/types';
 import {
@@ -64,9 +61,6 @@ interface SingleLayerProps {
   isLayoutEnlarged: boolean;
 }
 
-// Length at which the tooltip should be shown
-const CONST_NAME_LENGTH_TOOLTIP = 50;
-
 export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, isLast, isLayoutEnlarged }: SingleLayerProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/left-panel/single-layer', layerPath);
@@ -103,9 +97,6 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
 
   // Is visibility button disabled?
   const isLayerVisibleCapable = layerControls?.visibility;
-
-  // This is used to determine if the text should be wrapped in a tooltip
-  const shouldShowTooltip = (!!layerName && layerName.length > CONST_NAME_LENGTH_TOOLTIP) || isLayoutEnlarged;
 
   // Scroll this list item into view if selected
   useEffect(() => {
@@ -193,20 +184,6 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
     setSelectedLayerPath(layerPath);
     showLayerDetailsPanel?.(layerId || '');
   }, [layerPath, layerId, layerStatus, setSelectedLayerPath, showLayerDetailsPanel]);
-
-  const handleListItemKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLLIElement>) => {
-      // Log
-      logger.logTraceUseCallback('SINGLE-LAYER - handleListItemKeyDown');
-
-      // If clicked enter key
-      if (event.key === 'Enter' && event.currentTarget === event.target) {
-        // Redirect
-        handleLayerClick();
-      }
-    },
-    [handleLayerClick]
-  );
 
   const handleIconButtonUpKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLButtonElement>) => {
@@ -562,40 +539,43 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
     }
   }, [displayState, selectedFooterLayerListItemId.length]);
 
-  const AnimatedPaper = animated(Paper);
-
   return (
-    <AnimatedPaper className={memoContainerClass} data-layer-depth={depth}>
-      <ListItem id={layerId} key={layerName} divider tabIndex={0} onKeyDown={handleListItemKeyDown} onClick={handleLayerClick}>
-        <ListItemButton
-          selected={layerIsSelected || (layerChildIsSelected && !legendExpanded)}
-          tabIndex={-1}
-          sx={{
-            minHeight: '4.51rem',
-            ...((!inVisibleRange || parentHidden || !isVisible || layerStatus === 'error') && sxClasses.outOfRange),
-          }}
-          className={!inVisibleRange ? 'out-of-range' : ''}
+    <ListItem className={memoContainerClass} id={layerId} key={layerName} disablePadding={true} data-layer-depth={depth}>
+      <Box>
+        <Tooltip
+          title={t('layers.selectLayer', { layerName })}
+          placement="top"
+          enterDelay={theme.transitions.duration.tooltipDelay}
+          enterNextDelay={theme.transitions.duration.tooltipDelay}
+          arrow
         >
-          <LayerIcon layerPath={layerPath} />
-          <Tooltip title={layerName} placement="top" enterDelay={1000} arrow disableHoverListener={!shouldShowTooltip}>
+          <ListItemButton
+            onClick={handleLayerClick}
+            selected={layerIsSelected || (layerChildIsSelected && !legendExpanded)}
+            sx={{
+              minHeight: '4.51rem',
+              ...((!inVisibleRange || parentHidden || !isVisible || layerStatus === 'error') && sxClasses.outOfRange),
+            }}
+            className={!inVisibleRange ? 'out-of-range' : ''}
+          >
+            <LayerIcon layerPath={layerPath} />
             <ListItemText primary={layerName !== undefined ? layerName : layerId} secondary={memoLayerDescription} />
-          </Tooltip>
-          {!isLayoutEnlarged && (
-            <ListItemIcon className="rightIcons-container">
-              {memoMoreLayerButtons}
-              {memoArrowButtons}
-              {memoEditModeButtons}
-            </ListItemIcon>
-          )}
-        </ListItemButton>
+          </ListItemButton>
+        </Tooltip>
+        {!isLayoutEnlarged && (
+          <Box className="rightIcons-container" role="group" aria-label={t('layers.layerControls')!}>
+            {memoMoreLayerButtons}
+            {memoArrowButtons}
+            {memoEditModeButtons}
+          </Box>
+        )}
         {layerStatus === 'loading' && (
           <Box sx={sxClasses.progressBarSingleLayer}>
             <ProgressBar />
           </Box>
         )}
-      </ListItem>
-
+      </Box>
       {memoCollapse}
-    </AnimatedPaper>
+    </ListItem>
   );
 }

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -50,6 +50,7 @@ import {
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { useTimeSliderLayers, useTimeSliderStoreActions } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
 import { useNavigateToTab } from '@/core/components/common/hooks/use-navigate-to-tab';
+import { useGeoViewMapId } from '@/core/stores/geoview-store';
 
 // TODO: WCAG Issue #3108 - Fix layers.moreInfo button (button nested within a button)
 // TODO: WCAG Issue #3108 - Check all disabled buttons. They may need special treatment. Need to find instance in UI first)
@@ -57,6 +58,7 @@ import { useNavigateToTab } from '@/core/components/common/hooks/use-navigate-to
 
 interface LayerDetailsProps {
   layerDetails: TypeLegendLayer;
+  containerType?: 'appBar' | 'footerBar';
 }
 
 interface SubLayerProps {
@@ -109,7 +111,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/right-panel/layer-details');
 
-  const { layerDetails } = props;
+  const { layerDetails, containerType = 'footerBar' } = props;
 
   const { t } = useTranslation<string>();
 
@@ -119,6 +121,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
 
   const [isInfoCollapse, setIsInfoCollapse] = useState(false);
   const [allSublayersVisible, setAllSublayersVisible] = useState(true);
+  const mapId = useGeoViewMapId();
 
   // get store actions
   const highlightedLayer = useLayerHighlightedLayer();
@@ -170,6 +173,9 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
 
   // Get the localized layer type
   const memoLocalizedLayerType = useMemo(() => UtilAddLayer.getLocalizeLayerType(language, true), [language]);
+
+  // Generate unique table details button ID
+  const tableDetailsButtonId = `table-details-${containerType}-${mapId}`;
 
   // GV Wrapped in useEffect since it was throwing a warning otherwise
   useEffect(() => {
@@ -234,7 +240,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
         logger.logPromiseFailed('Failed to triggerGetAllFeatureInfo in single-layer.handleLayerClick', error);
       });
     }
-    enableFocusTrap({ activeElementId: 'layerDataTable', callbackElementId: `table-details` });
+    enableFocusTrap({ activeElementId: 'layerDataTable', callbackElementId: tableDetailsButtonId });
   };
 
   const handleHighlightLayer = (): void => {
@@ -387,7 +393,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
 
     return (
       <IconButton
-        id="table-details"
+        id={tableDetailsButtonId}
         aria-label={isDisabled ? t('layers.tableViewNone') : t('legend.tableDetails')}
         className="buttonOutline"
         onClick={handleOpenTable}
@@ -609,6 +615,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
     );
   };
 
+  // TODO: WCAG Issue #3116 - Consider using CSS rather than Divider for cleaner HTML structure
   // Render
   return (
     <Paper sx={sxClasses.layerDetails}>
@@ -677,13 +684,13 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
             )}
             {layerDetails.controls?.opacity !== false && <LayerOpacityControl layerDetails={layerDetails} />}
           </Box>
-          <Divider sx={{ marginTop: '10px', marginBottom: '10px' }} variant="middle" />
+          <Divider sx={{ height: 'auto', marginTop: '10px', marginBottom: '10px' }} variant="middle" />
           {renderWMSImage()}
           <Box>
             {layerDetails.items?.length > 0 && renderItems()}
             {layerDetails.children.length > 0 && renderSubLayers(layerDetails)}
           </Box>
-          <Divider sx={{ marginTop: '10px', marginBottom: '10px' }} variant="middle" />
+          <Divider sx={{ height: 'auto', marginTop: '10px', marginBottom: '10px' }} variant="middle" />
           {renderInfo()}
           {layerDetails.layerAttribution &&
             layerDetails.layerAttribution.map((attribution) => {

--- a/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
@@ -6,19 +6,9 @@ import type { TypeLegendItem } from '@/core/components/layers/types';
 import { useLayerSelectorControls, useLayerStoreActions } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { getSxClasses } from './legend-styles';
 import { logger } from '@/core/utils/logger';
+import { generateId } from '@/core/utils/utilities';
 import { useMapSelectorIsLayerHiddenOnMap } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { useGeoViewMapId } from '@/core/stores/geoview-store';
-
-// TODO: WCAG Issue #3218 - Remove and use the random id generator utility function (utilities.ts)
-// Sanitize string to create a valid HTML id attribute
-// Replace spaces and special characters with hyphens and convert to lowercase
-// example "Layer Name 123!" becomes "layer-name-123-"
-const sanitizeId = (str: string): string => {
-  return str
-    .toLowerCase()
-    .replace(/[^a-z0-9-_]/g, '-')
-    .replace(/-+/g, '-');
-};
 
 interface ItemsListProps {
   items: TypeLegendItem[];
@@ -26,28 +16,28 @@ interface ItemsListProps {
 }
 
 // Extracted ListItem Component
-// Apply style to increase left/right tooltip area (padding: '0 18px 0 18px', margin: '0 -18px 0 -18px')
-
 const LegendListItem = memo(
   ({
     item: { icon, name, isVisible },
     layerVisible,
-    showVisibilityTooltip: { show, value },
+    canToggle,
     showNameTooltip,
     onToggle,
     sxClasses,
-    mapId,
+    id,
   }: {
     item: TypeLegendItem;
     layerVisible: boolean;
-    showVisibilityTooltip: { show: boolean; value: string };
+    canToggle: boolean;
     showNameTooltip: boolean;
     onToggle?: () => void;
     sxClasses: Record<string, object>;
-    mapId: string;
+    id: string;
   }): JSX.Element => {
+    const { t } = useTranslation<string>();
+    const theme = useTheme();
+    const tooltipTitle = canToggle ? `${isVisible && layerVisible ? t('general.hide') : t('general.show')} ${name}` : '';
     const getItemClassName = (): string | undefined => {
-      if (!show) return undefined;
       return !isVisible || !layerVisible ? 'unchecked' : 'checked';
     };
 
@@ -55,50 +45,28 @@ const LegendListItem = memo(
 
     return (
       <ListItem sx={sxClasses.layerListItem} disablePadding className={`layerListItem ${itemClassName || ''}`}>
-        {onToggle ? (
+        <Tooltip
+          title={tooltipTitle || (showNameTooltip ? name : '')}
+          placement="top"
+          enterDelay={theme.transitions.duration.tooltipDelay}
+          enterNextDelay={theme.transitions.duration.tooltipDelay}
+        >
           <ListItemButton
-            id={`legend-item-${sanitizeId(name)}-${mapId}`}
-            component="button"
-            onClick={onToggle}
+            id={id}
+            onClick={canToggle && onToggle ? onToggle : undefined}
+            disabled={!canToggle || !onToggle}
             disableRipple
             sx={sxClasses.layerListItemButton}
             className={`layerListItemButton ${itemClassName || ''}`}
           >
             <ListItemIcon>
-              <Tooltip title={show ? value : ''} key={`Tooltip-${name}-${icon}1`} placement="left" disableHoverListener={!show}>
-                <Box sx={{ display: 'flex', padding: '0 18px 0 18px', margin: '0 -18px 0 -18px' }}>
-                  {icon ? <Box component="img" alt="" src={icon} /> : <BrowserNotSupportedIcon />}
-                </Box>
-              </Tooltip>
+              <Box sx={{ display: 'flex', padding: '0 18px 0 18px', margin: '0 -18px 0 -18px' }}>
+                {icon ? <Box component="img" alt="" src={icon} /> : <BrowserNotSupportedIcon />}
+              </Box>
             </ListItemIcon>
-            <Tooltip
-              title={showNameTooltip ? name : ''}
-              key={`Tooltip-${name}-${icon}2`}
-              placement="top"
-              disableHoverListener={!showNameTooltip}
-            >
-              <ListItemText primary={name} />
-            </Tooltip>
+            <ListItemText primary={name} />
           </ListItemButton>
-        ) : (
-          <>
-            <ListItemIcon>
-              <Tooltip title={show ? value : ''} key={`Tooltip-${name}-${icon}1`} placement="left" disableHoverListener={!show}>
-                <Box sx={{ display: 'flex', padding: '0 18px 0 18px', margin: '0 -18px 0 -18px' }}>
-                  {icon ? <Box component="img" alt="" src={icon} /> : <BrowserNotSupportedIcon />}
-                </Box>
-              </Tooltip>
-            </ListItemIcon>
-            <Tooltip
-              title={showNameTooltip ? name : ''}
-              key={`Tooltip-${name}-${icon}2`}
-              placement="top"
-              disableHoverListener={!showNameTooltip}
-            >
-              <ListItemText primary={name} />
-            </Tooltip>
-          </>
-        )}
+        </Tooltip>
       </ListItem>
     );
   }
@@ -115,9 +83,9 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
   // Hooks
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const { t } = useTranslation<string>();
   const mapId = useGeoViewMapId();
   const lastToggledRef = useRef<string | null>(null);
+  const itemIdMapRef = useRef<Map<string, string>>(new Map());
 
   const { toggleItemVisibility, getLayer } = useLayerStoreActions();
   const layerControls = useLayerSelectorControls(layerPath);
@@ -126,15 +94,33 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
   const canToggleItemVisibility = legendLayer?.canToggle && layerControls?.visibility !== false;
 
   /**
+   * Generates or retrieves a stable HTML ID for a legend item.
+   * Uses a composite key (name + geometryType + icon) to uniquely identify items.
+   * Once generated, the same item will always receive the same ID across re-renders.
+   *
+   * @param item - The legend item to generate an ID for
+   * @returns A stable, unique ID in format: "legend-item-{randomId}-{mapId}"
+   */
+  const getItemId = (item: TypeLegendItem): string => {
+    const itemKey = `${item.name}-${item.geometryType}-${item.icon}`;
+
+    if (!itemIdMapRef.current.has(itemKey)) {
+      itemIdMapRef.current.set(itemKey, `legend-item-${generateId(18)}-${mapId}`);
+    }
+    return itemIdMapRef.current.get(itemKey)!;
+  };
+
+  /**
    * Handles toggling of class visibility when the legend item is clicked.
    * @param {TypeLegendItem} item - the item to change the visibility of
+   * @param {string} itemId - The HTML ID of the item for focus restoration
    */
   const handleToggleItemVisibility = useCallback(
-    (item: TypeLegendItem): void => {
-      lastToggledRef.current = `legend-item-${sanitizeId(item.name)}-${mapId}`;
+    (item: TypeLegendItem, itemId: string): void => {
+      lastToggledRef.current = itemId;
       toggleItemVisibility(layerPath, item);
     },
-    [layerPath, toggleItemVisibility, mapId]
+    [layerPath, toggleItemVisibility]
   );
 
   // Keep focus on layers when they are toggled using keyboard
@@ -155,24 +141,26 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
   return (
     <List className="layerList" sx={sxClasses.layerList}>
       {items.map((item) => {
+        const itemId = getItemId(item);
+        const canToggle = Boolean(
+          canToggleItemVisibility && !layerHidden && legendLayer.styleConfig?.[item.geometryType]?.fields[0] !== undefined
+        );
+
         // Common properties for the legend list item
         const commonProps = {
           item,
           layerVisible: !layerHidden,
-          showVisibilityTooltip: {
-            show: Boolean(canToggleItemVisibility && !layerHidden && legendLayer.styleConfig?.[item.geometryType]?.fields[0] !== undefined),
-            value: t('layers.toggleItemVisibility'),
-          },
+          canToggle,
           showNameTooltip: item.name.length > CONST_NAME_LENGTH_TOOLTIP,
         };
 
         return (
           <LegendListItem
             key={`${item.name}-${item.isVisible}-${item.icon}`}
+            id={itemId}
             {...commonProps}
-            onToggle={commonProps.showVisibilityTooltip.show ? () => handleToggleItemVisibility(item) : undefined}
+            onToggle={canToggle ? () => handleToggleItemVisibility(item, itemId) : undefined}
             sxClasses={sxClasses}
-            mapId={mapId}
           />
         );
       })}

--- a/packages/geoview-core/src/core/types/material-ui.d.ts
+++ b/packages/geoview-core/src/core/types/material-ui.d.ts
@@ -61,6 +61,7 @@ declare module '@mui/material/styles/createPalette' {
 
 declare module '@mui/material/styles/createTransitions' {
   interface Duration {
+    tooltipDelay?: number;
     splash: number;
   }
 }

--- a/packages/geoview-core/src/ui/list/list-item-button.tsx
+++ b/packages/geoview-core/src/ui/list/list-item-button.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, type Ref } from 'react';
 import type { ListItemButtonProps } from '@mui/material';
 import { ListItemButton as MaterialListItemButton } from '@mui/material';
 import { logger } from '@/core/utils/logger';
@@ -8,19 +9,21 @@ import { logger } from '@/core/utils/logger';
  * full compatibility with Material-UI's List Item Button props.
  *
  * @param {ListItemButtonProps} props - All valid Material-UI List Item Button props
+ * @param {Ref<HTMLDivElement>} ref - Reference to the underlying HTML element
  * @returns {JSX.Element} The List Item Button component
  */
-function ListItemButtonUI(props: ListItemButtonProps): JSX.Element {
+function ListItemButtonUI(props: ListItemButtonProps, ref: Ref<HTMLDivElement>): JSX.Element {
   logger.logTraceRenderDetailed('ui/list/list-item-button', props);
 
   // Get constant from props
   const { children, className, style } = props;
 
   return (
-    <MaterialListItemButton className={className || ''} style={style || undefined} {...props}>
+    <MaterialListItemButton ref={ref} className={className || ''} style={style || undefined} {...props}>
       {children !== undefined && children}
     </MaterialListItemButton>
   );
 }
 
-export const ListItemButton = ListItemButtonUI;
+// Export the ListItemButton using forwardRef so that passing ref is permitted and functional
+export const ListItemButton = forwardRef<HTMLDivElement, ListItemButtonProps>(ListItemButtonUI);

--- a/packages/geoview-core/src/ui/style/themeOptionsGenerator.ts
+++ b/packages/geoview-core/src/ui/style/themeOptionsGenerator.ts
@@ -242,6 +242,7 @@ export const generateThemeOptions = (geoViewColors: IGeoViewColors = defaultGeoV
         enteringScreen: 225,
         // recommended when something is leaving screen
         leavingScreen: 195,
+        tooltipDelay: 1000,
         splash: 1500,
       },
       easing: {
@@ -295,6 +296,15 @@ export const generateThemeOptions = (geoViewColors: IGeoViewColors = defaultGeoV
             borderStyle: 'solid',
             boxShadow: `0px 12px 9px -13px ${geoViewColors.bgColor.darken(0.2, 0.5)}`,
 
+            '&.unbordered': {
+              borderStyle: 'none',
+            },
+          },
+        },
+      },
+      MuiListItem: {
+        styleOverrides: {
+          root: {
             '&.layer-panel': {
               boxShadow: 'none',
               '&[data-layer-depth="0"], &:not([data-layer-depth])': {
@@ -309,7 +319,7 @@ export const generateThemeOptions = (geoViewColors: IGeoViewColors = defaultGeoV
                 backgroundColor: 'unset',
               },
 
-              '& .MuiListItemButton-root': {
+              '& .MuiListItemButton-root:not(.Mui-focusVisible)': {
                 backgroundColor: 'transparent !important',
               },
 
@@ -341,10 +351,6 @@ export const generateThemeOptions = (geoViewColors: IGeoViewColors = defaultGeoV
                   color: geoViewColors.info.main,
                 },
               },
-            },
-
-            '&.unbordered': {
-              borderStyle: 'none',
             },
           },
         },


### PR DESCRIPTION
	* list-item-button: add ref forwarding to ListItemButton wrapper to fix MUI Tooltip ref warning

	* all panels: add "guide" buttons to "right-main". Remove them from "right-top" (responsive-grid-layout.tsx)
	* all panels: add focus trap to "right-main" when item from "left-main" is selected (responsive-grid-layout.tsx)
	* all panels: add "close selection" button to right-main unless only guide is available (WCAG mode) (responsive-grid-layout.tsx)
	* all panels: add auto focus to "close selection" button when right-main opens (WCAG mode) (responsive-grid-layout.tsx)
	* all panels: map esc key to most relevant close button (responsive-grid-layout.tsx)
	* all panels: return focus to the full screen button when full screen is closed (FullScreenDialog)

	* layers panel: fix tooltip to include layer name and description
	* layers panel: fix to allow items to be accessible via keyboard (enter and spacebar trigger on Click)
	* layers panel: remove now redundant handleListItemKeyDown event handler. <ListItemButton> handles this natively
	* layers panel: removed length condition for displaying layer item tooltip. it's always displayed with a delay (1000ms)
	* layers panel: update layer item tooltip to "Select layer name"

	* details panel: disable "Show coordinate info" Switch when no features have been selected
	* details panel: prevent "Show coordinate info" Switch from opening the sub-panel
	* details panel: remove "Close selection" button when no features have been selected
	* details panel: disable "guide" button when only guide is available (prevent unnecessary toggle)
	* details panel: keep focus on prev/next button when first/last feature reached (keyboard navigation)
	* details panel: update layer list item tooltip to "Select layer name" with a delay (1000ms)

	* legend panel: update to use random id generator
	* legend panel: simplify LegendListItem component for consistent HTML output (use disabled buttons rather than conditional <ListItemButton> output)
	* legend panel: fix tooltip (wasn't displaying on keyboard focus)
	* legend panel: leave left "border' enabled when visibility is hidden (3216)
	* legend panel: update legend item to use a single tooltip (show/hide + name).
	* legend panel: removed length condition for displaying legend item tooltip. its always displayed with a delay (1000ms)

	* Add tooltipDelay to theme (1000ms)
	* Updates to use more semantic HTML
	* Updates to Global CSS so that themeOptionsGenerator.ts styles apply to MuiListItem layer-panel
	* Updates to translations

# Description

Changes related to accessible keyboard navigation within the appbar panels (details, layers, legend). This includes global changes to (responsive-grid-layout)

Fixes #3216 #3217 #3218 #3219 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested manually using WCAG mode (keyboard) and mostly with the "Map Export - Large Legend" config. Tab, enter, spacebar, esc key, and keyboard focus should behave as expected for the large majority of the UI.
Tested using non-WCAG mode to make sure UI was not negatively impacted.

See each issue for testing use cases.

[[__Add the URL for your deploy!__]()](https://kenchase.github.io/geoview/)

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3241)
<!-- Reviewable:end -->
