### PR TITLE
hotfix: loads geoCore chart configs through config

### DIFF
--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
@@ -15,6 +15,7 @@ import type { OgcWfsLayerEntryConfig } from '@/api/config/validation-classes/vec
 import type { AbstractBaseLayerEntryConfigProps } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
 import { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
 import type { TypeWMSLayerConfig } from '@/geo/layer/geoview-layers/raster/wms';
+import { normalizeDatacubeAccessPath } from '@/core/utils/utilities';
 import { Projection } from '@/geo/utils/projection';
 import { WFS } from '@/geo/layer/geoview-layers/vector/wfs';
 
@@ -345,8 +346,9 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
     // Get the metadata access path
     let metadataAccessPath = this.getMetadataAccessPath()!;
 
-    // Normalize it
-    metadataAccessPath = metadataAccessPath.replace('wrapper/ramp/ogc', 'wrapper/ogc');
+    // Normalize it - datacube specific normalization
+
+    metadataAccessPath = normalizeDatacubeAccessPath(metadataAccessPath);
 
     // Set the normalized url in the metadata access path
     this.setMetadataAccessPath(metadataAccessPath);
@@ -356,8 +358,8 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
 
     // If any, normalize it as well in case the provided one also needed to be normalized
     if (dataAccessPath) {
-      // Normalize it
-      dataAccessPath = dataAccessPath.replace('wrapper/ramp/ogc', 'wrapper/ogc');
+      // Normalize it - datacube specific normalization
+      dataAccessPath = normalizeDatacubeAccessPath(dataAccessPath);
     } else {
       // No data access path was provided, use the newly normalized metadata access path
       dataAccessPath = metadataAccessPath;

--- a/packages/geoview-core/src/core/utils/utilities.ts
+++ b/packages/geoview-core/src/core/utils/utilities.ts
@@ -1151,3 +1151,13 @@ export function isLocalhost(): boolean {
   if (typeof window === 'undefined' || !window.location) return false;
   return window.location.hostname === 'localhost' && window.location.port === '8080';
 }
+
+/**
+ * Normalizes a WMS accesspath if it is from datacube.
+ * @param {string} path - The original access path.
+ * @returns {string} The normalized access path.
+ */
+export function normalizeDatacubeAccessPath(path: string): string {
+  //TODO: extract to list of exceptions / normalizations?
+  return path.toLowerCase().includes('datacube') ? path.replace('wrapper/ramp/ogc', 'wrapper/ogc').replace('/ows/', '/wrapper/ogc/') : path;
+}

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -31,7 +31,7 @@ import {
   LayerEntryConfigLayerIdNotFoundError,
   LayerEntryConfigWMSSubLayerNotFoundError,
 } from '@/core/exceptions/layer-entry-config-exceptions';
-import { deepMergeObjects } from '@/core/utils/utilities';
+import { deepMergeObjects, normalizeDatacubeAccessPath } from '@/core/utils/utilities';
 import { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { GVWMS } from '@/geo/layer/gv-layers/raster/gv-wms';
 import type { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
@@ -538,6 +538,9 @@ export class WMS extends AbstractGeoViewRaster {
 
     // Set the metadata access path
     this.metadataAccessPath = metadata?.Capability.Request.GetMap.DCPType[0].HTTP.Get.OnlineResource['@attributes']['xlink:href'];
+
+    // Normalize it - datacube specific normalization
+    this.metadataAccessPath = normalizeDatacubeAccessPath(this.metadataAccessPath);
 
     // Propagate the metadata access path to all data access path of the layers underneath
     this.listOfLayerEntryConfig.forEach((layerEntry) => {

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -2537,7 +2537,17 @@ export class LayerApi {
     let promise: Promise<TypeGeoviewLayerConfig>;
     if (mapConfigLayerEntryIsGeoCore(entry)) {
       // Working with a GeoCore layer
-      promise = GeoCore.createLayerConfigFromUUID(entry.geoviewLayerId, language, mapId, entry).then((response) => response.config);
+      promise = GeoCore.createLayerConfigFromUUID(entry.geoviewLayerId, language, mapId, entry).then((response) => {
+        // If a Geochart is initialized
+        if (GeochartEventProcessor.isGeochartInitialized(mapId)) {
+          // For each geocharts configuration
+          Object.entries(response.geocharts).forEach(([layerPath, geochartConfig]) => {
+            // Add a GeoChart configuration on-the-fly
+            GeochartEventProcessor.addGeochartChart(mapId, layerPath, geochartConfig);
+          });
+        }
+        return response.config;
+      });
     } else if (mapConfigLayerEntryIsGeoPackage(entry)) {
       // Working with a geopackage layer
       promise = GeoPackageReader.createLayerConfigFromGeoPackage(entry as GeoPackageLayerConfig);


### PR DESCRIPTION
also checks datacube links and replaces 'ows'

# Description

Adds charts from geocore layers added through the map config and adds an additional check for datacube links.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/sandbox.html
Config for charts:
{
    "map": {
        "interaction": "dynamic",
        "viewSettings": {
            "projection": 3857
        },
        "basemapOptions": {
            "basemapId": "transport",
            "shaded": false,
            "labeled": false
        },
        "listOfGeoviewLayerConfig": [
            {
                "geoviewLayerId": "21b821cf-0f1c-40ee-8925-eab12d357668",
                "geoviewLayerType": "geoCore"
            }
        ]
    },
    "theme": "geo.ca",
    "appBar": {
        "tabs": {
            "core": [
                "geolocator",
                "legend",
                "details",
                "export"
            ]
        }
    },
    "components": [
        "north-arrow",
        "overview-map"
    ],
    "footerBar": {
        "tabs": {
            "core": [
                "layers",
                "geochart"
            ]
        }
    },
    "corePackages": []
}

Config for datacube:
{
    "map": {
        "interaction": "dynamic",
        "viewSettings": {
            "projection": 3857
        },
        "basemapOptions": {
            "basemapId": "transport",
            "shaded": false,
            "labeled": false
        },
        "listOfGeoviewLayerConfig": [
           {
             "geoviewLayerId": "digital-terrain-model",
             "geoviewLayerName": "Digital Terrain model",
             "geoviewLayerType": "ogcWms",
             "metadataAccessPath": "https://datacube.services.geo.ca/web/elevation.xml",
             "listOfLayerEntryConfig": [
                {
                  "layerId": "dtm-hillshade",
                  "layerName": "Digital Terrain model"
               }
            ]
          }
        ]
    },
    "theme": "geo.ca",
    "appBar": {
        "tabs": {
            "core": [
                "geolocator",
                "legend",
                "details",
                "export"
            ]
        }
    },
    "components": [
        "north-arrow",
        "overview-map"
    ],
    "footerBar": {
        "tabs": {
            "core": [
                "layers",
                "geochart"
            ]
        }
    },
    "corePackages": []
}

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3262)
<!-- Reviewable:end -->
