### PR TITLE
fix(wcag): accessible keyboard navigation

### DIFF
--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -2,6 +2,7 @@
   "general": {
     "add": "Add",
     "close": "Close",
+    "closeSelection": "Close selection",
     "exit": "Exit",
     "layers": "Layers",
     "name": "Name",
@@ -226,7 +227,6 @@
     "title": "Details",
     "zoomTo": "Zoom to feature",
     "select": "Highlight feature on map",
-    "closeSelection": "Close selection",
     "externalLink": "External Link",
     "feature": "feature",
     "selected": "selected",
@@ -372,7 +372,6 @@
     "features": "feature(s)",
     "featureFiltered": "features filtered",
     "images": "Images",
-    "close": "Close",
     "noFeatures": "unknown...",
     "showing": "showing",
     "total": "total",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -2,6 +2,7 @@
   "general": {
     "add": "Ajouter",
     "close": "Fermer",
+    "closeSelection": "Fermer la sélection",
     "layers": "Couches",
     "name": "Nom",
     "exit": "Sortir",
@@ -226,7 +227,6 @@
     "title": "Détails",
     "zoomTo": "Zoom à l'élément",
     "select": "Sélectionner l'élément sur la carte",
-    "closeSelection": "Fermer la sélection",
     "externalLink": "Lien externe",
     "feature": "élément",
     "selected": "sélectionné",
@@ -372,7 +372,6 @@
     "features": "Élément(s)",
     "featureFiltered": "élément filtré(s)",
     "images": "Images",
-    "close": "Fermer",
     "noFeatures": "inconnue...",
     "showing": "affiché(s)",
     "total": "total",

--- a/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
@@ -38,7 +38,7 @@ import Notifications from '@/core/components/notifications/notifications';
 import Version from './buttons/version';
 import { getSxClasses } from './app-bar-style';
 import { enforceArrayOrder, helpClosePanelById, helpOpenPanelById } from './app-bar-helper';
-import { CONTAINER_TYPE } from '@/core/utils/constant';
+import { CONTAINER_TYPE, TIMEOUT } from '@/core/utils/constant';
 import type { TypeValidAppBarCoreProps } from '@/api/types/map-schema-types';
 import { DEFAULT_APPBAR_CORE, DEFAULT_APPBAR_TABS_ORDER } from '@/api/types/map-schema-types';
 import { camelCase, handleEscapeKey } from '@/core/utils/utilities';
@@ -424,12 +424,15 @@ export function AppBar(props: AppBarProps): JSX.Element {
               }
               onGeneralClose={() => {
                 handleGeneralCloseClicked(buttonPanel.button?.id ?? '');
-                // Match ESC key behavior - return focus to the panel button
+
                 if (isFocusTrapped) {
-                  // Defer focus until after React updates DOM and completes paint cycle
-                  requestAnimationFrame(() => {
-                    document.getElementById(`${tabId}-panel-btn-${mapId}`)?.focus();
-                  });
+                  // use same timeout value as handleEscapeKey to align with panel close timing
+                  setTimeout(() => {
+                    const targetButton = document.getElementById(`${tabId}-panel-btn-${mapId}`) as HTMLButtonElement;
+                    if (targetButton) {
+                      targetButton.focus();
+                    }
+                  }, TIMEOUT.handleEsc);
                 }
               }}
             />

--- a/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
@@ -3,14 +3,14 @@ import { useTranslation } from 'react-i18next';
 import type { Theme } from '@mui/material';
 import { Typography, Box, Link, SvgIcon, ClickAwayListener, List, Paper, useTheme } from '@mui/material';
 
-import { GITHUB_REPO, GEO_URL_TEXT } from '@/core/utils/constant';
+import { GITHUB_REPO, GEO_URL_TEXT, CONTAINER_TYPE } from '@/core/utils/constant';
 import { GeoCaIcon, IconButton, Popper, CloseIcon } from '@/ui';
 import { useGeoViewMapId } from '@/core/stores/geoview-store';
 import { useMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { GitHubIcon } from '@/ui/icons';
 import { handleEscapeKey } from '@/core/utils/utilities';
 import { FocusTrapContainer } from '@/core/components/common/focus-trap-container';
-import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useUIActiveTrapGeoView, useUIStoreActions } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { DateMgt } from '@/core/utils/date-mgt';
 import { logger } from '@/core/utils/logger';
 import type { SxStyles } from '@/ui/style/types';
@@ -92,6 +92,7 @@ export default function Version(): JSX.Element {
   // Store
   const interaction = useMapInteraction();
   const activeTrapGeoView = useUIActiveTrapGeoView();
+  const { enableFocusTrap, disableFocusTrap } = useUIStoreActions();
 
   // Get container
   const mapId = useGeoViewMapId();
@@ -102,16 +103,29 @@ export default function Version(): JSX.Element {
   const [open, setOpen] = useState(false);
 
   // Handlers
-  const handleOpenPopover = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
-    logger.logTraceUseCallback('VERSION - open');
-    setAnchorEl(event.currentTarget);
-    setOpen((prev) => !prev);
-  }, []);
+  const handleOpenPopover = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      logger.logTraceUseCallback('VERSION - open');
+      setAnchorEl(event.currentTarget);
+      setOpen((prev) => !prev);
+
+      // Register focus trap with button as the return target
+      enableFocusTrap({
+        activeElementId: `${mapId}-version`,
+        callbackElementId: `version-button-${mapId}`,
+      });
+    },
+    [mapId, enableFocusTrap]
+  );
 
   const handleClickAway = useCallback(() => {
     logger.logTraceUseCallback('VERSION - close');
-    if (open) setOpen(false);
-  }, [open]);
+    if (open) {
+      setOpen(false);
+      // Restore focus to the button that opened the panel
+      disableFocusTrap();
+    }
+  }, [open, disableFocusTrap]);
 
   return (
     <ClickAwayListener mouseEvent="onMouseDown" touchEvent="onTouchStart" onClickAway={handleClickAway}>
@@ -155,7 +169,7 @@ export default function Version(): JSX.Element {
           }}
           handleKeyDown={(key, callBackFn) => handleEscapeKey(key, '', false, callBackFn)}
         >
-          <FocusTrapContainer id={`${mapId}-version`} open={open && activeTrapGeoView}>
+          <FocusTrapContainer id={`${mapId}-version`} open={open && activeTrapGeoView} containerType={CONTAINER_TYPE.APP_BAR}>
             <Paper component="section" sx={sxClasses.versionInfoPanel}>
               <Box component="header" sx={sxClasses.versionHeading}>
                 <Typography sx={sxClasses.versionsInfoTitle} component="h2" id="version-info-title">

--- a/packages/geoview-core/src/core/components/common/focus-trap-container.tsx
+++ b/packages/geoview-core/src/core/components/common/focus-trap-container.tsx
@@ -6,11 +6,12 @@ import { logger } from '@/core/utils/logger';
 import { useUIActiveFocusItem, useUIActiveTrapGeoView, useUIStoreActions } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { CONTAINER_TYPE, TIMEOUT } from '@/core/utils/constant';
+import { useGeoViewMapId } from '@/core/stores/geoview-store';
 
 interface FocusTrapContainerProps {
   children: ReactNode;
   id: string;
-  containerType?: TypeContainerBox;
+  containerType: TypeContainerBox;
   open?: boolean;
 }
 
@@ -43,6 +44,7 @@ export const FocusTrapContainer = memo(function FocusTrapContainer({
   const { disableFocusTrap, enableFocusTrap } = useUIStoreActions();
   const activeTrapGeoView = useUIActiveTrapGeoView();
   const focusItem = useUIActiveFocusItem();
+  const mapId = useGeoViewMapId();
 
   // Callbacks
   const handleClose = useCallback((): void => {
@@ -65,6 +67,10 @@ export const FocusTrapContainer = memo(function FocusTrapContainer({
   }, [disableFocusTrap, enableFocusTrap, id, containerType]);
 
   // Memoize
+
+  // the exit button only ever appears in the footerBar so it's hardcoded here
+  const exitBtnId = `${mapId}-${CONTAINER_TYPE.FOOTER_BAR}-${id}-panel-close-btn`;
+
   const isActive = useMemo(() => {
     // Log
     logger.logTraceUseMemo('FOCUS-TRAP-ELEMENT - isActive');
@@ -109,9 +115,9 @@ export const FocusTrapContainer = memo(function FocusTrapContainer({
       logger.logTraceUseEffect('FOCUS-TRAP-ELEMENT - focusItem', focusItem);
 
       // SetTimeout with a delay of 0 to force the rendering
-      setTimeout(() => document.getElementById(`${id}-exit-btn`)?.focus(), TIMEOUT.focusDelay);
+      setTimeout(() => document.getElementById(exitBtnId)?.focus(), TIMEOUT.focusDelay);
     }
-  }, [focusItem, id]);
+  }, [focusItem, id, exitBtnId]);
 
   // For footer panels, auto-activate focus trap when panel becomes active
   useEffect(() => {
@@ -157,7 +163,7 @@ export const FocusTrapContainer = memo(function FocusTrapContainer({
     <FocusTrap open={isActive} disableAutoFocus disableRestoreFocus>
       <Box tabIndex={-1} sx={{ height: '100%' }}>
         {showExitButton && (
-          <Button id={`${id}-exit-btn`} type="text" autoFocus onClick={handleClose} sx={exitButtonStyles}>
+          <Button id={exitBtnId} type="text" autoFocus onClick={handleClose} sx={exitButtonStyles}>
             {t('general.exit')}
           </Button>
         )}

--- a/packages/geoview-core/src/core/components/common/layout.tsx
+++ b/packages/geoview-core/src/core/components/common/layout.tsx
@@ -23,7 +23,7 @@ interface LayoutProps {
   onGuideIsOpen?: (isGuideOpen: boolean) => void;
   onRightPanelClosed?: () => void;
   onRightPanelVisibilityChanged?: (isVisible: boolean) => void;
-  containerType?: TypeContainerBox;
+  containerType: TypeContainerBox;
   hideEnlargeBtn?: boolean;
   toggleMode?: boolean;
 }
@@ -54,7 +54,7 @@ const Layout = forwardRef(
       onGuideIsOpen,
       onRightPanelClosed,
       onRightPanelVisibilityChanged,
-      containerType = CONTAINER_TYPE.FOOTER_BAR,
+      containerType,
       hideEnlargeBtn,
       toggleMode = false,
     }: LayoutProps,

--- a/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
@@ -30,7 +30,7 @@ interface ResponsiveGridLayoutProps {
   onRightPanelClosed?: () => void;
   onRightPanelVisibilityChanged?: (isVisible: boolean) => void;
   hideEnlargeBtn?: boolean;
-  containerType?: TypeContainerBox;
+  containerType: TypeContainerBox;
   toggleMode?: boolean;
 }
 
@@ -39,6 +39,13 @@ interface ResponsiveGridLayoutExposedMethods {
   setRightPanelFocus: () => void;
   closeBtnRef?: React.RefObject<HTMLButtonElement>;
 }
+
+/**
+ * GV modal element IDs that can open within the right panel. Update this list as new modals are added.
+ * These modals should prevent focus trapping when active to avoid
+ * conflicts between the FocusTrap and modal's own focus management.
+ */
+const MODAL_ELEMENT_IDS = ['layerDataTable', 'featureDetailDataTable'] as const;
 
 const ResponsiveGridLayout = forwardRef(
   (
@@ -321,9 +328,9 @@ const ResponsiveGridLayout = forwardRef(
             setIsRightPanelVisible(false);
             onRightPanelClosed?.();
           }}
-          tooltip={t('details.closeSelection')!}
+          tooltip={t('general.closeSelection')!}
         >
-          {t('dataTable.close')}
+          {t('general.close')}
         </Button>
       );
     };
@@ -439,8 +446,12 @@ const ResponsiveGridLayout = forwardRef(
     const renderRightContent = (): JSX.Element => {
       const content = !isGuideOpen ? rightMain : renderGuide();
 
-      // Only trap focus when: WCAG mode on, right panel is visible, not fullscreen, has feature content, AND no modal is open
-      const shouldTrapFocus = isFocusTrap && isRightPanelVisible && !isFullScreen && hasContent && !focusItem.activeElementId;
+      // Check if a modal is currently open within the right panel
+      const isModalOpen =
+        focusItem.activeElementId !== false && (MODAL_ELEMENT_IDS as readonly string[]).includes(focusItem.activeElementId);
+
+      // Only trap focus when: WCAG mode on, right panel is visible, not fullscreen, has feature content, AND no modal is open within it
+      const shouldTrapFocus = isFocusTrap && isRightPanelVisible && !isFullScreen && hasContent && !isModalOpen;
 
       // Wrap the content box in FocusTrap - control activation via 'open' prop
       // disableAutoFocus is used to prevent modals fighting for focus when opened

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -29,14 +29,14 @@ import type { TypeContainerBox } from '@/core/types/global-types';
 import DataSkeleton from './data-skeleton';
 
 interface DataPanelType {
-  containerType?: TypeContainerBox;
+  containerType: TypeContainerBox;
 }
 /**
  * Build Data panel from map.
  * @returns {JSX.Element} Data table as react element.
  */
 
-export function Datapanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: DataPanelType): JSX.Element {
+export function Datapanel({ containerType }: DataPanelType): JSX.Element {
   // Log
   logger.logTraceRender('components/data-table/data-panel');
 
@@ -165,13 +165,12 @@ export function Datapanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: DataPan
     // If we have a selected layer, tell disableFocusTrap to focus it
     if (selectedLayerPath) {
       // Build the full layer list item ID that matches the DOM
-      // Format: {mapId}-{tabId}-{layerPath}
-      const layerListItemId = `${mapId}-${TABS.DATA_TABLE}-${selectedLayerPath}`;
+      const layerListItemId = `${mapId}-${containerType}-${TABS.DATA_TABLE}-${selectedLayerPath}`;
       disableFocusTrap(layerListItemId);
     } else {
       disableFocusTrap('no-focus');
     }
-  }, [mapId, selectedLayerPath, disableFocusTrap]);
+  }, [mapId, selectedLayerPath, disableFocusTrap, containerType]);
 
   /**
    * Checks if layer is disabled when layer is selected and features have null value.
@@ -304,7 +303,7 @@ export function Datapanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: DataPan
 
     return orderedLayerData.map((layer) => ({
       ...layer,
-      layerUniqueId: `${mapId}-${TABS.DATA_TABLE}-${layer.layerPath}`,
+      layerUniqueId: `${mapId}-${containerType}-${TABS.DATA_TABLE}-${layer.layerPath}`,
       layerFeatures: getFeaturesOfLayer(layer.layerPath),
       tooltip: getLayerTooltip(layer.layerName ?? '', layer.layerPath),
       mapFilteredIcon: isMapFilteredSelectedForLayer(layer.layerPath) && (

--- a/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
@@ -11,6 +11,7 @@ import {
   useUIStoreActions,
   useUIFooterBarComponents,
   useUIAppbarComponents,
+  useUIActiveTrapGeoView,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { useLayerSelectedLayerPath } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { useDataTableStoreActions } from '@/core/stores/store-interface-and-intial-values/data-table-state';
@@ -49,6 +50,7 @@ export default function DataTableModal(): JSX.Element {
   const footerBarComponents = useUIFooterBarComponents();
   const appBarComponents = useUIAppbarComponents();
   const { setSelectedLayerPath: setDataTableSelectedLayerPath } = useDataTableStoreActions();
+  const isFocusTrap = useUIActiveTrapGeoView();
 
   const dataTableLocalization = language === 'fr' ? MRTLocalizationFR : MRTLocalizationEN;
 
@@ -197,7 +199,7 @@ export default function DataTableModal(): JSX.Element {
           )}
           {!isLoading && (
             <>
-              {hasDataTableTab && selectedLayer && (
+              {hasDataTableTab && selectedLayer && !isFocusTrap && (
                 <Box sx={{ display: 'flex', justifyContent: 'flex-start', marginBottom: 2 }}>
                   <Button
                     variant="outlined"

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -104,7 +104,6 @@ function DataTable({ data, layerPath, containerType }: DataTableProps): JSX.Elem
   const { enableFocusTrap } = useUIStoreActions();
 
   const mapId = useGeoViewMapId();
-  const tableDetailsButtonId = `table-details-${containerType}-${mapId}`;
 
   const handleDensityChange = (updaterOrValue: MRTDensityState | ((prevState: MRTDensityState) => MRTDensityState)): void => {
     setDensity(updaterOrValue);
@@ -433,7 +432,10 @@ function DataTable({ data, layerPath, containerType }: DataTableProps): JSX.Elem
       filterArray = filterArray.filter((record) => record.featureIcon);
     }
 
-    return (filterArray ?? []).map((feature) => {
+    return (filterArray ?? []).map((feature, featureIndex) => {
+      // Create unique button ID per feature
+      const featureDetailsButtonId = `${mapId}-${containerType}-table-details-btn-${featureIndex}`;
+
       const icon = feature.featureIcon ? (
         <Box component="img" alt={feature?.nameField ?? ''} src={feature.featureIcon} className="layer-icon" />
       ) : (
@@ -460,12 +462,13 @@ function DataTable({ data, layerPath, containerType }: DataTableProps): JSX.Elem
         ),
         DETAILS: (
           <IconButton
+            id={featureDetailsButtonId}
             color="primary"
             aria-label={t('dataTable.details')}
             tooltipPlacement="top"
             onClick={() => {
               setSelectedFeature(feature);
-              enableFocusTrap({ activeElementId: 'featureDetailDataTable', callbackElementId: tableDetailsButtonId });
+              enableFocusTrap({ activeElementId: 'featureDetailDataTable', callbackElementId: featureDetailsButtonId });
             }}
           >
             <InfoOutlinedIcon />

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -36,7 +36,7 @@ import { CoordinateInfo, CoordinateInfoSwitch } from './coordinate-info';
 import type { TypeContainerBox } from '@/core/types/global-types';
 
 interface DetailsPanelType {
-  containerType?: TypeContainerBox;
+  containerType: TypeContainerBox;
 }
 
 /**
@@ -45,7 +45,7 @@ interface DetailsPanelType {
  * @param {DetailsPanelProps} props The properties passed to LayersListFooter
  * @returns {JSX.Element} the layers list
  */
-export function DetailsPanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: DetailsPanelType): JSX.Element {
+export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
   logger.logTraceRender('components/details/details-panel');
 
   // Hooks

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -25,6 +25,7 @@ import { GeoUtilities } from '@/geo/utils/utilities';
 import type { TypeFeatureInfoEntry, TypeFieldEntry } from '@/api/types/map-schema-types';
 import { FeatureInfoTable } from './feature-info-table';
 import { getSxClasses } from './details-style';
+import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 
 interface FeatureInfoProps {
   feature: TypeFeatureInfoEntry;
@@ -80,6 +81,7 @@ const FeatureHeader = memo(function FeatureHeader({
   const { t } = useTranslation();
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const isFocusTrap = useUIActiveTrapGeoView();
 
   return (
     <Box sx={HEADER_STYLES.container}>
@@ -110,7 +112,8 @@ const FeatureHeader = memo(function FeatureHeader({
           [theme.breakpoints.down('sm')]: { display: 'none' },
         }}
       >
-        {hasGeochart && (
+        {/* Hidden in WCAG mode - keyboard users can Tab to layer panel instead */}
+        {hasGeochart && !isFocusTrap && (
           <IconButton
             color="primary"
             aria-label={t('details.selectLayerAndScrollChart')}

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -134,11 +134,11 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
     logger.logTraceUseMemo('FOOTER-BAR - memoTabs');
 
     return {
-      legend: { icon: <LegendIcon />, content: <Legend /> },
+      legend: { icon: <LegendIcon />, content: <Legend containerType={CONTAINER_TYPE.FOOTER_BAR} /> },
       layers: { icon: <LayersOutlinedIcon />, content: <LayersPanel containerType={CONTAINER_TYPE.FOOTER_BAR} /> },
-      details: { icon: <InfoOutlinedIcon />, content: <DetailsPanel /> },
-      'data-table': { icon: <StorageIcon />, content: <Datapanel /> },
-      guide: { icon: <QuestionMarkIcon />, content: <Guide /> },
+      details: { icon: <InfoOutlinedIcon />, content: <DetailsPanel containerType={CONTAINER_TYPE.FOOTER_BAR} /> },
+      'data-table': { icon: <StorageIcon />, content: <Datapanel containerType={CONTAINER_TYPE.FOOTER_BAR} /> },
+      guide: { icon: <QuestionMarkIcon />, content: <Guide containerType={CONTAINER_TYPE.FOOTER_BAR} /> },
     } as Record<string, Tab>;
   }, []);
 

--- a/packages/geoview-core/src/core/components/geolocator/geolocator.tsx
+++ b/packages/geoview-core/src/core/components/geolocator/geolocator.tsx
@@ -14,7 +14,7 @@ import { useGeolocator } from '@/core/components/geolocator/hooks/use-geolocator
 import { GeolocatorBar } from '@/core/components/geolocator/geolocator-bar';
 import { handleEscapeKey } from '@/core/utils/utilities';
 import { useGeoViewMapId } from '@/core/stores/geoview-store';
-import { TIMEOUT } from '@/core/utils/constant';
+import { CONTAINER_TYPE, TIMEOUT } from '@/core/utils/constant';
 
 export interface GeoListItem {
   key: string;
@@ -132,7 +132,11 @@ export function Geolocator(): JSX.Element {
       className="appbar-panel-geolocator-search"
       id={`appbar-panel-geolocator-${mapId}`}
     >
-      <FocusTrapContainer open={tabId === DEFAULT_APPBAR_CORE.GEOLOCATOR && isOpen && activeTrapGeoView} id="geolocator-focus-trap">
+      <FocusTrapContainer
+        open={tabId === DEFAULT_APPBAR_CORE.GEOLOCATOR && isOpen && activeTrapGeoView}
+        id="geolocator-focus-trap"
+        containerType={CONTAINER_TYPE.APP_BAR}
+      >
         <Box sx={sxClasses.geolocator}>
           <GeolocatorBar
             searchValue={searchValue}

--- a/packages/geoview-core/src/core/components/guide/guide.tsx
+++ b/packages/geoview-core/src/core/components/guide/guide.tsx
@@ -11,7 +11,7 @@ import { getSxClasses } from './guide-style';
 import type { LayerListEntry } from '@/core/components/common';
 import { Layout } from '@/core/components/common';
 import { useGeoViewMapId } from '@/core/stores/geoview-store';
-import { CONTAINER_TYPE, TABS } from '@/core/utils/constant';
+import { TABS } from '@/core/utils/constant';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { GuideSearch } from './guide-search';
 
@@ -20,7 +20,7 @@ interface GuideListItem extends LayerListEntry {
 }
 
 interface GuideType {
-  containerType?: TypeContainerBox;
+  containerType: TypeContainerBox;
 }
 
 /**
@@ -29,7 +29,7 @@ interface GuideType {
  * @returns {JSX.Element} the guide (help) component
  */
 // Memoizes entire component, preventing re-renders if props haven't changed
-export const Guide = memo(function GuidePanel({ containerType = CONTAINER_TYPE.FOOTER_BAR }: GuideType): JSX.Element {
+export const Guide = memo(function GuidePanel({ containerType }: GuideType): JSX.Element {
   logger.logTraceRender('components/guide/guide');
 
   // Hooks
@@ -96,10 +96,10 @@ export const Guide = memo(function GuidePanel({ containerType = CONTAINER_TYPE.F
         layerStatus: 'loaded',
         queryStatus: 'processed',
         content: createMarkdownComponent(content),
-        layerUniqueId: `${mapId}-${TABS.GUIDE}-${item ?? ''}`,
+        layerUniqueId: `${mapId}-${containerType}-${TABS.GUIDE}-${item ?? ''}`,
       };
     });
-  }, [guide, mapId, createMarkdownComponent]);
+  }, [guide, mapId, createMarkdownComponent, containerType]);
 
   /**
    * Memo version of layer list with markdown content

--- a/packages/geoview-core/src/core/components/layers/layers-panel.tsx
+++ b/packages/geoview-core/src/core/components/layers/layers-panel.tsx
@@ -11,9 +11,11 @@ import { ResponsiveGridLayout } from '@/core/components/common/responsive-grid-l
 import { Typography } from '@/ui/typography/typography';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { useUIStoreActions } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { TABS } from '@/core/utils/constant';
+import { useGeoViewMapId } from '@/core/stores';
 
 interface TypeLayersPanel {
-  containerType?: TypeContainerBox;
+  containerType: TypeContainerBox;
 }
 
 export function LayersPanel({ containerType }: TypeLayersPanel): JSX.Element {
@@ -28,13 +30,13 @@ export function LayersPanel({ containerType }: TypeLayersPanel): JSX.Element {
   const { setSelectedFooterLayerListItemId, disableFocusTrap } = useUIStoreActions();
 
   const responsiveLayoutRef = useRef<ResponsiveGridLayoutExposedMethods>(null);
+  const mapId = useGeoViewMapId();
 
   const showLayerDetailsPanel = useCallback(
     (layerId: string): void => {
       // Log
       logger.logTraceUseCallback('LAYERS-PANEL - showLayerDetailsPanel');
 
-      // Just set visibility - focus will be handled automatically by useEffect
       responsiveLayoutRef.current?.setIsRightPanelVisible(true);
       responsiveLayoutRef.current?.setRightPanelFocus();
       setSelectedFooterLayerListItemId(`${layerId}`);
@@ -44,8 +46,8 @@ export function LayersPanel({ containerType }: TypeLayersPanel): JSX.Element {
 
   const leftPanel = (): JSX.Element => {
     return (
-      <Box id="layers-left-panel">
-        <LeftPanel showLayerDetailsPanel={showLayerDetailsPanel} isLayoutEnlarged={isLayoutEnlarged} />
+      <Box>
+        <LeftPanel showLayerDetailsPanel={showLayerDetailsPanel} isLayoutEnlarged={isLayoutEnlarged} containerType={containerType} />
       </Box>
     );
   };
@@ -99,12 +101,13 @@ export function LayersPanel({ containerType }: TypeLayersPanel): JSX.Element {
     logger.logTraceUseCallback('LAYERS-PANEL - handleRightPanelClosed');
 
     // If we have a selected layer, tell disableFocusTrap to focus it
-    if (selectedLayer?.layerId) {
-      disableFocusTrap(selectedLayer.layerId);
+    if (selectedLayer?.layerPath) {
+      const layerListItemId = `${mapId}-${containerType}-${TABS.LAYERS}-${selectedLayer.layerPath}`;
+      disableFocusTrap(layerListItemId);
     } else {
       disableFocusTrap('no-focus');
     }
-  }, [selectedLayer, disableFocusTrap]);
+  }, [mapId, selectedLayer, disableFocusTrap, containerType]);
 
   return (
     <ResponsiveGridLayout

--- a/packages/geoview-core/src/core/components/layers/left-panel/delete-undo-button.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/delete-undo-button.tsx
@@ -11,6 +11,7 @@ interface DeleteUndoButtonProps {
   layerPath: string;
   layerId: string;
   layerRemovable: boolean;
+  focusTargetIdAfterDelete?: string;
 }
 
 interface UndoButtonProps {
@@ -53,7 +54,7 @@ export function DeleteUndoButton(props: DeleteUndoButtonProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/left-panel/delete-undo-button/DeleteUndoButton');
 
-  const { layerPath, layerId, layerRemovable } = props;
+  const { layerPath, layerId, layerRemovable, focusTargetIdAfterDelete } = props;
 
   const { t } = useTranslation<string>();
 
@@ -63,7 +64,7 @@ export function DeleteUndoButton(props: DeleteUndoButtonProps): JSX.Element {
   // get store actions
   const { deleteLayer, setLayerDeleteInProgress, getLayerDeleteInProgress } = useLayerStoreActions();
   const { setOrToggleLayerVisibility, removeLayerHighlights } = useMapStoreActions();
-  const { setSelectedFooterLayerListItemId } = useUIStoreActions();
+  const { setSelectedFooterLayerListItemId, disableFocusTrap } = useUIStoreActions();
   const isVisible = useMapSelectorLayerVisibility(layerPath);
 
   const handleDeleteClick = (): void => {
@@ -109,6 +110,9 @@ export function DeleteUndoButton(props: DeleteUndoButtonProps): JSX.Element {
     if (progress === 100) {
       deleteLayer(layerPath);
       setInUndoState(false);
+
+      // set focus after deletion
+      disableFocusTrap(focusTargetIdAfterDelete || 'no-focus');
     }
     return undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
@@ -1,21 +1,22 @@
 import { useCallback, useMemo } from 'react';
 import { useTheme } from '@mui/material/styles';
 import { List } from '@/ui';
-import { useGeoViewMapId, useMapOrderedLayers } from '@/core/stores';
+import { useMapOrderedLayers } from '@/core/stores';
 import { logger } from '@/core/utils/logger';
 import type { TypeLegendLayer } from '@/core/components/layers/types';
-import { TABS } from '@/core/utils/constant';
 import { SingleLayer } from './single-layer';
 import { getSxClasses } from './left-panel-styles';
+import type { TypeContainerBox } from '@/core/types/global-types';
 
 interface LayerListProps {
   depth: number;
   layersList: TypeLegendLayer[];
   showLayerDetailsPanel: (layerId: string) => void;
   isLayoutEnlarged: boolean;
+  containerType: TypeContainerBox;
 }
 
-export function LayersList({ layersList, showLayerDetailsPanel, isLayoutEnlarged, depth }: LayerListProps): JSX.Element {
+export function LayersList({ layersList, showLayerDetailsPanel, isLayoutEnlarged, depth, containerType }: LayerListProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/left-panel/layers-list', `Count ${layersList.length}`);
 
@@ -24,7 +25,6 @@ export function LayersList({ layersList, showLayerDetailsPanel, isLayoutEnlarged
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // Store
-  const mapId = useGeoViewMapId();
   const layerPathOrder = useMapOrderedLayers();
 
   // ? I doubt we want to define an explicit type for style properties?
@@ -49,10 +49,6 @@ export function LayersList({ layersList, showLayerDetailsPanel, isLayoutEnlarged
       const isFirst = index === 0;
       const isLast = index === sortedLayers.length - 1;
 
-      // TODO: Check - What is this for!? Set the layerId
-      // eslint-disable-next-line no-param-reassign
-      layer.layerId = `${mapId}-${TABS.LAYERS}-${layer.layerPath}`;
-
       return (
         <SingleLayer
           key={layer.layerPath}
@@ -62,10 +58,11 @@ export function LayersList({ layersList, showLayerDetailsPanel, isLayoutEnlarged
           isFirst={isFirst}
           isLast={isLast}
           isLayoutEnlarged={isLayoutEnlarged}
+          containerType={containerType}
         />
       );
     });
-  }, [depth, isLayoutEnlarged, mapId, showLayerDetailsPanel, layersList, layerPathOrder]);
+  }, [depth, isLayoutEnlarged, showLayerDetailsPanel, layersList, layerPathOrder, containerType]);
 
   return <List sx={getListClass()}>{memoLegendItems}</List>;
 }

--- a/packages/geoview-core/src/core/components/layers/left-panel/left-panel.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/left-panel.tsx
@@ -2,13 +2,15 @@ import { useLayerDisplayState, useLayerLegendLayers } from '@/core/stores/store-
 import { LayersList } from './layers-list';
 import { AddNewLayer } from './add-new-layer/add-new-layer';
 import { logger } from '@/core/utils/logger';
+import type { TypeContainerBox } from '@/core/types/global-types';
 
 interface LeftPanelProps {
   showLayerDetailsPanel: (layerId: string) => void;
   isLayoutEnlarged: boolean;
+  containerType: TypeContainerBox;
 }
 
-export function LeftPanel({ showLayerDetailsPanel, isLayoutEnlarged }: LeftPanelProps): JSX.Element {
+export function LeftPanel({ showLayerDetailsPanel, isLayoutEnlarged, containerType }: LeftPanelProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/left-panel/left-panel');
 
@@ -21,6 +23,12 @@ export function LeftPanel({ showLayerDetailsPanel, isLayoutEnlarged }: LeftPanel
   }
 
   return (
-    <LayersList layersList={legendLayers} depth={0} showLayerDetailsPanel={showLayerDetailsPanel} isLayoutEnlarged={isLayoutEnlarged} />
+    <LayersList
+      layersList={legendLayers}
+      depth={0}
+      showLayerDetailsPanel={showLayerDetailsPanel}
+      isLayoutEnlarged={isLayoutEnlarged}
+      containerType={containerType}
+    />
   );
 }

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -47,7 +47,8 @@ import { Divider } from '@/ui/divider/divider';
 import { useGeoViewMapId } from '@/core/stores/geoview-store';
 import type { TypeLayerControls } from '@/api/types/layer-schema-types';
 import { scrollListItemIntoView } from '@/core/utils/utilities';
-import { TIMEOUT } from '@/core/utils/constant';
+import { TIMEOUT, TABS } from '@/core/utils/constant';
+import type { TypeContainerBox } from '@/core/types/global-types';
 
 // TODO: WCAG Issue #3108 - Check all disabled buttons. They may need special treatment. Need to find instance in UI first)
 // TODO: WCAG Issue #3108 - Check all icon buttons for "state related" aria values (i.e aria-checked, aria-disabled, etc.)
@@ -59,9 +60,18 @@ interface SingleLayerProps {
   isFirst: boolean;
   isLast: boolean;
   isLayoutEnlarged: boolean;
+  containerType: TypeContainerBox;
 }
 
-export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, isLast, isLayoutEnlarged }: SingleLayerProps): JSX.Element {
+export function SingleLayer({
+  depth,
+  layerPath,
+  showLayerDetailsPanel,
+  isFirst,
+  isLast,
+  isLayoutEnlarged,
+  containerType,
+}: SingleLayerProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/left-panel/single-layer', layerPath);
 
@@ -106,6 +116,9 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
 
   // State to track if delete button should show for loading layers
   const [showDeleteOnLoading, setShowDeleteOnLoading] = useState(false);
+
+  // State to track if the layer item has focus within for accessibility purposes
+  const [hasFocusWithin, setHasFocusWithin] = useState(false);
 
   // Is visibility button disabled?
   const isLayerVisibleCapable = layerControls?.visibility;
@@ -219,6 +232,24 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
     setSelectedLayerPath(layerPath);
     showLayerDetailsPanel?.(layerId || '');
   }, [layerPath, layerId, layerStatus, setSelectedLayerPath, showLayerDetailsPanel, getLayerDeleteInProgress, deleteLayer]);
+
+  // Handlers for keyboard navigation of the sorting arrows and action buttons for accessibility
+  const handleFocusWithin = useCallback((): void => {
+    // Log
+    logger.logTraceUseCallback('SINGLE-LAYER - handleFocusWithin');
+
+    setHasFocusWithin(true);
+  }, []);
+
+  const handleBlurWithin = useCallback((event: React.FocusEvent<HTMLElement>): void => {
+    // Log
+    logger.logTraceUseCallback('SINGLE-LAYER - handleBlurWithin');
+
+    // Only blur if focus moved outside this layer item
+    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+      setHasFocusWithin(false);
+    }
+  }, []);
 
   const handleArrowClick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>, direction: number) => {
@@ -345,12 +376,12 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
     // Log
     logger.logTraceUseMemo('SINGLE-LAYER - memoEditModeButtons', layerPath);
 
-    if (layerIsSelected && displayState === 'view') {
+    if ((layerIsSelected || hasFocusWithin) && displayState === 'view') {
       return (
         <>
           <IconButton
             className="buttonOutline"
-            id={`${mapId}-${layerPath}-up-order`}
+            id={`${mapId}-${containerType}-${layerPath}-up-order`}
             aria-label={t('layers.moveLayerUp')}
             disabled={isFirst}
             edge="end"
@@ -362,7 +393,7 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
           </IconButton>
           <IconButton
             className="buttonOutline"
-            id={`${mapId}-${layerPath}-down-order`}
+            id={`${mapId}-${containerType}-${layerPath}-down-order`}
             aria-label={t('layers.moveLayerDown')}
             disabled={isLast}
             edge="end"
@@ -397,6 +428,8 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
     mapId,
     t,
     theme.palette.geoViewColor.bgColor.dark,
+    containerType,
+    hasFocusWithin,
   ]);
 
   // Memoize the MoreLayerButtons component section
@@ -407,7 +440,14 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
     if ((layerStatus === 'processing' || layerStatus === 'loading') && displayState === 'view') {
       // Show delete button after 5 seconds for loading layers
       if (showDeleteOnLoading) {
-        return <DeleteUndoButton layerPath={layerPath} layerId={layerId!} layerRemovable={layerControls?.remove !== false} />;
+        return (
+          <DeleteUndoButton
+            layerPath={layerPath}
+            layerId={layerId!}
+            layerRemovable={layerControls?.remove !== false}
+            focusTargetIdAfterDelete={`${mapId}-${containerType}-${TABS.LAYERS}-panel-close-btn`}
+          />
+        );
       }
       return null;
     }
@@ -426,7 +466,12 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
           >
             <LoopIcon />
           </IconButton>
-          <DeleteUndoButton layerPath={layerPath} layerId={layerId!} layerRemovable={layerControls?.remove !== false} />
+          <DeleteUndoButton
+            layerPath={layerPath}
+            layerId={layerId!}
+            layerRemovable={layerControls?.remove !== false}
+            focusTargetIdAfterDelete={`${mapId}-${containerType}-${TABS.LAYERS}-panel-close-btn`}
+          />
         </>
       );
     }
@@ -495,6 +540,8 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
     layerChildren,
     handleReload,
     parentHidden,
+    containerType,
+    mapId,
   ]);
 
   // Memoize the arrow buttons component section
@@ -536,10 +583,11 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
           layersList={layerChildren}
           isLayoutEnlarged={isLayoutEnlarged}
           showLayerDetailsPanel={showLayerDetailsPanel}
+          containerType={containerType}
         />
       </Collapse>
     );
-  }, [depth, isLayoutEnlarged, layerChildren, legendExpanded, showLayerDetailsPanel]);
+  }, [depth, isLayoutEnlarged, layerChildren, legendExpanded, showLayerDetailsPanel, containerType]);
 
   // Memoize the container class section
   const memoContainerClass = useMemo(() => {
@@ -593,8 +641,19 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
     }
   }, [layerIsSelected]);
 
+  // Build unique ID format
+  const layerListItemId = `${mapId}-${containerType}-${TABS.LAYERS}-${layerPath}`;
+
   return (
-    <ListItem ref={layerItemRef} className={memoContainerClass} key={layerName} disablePadding={true} data-layer-depth={depth}>
+    <ListItem
+      ref={layerItemRef}
+      className={memoContainerClass}
+      key={layerName}
+      disablePadding={true}
+      data-layer-depth={depth}
+      onFocus={handleFocusWithin}
+      onBlur={handleBlurWithin}
+    >
       <Box>
         <Tooltip
           title={t('layers.selectLayer', { layerName })}
@@ -616,7 +675,9 @@ export function SingleLayer({ depth, layerPath, showLayerDetailsPanel, isFirst, 
           }}
         >
           <ListItemButton
-            id={layerId}
+            // TODO: WCAG Issue #3116 - The ID is not using store value selectedFooterLayerListItemId (id={layerId}). Check if this is correct...
+            // TODO: WCAG Issue #3116 - ... layers-list was previously mutating the layer.layerId value is any case: (layer.layerId = `${mapId}-${TABS.LAYERS}-${layer.layerPath}`;
+            id={layerListItemId}
             onClick={handleLayerClick}
             selected={layerIsSelected || (layerChildIsSelected && !legendExpanded)}
             sx={{

--- a/packages/geoview-core/src/core/components/layers/right-panel/delete-undo-button.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/delete-undo-button.tsx
@@ -11,6 +11,7 @@ interface DeleteUndoButtonProps {
   layerPath: string;
   layerId: string;
   layerRemovable: boolean;
+  focusTargetIdAfterDelete?: string;
 }
 
 interface UndoButtonProps {
@@ -53,7 +54,7 @@ export function DeleteUndoButton(props: DeleteUndoButtonProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/right-panel/delete-undo-button/DeleteUndoButton');
 
-  const { layerPath, layerId, layerRemovable } = props;
+  const { layerPath, layerId, layerRemovable, focusTargetIdAfterDelete } = props;
 
   const { t } = useTranslation<string>();
 
@@ -63,7 +64,7 @@ export function DeleteUndoButton(props: DeleteUndoButtonProps): JSX.Element {
   // get store actions
   const { deleteLayer, setLayerDeleteInProgress, getLayerDeleteInProgress } = useLayerStoreActions();
   const { setOrToggleLayerVisibility, removeLayerHighlights } = useMapStoreActions();
-  const { setSelectedFooterLayerListItemId } = useUIStoreActions();
+  const { setSelectedFooterLayerListItemId, disableFocusTrap } = useUIStoreActions();
   const isVisible = useMapSelectorLayerVisibility(layerPath);
 
   const handleDeleteClick = (): void => {
@@ -109,6 +110,9 @@ export function DeleteUndoButton(props: DeleteUndoButtonProps): JSX.Element {
     if (progress === 100) {
       deleteLayer(layerPath);
       setInUndoState(false);
+
+      // set focus after deletion
+      disableFocusTrap(focusTargetIdAfterDelete || 'no-focus');
     }
     return undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -29,7 +29,7 @@ import {
   useLayerSelectorFilterClass,
   useLayerStoreActions,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import { useUIStoreActions } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useUIStoreActions, useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import {
   useDataTableAllFeaturesDataArray,
   useDataTableFilterSelector,
@@ -40,7 +40,7 @@ import { generateId, isValidUUID } from '@/core/utils/utilities';
 import { LayerIcon } from '@/core/components/common/layer-icon';
 import { LayerOpacityControl } from './layer-opacity-control/layer-opacity-control';
 import { logger } from '@/core/utils/logger';
-import { LAYER_STATUS } from '@/core/utils/constant';
+import { LAYER_STATUS, TABS } from '@/core/utils/constant';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import { Collapse } from '@/ui/collapse/collapse';
 import { Button } from '@/ui/button/button';
@@ -63,6 +63,7 @@ import {
 import { useNavigateToTab } from '@/core/components/common/hooks/use-navigate-to-tab';
 import { useGeoViewMapId } from '@/core/stores/geoview-store';
 import { DeleteUndoButton } from '@/core/components/layers/right-panel/delete-undo-button';
+import type { TypeContainerBox } from '@/core/types/global-types';
 
 // TODO: WCAG Issue #3108 - Fix layers.moreInfo button (button nested within a button)
 // TODO: WCAG Issue #3108 - Check all disabled buttons. They may need special treatment. Need to find instance in UI first)
@@ -70,7 +71,7 @@ import { DeleteUndoButton } from '@/core/components/layers/right-panel/delete-un
 
 interface LayerDetailsProps {
   layerDetails: TypeLegendLayer;
-  containerType?: 'appBar' | 'footerBar';
+  containerType: TypeContainerBox;
 }
 
 interface SubLayerProps {
@@ -123,7 +124,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/right-panel/layer-details');
 
-  const { layerDetails, containerType = 'footerBar' } = props;
+  const { layerDetails, containerType } = props;
 
   const { t } = useTranslation<string>();
 
@@ -168,6 +169,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   const layerHidden = useMapSelectorIsLayerHiddenOnMap(layerDetails.layerPath);
   const timeSliderLayers = useTimeSliderLayers();
   const timeSliderActions = useTimeSliderStoreActions();
+  const isFocusTrap = useUIActiveTrapGeoView();
 
   // Use navigate hook for time slider (only if time slider state exists)
   const navigateToTimeSlider = useNavigateToTab(
@@ -423,7 +425,10 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
     const isLayerInTimeSlider = timeSliderLayers && timeSliderLayers[layerDetails.layerPath];
     const isDisabled = layerHidden || parentHidden;
 
-    if (isLayerInTimeSlider) {
+    // Button to navigate to Time Slider panel and select this layer
+    // Hidden in WCAG mode - keyboard users can Tab to Time Slider Panel instead
+    // TODO: WCAG - Consider showing button in WCAG mode (requires re-working WCAG UX)
+    if (isLayerInTimeSlider && !isFocusTrap) {
       return (
         <IconButton
           aria-label={t('layers.selectLayerAndScrollTimeSlider')}
@@ -477,6 +482,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
         layerPath={layerDetails.layerPath}
         layerId={layerDetails.layerId}
         layerRemovable={isRemovable}
+        focusTargetIdAfterDelete={`${mapId}-${containerType}-${TABS.LAYERS}-panel-close-btn`}
       />
     );
   }

--- a/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
@@ -23,7 +23,11 @@ import {
   useLayerSelectorControls,
   useLayerSelectorStatus,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import { useUIFooterBarComponents, useUIAppbarComponents } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import {
+  useUIFooterBarComponents,
+  useUIAppbarComponents,
+  useUIActiveTrapGeoView,
+} from '@/core/stores/store-interface-and-intial-values/ui-state';
 import type { TypeLegendItem, TypeLegendLayer } from '@/core/components/layers/types';
 import {
   useMapStoreActions,
@@ -37,6 +41,7 @@ import { useNavigateToTab } from '@/core/components/common/hooks/use-navigate-to
 
 // TODO: WCAG Issue #3108 - Check all icon buttons for aria-label clarity and translations
 // TODO: WCAG Issue #3108 - Check all icon buttons for "state related" aria values (i.e aria-checked, aria-disabled, etc.)
+// TODO: WCAG - Consider showing Show in Time Slider button in WCAG mode (requires re-working WCAG UX)
 
 interface SecondaryControlsProps {
   layerPath: string;
@@ -130,6 +135,7 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
   const isInVisibleRange = useMapSelectorLayerInVisibleRange(layerPath);
   const parentHidden = useMapSelectorLayerParentHidden(layerPath);
   const highlightedLayer = useLayerHighlightedLayer();
+  const isFocusTrap = useUIActiveTrapGeoView();
 
   // Is visibility button disabled?
   const isLayerVisibleCapable = layerControls?.visibility ?? false;
@@ -151,8 +157,10 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
     <Stack direction="row" alignItems="center" sx={sxClasses.layerStackIcons}>
       {!!subTitle.length && <Typography fontSize={14}>{subTitle}</Typography>}
       <Box sx={{ ...sxClasses.subtitle, display: 'flex', alignItems: 'center' }}>
-        {/* Button to select layer in panel and scroll to footer */}
-        {hasLayersTab && (
+        {/* Button to select layer in panel and scroll to footer
+            Hidden in WCAG mode - keyboard users can Tab to layer panel instead
+          */}
+        {hasLayersTab && !isFocusTrap && (
           <Box sx={sxClasses.buttonDivider}>
             <IconButton
               aria-label={t('legend.selectLayerAndScroll')}

--- a/packages/geoview-core/src/core/components/legend/legend.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend.tsx
@@ -10,10 +10,11 @@ import { getSxClassesMain, getSxClasses } from './legend-styles';
 import { LegendLayer } from './legend-layer';
 import type { TypeLegendLayer } from '@/core/components/layers/types';
 import { CONTAINER_TYPE } from '@/core/utils/constant';
+import type { TypeContainerBox } from '@/core/types/global-types';
 import { useEventListener } from '@/core/components/common/hooks/use-event-listener';
 
 interface LegendType {
-  containerType?: 'appBar' | 'footerBar';
+  containerType: TypeContainerBox;
 }
 
 // Constant style outside of render (styles)
@@ -44,7 +45,7 @@ const responsiveWidths = {
   },
 } as const;
 
-export function Legend({ containerType = CONTAINER_TYPE.FOOTER_BAR }: LegendType): JSX.Element | null {
+export function Legend({ containerType }: LegendType): JSX.Element | null {
   logger.logTraceRender('components/legend/legend');
 
   // Hooks

--- a/packages/geoview-core/src/core/containers/focus-trap.tsx
+++ b/packages/geoview-core/src/core/containers/focus-trap.tsx
@@ -8,7 +8,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { Modal, Button } from '@/ui';
 import { UseHtmlToReact } from '@/core/components/common/hooks/use-html-to-react';
 import { getFocusTrapSxClasses } from './containers-style';
-import { ARROW_KEY_CODES } from '@/core/utils/constant';
+import { ARROW_KEY_CODES, TIMEOUT } from '@/core/utils/constant';
 import { useAppGeoviewHTMLElement, useAppStoreActions } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { useUIActiveTrapGeoView, useUIStoreActions } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { logger } from '@/core/utils/logger';
@@ -74,6 +74,79 @@ export function FocusTrapDialog(props: FocusTrapProps): JSX.Element {
     logger.logTraceUseEffect('FOCUS-TRAP - shellElementRef');
     shellElementRef.current = geoviewElement.querySelector('.geoview-shell') as HTMLElement;
   }, [geoviewElement]);
+
+  /**
+   * Add effects to intercept first Tab key press and make sure focus goes to the top link
+   * When the app loads and focus is inside the map container, keyboard users won't see the Keyboard navigation dialog
+   * This sets focus to top link and ensures keyboard users will tab into the dialog
+   */
+  const hasBeenPromptedRef = useRef(false);
+
+  // Set initial focus to toplink on mount
+  useEffect(() => {
+    logger.logTraceUseEffect('FOCUS-TRAP - initial focus setup');
+
+    // Small delay to ensure DOM is ready and other components have initialized
+    const focusTimeout = setTimeout(() => {
+      const topLink = document.getElementById(`toplink-${focusTrapId}`);
+
+      if (topLink && !activeTrapGeoView && !hasBeenPromptedRef.current) {
+        const currentFocus = document.activeElement;
+
+        // Only set focus if current focus is within the geoview container
+        // This prevents stealing focus from elements outside the viewer
+        if (geoviewElement.contains(currentFocus)) {
+          topLink.focus();
+          hasBeenPromptedRef.current = true;
+        }
+      }
+    }, TIMEOUT.topLinkFocusDelay); // Delay to let panels initialize
+
+    return () => clearTimeout(focusTimeout);
+  }, [focusTrapId, activeTrapGeoView, geoviewElement]);
+
+  // Intercept Tab navigation within geoview container to ensure toplink is visited
+  useEffect(() => {
+    logger.logTraceUseEffect('FOCUS-TRAP - Tab navigation guard');
+
+    const handleTabNavigation = (evt: KeyboardEvent): void => {
+      // Only intercept Tab key
+      if (evt.key !== 'Tab' || activeTrapGeoView || hasBeenPromptedRef.current) {
+        return;
+      }
+
+      const topLink = document.getElementById(`toplink-${focusTrapId}`);
+      const bottomLink = document.getElementById(`bottomlink-${focusTrapId}`);
+      const currentFocus = document.activeElement;
+
+      // Only intercept if focus is within geoview container
+      if (!currentFocus || !geoviewElement.contains(currentFocus)) {
+        return;
+      }
+
+      // Always redirect to toplink when NOT on toplink or bottomlink
+      // This ensures keyboard users encounter the navigation dialog
+      if (currentFocus !== topLink && currentFocus !== bottomLink) {
+        evt.preventDefault();
+        topLink?.focus();
+      }
+    };
+
+    // Use capture phase to intercept before other handlers
+    // Scope to geoviewElement to avoid conflicts with other maps
+    geoviewElement.addEventListener('keydown', handleTabNavigation, { capture: true });
+
+    return () => {
+      geoviewElement.removeEventListener('keydown', handleTabNavigation, { capture: true });
+    };
+  }, [focusTrapId, geoviewElement, activeTrapGeoView]);
+
+  // Reset prompt flag when modal is dismissed (user made a choice)
+  useEffect(() => {
+    if (open) {
+      hasBeenPromptedRef.current = true;
+    }
+  }, [open]);
 
   /**
    * Disable scrolling on keydown space, so that screen doesnt scroll down.

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
@@ -179,7 +179,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
         });
       },
       // TODO: WCAG Issue #3222 RAF seems to be working well for timing purposes
-      // (RAF ensures that modal transitions, focal trap releases, and DOM updates, are completed before focus restoration takes place)
+      // (RAF ensures that modal transitions, focus trap releases, and DOM updates, are completed before focus restoration takes place)
       // Try removing setTimeout from all instances of disableFocusTrap as that might now be redundant
       // See issue #3222 for more detail.
       disableFocusTrap: (callBackElementId: string) => {

--- a/packages/geoview-core/src/core/utils/constant.ts
+++ b/packages/geoview-core/src/core/utils/constant.ts
@@ -109,6 +109,7 @@ export const TIMEOUT: Record<string, number> = {
 
   guideReturnFocus: 200,
   exportPreview: 200,
+  topLinkFocusDelay: 200,
 
   focusDelayLightbox: 250,
   guideSearchSectionExpand: 300,

--- a/packages/geoview-core/src/ui/panel/panel.tsx
+++ b/packages/geoview-core/src/ui/panel/panel.tsx
@@ -19,6 +19,7 @@ import { FocusTrapContainer } from '@/core/components/common';
 import { delay } from '@/core/utils/utilities';
 import { logger } from '@/core/utils/logger';
 import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { CONTAINER_TYPE } from '@/core/utils/constant';
 
 /**
  * Interface for panel properties
@@ -103,7 +104,7 @@ function PanelUI(props: TypePanelAppProps): JSX.Element {
       id={`appbar-panel-${panel.panelId || ''}-${mapId}`}
       className={`appbar-panel appbar-panel-${panelId}`}
     >
-      <FocusTrapContainer open={isFocusTrapped} id="app-bar-focus-trap">
+      <FocusTrapContainer open={isFocusTrapped} id="app-bar-focus-trap" containerType={CONTAINER_TYPE.APP_BAR}>
         <Card
           sx={{
             ...sxClasses.panelCard,
@@ -127,6 +128,7 @@ function PanelUI(props: TypePanelAppProps): JSX.Element {
             action={
               open ? (
                 <IconButton
+                  id={`${mapId}-${CONTAINER_TYPE.APP_BAR}-${panel.panelId || ''}-panel-close-btn`}
                   aria-label={t('general.close')}
                   tooltipPlacement="right"
                   size="small"

--- a/packages/geoview-core/src/ui/tabs/tab-panel.tsx
+++ b/packages/geoview-core/src/ui/tabs/tab-panel.tsx
@@ -13,7 +13,7 @@ export interface TypeTabPanelProps {
   value: number;
   id: string;
   children?: ReactNode;
-  containerType?: TypeContainerBox;
+  containerType: TypeContainerBox;
   tabId: string;
   className?: string;
 }

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -52,7 +52,7 @@ export interface TypeTabsProps {
   onSelectedTabChanged?: (tab: TypeTabs) => void;
   onOpenKeyboard?: (uiFocus: FocusItemProps) => void;
   onCloseKeyboard?: () => void;
-  containerType?: TypeContainerBox;
+  containerType: TypeContainerBox;
   appHeight: string;
   hiddenTabs: string[];
   isFullScreen: boolean;
@@ -214,7 +214,20 @@ function TabsUI(props: TypeTabsProps): JSX.Element {
 
     const tabPanel = tabPanelRef?.current;
     const handleFooterbarEscapeKey = (event: KeyboardEvent): void => {
-      if (!isCollapsed) {
+      if (!isCollapsed && event.key === 'Escape') {
+        // Check if ESC originated from within the right panel content
+        // where ResponsiveGridLayout's handler would manage focus
+        const target = event.target as HTMLElement;
+        const isFromRightPanel = target.closest('.responsive-layout-right-main-content');
+
+        if (isFromRightPanel) {
+          // ESC is from right panel - ResponsiveGridLayout will handle it
+          // (including proper focus restoration to layer list item when close button is visible)
+          return;
+        }
+
+        // ESC is from elsewhere (e.g., left panel/layer list when right panel is closed)
+        // Handle it the traditional way - focus the tab button
         handleEscapeKey(event.key, tabs[selectedTab ?? 0]?.id, true, () => {
           onCloseKeyboard?.();
         });

--- a/packages/geoview-geochart/src/geochart-panel.tsx
+++ b/packages/geoview-geochart/src/geochart-panel.tsx
@@ -20,7 +20,7 @@ import {
 import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 import { logger } from 'geoview-core/core/utils/logger';
-import { TABS } from 'geoview-core/core/utils/constant';
+import { CONTAINER_TYPE, TABS } from 'geoview-core/core/utils/constant';
 
 import { GeoChart } from './geochart';
 import type { GeoViewGeoChartRootConfig } from './geochart-types';
@@ -278,6 +278,7 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
           onLayerListClicked={handleLayerChange}
           onIsEnlargeClicked={handleIsEnlargeClicked}
           guideContentIds={['chart', 'chart.children.chartTypes', 'chart.children.chartControls']}
+          containerType={CONTAINER_TYPE.FOOTER_BAR}
         >
           {selectedLayerPath && (
             <Box sx={{ '& .MuiButtonGroup-groupedHorizontal.MuiButton-textSizeMedium': { fontSize: '0.9rem' } }}>

--- a/packages/geoview-time-slider/src/time-slider-panel.tsx
+++ b/packages/geoview-time-slider/src/time-slider-panel.tsx
@@ -11,7 +11,7 @@ import { useMapStoreActions, useMapAllVisibleandInRangeLayers } from 'geoview-co
 import { useLayerLegendLayers } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 import { Box } from 'geoview-core/ui';
 import { logger } from 'geoview-core/core/utils/logger';
-import { TABS } from 'geoview-core/core/utils/constant';
+import { CONTAINER_TYPE, TABS } from 'geoview-core/core/utils/constant';
 
 import { DateMgt } from 'geoview-core/core/utils/date-mgt';
 import { TimeSlider } from './time-slider';
@@ -164,6 +164,7 @@ export function TimeSliderPanel(props: TypeTimeSliderProps): JSX.Element {
       onLayerListClicked={handleClickLayerList}
       layerList={memoLayersList}
       guideContentIds={['timeSlider']}
+      containerType={CONTAINER_TYPE.FOOTER_BAR}
     >
       {renderContent()}
     </Layout>


### PR DESCRIPTION
* appbar: fix bug with focus not returning to correct appbar item on panel close
* legend panel: hide Show in layers button in WCAG mode
* layers panel: hide Time slider button in WCAG mode
* data panel: details modal returns focus to correct icon on close (using unique HTML element IDs for appBar and footerBar layer buttons)
* layers panel: closing right panel returns focus to correct layer in the left panel (using unique HTML element IDs for appBar and footerBar layer buttons)
* layers panel: focus on close/exit button after layer is deleted
* version popup: return focus to correct appBar icon on close
* footer panel: when right panel open, esc key now closes the right panel (like the Close selection button does)
* focus trap: set focus to top link on first tab/shift tab. ensures keyboard users will tab into the keyboard navigation dialog even if focus is elsewhere on load
* global: add unique HTML element IDs to various HTML elements that were generating duplicate IDs
* global: remove ids that are not in use
* global: update translations
* global: fix typos

# Description

Overall improvements to keyboard navigation and focus management in WCAG mode. Especially when navigating the footerBar panels.

Fixes #3242 #3244 #3245 #3261 #3272 #3273

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested manually in WCAG mode using keyboard navigation.

[__Add the URL for your deploy!__](https://kenchase.github.io/geoview)


# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3280)
<!-- Reviewable:end -->
