### PR TITLE
feat(renderer): Incorporate visual variables into the geoview renderer

### DIFF
--- a/packages/geoview-core/public/configs/navigator/demos/24-feature-visual-variables.json
+++ b/packages/geoview-core/public/configs/navigator/demos/24-feature-visual-variables.json
@@ -1,0 +1,134 @@
+{
+  "map": {
+    "interaction": "dynamic",
+    "viewSettings": {
+      "projection": 3857
+    },
+    "basemapOptions": {
+      "basemapId": "transport",
+      "shaded": false,
+      "labeled": true
+    },
+    "listOfGeoviewLayerConfig": [
+      {
+        "geoviewLayerId":"WindDirection",
+        "geoviewLayerName":"Wind Direction with rotation",
+        "metadataAccessPath":"https://services9.arcgis.com/RHVPKKiFTONKtxq3/ArcGIS/rest/services/NOAA_METAR_current_wind_speed_direction_v1/FeatureServer",
+        "geoviewLayerType":"esriFeature",
+        "listOfLayerEntryConfig": [
+          {
+              "layerId":"0"
+          }
+        ]
+      },
+      {
+        "geoviewLayerId": "historical-flood",
+        "geoviewLayerName": "Variable Size Opacity and Color by field value",
+        "metadataAccessPath": "https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/historical_flood_event_en/MapServer",
+        "geoviewLayerType": "esriFeature",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "0",
+            "layerStyle": {
+              "Point": {
+                "type": "simple",
+                "fields": [],
+                "hasDefault": false,
+                "info": [
+                  {
+                    "visible": true,
+                    "values": [],
+                    "settings": {
+                      "type": "simpleSymbol",
+                      "rotation": 0,
+                      "color": "rgba(0,255,0,0)",
+                      "stroke": {
+                        "color": "rgba(0,0,0,1)",
+                        "lineStyle": "solid",
+                        "width": 1
+                      },
+                      "size": 4,
+                      "symbol": "circle",
+                      "offset": [
+                        0,
+                        0
+                      ]
+                    }
+                  }
+                ],
+                "visualVariables": [
+                  {
+                    "type": "colorInfo",
+                    "field": "OBJECTID",
+                    "stops": [
+                      {
+                        "value": 1,
+                        "color": [
+                          255,
+                          0,
+                          0,
+                          255
+                        ]
+                      },
+                      {
+                        "value": 1684,
+                        "color": [
+                          0,
+                          0,
+                          255,
+                          255
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "sizeInfo",
+                    "field": "OBJECTID",
+                    "stops": [
+                      {
+                        "value": 1,
+                        "size": 8
+                      },
+                      {
+                        "value": 1684,
+                        "size": 16
+                      }
+                    ]
+                  },
+                  {
+                    "type": "opacityInfo",
+                    "field": "OBJECTID",
+                    "stops": [
+                      {
+                        "value": 1,
+                        "opacity": 0.5
+                      },
+                      {
+                        "value": 1684,
+                        "opacity": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "components": ["overview-map", "north-arrow"],
+  "overviewMap": { "hideOnZoom": 7 },
+  "footerBar": {
+    "tabs": {
+      "core": ["layers", "data-table"]
+    }
+  },
+  "corePackages": [],
+  "theme": "geo.ca",
+  "appBar": {
+    "tabs": {
+      "core": ["geolocator", "legend", "details", "export"]
+    }
+  }
+}

--- a/packages/geoview-core/public/templates/demos-navigator.html
+++ b/packages/geoview-core/public/templates/demos-navigator.html
@@ -63,6 +63,7 @@
           <option value="./configs/navigator/demos/21-circumpolar.json">Circumpolar View</option>
           <option value="./configs/navigator/demos/22-initial-settings.json">Initial Settings</option>
           <option value="./configs/navigator/demos/23-configured-feature-labels.json">Layer Text / Label Settings</option>
+          <option value="./configs/navigator/demos/24-feature-visual-variables.json">Feature Visual Variables from Renderer</option>
         </select>
       </div>
     </div>

--- a/packages/geoview-core/src/api/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/types/map-schema-types.ts
@@ -598,6 +598,7 @@ export type TypeLayerStyleSettings = {
   // If true, last style info from info array is default style.
   hasDefault: boolean;
   info: TypeLayerStyleConfigInfo[];
+  visualVariables?: TypeLayerStyleVisualVariable[];
 };
 
 /** Information needed to render the feature. */
@@ -619,6 +620,32 @@ export type TypeLayerStyleConfigInfo = {
 
   /** The geometry settings. */
   settings: TypeBaseVectorGeometryConfig;
+};
+
+/**
+ * Indiviual feature style modifications sometimes specified in ESRI Renderer
+ * https://developers.arcgis.com/documentation/mapping-and-location-services/data-visualization/data-driven-styles/visual-variables/
+ */
+export type TypeLayerStyleVisualVariable = {
+  type: 'color' | 'size' | 'rotation' | 'opacity';
+  field: string;
+  normalizationField?: string;
+  stops?: TypeEsriStyleStops[];
+  minDataValue?: number;
+  maxDataValue?: number;
+  minSize?: number;
+  maxSize?: number;
+  rotationType?: 'geographic' | 'arithmetic';
+  valueExpression?: string;
+};
+
+/** Stops for Visual Variable modifications */
+export type TypeEsriStyleStops = {
+  value: string | number;
+  // Assuming RGB
+  color?: string;
+  size?: number;
+  opacity?: number;
 };
 
 /**

--- a/packages/geoview-core/src/api/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/types/map-schema-types.ts
@@ -625,9 +625,11 @@ export type TypeLayerStyleConfigInfo = {
 /**
  * Indiviual feature style modifications sometimes specified in ESRI Renderer
  * https://developers.arcgis.com/documentation/mapping-and-location-services/data-visualization/data-driven-styles/visual-variables/
+ * Rest specific documentation
+ * https://developers.arcgis.com/web-map-specification/objects/colorInfo_visualVariable/
  */
 export type TypeLayerStyleVisualVariable = {
-  type: 'color' | 'size' | 'rotation' | 'opacity';
+  type: 'colorInfo' | 'sizeInfo' | 'rotationInfo' | 'opacityInfo';
   field: string;
   normalizationField?: string;
   stops?: TypeEsriStyleStops[];

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -1508,14 +1508,14 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     const styleSettings = layerStyle[geometryType];
     const { type } = styleSettings;
 
-    const featureStyle = GeoviewRenderer.processStyle[type][geometryType](
-      styleSettings,
-      feature,
+    const options = {
       filterEquation,
-      true,
+      legendFilterIsOff: true,
       domainsLookup,
-      aliasLookup
-    );
+      aliasLookup,
+    };
+
+    const featureStyle = GeoviewRenderer.processStyle[type][geometryType](styleSettings, feature, options);
 
     if (!featureStyle) {
       return GeoviewRenderer.getFeatureImageSource(feature, layerStyle, filterEquation, true, domainsLookup, aliasLookup);

--- a/packages/geoview-core/src/geo/utils/renderer/esri-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/esri-renderer.ts
@@ -13,6 +13,7 @@ import type {
   TypeLayerStyleSettings,
   TypeStyleGeometry,
   TypeSymbol,
+  TypeLayerStyleVisualVariable,
 } from '@/api/types/map-schema-types';
 import {
   isFilledPolygonVectorConfig,
@@ -409,6 +410,9 @@ export abstract class EsriRenderer {
       };
       if (styleGeometry) {
         style[styleGeometry] = styleSettings;
+        if (renderer.visualVariables) {
+          style[styleGeometry].visualVariables = renderer.visualVariables;
+        }
         return style;
       }
     }
@@ -441,6 +445,9 @@ export abstract class EsriRenderer {
       };
       if (styleGeometry) {
         style[styleGeometry] = styleSettings;
+        if (renderer.visualVariables) {
+          style[styleGeometry].visualVariables = renderer.visualVariables;
+        }
         return style;
       }
     }
@@ -507,6 +514,9 @@ export abstract class EsriRenderer {
         };
 
         style[styleGeometry] = styleSettings;
+        if (renderer.visualVariables) {
+          style[styleGeometry].visualVariables = renderer.visualVariables;
+        }
         return style;
       }
     }
@@ -521,6 +531,7 @@ export type EsriRendererTypes = 'uniqueValue' | 'simple' | 'classBreaks';
 
 export type EsriBaseRenderer = {
   type: EsriRendererTypes;
+  visualVariables?: TypeLayerStyleVisualVariable[];
 };
 
 type TypeEsriColor = [number, number, number, number];

--- a/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
@@ -1407,7 +1407,7 @@ export abstract class GeoviewRenderer {
         return [r, g, b, a];
       }
       if (color.startsWith('rgba')) {
-        const matches = color.match(/^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})(?:\s*,\s*(\d*\.?\d+))?\s*\)$/);
+        const matches = color.match(/^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})(?:\s*,\s*(1|0|0?\.\d+|1\.0+))?\s*\)$/);
         if (matches) {
           return [parseInt(matches[1], 10), parseInt(matches[2], 10), parseInt(matches[3], 10), parseFloat(matches[4] || '1')];
         }

--- a/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
@@ -81,6 +81,7 @@ export abstract class GeoviewRenderer {
    * @param {boolean} increment - True, if we want to skip to next color
    *
    * @returns {string} The current default color string.
+   * @static
    */
   // TODO: MINOR - Create a mechanism to have one counter by map if needed with a small class who reuse the static function
   static getDefaultColor(alpha: number, increment: boolean = false): string {
@@ -97,6 +98,7 @@ export abstract class GeoviewRenderer {
    * @param {FeatureLike} feature - The feature to check
    *
    * @returns {TypeStyleGeometry} The type of geometry (Point, LineString, Polygon).
+   * @static
    */
   static getGeometryType(feature: FeatureLike): TypeStyleGeometry {
     const geometryType = feature.getGeometry()?.getType();
@@ -119,6 +121,7 @@ export abstract class GeoviewRenderer {
    * @param {string} base64 - The base64-encoded SVG string, optionally including
    *   query parameters (e.g. `"base64:...?...fill=%23ff0000&outline=%23000000"`).
    * @returns {string} The decoded, cleaned, and parameter-substituted SVG XML string.
+   * @static
    */
   static base64ToSVGString(base64: string): string {
     if (!base64) return base64;
@@ -162,6 +165,7 @@ export abstract class GeoviewRenderer {
    * embed or transmit SVG data in formats where raw XML is not permitted.
    * @param {string} svgXML - The raw SVG XML string to encode.
    * @returns {string} A base64-encoded representation of the SVG string.
+   * @static
    */
   static SVGStringToBase64(svgXML: string): string {
     return window.btoa(svgXML);
@@ -173,6 +177,7 @@ export abstract class GeoviewRenderer {
    * @param {string} src - Source information (base64 image) of the image to load.
    *
    * @returns {Promise<HTMLImageElement>} A promise that the image is loaded.
+   * @static
    */
   static loadImage(src: string): Promise<HTMLImageElement | null> {
     const promisedImage = new Promise<HTMLImageElement | null>((resolve) => {
@@ -195,6 +200,7 @@ export abstract class GeoviewRenderer {
    * @param {Style} pointStyle - Style associated to the point symbol.
    *
    * @returns {Promise<HTMLCanvasElement>} A promise that the canvas is created.
+   * @static
    */
   static async createIconCanvas(pointStyle?: Style): Promise<HTMLCanvasElement | null> {
     try {
@@ -227,6 +233,7 @@ export abstract class GeoviewRenderer {
    * @param {Style} pointStyle - Style associated to the point symbol.
    *
    * @returns {Promise<HTMLCanvasElement>} A promise that the canvas is created.
+   * @static
    */
   static createPointCanvas(pointStyle?: Style): HTMLCanvasElement {
     const size = pointStyle?.getImage()?.getSize();
@@ -247,6 +254,7 @@ export abstract class GeoviewRenderer {
    * @param {Style} lineStringStyle - Style associated to the lineString.
    *
    * @returns {Promise<HTMLCanvasElement>} A promise that the canvas is created.
+   * @static
    */
   static createLineStringCanvas(lineStringStyle?: Style): HTMLCanvasElement {
     const drawingCanvas = document.createElement('canvas');
@@ -277,6 +285,7 @@ export abstract class GeoviewRenderer {
    * @param {Style} polygonStyle - Style associated to the polygon.
    *
    * @returns {Promise<HTMLCanvasElement>} A promise that the canvas is created.
+   * @static
    */
   static createPolygonCanvas(polygonStyle?: Style): HTMLCanvasElement {
     const drawingCanvas = document.createElement('canvas');
@@ -317,6 +326,7 @@ export abstract class GeoviewRenderer {
    * for the stroke options creation.
    *
    * @returns {StrokeOptions} The stroke options created.
+   * @static
    */
   static createStrokeOptions(settings: TypeSimpleSymbolVectorConfig | TypeLineStringVectorConfig | TypePolygonVectorConfig): StrokeOptions {
     // eslint-disable-next-line no-param-reassign
@@ -346,6 +356,7 @@ export abstract class GeoviewRenderer {
    *
    * @param {FilterNodeType} operator - Operator to execute.
    * @param {FilterNodeType[]} dataStack - Data stack to use for the operator execution.
+   * @static
    */
   static executeOperator(operator: FilterNodeType, dataStack: FilterNodeType[]): void {
     if (operator.nodeType === NodeType.binary) {
@@ -542,6 +553,7 @@ export abstract class GeoviewRenderer {
    * @param {FilterNodeType[]} filterEquation - Filter used to find the visibility value to return.
    *
    * @returns {boolean | undefined} The visibility flag for the feature specified.
+   * @static
    */
   static featureIsNotVisible(feature: Feature, filterEquation: FilterNodeType[]): boolean | undefined {
     const operatorStack: FilterNodeType[] = [];
@@ -622,6 +634,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeSimpleSymbolVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processCircleSymbol(settings: TypeSimpleSymbolVectorConfig): Style | undefined {
     // eslint-disable-next-line no-param-reassign
@@ -646,6 +659,7 @@ export abstract class GeoviewRenderer {
    * @param {number} angle - Angle to use for the symbol creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processStarShapeSymbol(settings: TypeSimpleSymbolVectorConfig, points: number, angle: number): Style | undefined {
     // eslint-disable-next-line no-param-reassign
@@ -673,6 +687,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeSimpleSymbolVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processStarSymbol(settings: TypeSimpleSymbolVectorConfig): Style | undefined {
     return this.processStarShapeSymbol(settings, 5, 0);
@@ -684,6 +699,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeSimpleSymbolVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processXSymbol(settings: TypeSimpleSymbolVectorConfig): Style | undefined {
     return this.processStarShapeSymbol(settings, 4, Math.PI / 4);
@@ -695,6 +711,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeSimpleSymbolVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processPlusSymbol(settings: TypeSimpleSymbolVectorConfig): Style | undefined {
     return this.processStarShapeSymbol(settings, 4, 0);
@@ -709,6 +726,7 @@ export abstract class GeoviewRenderer {
    * @param {[number, number]} scale - Scale to use for the symbol creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processRegularShape(
     settings: TypeSimpleSymbolVectorConfig,
@@ -741,6 +759,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeSimpleSymbolVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processSquareSymbol(settings: TypeSimpleSymbolVectorConfig): Style | undefined {
     return this.processRegularShape(settings, 4, Math.PI / 4, [1, 1]);
@@ -752,6 +771,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeSimpleSymbolVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processDiamondSymbol(settings: TypeSimpleSymbolVectorConfig): Style | undefined {
     return this.processRegularShape(settings, 4, 0, [0.75, 1]);
@@ -763,6 +783,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeSimpleSymbolVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processTriangleSymbol(settings: TypeSimpleSymbolVectorConfig): Style | undefined {
     return this.processRegularShape(settings, 3, 0, [1, 1]);
@@ -774,6 +795,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeIconSymbolVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processIconSymbol(settings: TypeIconSymbolVectorConfig): Style | undefined {
     const iconOptions: IconOptions = {};
@@ -796,6 +818,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeStyleProcessorOptions} options - Optional processing options.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processSimplePoint(
     styleSettings: TypeLayerStyleSettings | TypeKindOfVectorSettings,
@@ -834,6 +857,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeStyleProcessorOptions} options - Optional processing options.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processSimpleLineString(
     styleSettings: TypeLayerStyleSettings | TypeKindOfVectorSettings,
@@ -872,6 +896,7 @@ export abstract class GeoviewRenderer {
    * @param {TypePolygonVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processSolidFill(settings: TypePolygonVectorConfig, geometry?: Geometry): Style | undefined {
     // eslint-disable-next-line no-param-reassign
@@ -891,6 +916,7 @@ export abstract class GeoviewRenderer {
    * @param {TypePolygonVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processNullFill(settings: TypePolygonVectorConfig, geometry?: Geometry): Style | undefined {
     // eslint-disable-next-line no-param-reassign
@@ -911,6 +937,7 @@ export abstract class GeoviewRenderer {
    * @param {FillPatternLine[]} FillPatternLines - Fill pattern lines needed to create the fill.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processPatternFill(
     settings: TypePolygonVectorConfig,
@@ -982,6 +1009,7 @@ export abstract class GeoviewRenderer {
    * @param {TypePolygonVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processBackwardDiagonalFill(settings: TypePolygonVectorConfig, geometry?: Geometry): Style | undefined {
     return this.processPatternFill(settings, this.FillPatternSettings.backwardDiagonal, geometry);
@@ -993,6 +1021,7 @@ export abstract class GeoviewRenderer {
    * @param {TypePolygonVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processForwardDiagonalFill(settings: TypePolygonVectorConfig, geometry?: Geometry): Style | undefined {
     return this.processPatternFill(settings, this.FillPatternSettings.forwardDiagonal, geometry);
@@ -1004,6 +1033,7 @@ export abstract class GeoviewRenderer {
    * @param {TypePolygonVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processCrossFill(settings: TypePolygonVectorConfig, geometry?: Geometry): Style | undefined {
     return this.processPatternFill(settings, this.FillPatternSettings.cross, geometry);
@@ -1015,6 +1045,7 @@ export abstract class GeoviewRenderer {
    * @param {TypePolygonVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processDiagonalCrossFill(settings: TypePolygonVectorConfig, geometry?: Geometry): Style | undefined {
     return this.processPatternFill(settings, this.FillPatternSettings.diagonalCross, geometry);
@@ -1026,6 +1057,7 @@ export abstract class GeoviewRenderer {
    * @param {TypePolygonVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processHorizontalFill(settings: TypePolygonVectorConfig, geometry?: Geometry): Style | undefined {
     return this.processPatternFill(settings, this.FillPatternSettings.horizontal, geometry);
@@ -1037,6 +1069,7 @@ export abstract class GeoviewRenderer {
    * @param {TypePolygonVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processVerticalFill(settings: TypePolygonVectorConfig, geometry?: Geometry): Style | undefined {
     return this.processPatternFill(settings, this.FillPatternSettings.vertical, geometry);
@@ -1048,6 +1081,7 @@ export abstract class GeoviewRenderer {
    * @param {TypePolygonVectorConfig} settings - Settings to use for the Style creation.
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processDotFill(settings: TypePolygonVectorConfig, geometry?: Geometry): Style | undefined {
     return this.processPatternFill(settings, this.FillPatternSettings.dot, geometry);
@@ -1061,6 +1095,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeStyleProcessorOptions} options - Optional processing options
    *
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processSimplePolygon(
     styleSettings: TypeLayerStyleSettings | TypeKindOfVectorSettings,
@@ -1105,6 +1140,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeVectorLayerStyles} layerStyle - Object that will receive the created canvas.
    * @param {TypeLayerStyleConfigInfo[]} arrayOfPointStyleConfig - Array of point style configuration.
    * @returns {Promise<TypeVectorLayerStyles>} A promise that the vector layer style is created.
+   * @static
    */
   static async processArrayOfPointStyleConfig(
     layerStyles: TypeVectorLayerStyles,
@@ -1148,6 +1184,7 @@ export abstract class GeoviewRenderer {
    * created.
    *
    * @returns {Promise<TypeVectorLayerStyles>} A promise that the layer styles are processed.
+   * @static
    */
   static async getPointStyleSubRoutine(
     defaultSettings?: TypeKindOfVectorSettings,
@@ -1194,6 +1231,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeStyleConfig} styleConfig - The style configuration.
    *
    * @returns {Promise<TypeVectorLayerStyles>} A promise that the layer styles are processed.
+   * @static
    */
   static async getLegendStyles(styleConfig: TypeLayerStyleConfig | undefined): Promise<TypeVectorLayerStyles> {
     try {
@@ -1272,6 +1310,7 @@ export abstract class GeoviewRenderer {
    * @param {string} label - Label for the style.
    *
    * @returns {TypeLayerStyleConfigInfo | undefined} The Style configuration created. Undefined if unable to create it.
+   * @static
    */
   static createDefaultStyle(geometryType: TypeStyleGeometry, label: string): TypeLayerStyleSettings | undefined {
     if (geometryType === 'Point') {
@@ -1316,6 +1355,7 @@ export abstract class GeoviewRenderer {
    * @param {number} output1 - The output at the lower value.
    * @param {number} output2 - The output at the upper value.
    * @returns {number} The interpolated output value.
+   * @static
    */
   static interpolateValue(value: number, value1: number, value2: number, output1: number, output2: number): number {
     if (value1 === value2) return output1;
@@ -1331,7 +1371,8 @@ export abstract class GeoviewRenderer {
    * @param {number} value2 - The upper data value.
    * @param {string | number[]} color1 - The hex color at the lower value.
    * @param {string | number[]} color2 - The hex color at the upper value.
-   * @returns {string} The interpolated color in rgba format.
+   * @returns {string} The interpolated color in rgba format.stat
+   * @static
    */
   static interpolateColor(value: number, value1: number, value2: number, color1: string | number[], color2: string | number[]): string {
     /**
@@ -1345,12 +1386,15 @@ export abstract class GeoviewRenderer {
           logger.logWarning('Invalid color array length, expected at least 3 values [r,g,b]:', color);
           return [255, 0, 0, 1];
         }
+
         // Safely get values that may be less then 0 or greater than 255
         const r = Math.max(0, Math.min(255, color[0]));
         const g = Math.max(0, Math.min(255, color[1]));
         const b = Math.max(0, Math.min(255, color[2]));
+
         // Alpha is optional, defaults to 255 (fully opaque), convert to 0-1 range
         const a = color.length > 3 ? Math.max(0, Math.min(255, color[3])) / 255 : 1;
+
         return [r, g, b, a];
       }
 
@@ -1363,7 +1407,7 @@ export abstract class GeoviewRenderer {
         return [r, g, b, a];
       }
       if (color.startsWith('rgba')) {
-        const matches = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+),?\s*([\d.]+)?\)/);
+        const matches = color.match(/^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})(?:\s*,\s*(\d*\.?\d+))?\s*\)$/);
         if (matches) {
           return [parseInt(matches[1], 10), parseInt(matches[2], 10), parseInt(matches[3], 10), parseFloat(matches[4] || '1')];
         }
@@ -1390,6 +1434,7 @@ export abstract class GeoviewRenderer {
    * @param {string} expression - Expression string (e.g., "$feature[\"FIELD_NAME\"] + 90")
    * @param {Feature} feature - Feature containing field data
    * @returns {number | null} The evaluated result or null if evaluation fails
+   * @static
    */
   static evaluateValueExpression(expression: string, feature: Feature): number | null {
     try {
@@ -1407,7 +1452,7 @@ export abstract class GeoviewRenderer {
       });
 
       // Safety check: only allow numbers, operators, and whitespace
-      if (!/^(null|\d+\.?\d*|\.\d+|\s|[+\-*/().%^])+$/i.test(evaluableExpression)) {
+      if (!/^[\d+\-*/().%^ \t\r\n]+$/i.test(evaluableExpression)) {
         logger.logWarning('Invalid characters in expression:', expression);
         return null;
       }
@@ -1430,6 +1475,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeLayerStyleVisualVariable[]} visualVariables - Visual variable configurations.
    * @param {TypeAliasLookup?} aliasLookup - Optional lookup table for field name aliases.
    * @returns {Style} The modified style with visual variables applied.
+   * @static
    */
   static applyVisualVariables(style: Style, feature: Feature, visualVariables: TypeLayerStyleVisualVariable[]): Style {
     if (!visualVariables || visualVariables.length === 0) return style;
@@ -1493,6 +1539,7 @@ export abstract class GeoviewRenderer {
    * @param {Style} style - The style to modify.
    * @param {number} dataValue - The data value from the feature.
    * @param {TypeLayerStyleVisualVariable} visualVar - The visual variable configuration.
+   * @static
    */
   static applyColorVisualVariable(style: Style, dataValue: number, visualVar: TypeLayerStyleVisualVariable): void {
     if (!visualVar.stops || visualVar.stops.length < 2) return;
@@ -1553,6 +1600,7 @@ export abstract class GeoviewRenderer {
    * @param {Style} style - The style to modify.
    * @param {number} dataValue - The data value from the feature.
    * @param {TypeLayerStyleVisualVariable} visualVar - The visual variable configuration.
+   * @static
    */
   static applySizeVisualVariable(style: Style, dataValue: number, visualVar: TypeLayerStyleVisualVariable): void {
     let size: number | undefined;
@@ -1621,6 +1669,7 @@ export abstract class GeoviewRenderer {
    * @param {Style} style - The style to modify.
    * @param {number} dataValue - The data value from the feature.
    * @param {TypeLayerStyleVisualVariable} visualVar - The visual variable configuration.
+   * @static
    */
   static applyRotationVisualVariable(style: Style, dataValue: number, visualVar: TypeLayerStyleVisualVariable): void {
     const image = style.getImage();
@@ -1650,6 +1699,7 @@ export abstract class GeoviewRenderer {
    * @param {Style} style - The style to modify.
    * @param {number} dataValue - The data value from the feature.
    * @param {TypeLayerStyleVisualVariable} visualVar - The visual variable configuration.
+   * @static
    */
   static applyOpacityVisualVariable(style: Style, dataValue: number, visualVar: TypeLayerStyleVisualVariable): void {
     if (!visualVar.stops || visualVar.stops.length < 2) return;
@@ -1741,6 +1791,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeLayerMetadataFields[]?} domainsLookup - An optional lookup table to handle coded value domains.
    * @param {TypeAliasLookup?} aliasLookup - An optional lookup table to handle field name aliases.
    * @returns {TypeLayerStyleConfigInfo | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static searchUniqueValueEntry(
     fields: string[],
@@ -1821,6 +1872,7 @@ export abstract class GeoviewRenderer {
    * @param {Feature?} feature - Feature used to test the unique value conditions.
    * @param {TypeStyleProcessorOptions?} options - Optional processing options.
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processUniqueValuePoint(
     styleSettings: TypeLayerStyleSettings | TypeKindOfVectorSettings,
@@ -1857,6 +1909,7 @@ export abstract class GeoviewRenderer {
    * @param {Feature?} feature - Feature used to test the unique value conditions.
    * @param {TypeStyleProcessorOptions?} options - Optional processing options.
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processUniqueLineString(
     styleSettings: TypeLayerStyleSettings | TypeKindOfVectorSettings,
@@ -1889,6 +1942,7 @@ export abstract class GeoviewRenderer {
    * @param {Feature?} feature - Feature used to test the unique value conditions.
    * @param {TypeStyleProcessorOptions?} options - Optional processing options.
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processUniquePolygon(
     styleSettings: TypeLayerStyleSettings | TypeKindOfVectorSettings,
@@ -1921,6 +1975,7 @@ export abstract class GeoviewRenderer {
    * @param {Feature} feature - Feature used to test the class break conditions.
    * @param {TypeAliasLookup?} aliasLookup - An optional lookup table to handle field name aliases.
    * @returns {number | undefined} The index of the entry. Undefined if unable to find it.
+   * @static
    */
   static searchClassBreakEntry(
     field: string,
@@ -1987,6 +2042,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeLayerStyleValueCondition[]} conditions - Two-element array describing the boundary operators.
    * @returns {boolean} True if the value satisfies the interval according to the conditions, false otherwise.
    * @throws {NotSupportedError} If `conditions` contains an unsupported combination of operators.
+   * @static
    */
   static searchClassBreakEntryCheck(value: number, min: number, max: number, conditions: TypeLayerStyleValueCondition[]): boolean {
     // Depending on the conditions for minimum and maximum
@@ -2011,6 +2067,7 @@ export abstract class GeoviewRenderer {
    * @param {Feature} feature - Feature used to test the unique value conditions.
    * @param {TypeStyleProcessorOptions?} options - Optional processing options.
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processClassBreaksPoint(
     styleSettings: TypeLayerStyleSettings | TypeKindOfVectorSettings,
@@ -2048,6 +2105,7 @@ export abstract class GeoviewRenderer {
    * @param {Feature} feature - Feature used to test the unique value conditions.
    * @param {TypeStyleProcessorOptions?} options - Optional processing options.
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processClassBreaksLineString(
     styleSettings: TypeLayerStyleSettings | TypeKindOfVectorSettings,
@@ -2084,6 +2142,7 @@ export abstract class GeoviewRenderer {
    * @param {Feature} feature - Feature used to test the unique value conditions.
    * @param {TypeStyleProcessorOptions?} options - Optional processing options.
    * @returns {Style | undefined} The Style created. Undefined if unable to create it.
+   * @static
    */
   static processClassBreaksPolygon(
     styleSettings: TypeLayerStyleSettings | TypeKindOfVectorSettings,
@@ -2127,6 +2186,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeLayerTextConfig?} layerText - An optional text configuration to apply to the feature
    * @param {() => Promise<string | null>} callbackWhenCreatingStyle - An optional callback to execute when a new style had to be created
    * @returns {Style | undefined} The style applied to the feature or undefined if not found.
+   * @static
    */
   static getAndCreateFeatureStyle(
     feature: FeatureLike,
@@ -2191,6 +2251,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeLayerMetadataFields[]?} domainsLookup - An optional lookup table to handle coded value domains.
    * @param {TypeAliasLookup?} aliasLookup - An optional lookup table to handle field name aliases.
    * @returns {string} The icon associated to the feature or a default empty one.
+   * @static
    */
   static getFeatureImageSource(
     feature: Feature,
@@ -2272,6 +2333,7 @@ export abstract class GeoviewRenderer {
    * @param {FilterNodeType[]} keywordArray - Array of keywords to process.
    *
    * @returns {FilterNodeType[]} The new keywords array with all nodes classified.
+   * @static
    */
   static classifyUnprocessedNodes(keywordArray: FilterNodeType[]): FilterNodeType[] {
     return keywordArray.map((node, i) => {
@@ -2318,6 +2380,7 @@ export abstract class GeoviewRenderer {
    * @param {RegExp} regExp - An optional regular expression to use for the extraction.
    *
    * @returns {FilterNodeType[]} The new keywords array.
+   * @static
    */
   static extractKeyword(filterNodeArray: FilterNodeType[], keyword: string, regExp?: RegExp): FilterNodeType[] {
     const getNodeType = (keywordValue: string): NodeType => {
@@ -2360,6 +2423,7 @@ export abstract class GeoviewRenderer {
    * @param {FilterNodeType[]} keywordArray - Array of keywords to process.
    *
    * @returns {FilterNodeType[]} The new keywords array with all string nodes classified.
+   * @static
    */
   static extractStrings(keywordArray: FilterNodeType[]): FilterNodeType[] {
     let stringNeeded = false;
@@ -2409,6 +2473,7 @@ export abstract class GeoviewRenderer {
    * @param {FilterNodeType[]} filterNodeArrayType - Node array to analyse.
    *
    * @returns {FilterNodeType[]} The new node array with all nodes classified.
+   * @static
    */
   static analyzeLayerFilter(filterNodeArrayType: FilterNodeType[]): FilterNodeType[] {
     let resultingKeywordArray = filterNodeArrayType;
@@ -2555,6 +2620,7 @@ export abstract class GeoviewRenderer {
    * @param {TypeLayerTextConfig} layerText - The layer text configuration
    * @param {TypeAliasLookup} aliasLookup - The alias lookup
    * @returns {Text | undefined} The text style
+   * @static
    */
   static getTextStyle = (
     feature: FeatureLike,
@@ -2604,6 +2670,7 @@ export abstract class GeoviewRenderer {
    * @param {FeatureLike} feature - The feature to create the text style for
    * @param {TypeLayerTextConfig} textSettings - The text style settings
    * @returns {Text | undefined} The text style
+   * @static
    */
   static createTextStyle = (feature: FeatureLike, textSettings: TypeLayerTextConfig): Text | undefined => {
     const {
@@ -2704,6 +2771,7 @@ export abstract class GeoviewRenderer {
    * @param {number} zoom - The zoom level (0-20)
    * @param {TypeValidMapProjectionCodes} projection - The map projection (3857 for Web Mercator, 3978 for Canada Lambert)
    * @returns {number} Approximate resolution for the given zoom and projection
+   * @static
    */
   static getApproximateResolution(zoom: number, projection: TypeValidMapProjectionCodes = 3857): number {
     if (projection === 3978) {
@@ -2720,6 +2788,7 @@ export abstract class GeoviewRenderer {
    * @param {number} width - The maximum width per line
    * @param {number} maxLines - Maximum number of lines (optional, overrides width if needed)
    * @returns {string} The wrapped text
+   * @static
    */
   static wrapText(str: string, width: number, maxLines?: number): string {
     if (!maxLines) {
@@ -2777,6 +2846,7 @@ export abstract class GeoviewRenderer {
    * @param {string} str - The text to wrap
    * @param {number} width - The maximum width of each line
    * @returns {string} The wrapped text
+   * @static
    */
   static wrapTextByWidth(str: string, width: number): string {
     // No wrapping required
@@ -2817,6 +2887,7 @@ export abstract class GeoviewRenderer {
    * @param {string} template - The text template with {field-name} placeholders
    * @param {FeatureLike} feature - The feature to get field values from
    * @returns {string} The processed text with field values substituted
+   * @static
    */
   static processTextTemplate(template: string, feature: FeatureLike): string {
     return template.replace(/\{(\w+)(?::([^}]+))?\}/g, (match, fieldName, format) => {

--- a/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
@@ -843,7 +843,7 @@ export abstract class GeoviewRenderer {
     const visualVarsToApply = visualVariables || ('visualVariables' in styleSettings ? styleSettings.visualVariables : undefined);
 
     if (style && feature && visualVarsToApply) {
-      style = this.applyVisualVariables(style, feature, visualVarsToApply);
+      style = this.#applyVisualVariables(style, feature, visualVarsToApply);
     }
 
     return style;
@@ -884,7 +884,7 @@ export abstract class GeoviewRenderer {
     const visualVarsToApply = visualVariables || ('visualVariables' in styleSettings ? styleSettings.visualVariables : undefined);
 
     if (style && feature && visualVarsToApply) {
-      style = this.applyVisualVariables(style, feature, visualVarsToApply);
+      style = this.#applyVisualVariables(style, feature, visualVarsToApply);
     }
 
     return style;
@@ -1126,7 +1126,7 @@ export abstract class GeoviewRenderer {
     const visualVarsToApply = visualVariables || ('visualVariables' in styleSettings ? styleSettings.visualVariables : undefined);
 
     if (style && feature && visualVarsToApply) {
-      style = this.applyVisualVariables(style, feature, visualVarsToApply);
+      style = this.#applyVisualVariables(style, feature, visualVarsToApply);
     }
 
     return style;
@@ -1475,9 +1475,9 @@ export abstract class GeoviewRenderer {
    * @param {TypeLayerStyleVisualVariable[]} visualVariables - Visual variable configurations.
    * @param {TypeAliasLookup?} aliasLookup - Optional lookup table for field name aliases.
    * @returns {Style} The modified style with visual variables applied.
-   * @static
+   * @static @private
    */
-  static applyVisualVariables(style: Style, feature: Feature, visualVariables: TypeLayerStyleVisualVariable[]): Style {
+  static #applyVisualVariables(style: Style, feature: Feature, visualVariables: TypeLayerStyleVisualVariable[]): Style {
     if (!visualVariables || visualVariables.length === 0) return style;
 
     const modifiedStyle = style.clone();
@@ -1514,16 +1514,16 @@ export abstract class GeoviewRenderer {
       // Apply based on visual variable type
       switch (visualVar.type) {
         case 'colorInfo':
-          this.applyColorVisualVariable(modifiedStyle, dataValue, visualVar);
+          this.#applyColorVisualVariable(modifiedStyle, dataValue, visualVar);
           break;
         case 'sizeInfo':
-          this.applySizeVisualVariable(modifiedStyle, dataValue, visualVar);
+          this.#applySizeVisualVariable(modifiedStyle, dataValue, visualVar);
           break;
         case 'rotationInfo':
-          this.applyRotationVisualVariable(modifiedStyle, dataValue, visualVar);
+          this.#applyRotationVisualVariable(modifiedStyle, dataValue, visualVar);
           break;
         case 'opacityInfo':
-          this.applyOpacityVisualVariable(modifiedStyle, dataValue, visualVar);
+          this.#applyOpacityVisualVariable(modifiedStyle, dataValue, visualVar);
           break;
         default:
           break;
@@ -1539,9 +1539,9 @@ export abstract class GeoviewRenderer {
    * @param {Style} style - The style to modify.
    * @param {number} dataValue - The data value from the feature.
    * @param {TypeLayerStyleVisualVariable} visualVar - The visual variable configuration.
-   * @static
+   * @static @private
    */
-  static applyColorVisualVariable(style: Style, dataValue: number, visualVar: TypeLayerStyleVisualVariable): void {
+  static #applyColorVisualVariable(style: Style, dataValue: number, visualVar: TypeLayerStyleVisualVariable): void {
     if (!visualVar.stops || visualVar.stops.length < 2) return;
 
     // Find the two stops that bracket the data value
@@ -1600,9 +1600,9 @@ export abstract class GeoviewRenderer {
    * @param {Style} style - The style to modify.
    * @param {number} dataValue - The data value from the feature.
    * @param {TypeLayerStyleVisualVariable} visualVar - The visual variable configuration.
-   * @static
+   * @static @private
    */
-  static applySizeVisualVariable(style: Style, dataValue: number, visualVar: TypeLayerStyleVisualVariable): void {
+  static #applySizeVisualVariable(style: Style, dataValue: number, visualVar: TypeLayerStyleVisualVariable): void {
     let size: number | undefined;
 
     // Method 1: Using min/max data values and sizes
@@ -1669,9 +1669,9 @@ export abstract class GeoviewRenderer {
    * @param {Style} style - The style to modify.
    * @param {number} dataValue - The data value from the feature.
    * @param {TypeLayerStyleVisualVariable} visualVar - The visual variable configuration.
-   * @static
+   * @static @private
    */
-  static applyRotationVisualVariable(style: Style, dataValue: number, visualVar: TypeLayerStyleVisualVariable): void {
+  static #applyRotationVisualVariable(style: Style, dataValue: number, visualVar: TypeLayerStyleVisualVariable): void {
     const image = style.getImage();
     if (!image) return;
 
@@ -1699,9 +1699,9 @@ export abstract class GeoviewRenderer {
    * @param {Style} style - The style to modify.
    * @param {number} dataValue - The data value from the feature.
    * @param {TypeLayerStyleVisualVariable} visualVar - The visual variable configuration.
-   * @static
+   * @static @private
    */
-  static applyOpacityVisualVariable(style: Style, dataValue: number, visualVar: TypeLayerStyleVisualVariable): void {
+  static #applyOpacityVisualVariable(style: Style, dataValue: number, visualVar: TypeLayerStyleVisualVariable): void {
     if (!visualVar.stops || visualVar.stops.length < 2) return;
 
     const sortedStops = [...visualVar.stops].sort((a, b) => Number(a.value) - Number(b.value));

--- a/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
@@ -1184,9 +1184,9 @@ export abstract class GeoviewRenderer {
    * created.
    *
    * @returns {Promise<TypeVectorLayerStyles>} A promise that the layer styles are processed.
-   * @static
+   * @static @private
    */
-  static async getPointStyleSubRoutine(
+  static async #getPointStyleSubRoutine(
     defaultSettings?: TypeKindOfVectorSettings,
     arrayOfPointStyleConfig?: TypeLayerStyleConfigInfo[]
   ): Promise<TypeVectorLayerStyles> {
@@ -1242,13 +1242,13 @@ export abstract class GeoviewRenderer {
         // ======================================================================================================================
         // Point style configuration ============================================================================================
         if (styleConfig.Point.type === 'simple') {
-          const layerStyles = await this.getPointStyleSubRoutine(styleConfig.Point.info[0].settings);
+          const layerStyles = await this.#getPointStyleSubRoutine(styleConfig.Point.info[0].settings);
           legendStyles.Point = layerStyles.Point;
         } else {
           const defaultSettings = styleConfig.Point.hasDefault
             ? styleConfig.Point.info[styleConfig.Point.info.length - 1].settings
             : undefined;
-          const layerStyles = await this.getPointStyleSubRoutine(defaultSettings, styleConfig.Point.info);
+          const layerStyles = await this.#getPointStyleSubRoutine(defaultSettings, styleConfig.Point.info);
           legendStyles.Point = layerStyles.Point;
         }
       }


### PR DESCRIPTION
# Description

Some ESRI feature services have visualVariables that can alter feature's symbol based on a field value. This now incorporates this type of styling.

Fixes #3233 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
### Host updated @ 2026-01-15 4:55 PM
Created a navigator page that pulls in a FeatureService which has a rotation applied by a visual variable. Also created a layer and manually set visual variables for color, size, and opacity to make sure they are working. Example services are hard to find, so may still require some adjustments. 

[Visual Variable navigator page](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/demos/24-feature-visual-variables.json)

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3253)
<!-- Reviewable:end -->
