### PR TITLE
feat(zoom): zoomToLayerExtent added to layer API

### DIFF
--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -563,8 +563,11 @@ export class LegendEventProcessor extends AbstractEventProcessor {
     const { layerPath } = legendResultSetEntry;
     const layerPathNodes = layerPath.split('/');
 
-    const setLayerControls = (layerConfig: ConfigBaseClass, isChild: boolean = false): TypeLayerControls => {
+    const setLayerControls = (layerConfig: ConfigBaseClass, isChild: boolean = false, layer?: AbstractBaseGVLayer): TypeLayerControls => {
       const removeDefault = isChild ? MapEventProcessor.getGeoViewMapConfig(mapId)?.globalSettings?.canRemoveSublayers !== false : true;
+
+      // Check if the layer has a minZoom or maxZoom defined, so we know if it needs the visible scale button.
+      const visibleScale: boolean = Number.isFinite(layer?.getMinZoom()) || Number.isFinite(layer?.getMaxZoom());
 
       // Get the initial settings
       const initialSettings = layerConfig.getInitialSettings();
@@ -579,6 +582,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
         table: initialSettings?.controls?.table ?? true, // default: true
         visibility: initialSettings?.controls?.visibility ?? true, // default: true
         zoom: initialSettings?.controls?.zoom ?? true, // default: true
+        visibleScale, // default: false
       };
     };
 
@@ -660,7 +664,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
           items = GeoUtilities.getLayerItemsFromIcons(legendResultSetEntry.data.type, icons);
         }
 
-        const controls: TypeLayerControls = setLayerControls(layerConfig, currentLevel > 2);
+        const controls: TypeLayerControls = setLayerControls(layerConfig, currentLevel > 2, layer);
 
         // Get the schema tag
         const schemaTag = legendResultSetEntry.data?.type ?? layerConfig.getSchemaTag();

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/map-event-processor.ts
@@ -69,7 +69,7 @@ import { getAppCrosshairsActive } from '@/core/stores/store-interface-and-intial
 import type { TypeHoverFeatureInfo } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import { ConfigBaseClass } from '@/api/config/validation-classes/config-base-class';
 
-import { InvalidExtentError, PluginError } from '@/core/exceptions/geoview-exceptions';
+import { InvalidExtentError, NoBoundsError, PluginError } from '@/core/exceptions/geoview-exceptions';
 import { AbstractGVVectorTile } from '@/geo/layer/gv-layers/vector/abstract-gv-vector-tile';
 import { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
 import { GroupLayerEntryConfig } from '@/api/config/validation-classes/group-layer-entry-config';
@@ -1392,6 +1392,29 @@ export class MapEventProcessor extends AbstractEventProcessor {
         // Log error
         logger.logPromiseFailed('in getBounds in MapEventProcessor.zoomToLayerVisibleScale', error);
       });
+  }
+
+  /**
+   * Zoom to extents of a layer.
+   *
+   * @param mapId - ID of map to zoom on
+   * @param layerPath - The path of the layer to zoom to.
+   * @throws {NoBoundsError} When the layer doesn't have bounds.
+   */
+  static zoomToLayerExtent(mapId: string, layerPath: string, fitOptions?: FitOptions): Promise<void> {
+    // Define some zoom options
+    const options: FitOptions = fitOptions ?? { padding: OL_ZOOM_PADDING, duration: OL_ZOOM_DURATION };
+
+    // Get the layer bounds
+    const bounds = LegendEventProcessor.getLayerBounds(mapId, layerPath);
+
+    // If found
+    if (bounds) {
+      return MapEventProcessor.zoomToExtent(mapId, bounds, options);
+    }
+
+    // Failed
+    throw new NoBoundsError(layerPath);
   }
 
   /**

--- a/packages/geoview-core/src/api/types/layer-schema-types.ts
+++ b/packages/geoview-core/src/api/types/layer-schema-types.ts
@@ -366,6 +366,8 @@ export type TypeLayerControls = {
   visibility?: boolean;
   /** Is zoom available for layer. Default = true */
   zoom?: boolean;
+  /** Is visible scale control available for layer. Default = false */
+  visibleScale?: boolean;
 };
 
 /** Initial settings for layer states. */

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -1,6 +1,5 @@
 import { useStore } from 'zustand';
 
-import type { FitOptions } from 'ol/View';
 import type { Extent } from 'ol/extent';
 
 import { useGeoViewStore } from '@/core/stores/stores-managers';
@@ -11,14 +10,12 @@ import type { TypeFeatureInfoEntryPartial, TypeLayerStyleConfig, TypeResultSet, 
 import { DateMgt, type TemporalMode, type TimeDimension, type TimeIANA, type TypeDisplayDateFormat } from '@/core/utils/date-mgt';
 import type { TypeGeoviewLayerType, TypeLayerStatus } from '@/api/types/layer-schema-types';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
-import { OL_ZOOM_DURATION, OL_ZOOM_PADDING } from '@/core/utils/constant';
 import { MapEventProcessor } from '@/api/event-processors/event-processor-children/map-event-processor';
 import type { TypeVectorLayerStyles } from '@/geo/utils/renderer/geoview-renderer';
 import { LegendEventProcessor } from '@/api/event-processors/event-processor-children/legend-event-processor';
 import { AppEventProcessor } from '@/api/event-processors/event-processor-children/app-event-processor';
 import { GVEsriDynamic } from '@/geo/layer/gv-layers/raster/gv-esri-dynamic';
 import { LayerNotEsriDynamicError } from '@/core/exceptions/layer-exceptions';
-import { NoBoundsError } from '@/core/exceptions/geoview-exceptions';
 import { logger } from '@/core/utils/logger';
 
 // #region INTERFACES & TYPES
@@ -303,22 +300,13 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Zoom to extents of a layer.
-       * @param {string} layerPath - The path of the layer to zoom to.
+       *
+       * @param layerPath - The path of the layer to zoom to.
+       * @throws {NoBoundsError} When the layer doesn't have bounds.
        */
       zoomToLayerExtent: (layerPath: string): Promise<void> => {
-        // Define some zoom options
-        const options: FitOptions = { padding: OL_ZOOM_PADDING, duration: OL_ZOOM_DURATION };
-
-        // Get the layer bounds
-        const bounds = LegendEventProcessor.getLayerBounds(get().mapId, layerPath);
-
-        // If found
-        if (bounds) {
-          return MapEventProcessor.zoomToExtent(get().mapId, bounds, options);
-        }
-
-        // Failed
-        throw new NoBoundsError(layerPath);
+        // Redirect
+        return MapEventProcessor.zoomToLayerExtent(get().mapId, layerPath);
       },
 
       zoomToLayerVisibleScale: (layerPath: string): void => {

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -1,6 +1,7 @@
 import type BaseLayer from 'ol/layer/Base';
 import type { Extent } from 'ol/extent';
 import type { GeoJSONObject } from 'ol/format/GeoJSON';
+import type { FitOptions } from 'ol/View';
 
 import { GeoCore } from '@/api/config/geocore';
 import { GeometryApi } from '@/geo/layer/geometry/geometry';
@@ -1321,6 +1322,18 @@ export class LayerApi {
 
     // Return the final bounds
     return boundsUnion;
+  }
+
+  /**
+   * Zoom to extents of a layer.
+   *
+   * @param layerPath - The path of the layer to zoom to.
+   * @param fitOptions - Optional fit options for zooming.
+   * @throws {NoBoundsError} When the layer doesn't have bounds.
+   */
+  zoomToLayerExtent(layerPath: string, fitOptions?: FitOptions): Promise<void> {
+    // Redirect to the map viewer function
+    return MapEventProcessor.zoomToLayerExtent(this.getMapId(), layerPath, fitOptions);
   }
 
   /**


### PR DESCRIPTION
Also adds visibleScale to layer store controls

# Description

zoomToLayerExtent added to layer API and visibleScale added to layer controls

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

cgpv.api.getMapViewer('map1').layer.zoomToLayerExtent('geojsonLYR1/base-group/lines.json') 
at: https://damonu2.github.io/geoview/layers-navigator.html?config=./configs/navigator/layers/geojson.json

https://damonu2.github.io/geoview/demos-navigator.html - check legend layers controls

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ]I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3338)
<!-- Reviewable:end -->
