### PR TITLE
Fixing the layer disable when 0 feature selected

### DIFF
--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -62,7 +62,7 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
     .trim();
 
   // Constant for state
-  const isDisabled = layer?.isDisabled;
+  const isDisabled = layer?.numOffeatures === 0 || layer?.isDisabled;
   const isLoading =
     layer.queryStatus === 'processing' ||
     layer.layerStatus === 'loading' ||


### PR DESCRIPTION
# Description

When 0 feature were selected, the UI wasn't disabling the layer box anymore.
Fixed.
<img width="480" height="412" alt="image" src="https://github.com/user-attachments/assets/d84ba5d5-bbaf-4611-a9e2-8f4299a28c9e" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hosted Jan 15 @ 10h : https://alex-nrcan.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3252)
<!-- Reviewable:end -->
