### PR TITLE
fix(details): possible fix for OSDP coverage issue

### DIFF
--- a/packages/geoview-core/src/api/event-processors/abstract-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/abstract-event-processor.ts
@@ -136,8 +136,18 @@ export abstract class AbstractEventProcessor {
     // Log
     // logger.logDebug('Propagate in batch - buffering...', mapId, traceProcessorIndication, batchPropagationObject[mapId].length);
 
+    // Clone the layer data array to preserve snapshot of features at this moment, avoiding issues with non-cloneable properties
+    const clonedLayerDataArray = layerDataArray.map((layer) => {
+      if ('features' in layer)
+        return {
+          ...layer,
+          features: layer.features ? [...layer.features] : [],
+        };
+      return layer;
+    });
+
     // Pile up the array
-    batchPropagationObject[mapId].push(layerDataArray);
+    batchPropagationObject[mapId].push(clonedLayerDataArray);
 
     // If there's a layer path bypass set
     let layerDataBypass;


### PR DESCRIPTION
# Description

Clones the features of the layerDataArray in feature-info-event-processor.ts before propagating to store, preventing changes before batch timing finishes. Possible fix for OSDP-2103/Issue #3329

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/layers-navigator.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3330)
<!-- Reviewable:end -->
