### PR TITLE
feat(footer): Add data-footer-height attribute for manually setting the footer bar height

### DIFF
--- a/docs/app/config/create-map.md
+++ b/docs/app/config/create-map.md
@@ -18,7 +18,7 @@ Specifically, it looks for `<div>` elements with certain attributes that identif
 **Typical requirements for a GeoView map container:**
 - The element is a `<div>`.
 - It has the class attribute value `geoview-map`.
-- It may include additional attributes such as `data-config`, `data-config-url`, `data-lang`, or `data-shared` to specify map configuration, language, or shared state.
+- It may include additional attributes such as `data-config`, `data-config-url`, `data-lang`, `data-footer-height` or `data-shared` to specify map configuration, language, footer height, or shared state.
 - The `data-config` has precedence over `data-config-url` if both are provided.
 
 **Example:**
@@ -28,6 +28,7 @@ Specifically, it looks for `<div>` elements with certain attributes that identif
   class="geoview-map"
   data-lang="en"
   data-config-url="path/to/config.json"
+  data-footer-height="50vh"
   style="width: 100%; height: 400px;"
 ></div>
 ```
@@ -73,6 +74,21 @@ The `data-config-url` attribute specifies a URL to a JSON configuration file. Th
 ```
 
 The JSON file should have the same structure as the inline `data-config` value.
+
+#### `data-footer-height`
+
+The `data-footer-height` attribute allows for manually setting the height of the footer bar so that it is not default 600px or the same height as the map. The value can be any css height value although pixels (px) and view height (vh) are recommended.
+
+```html
+<div
+  id="myMap"
+  class="geoview-map"
+  data-lang="en"
+  data-footer-height="450px"
+  data-config-url="configs/map-config.json"
+  style="width: 100%; height: 400px;"
+></div>
+```
 
 ##### `data-shared`
 

--- a/packages/geoview-core/public/configs/footer-tabs-config.json
+++ b/packages/geoview-core/public/configs/footer-tabs-config.json
@@ -28,7 +28,8 @@
   "footerBar": {
     "tabs": {
       "core": ["legend", "layers"]
-    }
+    },
+    "collapsed": false
   },
   "corePackages": [],
   "externalPackages": []

--- a/packages/geoview-core/public/index.html
+++ b/packages/geoview-core/public/index.html
@@ -168,6 +168,7 @@
             <li><a href="./demo-geojson-inject.html">GeoJSON Injection</a></li>
             <li><a href="./demo-esri-renderer.html">ESRI Custom Renderer</a></li>
             <li><a href="./demo-wfs-renderer.html">WFS Custom Renderer</a></li>
+            <li><a href="./demo-custom-footer-height.html">Custom Footer Height</a></li>
           </ul>
         </div>
       </div>

--- a/packages/geoview-core/public/templates/demos/demo-custom-footer-height.html
+++ b/packages/geoview-core/public/templates/demos/demo-custom-footer-height.html
@@ -30,7 +30,7 @@
   data-config-url="../configs/footer-tabs-config.json"&gt;&lt;/div&gt;
       </textarea>
     </div>
-    <div id="Map1" class="geoview-map" data-lang="en" data-footer-height="400px" data-config-url="../configs/footer-tabs-config.json"></div>
+    <div id="Map1" class="geoview-map" data-lang="en" data-footer-height="400px" data-config-url="./configs/footer-tabs-config.json"></div>
 
     <div class="demo-section">
       <h4 id="HMap2">Footer height: 100vh</h4>
@@ -41,7 +41,7 @@
   data-config-url="../configs/footer-tabs-config.json"&gt;&lt;/div&gt;
       </textarea>
     </div>
-    <div id="Map2" class="geoview-map" data-lang="en" data-footer-height="100vh" data-config-url="../configs/footer-tabs-config.json"></div>
+    <div id="Map2" class="geoview-map" data-lang="en" data-footer-height="100vh" data-config-url="./configs/footer-tabs-config.json"></div>
     <div>
       <a class="ref-link" href="#top">Top</a>
     </div>
@@ -50,21 +50,8 @@
     <script>
       insertPageHeader();
 
-
-
-      // Register handler when map has been initialized
-      cgpv.onMapInit((mapViewer) => {
-        listenToLegendLayerSetChanges(`H${mapViewer.mapId}-state`, mapViewer);
-      });
-
       // initialize cgpv
       cgpv.init();
-
-      // create snippets
-      window.addEventListener('load', () => {
-        createCodeSnippet();
-        createConfigSnippet();
-      });
     </script>
   </body>
 </html>

--- a/packages/geoview-core/public/templates/demos/demo-custom-footer-height.html
+++ b/packages/geoview-core/public/templates/demos/demo-custom-footer-height.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Demo - Canadian Geospatial Platform Viewer</title>
+    <link rel="shortcut icon" href="./favicon.ico" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="msapplication-config" content="./img/browserconfig.xml" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="theme-color" content="#ffffff" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto|Montserrat:200,300,400,900|Merriweather" rel="stylesheet" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+
+  <body>
+    <div id="page-header">Custom Footer Height Demo</div>
+    <div class="back-to-main">
+      <a href="./index.html?tab=specific-demos">← Back to Main</a>
+    </div>
+
+    <div class="demo-section">
+      <h4 id="HMap1">Footer height: 400px</h4>
+      <textarea id="configTextArea1" cols="100" rows="5" readonly="">
+&lt;div id="Map1" class="geoview-map" 
+  data-lang="en" 
+  data-footer-height="400px" 
+  data-config-url="../configs/footer-tabs-config.json"&gt;&lt;/div&gt;
+      </textarea>
+    </div>
+    <div id="Map1" class="geoview-map" data-lang="en" data-footer-height="400px" data-config-url="../configs/footer-tabs-config.json"></div>
+
+    <div class="demo-section">
+      <h4 id="HMap2">Footer height: 100vh</h4>
+      <textarea id="configTextArea2" cols="100" rows="5" readonly="">
+&lt;div id="Map2" class="geoview-map" 
+  data-lang="en" 
+  data-footer-height="100vh" 
+  data-config-url="../configs/footer-tabs-config.json"&gt;&lt;/div&gt;
+      </textarea>
+    </div>
+    <div id="Map2" class="geoview-map" data-lang="en" data-footer-height="100vh" data-config-url="../configs/footer-tabs-config.json"></div>
+    <div>
+      <a class="ref-link" href="#top">Top</a>
+    </div>
+
+    <script src="codedoc.js"></script>
+    <script>
+      insertPageHeader();
+
+
+
+      // Register handler when map has been initialized
+      cgpv.onMapInit((mapViewer) => {
+        listenToLegendLayerSetChanges(`H${mapViewer.mapId}-state`, mapViewer);
+      });
+
+      // initialize cgpv
+      cgpv.init();
+
+      // create snippets
+      window.addEventListener('load', () => {
+        createCodeSnippet();
+        createConfigSnippet();
+      });
+    </script>
+  </body>
+</html>

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -74,7 +74,8 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
   const isCollapsed = useUIFooterBarIsCollapsed();
   const shellContainer = useAppShellContainer();
   const { setActiveFooterBarTab, enableFocusTrap, disableFocusTrap, setFooterBarIsCollapsed } = useUIStoreActions();
-  const appHeight: number = useAppHeight();
+  const backupAppHeight: number = useAppHeight();
+  const appHeight = document.getElementById(mapId)?.getAttribute('data-footer-height') ?? `${backupAppHeight}px`;
   const hiddenTabs: string[] = useUIHiddenTabs();
 
   // get store config for footer bar tabs to add (similar logic as in app-bar)

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -203,8 +203,10 @@ export class EsriUtilities {
     } else if (layer instanceof EsriFeature) {
       // If the metadata for the particular layer doesn't indicate 'Feature Layer' as the type
       // GV: Older ArcGIS servers do not have a 'type' attribute for layers in the layers list and it can only be retrieved from the layer's metadata endpoint
-      // GV: This will incorrectly throw a warning in those cases, but at least it still loads with this setup
-      if (layer.getMetadata()!.layers[esriIndexForFeature].type !== 'Feature Layer') {
+      if (
+        Object.prototype.hasOwnProperty.call(layer.getMetadata()!.layers[esriIndexForFeature], 'type') &&
+        layer.getMetadata()!.layers[esriIndexForFeature].type !== 'Feature Layer'
+      ) {
         // Log warning
         GeoViewError.logWarning(new LayerNotFeatureLayerError(layerConfig.layerPath, layerConfig.getLayerNameCascade()));
       }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -202,6 +202,8 @@ export class EsriUtilities {
       }
     } else if (layer instanceof EsriFeature) {
       // If the metadata for the particular layer doesn't indicate 'Feature Layer' as the type
+      // GV: Older ArcGIS servers do not have a 'type' attribute for layers in the layers list and it can only be retrieved from the layer's metadata endpoint
+      // GV: This will incorrectly throw a warning in those cases, but at least it still loads with this setup
       if (layer.getMetadata()!.layers[esriIndexForFeature].type !== 'Feature Layer') {
         // Log warning
         GeoViewError.logWarning(new LayerNotFeatureLayerError(layerConfig.layerPath, layerConfig.getLayerNameCascade()));

--- a/packages/geoview-core/src/ui/tabs/tabs-style.ts
+++ b/packages/geoview-core/src/ui/tabs/tabs-style.ts
@@ -7,7 +7,7 @@ import type { SxStyles } from '@/ui/style/types';
  * @param {Theme} theme the theme object
  * @returns {Object} the sx classes object
  */
-export const getSxClasses = (theme: Theme, isMapFullScreen: boolean, appHeight: number): SxStyles => ({
+export const getSxClasses = (theme: Theme, isMapFullScreen: boolean, appHeight: string): SxStyles => ({
   rightIcons: {
     marginTop: 0,
     display: 'flex',
@@ -18,7 +18,7 @@ export const getSxClasses = (theme: Theme, isMapFullScreen: boolean, appHeight: 
     borderTop: 1,
     borderTopColor: 'divider',
     flexGrow: 1,
-    height: isMapFullScreen ? 'calc(100% - 56px)' : `calc(${appHeight}px - 56px)`,
+    height: isMapFullScreen ? 'calc(100% - 56px)' : `calc(${appHeight} - 56px)`,
     overflow: 'hidden',
     paddingTop: '0 !important',
     width: '100%',

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -53,7 +53,7 @@ export interface TypeTabsProps {
   onOpenKeyboard?: (uiFocus: FocusItemProps) => void;
   onCloseKeyboard?: () => void;
   containerType?: TypeContainerBox;
-  appHeight: number;
+  appHeight: string;
   hiddenTabs: string[];
   isFullScreen: boolean;
 }


### PR DESCRIPTION
# Description

Added a data-footer-height attribute for setting the height of the footer bar manually.

Fixes #3239 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Demo page shows setting the footer height by pixels and by view height.

[Footer Heights Demo Page](https://matthewmuehlhausernrcan.github.io/geoview/demo-custom-footer-height.html)

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3247)
<!-- Reviewable:end -->
