### PR TITLE
feat(WMS Style Selector): Add WMS Style Selector

### DIFF
--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -266,7 +266,8 @@
       "mosaicOperationBlend": "Blend",
       "mosaicOperationSum": "Sum",
       "orderAscending": "Oldest to Newest",
-      "orderDescending": "Newest to Oldest"
+      "orderDescending": "Newest to Oldest",
+      "selectWmsStyle": "Select WMS style"
     }
   },
   "details": {

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -266,7 +266,8 @@
       "mosaicOperationBlend": "Mélange",
       "mosaicOperationSum": "Somme",
       "orderAscending": "Plus ancien au plus récent",
-      "orderDescending": "Plus récent au plus ancien"
+      "orderDescending": "Plus récent au plus ancien",
+      "selectWmsStyle": "Sélectionner le style WMS"
     }
   },
   "details": {

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
@@ -197,7 +197,7 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
    * Retrieves the full style metadata objects available for this layer.
    * Returns the complete `TypeMetadataWMSCapabilityLayerStyle` objects from the layer metadata,
    * which include style names, legend URLs, and other style-related information.
-   * @returns {TypeMetadataWMSCapabilityLayerStyle[] | undefined} The list of available style metadata objects, or `undefined` if none are defined.
+   * @returns The list of available style metadata objects, or `undefined` if none are defined.
    */
   getStylesMetadata(): TypeMetadataWMSCapabilityLayerStyle[] | undefined {
     return this.getLayerMetadata()?.Style;

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
@@ -194,6 +194,16 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
   }
 
   /**
+   * Retrieves the full style metadata objects available for this layer.
+   * Returns the complete `TypeMetadataWMSCapabilityLayerStyle` objects from the layer metadata,
+   * which include style names, legend URLs, and other style-related information.
+   * @returns {TypeMetadataWMSCapabilityLayerStyle[] | undefined} The list of available style metadata objects, or `undefined` if none are defined.
+   */
+  getStylesMetadata(): TypeMetadataWMSCapabilityLayerStyle[] | undefined {
+    return this.getLayerMetadata()?.Style;
+  }
+
+  /**
    * Determines the style to apply for this layer.
    * Retrieves the list of available styles from the layer config/metadata and returns
    * the first available one as the default style to use. If no styles are defined,

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
@@ -175,13 +175,14 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
    * If styles are not yet cached, the method reads them from the layer metadata
    * and initializes the internal style list. The styles correspond to named
    * style definitions advertised by the WMS service (from the `Style` section of the metadata).
-   * @returns {string[] | undefined} The list of available style names, or `undefined` if none are defined.
+   *
+   * @returns The list of available style names, or `undefined` if none are defined.
    */
   getStyles(): string[] | undefined {
     // If no styles defined
     if (!this.#styles) {
       // Read styles from the metadata
-      const styles = this.getLayerMetadata()?.Style;
+      const styles = this.getStylesMetadata();
 
       // Update internal styles list
       if (styles?.length || 0 > 1) {
@@ -197,6 +198,7 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
    * Retrieves the full style metadata objects available for this layer.
    * Returns the complete `TypeMetadataWMSCapabilityLayerStyle` objects from the layer metadata,
    * which include style names, legend URLs, and other style-related information.
+   *
    * @returns The list of available style metadata objects, or `undefined` if none are defined.
    */
   getStylesMetadata(): TypeMetadataWMSCapabilityLayerStyle[] | undefined {

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -6,6 +6,7 @@ import type {
   TypeLayerControls,
   TypeLayerStatus,
   TypeMetadataEsriRasterFunctionInfos,
+  TypeMetadataWMSCapabilityLayerStyle,
   TypeMosaicMethod,
   TypeMosaicRule,
 } from '@/api/types/layer-schema-types';
@@ -30,6 +31,7 @@ import type { AbstractBaseGVLayer } from '@/geo/layer/gv-layers/abstract-base-la
 import { GVEsriImage } from '@/geo/layer/gv-layers/raster/gv-esri-image';
 import { logger } from '@/core/utils/logger';
 import { doTimeout, type DelayJob } from '@/core/utils/utilities';
+import { OgcWmsLayerEntryConfig } from '@/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config';
 
 // GV Important: See notes in header of MapEventProcessor file for information on the paradigm to apply when working with UIEventProcessor vs UIState
 
@@ -348,6 +350,43 @@ export class LegendEventProcessor extends AbstractEventProcessor {
   }
 
   /**
+   * Gets the active WMS style for a layer.
+   * @param mapId - The map identifier.
+   * @param layerPath - The layer path.
+   * @returns The active WMS style name.
+   */
+  static getLayerWmsStyle(mapId: string, layerPath: string): string | undefined {
+    return LegendEventProcessor.getLegendLayerInfo(mapId, layerPath)?.wmsStyle;
+  }
+
+  /**
+   * Sets the active WMS style for a layer.
+   * @param mapId - The map identifier.
+   * @param layerPath - The layer path.
+   * @param wmsStyleName - The WMS style name to set.
+   */
+  static setLayerWmsStyle(mapId: string, layerPath: string, wmsStyleName: string | undefined): void {
+    if (!wmsStyleName) return;
+    MapEventProcessor.getMapViewerLayerAPI(mapId).setLayerWmsStyle(layerPath, wmsStyleName);
+  }
+
+  /**
+   * Updates the active WMS style for a layer in the store.
+   * @param mapId - The map identifier.
+   * @param layerPath - The layer path.
+   * @param wmsStyleName - The WMS style name to set.
+   */
+  static setLayerWmsStyleInStore(mapId: string, layerPath: string, wmsStyleName: string | undefined): void {
+    const layers = LegendEventProcessor.getLayerState(mapId).legendLayers;
+    const layer = this.findLayerByPath(layers, layerPath);
+
+    if (layer) {
+      layer.wmsStyle = wmsStyleName;
+      this.getLayerState(mapId).setterActions.setLegendLayers(layers);
+    }
+  }
+
+  /**
    * Gets the raster function previews for the ESRI image layer.
    * @param mapId - The map identifier.
    * @param layerPath - The layer path.
@@ -358,6 +397,25 @@ export class LegendEventProcessor extends AbstractEventProcessor {
     if (!geoviewLayer || !(geoviewLayer instanceof GVEsriImage)) return new Map<string, Promise<string>>();
 
     return geoviewLayer.getRasterFunctionPreviews();
+  }
+
+  /**
+   * Retrieves the layer's available WMS styles.
+   *
+   * @param mapId - The unique identifier of the map instance.
+   * @param layerPath - The path to the layer.
+   * @returns The available WMS style names, or `undefined` if not available.
+   */
+  static getLayerWmsStyles(mapId: string, layerPath: string): TypeMetadataWMSCapabilityLayerStyle[] | undefined {
+    // Get the layer config
+    const layerConfig = MapEventProcessor.getMapViewerLayerAPI(mapId).getLayerEntryConfigIfExists(layerPath);
+
+    // Check if it's a WMS layer config
+    if (layerConfig && layerConfig instanceof OgcWmsLayerEntryConfig) {
+      return layerConfig.getStylesMetadata();
+    }
+
+    return undefined;
   }
 
   /**
@@ -382,6 +440,12 @@ export class LegendEventProcessor extends AbstractEventProcessor {
     const mosaicRule = this.getLayerMosaicRule(mapId, layerPath);
     if (mosaicRule) {
       settings.push('mosaicRule');
+    }
+
+    // Check if multiple WMS styles are available
+    const styles = this.getLayerWmsStyles(mapId, layerPath);
+    if (styles && styles.length > 1) {
+      settings.push('wmsStyles');
     }
 
     // Add other layer types with settings here

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -15,6 +15,7 @@ import type { TypeLegendLayer, TypeLegendLayerItem, TypeLegendItem } from '@/cor
 import { MapViewer } from '@/geo/map/map-viewer';
 import { GeoUtilities } from '@/geo/utils/utilities';
 import type { ConfigBaseClass } from '@/api/config/validation-classes/config-base-class';
+import { OgcWmsLayerEntryConfig } from '@/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config';
 import type {
   ILayerState,
   LegendQueryStatus,
@@ -31,7 +32,6 @@ import type { AbstractBaseGVLayer } from '@/geo/layer/gv-layers/abstract-base-la
 import { GVEsriImage } from '@/geo/layer/gv-layers/raster/gv-esri-image';
 import { logger } from '@/core/utils/logger';
 import { doTimeout, type DelayJob } from '@/core/utils/utilities';
-import { OgcWmsLayerEntryConfig } from '@/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config';
 
 // GV Important: See notes in header of MapEventProcessor file for information on the paradigm to apply when working with UIEventProcessor vs UIState
 

--- a/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
+++ b/packages/geoview-core/src/api/event-processors/event-processor-children/legend-event-processor.ts
@@ -242,6 +242,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Gets the active raster function for a layer.
+   *
    * @param mapId - The map identifier.
    * @param layerPath - The layer path.
    * @returns The active raster function identifier.
@@ -252,6 +253,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Sets the active raster function for a layer.
+   *
    * @param mapId - The map identifier.
    * @param layerPath - The layer path.
    * @param rasterFunctionId - The raster function identifier to set.
@@ -262,6 +264,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Updates the active raster function for a layer in the store.
+   *
    * @param mapId - The map identifier.
    * @param layerPath - The layer path.
    * @param rasterFunctionId - The raster function identifier to set.
@@ -281,6 +284,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Gets the allowed mosaic methods for a layer.
+   *
    * @param mapId - The map identifier.
    * @param layerPath - The layer path.
    * @returns The allowed mosaic methods or undefined.
@@ -295,6 +299,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Gets the active mosaic rule for a layer.
+   *
    * @param mapId - The map identifier.
    * @param layerPath - The layer path.
    * @returns The active mosaic rule or undefined.
@@ -305,6 +310,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Sets the active mosaic rule for a layer.
+   *
    * @param mapId - The map identifier.
    * @param layerPath - The layer path.
    * @param mosaicRule - The mosaic rule to set.
@@ -315,6 +321,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Updates the mosaicRule for a layer by merging new properties.
+   *
    * @param mapId - The map id.
    * @param layerPath - The layer path.
    * @param partialMosaicRule - An object with one or more mosaicRule properties to update.
@@ -336,6 +343,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Updates the active mosaic rule for a layer in the store.
+   *
    * @param mapId - The map identifier.
    * @param layerPath - The layer path.
    * @param mosaicRule - The mosaic rule to set.
@@ -351,6 +359,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Gets the active WMS style for a layer.
+   *
    * @param mapId - The map identifier.
    * @param layerPath - The layer path.
    * @returns The active WMS style name.
@@ -361,6 +370,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Sets the active WMS style for a layer.
+   *
    * @param mapId - The map identifier.
    * @param layerPath - The layer path.
    * @param wmsStyleName - The WMS style name to set.
@@ -372,6 +382,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Updates the active WMS style for a layer in the store.
+   *
    * @param mapId - The map identifier.
    * @param layerPath - The layer path.
    * @param wmsStyleName - The WMS style name to set.
@@ -388,6 +399,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Gets the raster function previews for the ESRI image layer.
+   *
    * @param mapId - The map identifier.
    * @param layerPath - The layer path.
    * @returns The raster function previews.
@@ -420,6 +432,7 @@ export class LegendEventProcessor extends AbstractEventProcessor {
 
   /**
    * Gets the available settings for a layer.
+   *
    * @param mapId - The map identifier.
    * @param layerPath - The layer path.
    * @returns Array of available setting types.

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/layer-settings-style.ts
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/layer-settings-style.ts
@@ -15,12 +15,12 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
     },
   },
 
-  // ESRI Image Styles
-  rasterFunctionMenu: {
+  // Shared styles for setting selector submenus (raster function, WMS style, etc.)
+  settingSelectorMenu: {
     '& .MuiPaper-root': {
       padding: '8px',
       maxHeight: '400px',
-      paddingRight: '16px', // Extra padding for scrollbar space
+      paddingRight: '16px',
       // Custom scrollbar styling
       '&::-webkit-scrollbar': {
         width: '8px',
@@ -41,7 +41,7 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
     },
   },
 
-  rasterFunctionMenuItem: {
+  settingSelectorMenuItem: {
     border: '1px solid',
     borderColor: 'divider',
     borderRadius: 2,
@@ -54,7 +54,20 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
       borderColor: 'primary.main',
     },
   },
-  previewImageContainer: {
+
+  settingSelectorListItemText: {
+    '& .MuiListItemText-primary': {
+      fontWeight: 600,
+    },
+  },
+
+  settingSelectorPreviewIcon: {
+    width: 100,
+    height: 100,
+  },
+
+  // ESRI Image Raster Function specific styles
+  rasterFunctionPreviewImageContainer: {
     width: 100,
     height: 100,
     border: '2px solid',
@@ -66,53 +79,21 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
     overflow: 'hidden',
     marginRight: '16px',
   },
-  previewImage: {
+
+  rasterFunctionPreviewImage: {
     width: '100%',
     height: '100%',
     objectFit: 'cover',
   },
-  previewIcon: {
-    width: 100,
-    height: 100,
-  },
 
-  rasterFunctionListItemText: {
-    '& .MuiListItemText-primary': {
-      fontWeight: 600,
-    },
-  },
-
-  // WMS Styles
-  wmsStyleMenu: {
-    '& .MuiPaper-root': {
-      padding: '8px',
-      maxHeight: '400px',
-      paddingRight: '16px',
-      '&::-webkit-scrollbar': {
-        width: '8px',
-      },
-      '&::-webkit-scrollbar-track': {
-        background: 'transparent',
-      },
-      '&::-webkit-scrollbar-thumb': {
-        backgroundColor: theme.palette.action.disabled,
-        borderRadius: '4px',
-        '&:hover': {
-          backgroundColor: theme.palette.action.hover,
-        },
-      },
-      scrollbarWidth: 'thin',
-      scrollbarColor: `${theme.palette.action.disabled} transparent`,
-    },
-  },
-
+  // WMS Style specific styles
   wmsStyleMenuItem: {
     border: '1px solid',
     borderColor: 'divider',
     borderRadius: 2,
     margin: '4px 0',
     padding: '12px',
-    alignItems: 'center', // Vertically center image and text
+    alignItems: 'center',
     '&:hover': {
       borderColor: 'primary.main',
     },
@@ -124,7 +105,7 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
   wmsStylePreviewImageContainer: {
     width: 100,
     minHeight: 100,
-    maxHeight: 200, // Cap maximum height
+    maxHeight: 200, // Cap maximum height to handle tall legend images
     border: '2px solid',
     borderColor: 'divider',
     borderRadius: 2,
@@ -140,16 +121,5 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
     height: 'auto', // Preserve aspect ratio
     maxHeight: '200px',
     objectFit: 'contain', // Show full image without cropping
-  },
-
-  wmsStylePreviewIcon: {
-    width: 100,
-    height: 100,
-  },
-
-  wmsStyleListItemText: {
-    '& .MuiListItemText-primary': {
-      fontWeight: 600,
-    },
   },
 });

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/layer-settings-style.ts
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/layer-settings-style.ts
@@ -15,6 +15,7 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
     },
   },
 
+  // ESRI Image Styles
   rasterFunctionMenu: {
     '& .MuiPaper-root': {
       padding: '8px',
@@ -76,6 +77,77 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
   },
 
   rasterFunctionListItemText: {
+    '& .MuiListItemText-primary': {
+      fontWeight: 600,
+    },
+  },
+
+  // WMS Styles
+  wmsStyleMenu: {
+    '& .MuiPaper-root': {
+      padding: '8px',
+      maxHeight: '400px',
+      paddingRight: '16px',
+      '&::-webkit-scrollbar': {
+        width: '8px',
+      },
+      '&::-webkit-scrollbar-track': {
+        background: 'transparent',
+      },
+      '&::-webkit-scrollbar-thumb': {
+        backgroundColor: theme.palette.action.disabled,
+        borderRadius: '4px',
+        '&:hover': {
+          backgroundColor: theme.palette.action.hover,
+        },
+      },
+      scrollbarWidth: 'thin',
+      scrollbarColor: `${theme.palette.action.disabled} transparent`,
+    },
+  },
+
+  wmsStyleMenuItem: {
+    border: '1px solid',
+    borderColor: 'divider',
+    borderRadius: 2,
+    margin: '4px 0',
+    padding: '12px',
+    alignItems: 'center', // Vertically center image and text
+    '&:hover': {
+      borderColor: 'primary.main',
+    },
+    '&.Mui-selected': {
+      borderColor: 'primary.main',
+    },
+  },
+
+  wmsStylePreviewImageContainer: {
+    width: 100,
+    minHeight: 100,
+    maxHeight: 200, // Cap maximum height
+    border: '2px solid',
+    borderColor: 'divider',
+    borderRadius: 2,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+    marginRight: '16px',
+  },
+
+  wmsStylePreviewImage: {
+    width: '100%',
+    height: 'auto', // Preserve aspect ratio
+    maxHeight: '200px',
+    objectFit: 'contain', // Show full image without cropping
+  },
+
+  wmsStylePreviewIcon: {
+    width: 100,
+    height: 100,
+  },
+
+  wmsStyleListItemText: {
     '& .MuiListItemText-primary': {
       fontWeight: 600,
     },

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/layer-settings.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/layer-settings.tsx
@@ -2,19 +2,22 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
 import { Menu, MenuItem, ListItemIcon, ListItemText, IconButton } from '@/ui';
-import { SettingsIcon, FunctionsIcon, CollectionsIcon } from '@/ui';
+import { SettingsIcon, FunctionsIcon, CollectionsIcon, PaletteIcon } from '@/ui';
 
 import { getSxClasses } from './layer-settings-style';
 import { useLayerStoreActions } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 import { RasterFunctionSelector } from './raster-function-selector';
+import { MosaicRuleSelector } from './mosaic-rule-selector';
+import { WmsStyleSelector } from './wms-style-selector';
 import type { TypeLegendLayer } from '../../types';
 import { logger } from '@/core/utils/logger';
-import { MosaicRuleSelector } from './mosaic-rule-selector';
 
 interface LayerSettingsProps {
   layerDetails: TypeLegendLayer;
 }
+
+type LayerSettingsTypes = 'rasterFunction' | 'mosaicRule' | 'wmsStyles';
 
 export function LayerSettings({ layerDetails }: LayerSettingsProps): JSX.Element | null {
   // Log
@@ -28,7 +31,7 @@ export function LayerSettings({ layerDetails }: LayerSettingsProps): JSX.Element
   // Hooks
   const { getLayerSettings } = useLayerStoreActions();
   const [settingsAnchorEl, setSettingsAnchorEl] = useState<null | HTMLElement>(null);
-  const [openSettingsType, setOpenSettingsType] = useState<'rasterFunction' | 'mosaicRule' | null>(null);
+  const [openSettingsType, setOpenSettingsType] = useState<LayerSettingsTypes | null>(null);
 
   // State
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -125,6 +128,21 @@ export function LayerSettings({ layerDetails }: LayerSettingsProps): JSX.Element
             <ListItemText>{t('layers.settings.updateMosaicRule')}</ListItemText>
           </MenuItem>
         )}
+
+        {availableSettings.includes('wmsStyles') && (
+          <MenuItem
+            selected={Boolean(settingsAnchorEl)}
+            onClick={(event) => {
+              setSettingsAnchorEl(event.currentTarget);
+              setOpenSettingsType('wmsStyles');
+            }}
+          >
+            <ListItemIcon>
+              <PaletteIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>{t('layers.settings.selectWmsStyle')}</ListItemText>
+          </MenuItem>
+        )}
       </Menu>
 
       {openSettingsType === 'rasterFunction' && (
@@ -141,6 +159,18 @@ export function LayerSettings({ layerDetails }: LayerSettingsProps): JSX.Element
 
       {openSettingsType === 'mosaicRule' && (
         <MosaicRuleSelector
+          layerDetails={layerDetails}
+          anchorEl={settingsAnchorEl}
+          onClose={() => {
+            setSettingsAnchorEl(null);
+            setOpenSettingsType(null);
+          }}
+          onClickOutside={handleClose}
+        />
+      )}
+
+      {openSettingsType === 'wmsStyles' && (
+        <WmsStyleSelector
           layerDetails={layerDetails}
           anchorEl={settingsAnchorEl}
           onClose={() => {

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/raster-function-selector.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/raster-function-selector.tsx
@@ -52,7 +52,7 @@ function RasterFunctionMenuItem({ info, isSelected, previewPromise, onSelect }: 
   const renderIcon = (): JSX.Element => {
     if (loading) {
       return (
-        <Box sx={sxClasses.previewImageContainer}>
+        <Box sx={sxClasses.rasterFunctionPreviewImageContainer}>
           <CircularProgress
             isLoaded={false}
             size={24}
@@ -70,22 +70,22 @@ function RasterFunctionMenuItem({ info, isSelected, previewPromise, onSelect }: 
     }
     if (previewSrc) {
       return (
-        <Box sx={sxClasses.previewImageContainer}>
-          <Box component="img" src={previewSrc} alt={info.name} sx={sxClasses.previewImage} />
+        <Box sx={sxClasses.rasterFunctionPreviewImageContainer}>
+          <Box component="img" src={previewSrc} alt={info.name} sx={sxClasses.rasterFunctionPreviewImage} />
         </Box>
       );
     }
     return (
-      <Box sx={sxClasses.previewImageContainer}>
-        <ImageNotSupportedIcon sx={sxClasses.previewIcon} />
+      <Box sx={sxClasses.rasterFunctionPreviewImageContainer}>
+        <ImageNotSupportedIcon sx={sxClasses.settingSelectorPreviewIcon} />
       </Box>
     );
   };
 
   return (
-    <MenuItem onClick={() => onSelect(info.name)} selected={isSelected} sx={sxClasses.rasterFunctionMenuItem}>
+    <MenuItem onClick={() => onSelect(info.name)} selected={isSelected} sx={sxClasses.settingSelectorMenuItem}>
       <ListItemIcon>{renderIcon()}</ListItemIcon>
-      <ListItemText primary={info.name} secondary={info.description} sx={sxClasses.rasterFunctionListItemText} />
+      <ListItemText primary={info.name} secondary={info.description} sx={sxClasses.settingSelectorListItemText} />
     </MenuItem>
   );
 }
@@ -170,7 +170,7 @@ export function RasterFunctionSelector(props: RasterFunctionSelectorProps): JSX.
       disableScrollLock
       anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
       transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-      sx={sxClasses.rasterFunctionMenu}
+      sx={sxClasses.settingSelectorMenu}
       slotProps={{
         list: {
           autoFocus: true,

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/wms-style-selector.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/wms-style-selector.tsx
@@ -52,7 +52,7 @@ function WmsStyleMenuItem({ style, isSelected, onSelect }: WmsStyleMenuItemProps
   const renderIcon = (): JSX.Element => {
     if (loading) {
       return (
-        <Box sx={sxClasses.previewImageContainer}>
+        <Box sx={sxClasses.wmsStylePreviewImageContainer}>
           <CircularProgress
             isLoaded={false}
             size={24}
@@ -77,7 +77,7 @@ function WmsStyleMenuItem({ style, isSelected, onSelect }: WmsStyleMenuItemProps
     }
     return (
       <Box sx={sxClasses.wmsStylePreviewImageContainer}>
-        <ImageNotSupportedIcon sx={sxClasses.wmsStylePreviewIcon} />
+        <ImageNotSupportedIcon sx={sxClasses.settingSelectorPreviewIcon} />
       </Box>
     );
   };
@@ -85,7 +85,7 @@ function WmsStyleMenuItem({ style, isSelected, onSelect }: WmsStyleMenuItemProps
   return (
     <MenuItem onClick={() => onSelect(style.Name)} selected={isSelected} sx={sxClasses.wmsStyleMenuItem}>
       <ListItemIcon>{renderIcon()}</ListItemIcon>
-      <ListItemText primary={style.Name} sx={sxClasses.wmsStyleListItemText} />
+      <ListItemText primary={style.Name} sx={sxClasses.settingSelectorListItemText} />
     </MenuItem>
   );
 }
@@ -161,7 +161,7 @@ export function WmsStyleSelector(props: WmsStyleSelectorProps): JSX.Element {
       disableScrollLock
       anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
       transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-      sx={sxClasses.wmsStyleMenu}
+      sx={sxClasses.settingSelectorMenu}
       slotProps={{
         list: {
           autoFocus: true,

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/wms-style-selector.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/wms-style-selector.tsx
@@ -1,0 +1,177 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useTheme } from '@mui/material/styles';
+import { Menu, MenuItem, ListItemIcon, ListItemText, Box, CircularProgress } from '@/ui';
+import { ImageNotSupportedIcon } from '@/ui';
+import { getSxClasses } from './layer-settings-style';
+import { useLayerStoreActions, useLayerSelectorWmsStyle } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import type { TypeLegendLayer } from '@/core/components/layers/types';
+import type { TypeMetadataWMSCapabilityLayerStyle } from '@/api/types/layer-schema-types';
+import { logger } from '@/core/utils/logger';
+
+interface WmsStyleSelectorProps {
+  layerDetails: TypeLegendLayer;
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  onClickOutside: (event: {}, reason?: 'backdropClick' | 'escapeKeyDown') => void;
+}
+
+interface WmsStyleMenuItemProps {
+  style: TypeMetadataWMSCapabilityLayerStyle;
+  isSelected: boolean;
+  onSelect: (name: string) => void;
+}
+
+function WmsStyleMenuItem({ style, isSelected, onSelect }: WmsStyleMenuItemProps): JSX.Element {
+  // Log
+  logger.logTraceRender('components/layers/right-panel/layer-settings/wms-style-selector > WmsStyleMenuItem');
+
+  // Hooks
+  const theme = useTheme();
+  const sxClasses = getSxClasses(theme);
+
+  // State
+  const [legendSrc, setLegendSrc] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // Log
+    logger.logTraceUseEffect(`WMS STYLE MENU ITEM - legend image - ${style.Name}`, style.LegendURL);
+
+    // Get the first legend URL if available
+    const legendUrl = style.LegendURL?.[0]?.OnlineResource?.['@attributes']?.['xlink:href'];
+
+    if (legendUrl) {
+      setLegendSrc(legendUrl);
+      setLoading(false);
+    } else {
+      setLegendSrc(null);
+      setLoading(false);
+    }
+  }, [style]);
+
+  const renderIcon = (): JSX.Element => {
+    if (loading) {
+      return (
+        <Box sx={sxClasses.previewImageContainer}>
+          <CircularProgress
+            isLoaded={false}
+            size={24}
+            sx={{
+              position: 'relative',
+              backgroundColor: 'transparent',
+            }}
+            sxCircular={{
+              width: '40px !important',
+              height: '40px !important',
+            }}
+          />
+        </Box>
+      );
+    }
+    if (legendSrc) {
+      return (
+        <Box sx={sxClasses.wmsStylePreviewImageContainer}>
+          <Box component="img" src={legendSrc} alt={style.Name} sx={sxClasses.wmsStylePreviewImage} />
+        </Box>
+      );
+    }
+    return (
+      <Box sx={sxClasses.wmsStylePreviewImageContainer}>
+        <ImageNotSupportedIcon sx={sxClasses.wmsStylePreviewIcon} />
+      </Box>
+    );
+  };
+
+  return (
+    <MenuItem onClick={() => onSelect(style.Name)} selected={isSelected} sx={sxClasses.wmsStyleMenuItem}>
+      <ListItemIcon>{renderIcon()}</ListItemIcon>
+      <ListItemText primary={style.Name} sx={sxClasses.wmsStyleListItemText} />
+    </MenuItem>
+  );
+}
+
+export function WmsStyleSelector(props: WmsStyleSelectorProps): JSX.Element {
+  // Log
+  logger.logTraceRender('components/layers/right-panel/layer-settings/wms-style-selector > WmsStyleSelector');
+
+  const { layerDetails, anchorEl, onClose, onClickOutside } = props;
+
+  // Hooks
+  const theme = useTheme();
+  const sxClasses = getSxClasses(theme);
+
+  // Store actions
+  const { setLayerWmsStyle, getLayerWmsAvailableStyles } = useLayerStoreActions();
+
+  // Store hooks
+  const currentWmsStyle = useLayerSelectorWmsStyle(layerDetails.layerPath);
+
+  // Get the full style metadata
+  const wmsStyleArray = useMemo(
+    () => getLayerWmsAvailableStyles(layerDetails.layerPath) || [],
+    [getLayerWmsAvailableStyles, layerDetails.layerPath]
+  );
+
+  const handleSelect = (wmsStyleName: string): void => {
+    setLayerWmsStyle(layerDetails.layerPath, wmsStyleName);
+  };
+
+  const handleClose = (event: {}, reason: 'backdropClick' | 'escapeKeyDown'): void => {
+    if (reason === 'backdropClick' && onClickOutside) {
+      // Clicking outside should close both menus
+      onClickOutside(event, reason);
+    } else if (reason === 'escapeKeyDown') {
+      // Escape should only close submenu
+      onClose();
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent): void => {
+    if (event.key === 'Tab') {
+      event.preventDefault();
+
+      // Get all menu items
+      const menuItems = event.currentTarget.querySelectorAll('[role="menuitem"]');
+      const currentIndex = Array.from(menuItems).findIndex((item) => item === document.activeElement);
+
+      let nextIndex;
+      if (currentIndex === -1) {
+        // No item focused, focus first item
+        nextIndex = 0;
+      } else if (event.shiftKey) {
+        // Shift+Tab: move up
+        nextIndex = currentIndex > 0 ? currentIndex - 1 : menuItems.length - 1;
+      } else {
+        // Tab: move down
+        nextIndex = currentIndex < menuItems.length - 1 ? currentIndex + 1 : 0;
+      }
+
+      (menuItems[nextIndex] as HTMLElement)?.focus();
+    } else if (event.key === 'Escape') {
+      onClose();
+    }
+  };
+
+  return (
+    <Menu
+      anchorEl={anchorEl}
+      open={Boolean(anchorEl)}
+      onClose={handleClose}
+      onKeyDown={handleKeyDown}
+      disableScrollLock
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      sx={sxClasses.wmsStyleMenu}
+      slotProps={{
+        list: {
+          autoFocus: true,
+          autoFocusItem: true,
+        },
+      }}
+    >
+      {wmsStyleArray.map((style) => (
+        <WmsStyleMenuItem key={style.Name} style={style} isSelected={currentWmsStyle === style.Name} onSelect={handleSelect} />
+      ))}
+    </Menu>
+  );
+}

--- a/packages/geoview-core/src/core/components/layers/types.ts
+++ b/packages/geoview-core/src/core/components/layers/types.ts
@@ -60,6 +60,7 @@ export interface TypeLegendLayer {
 
   rasterFunction?: string; // Active raster function for ESRI Image layers
   mosaicRule?: TypeMosaicRule; // Active mosaic rule for ESRI Image layers
+  wmsStyle?: string; // Active style for WMS layers
   opacity?: number;
   opacityMaxFromParent?: number;
   zoom?: number;

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -194,8 +194,9 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Gets the raster function info options of the layer.
-       * @param {string} layerPath - The layer path of the layer to get the options
-       * @returns {TypeMetadataEsriRasterFunctionInfos[] | undefined} The rasterFunctionInfos list of undefined
+       *
+       * @param layerPath - The layer path of the layer to get the options
+       * @returns The rasterFunctionInfos list or undefined
        */
       getLayerRasterFunctionInfos: (layerPath: string): TypeMetadataEsriRasterFunctionInfos[] | undefined => {
         try {
@@ -208,8 +209,9 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Gets the active raster function for a layer.
-       * @param {string} layerPath - The layer path.
-       * @returns {string | undefined} The active raster function identifier.
+       *
+       * @param layerPath - The layer path.
+       * @returns The active raster function identifier or undefined.
        */
       getLayerRasterFunction: (layerPath: string): string | undefined => {
         return LegendEventProcessor.getLayerRasterFunction(get().mapId, layerPath);
@@ -217,8 +219,9 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Fetches raster function previews for a layer.
-       * @param {string} layerPath - The layer path.
-       * @returns {Map<string, Promise<string>>} Map of raster function names to preview URLs.
+       *
+       * @param layerPath - The layer path.
+       * @returns Map of raster function names to Promises of preview URLs.
        */
       getLayerRasterFunctionPreviews: (layerPath: string): Map<string, Promise<string>> => {
         return LegendEventProcessor.getLayerRasterFunctionPreviews(get().mapId, layerPath);
@@ -226,6 +229,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Gets the allowed mosaic methods for a layer.
+       *
        * @param layerPath - The layer path.
        * @returns The allowed mosaic methods or undefined.
        */
@@ -235,6 +239,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Gets the available WMS styles for a layer.
+       *
        * @param layerPath - The layer path.
        * @returns The available WMS styles or undefined.
        */
@@ -244,6 +249,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Gets the available WMS styles for a layer.
+       *
        * @param layerPath - The layer path.
        * @returns The available WMS styles or undefined.
        */
@@ -253,8 +259,9 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Gets the available settings for a layer.
-       * @param {string} layerPath - The layer path.
-       * @returns {string[]} Array of available setting types.
+       *
+       * @param layerPath - The layer path.
+       * @returns Array of available setting types.
        */
       getLayerSettings: (layerPath: string): string[] => {
         return LegendEventProcessor.getLayerSettings(get().mapId, layerPath);
@@ -312,6 +319,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
        * Sets the visibility of all legend items in a layer.
        * This method updates the visibility of every item in the specified layer
        * asynchronously. Errors during the update are caught and logged.
+       *
        * @param {string} layerPath - The path identifying the target layer within the map.
        * @param {boolean} visibility - Whether all items in the layer should be visible.
        * @returns {void} This function does not return a value; errors are logged.
@@ -329,6 +337,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
        * This method updates the visibility of every item in the specified layer and
        * returns a promise that resolves once all changes have been applied and the
        * layer has optionally finished rendering.
+       *
        * @param {string} layerPath - The path identifying the target layer within the map.
        * @param {boolean} visibility - Whether all items in the layer should be visible.
        * @returns {Promise<void>} A promise that resolves once the visibility changes
@@ -390,8 +399,9 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Sets the active raster function for a layer.
-       * @param {string} layerPath - The layer path.
-       * @param {string | undefined} rasterFunctionId - The raster function identifier.
+       *
+       * @param layerPath - The layer path.
+       * @param rasterFunctionId - The raster function identifier.
        */
       setLayerRasterFunction: (layerPath: string, rasterFunctionId: string | undefined): void => {
         LegendEventProcessor.setLayerRasterFunction(get().mapId, layerPath, rasterFunctionId);
@@ -399,6 +409,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Sets the mosaic rule for a layer.
+       *
        * @param layerPath - The layer path.
        * @param mosaicRule The new mosaicRule object or undefined to clear the mosaic rule.
        */
@@ -408,6 +419,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Sets the ascending property of the mosaic rule for a layer.
+       *
        * @param layerPath - The layer path.
        * @param value - The new value for the ascending property.
        */
@@ -417,6 +429,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Sets the mosaic method property of the mosaic rule for a layer.
+       *
        * @param layerPath - The layer path.
        * @param value - The new value for the mosaic method property.
        */
@@ -426,6 +439,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Sets the mosaic operation property of the mosaic rule for a layer.
+       *
        * @param layerPath - The layer path.
        * @param value - The new value for the mosaic operation property.
        */
@@ -435,6 +449,7 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
 
       /**
        * Sets the WMS style for a layer.
+       *
        * @param layerPath - The layer path.
        * @param wmsStyleName - The name of the WMS style to set.
        */

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -12,6 +12,7 @@ import type {
   TypeGeoviewLayerType,
   TypeLayerStatus,
   TypeMetadataEsriRasterFunctionInfos,
+  TypeMetadataWMSCapabilityLayerStyle,
   TypeMosaicMethod,
   TypeMosaicOperation,
   TypeMosaicRule,
@@ -48,6 +49,8 @@ export interface ILayerState {
     getLayerRasterFunction: (layerPath: string) => string | undefined;
     getLayerRasterFunctionPreviews: (layerPath: string) => Map<string, Promise<string>>;
     getLayerAllowedMosaicMethods: (layerPath: string) => TypeMosaicMethod[] | undefined;
+    getLayerWmsStyle: (layerPath: string) => string | undefined;
+    getLayerWmsAvailableStyles: (layerPath: string) => TypeMetadataWMSCapabilityLayerStyle[] | undefined;
     getLayerSettings: (layerPath: string) => string[];
     refreshLayer: (layerPath: string) => Promise<void>;
     reloadLayer: (layerPath: string) => void;
@@ -65,6 +68,7 @@ export interface ILayerState {
     setLayerMosaicRuleAscending: (layerPath: string, value: boolean) => void;
     setLayerMosaicRuleMethod: (layerPath: string, value: TypeMosaicMethod) => void;
     setLayerMosaicRuleOperation: (layerPath: string, value: TypeMosaicOperation) => void;
+    setLayerWmsStyle: (layerPath: string, wmsStyleName: string) => void;
     setSelectedLayerPath: (layerPath: string | undefined) => void;
     zoomToLayerExtent: (layerPath: string) => Promise<void>;
     zoomToLayerVisibleScale: (layerPath: string) => void;
@@ -220,8 +224,31 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
         return LegendEventProcessor.getLayerRasterFunctionPreviews(get().mapId, layerPath);
       },
 
+      /**
+       * Gets the allowed mosaic methods for a layer.
+       * @param layerPath - The layer path.
+       * @returns The allowed mosaic methods or undefined.
+       */
       getLayerAllowedMosaicMethods: (layerPath: string): TypeMosaicMethod[] | undefined => {
         return LegendEventProcessor.getLayerAllowedMosaicMethods(get().mapId, layerPath);
+      },
+
+      /**
+       * Gets the available WMS styles for a layer.
+       * @param layerPath - The layer path.
+       * @returns The available WMS styles or undefined.
+       */
+      getLayerWmsStyle: (layerPath: string): string | undefined => {
+        return LegendEventProcessor.getLayerWmsStyle(get().mapId, layerPath);
+      },
+
+      /**
+       * Gets the available WMS styles for a layer.
+       * @param layerPath - The layer path.
+       * @returns The available WMS styles or undefined.
+       */
+      getLayerWmsAvailableStyles: (layerPath: string): TypeMetadataWMSCapabilityLayerStyle[] | undefined => {
+        return LegendEventProcessor.getLayerWmsStyles(get().mapId, layerPath);
       },
 
       /**
@@ -404,6 +431,11 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
        */
       setLayerMosaicRuleOperation: (layerPath: string, value: TypeMosaicOperation): void => {
         LegendEventProcessor.setLayerMosaicRuleProperty(get().mapId, layerPath, { mosaicOperation: value });
+      },
+
+      setLayerWmsStyle: (layerPath: string, wmsStyleName: string): void => {
+        // Redirect to processor
+        LegendEventProcessor.setLayerWmsStyle(get().mapId, layerPath, wmsStyleName);
       },
 
       /**
@@ -851,6 +883,7 @@ export const useLayerSelectorCanToggle = createLayerSelectorHook('canToggle');
 export const useLayerSelectorStyleConfig = createLayerSelectorHook('styleConfig');
 export const useLayerSelectorRasterFunction = createLayerSelectorHook('rasterFunction');
 export const useLayerSelectorMosaicRule = createLayerSelectorHook('mosaicRule');
+export const useLayerSelectorWmsStyle = createLayerSelectorHook('wmsStyle');
 
 // Store Actions
 export const useLayerStoreActions = (): LayerActions => useStore(useGeoViewStore(), (state) => state.layerState.actions);

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -433,6 +433,11 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
         LegendEventProcessor.setLayerMosaicRuleProperty(get().mapId, layerPath, { mosaicOperation: value });
       },
 
+      /**
+       * Sets the WMS style for a layer.
+       * @param layerPath - The layer path.
+       * @param wmsStyleName - The name of the WMS style to set.
+       */
       setLayerWmsStyle: (layerPath: string, wmsStyleName: string): void => {
         // Redirect to processor
         LegendEventProcessor.setLayerWmsStyle(get().mapId, layerPath, wmsStyleName);

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -67,6 +67,9 @@ export class GVWMS extends AbstractGVRaster {
   /** Indicates if the CRS is to be overridden, because the layer struggles loading on the map */
   #overrideCRS?: CRSOverride;
 
+  /** The currently active WMS style identifier */
+  #wmsStyle?: string;
+
   /**
    * Constructs a GVWMS layer to manage an OpenLayer layer.
    *
@@ -378,7 +381,7 @@ export class GVWMS extends AbstractGVRaster {
     try {
       // Get the layer config in a loaded phase
       const layerConfig = this.getLayerConfig();
-      const legendImage = await GVWMS.#getLegendImage(layerConfig);
+      const legendImage = await GVWMS.#getLegendImage(layerConfig, this.#wmsStyle);
 
       if (legendImage) {
         const image = await GeoviewRenderer.loadImage(legendImage as string);
@@ -606,7 +609,9 @@ export class GVWMS extends AbstractGVRaster {
    * @param {string} wmsStyleId - The style identifier to be used.
    */
   setWmsStyle(wmsStyleId: string): void {
-    // TODO: STYLES - Verify if we can apply more than one style at the same time since the parameter name is STYLES
+    // Update the current style
+    this.#wmsStyle = wmsStyleId;
+
     this.getOLSource()?.updateParams({ STYLES: wmsStyleId });
   }
 

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -1599,6 +1599,11 @@ export class LayerApi {
     this.legendsLayerSet.queryLegend(layerPath, true);
   }
 
+  /**
+   * Sets the WMS style for a WMS layer.
+   * @param layerPath - The layer path
+   * @param wmsStyle - The WMS style to apply
+   */
   setLayerWmsStyle(layerPath: string, wmsStyle: string): void {
     const layer = this.getGeoviewLayer(layerPath);
     if (!(layer instanceof GVWMS)) return;

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -1558,8 +1558,9 @@ export class LayerApi {
 
   /**
    * Updates the raster function for an ESRI Image layer.
-   * @param {string} layerPath - The path of the layer.
-   * @param {string | undefined} rasterFunctionId - The raster function ID to apply.
+   *
+   * @param layerPath - The path of the layer.
+   * @param rasterFunctionId - The raster function ID to apply or undefined to remove it.
    * @throws {LayerNotFoundError} When the layer couldn't be found at the given layer path.
    * @throws {LayerWrongTypeError} When the layer is not an ESRI Image layer.
    */
@@ -1574,6 +1575,7 @@ export class LayerApi {
     layer.setRasterFunction(rasterFunctionId);
 
     // Update the store
+    //TODO: REFACTOR - The store update should happen through a store adaptor via a setRasterFunctionChanged event raised by the layer
     LegendEventProcessor.setLayerRasterFunctionInStore(this.getMapId(), layerPath, rasterFunctionId);
 
     // Trigger legend re-query through the layer set system (forced refresh)
@@ -1582,8 +1584,9 @@ export class LayerApi {
 
   /**
    * Sets the mosaic rule for an ESRI Image layer.
-   * @param {string} layerPath - The layer path
-   * @param {TypeMosaicRule | undefined} mosaicRule - The mosaic rule to apply
+   *
+   * @param layerPath - The layer path
+   * @param mosaicRule - The mosaic rule to apply or undefined to remove it
    */
   setLayerMosaicRule(layerPath: string, mosaicRule: TypeMosaicRule | undefined): void {
     const layer = this.getGeoviewLayer(layerPath);
@@ -1593,6 +1596,7 @@ export class LayerApi {
     layer.setMosaicRule(mosaicRule);
 
     // Update the store
+    //TODO: REFACTOR - The store update should happen through a store adaptor via a setMosaicRuleChanged event raised by the layer
     LegendEventProcessor.setLayerMosaicRuleInStore(this.getMapId(), layerPath, mosaicRule);
 
     // Trigger legend re-query through the layer set system
@@ -1601,6 +1605,7 @@ export class LayerApi {
 
   /**
    * Sets the WMS style for a WMS layer.
+   *
    * @param layerPath - The layer path
    * @param wmsStyle - The WMS style to apply
    */
@@ -1612,6 +1617,7 @@ export class LayerApi {
     layer.setWmsStyle(wmsStyle);
 
     // Update the store
+    //TODO: REFACTOR - The store update should happen through a store adaptor via a setWmsStyleChanged event raised by the layer
     LegendEventProcessor.setLayerWmsStyleInStore(this.getMapId(), layerPath, wmsStyle);
 
     // Trigger legend re-query through the layer set system

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -1599,6 +1599,20 @@ export class LayerApi {
     this.legendsLayerSet.queryLegend(layerPath, true);
   }
 
+  setLayerWmsStyle(layerPath: string, wmsStyle: string): void {
+    const layer = this.getGeoviewLayer(layerPath);
+    if (!(layer instanceof GVWMS)) return;
+
+    // Update the WMS style
+    layer.setWmsStyle(wmsStyle);
+
+    // Update the store
+    LegendEventProcessor.setLayerWmsStyleInStore(this.getMapId(), layerPath, wmsStyle);
+
+    // Trigger legend re-query through the layer set system
+    this.legendsLayerSet.queryLegend(layerPath, true);
+  }
+
   /**
    * Changes a GeoJson Source of a GeoJSON layer at the given layer path.
    * @param {string} layerPath - The path of the layer.


### PR DESCRIPTION
# Description

Adds a setting for WMS layers with multiple styles for users to be able to select from the list of styles.

Fixes #3160 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
### Host Updated 2026-03-13 @ 10:45AM

On the WMS navigator page, the following layers have multiple styles that can be selected from:
Ice Cover
Test Spatiotemporel
BC Kelowna Wells

[__WMS Navigator Page__](https://matthewmuehlhausernrcan.github.io/geoview/layers-navigator.html?config=./configs/navigator/layers/wms.json)

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3346)
<!-- Reviewable:end -->
