### PR TITLE
feat(data-table): Filter the data table to the map extent

### DIFF
--- a/packages/geoview-core/public/configs/navigator/layers/esri-feature.json
+++ b/packages/geoview-core/public/configs/navigator/layers/esri-feature.json
@@ -280,7 +280,7 @@
   "overviewMap": { "hideOnZoom": 7 },
   "footerBar": {
     "tabs": {
-      "core": ["layers", "data-table"]
+      "core": ["layers", "data-table", "time-slider"]
     }
   },
   "corePackages": [],

--- a/packages/geoview-core/public/configs/navigator/layers/esri-feature.json
+++ b/packages/geoview-core/public/configs/navigator/layers/esri-feature.json
@@ -280,7 +280,7 @@
   "overviewMap": { "hideOnZoom": 7 },
   "footerBar": {
     "tabs": {
-      "core": ["layers", "data-table", "time-slider"]
+      "core": ["layers", "data-table"]
     }
   },
   "corePackages": [],

--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -455,7 +455,8 @@
     "filterToggle": "filters",
     "searchInputLabel": "Search data table columns",
     "tableControls": "Data table controls",
-    "tableAriaLabelWithLayer": "{{layerName}} data table"
+    "tableAriaLabelWithLayer": "{{layerName}} data table",
+    "filterDataToExtent": "Filter to extent"
   },
   "geoChart": {
     "noChartAvailable": "Click on the map on a layer with chart"

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -455,7 +455,8 @@
     "filterToggle": "les filtres",
     "searchInputLabel": "Rechercher dans les colonnes du tableau",
     "tableControls": "Contrôles du tableau de données",
-    "tableAriaLabelWithLayer": "Tableau de données {{layerName}}"
+    "tableAriaLabelWithLayer": "Tableau de données {{layerName}}",
+    "filterDataToExtent": "Filtrer dans l'étendue"
   },
   "geochart": {
     "noChartAvailable": "Cliquer sur une couche de la carte qui contient un graphique"

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -86,6 +86,33 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
   }, [mappedLayerData, visibleInRangeLayers, layerHiddenSet]);
 
   /**
+   * Applies filtering to the ordered layer data features.
+   */
+  const memoFilteredOrderedLayerData = useMemo(() => {
+    return memoOrderedLayerData.map((layer) => {
+      let { features } = layer;
+
+      // Apply extent filtering if enabled for the selected layer
+      if (features && getStoreDataTableFilterDataToExtent(mapId, layer.layerPath) && mapExtent) {
+        features = features.filter((feature) => {
+          const { geometry } = feature;
+          return geometry?.intersectsExtent(mapExtent);
+        });
+      }
+
+      // Apply unsymbolized feature filtering if configured
+      if (features && !showUnsymbolizedFeatures) {
+        features = features.filter((feature) => feature.featureIcon);
+      }
+
+      return {
+        ...layer,
+        features,
+      };
+    });
+  }, [memoOrderedLayerData, mapId, mapExtent, showUnsymbolizedFeatures]);
+
+  /**
    * Handles layer selection change from the layer list.
    */
   const handleLayerChange = useCallback(

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -8,7 +8,6 @@ import {
   useStoreDataTableSelectedLayerPath,
   useStoreDataTableAllFeaturesDataArray,
   useStoreDataTableLayerSettings,
-  getStoreDataTableFilterDataToExtent,
   setStoreSelectedLayerPath,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { useStoreAppShowUnsymbolizedFeatures } from '@/core/stores/store-interface-and-intial-values/app-state';
@@ -93,7 +92,7 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
       let { features } = layer;
 
       // Apply extent filtering if enabled for the selected layer
-      if (features && getStoreDataTableFilterDataToExtent(mapId, layer.layerPath) && mapExtent) {
+      if (features && datatableSettings[layer.layerPath]?.filterDataToExtent && mapExtent) {
         features = features.filter((feature) => {
           const { geometry } = feature;
           return geometry?.intersectsExtent(mapExtent);
@@ -110,7 +109,7 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
         features,
       };
     });
-  }, [memoOrderedLayerData, mapId, mapExtent, showUnsymbolizedFeatures]);
+  }, [memoOrderedLayerData, mapExtent, showUnsymbolizedFeatures, datatableSettings]);
 
   /**
    * Handles layer selection change from the layer list.

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -8,12 +8,14 @@ import {
   useStoreDataTableSelectedLayerPath,
   useStoreDataTableAllFeaturesDataArray,
   useStoreDataTableLayerSettings,
+  getStoreDataTableFilterDataToExtent,
   setStoreSelectedLayerPath,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { useStoreAppShowUnsymbolizedFeatures } from '@/core/stores/store-interface-and-intial-values/app-state';
 import {
   useStoreMapAllVisibleandInRangeLayers,
   useStoreMapIsLayerHiddenOnMapSet,
+  useStoreMapExtent,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { useStoreLayerNameSet, useStoreLayerStatusSet } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import {
@@ -56,6 +58,7 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
   const isFirstLoad = useRef<Record<string, boolean>>({});
 
   const mapId = useStoreGeoViewMapId();
+  const mapExtent = useStoreMapExtent();
   const uiController = useUIController();
   const layerSetController = useLayerSetController();
   const layerData = useStoreDataTableAllFeaturesDataArray();
@@ -119,19 +122,14 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
       }
 
       let featureStr = t('dataTable.noFeatures');
-      let features = memoOrderedLayerData?.find((layer) => layer.layerPath === layerPath)?.features;
-
-      // Filter unsymbolized features if configured
-      if (!showUnsymbolizedFeatures) {
-        features = features?.filter((feature) => feature.featureIcon);
-      }
+      const features = memoFilteredOrderedLayerData?.find((layer) => layer.layerPath === layerPath)?.features;
 
       if (features !== undefined) {
         featureStr = `${features?.length} ${t('dataTable.features')}`;
       }
       return featureStr;
     },
-    [datatableSettings, memoOrderedLayerData, showUnsymbolizedFeatures, t]
+    [datatableSettings, memoFilteredOrderedLayerData, t]
   );
 
   /**
@@ -285,13 +283,24 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
     if (!memoIsLayerDisabled() && memoIsSelectedLayerHasFeatures()) {
       return (
         <>
-          {memoOrderedLayerData
+          {memoFilteredOrderedLayerData
             .filter((data) => data.layerPath === selectedLayerPath)
-            .map((data: MappedLayerDataType) => (
-              <Box key={data.layerPath} ref={dataTableRef} className="data-table-panel" sx={{ height: '100%' }}>
-                <DataTable data={data} layerPath={data.layerPath} containerType={containerType} />
-              </Box>
-            ))}
+            .map((data: MappedLayerDataType) => {
+              // Get unfiltered count from orderedLayerData
+              const unfilteredLayer = memoOrderedLayerData.find((layer) => layer.layerPath === selectedLayerPath);
+              const unfilteredFeaturesCount = unfilteredLayer?.features?.length ?? 0;
+
+              return (
+                <Box key={data.layerPath} ref={dataTableRef} className="data-table-panel" sx={{ height: '100%' }}>
+                  <DataTable
+                    data={data}
+                    layerPath={data.layerPath}
+                    containerType={containerType}
+                    unfilteredFeaturesCount={unfilteredFeaturesCount}
+                  />
+                </Box>
+              );
+            })}
         </>
       );
     }

--- a/packages/geoview-core/src/core/components/data-table/data-table-types.ts
+++ b/packages/geoview-core/src/core/components/data-table/data-table-types.ts
@@ -19,4 +19,5 @@ export interface DataTableProps {
   data: MappedLayerDataType;
   layerPath: string;
   containerType: TypeContainerBox;
+  unfilteredFeaturesCount: number;
 }

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -95,7 +95,7 @@ const STRING_FIELD_FILTERS = ['contains', 'startsWith', 'endsWith'];
  * @returns The data table element
  */
 
-function DataTable({ data, layerPath, containerType }: DataTableProps): JSX.Element {
+function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: DataTableProps): JSX.Element {
   // Log
   logger.logTraceRender('components/data-table/data-table');
 
@@ -516,15 +516,10 @@ function DataTable({ data, layerPath, containerType }: DataTableProps): JSX.Elem
     const layerFilterEquation = GeoviewRenderer.createFilterNodeFromFilter(layerFilterClassAndTime);
 
     // Filter each features
-    let filterArray =
+    const filterArray =
       data?.features?.filter((f) => {
         return f.feature && GeoviewRenderer.featureRespectsFilterEquation(f.feature, layerFilterEquation);
       }) ?? [];
-
-    // Filter out unsymbolized features if the showUnsymbolizedFeatures config is false
-    if (!showUnsymbolizedFeatures) {
-      filterArray = filterArray.filter((record) => record.featureIcon);
-    }
 
     return (filterArray ?? []).map((feature, featureIndex) => {
       // Create unique button ID per feature
@@ -928,7 +923,15 @@ function DataTable({ data, layerPath, containerType }: DataTableProps): JSX.Elem
   }, [globalFilter]);
 
   // set toolbar custom action message in store.
-  useToolbarActionMessage({ data, columnFilters, globalFilter, layerPath, tableInstance: useTable, showUnsymbolizedFeatures });
+  useToolbarActionMessage({
+    data,
+    columnFilters,
+    globalFilter,
+    layerPath,
+    tableInstance: useTable,
+    showUnsymbolizedFeatures,
+    unfilteredFeaturesCount,
+  });
 
   return (
     <Box ref={dataTableWrapperRef} sx={sxClasses.dataTableWrapper} className="data-table-wrapper">

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -921,17 +921,6 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
     prevGlobalFilterRef.current = globalFilter ?? '';
   }, [globalFilter]);
 
-  // set toolbar custom action message in store.
-  // useToolbarActionMessage({
-  //   data,
-  //   columnFilters,
-  //   globalFilter,
-  //   layerPath,
-  //   tableInstance: useTable,
-  //   showUnsymbolizedFeatures,
-  //   unfilteredFeaturesCount,
-  // });
-
   return (
     <Box ref={dataTableWrapperRef} sx={sxClasses.dataTableWrapper} className="data-table-wrapper">
       <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={language}>

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -50,14 +50,14 @@ import {
   setStoreSelectedFeature,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { useStoreTimeSliderFilter } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
-import { useStoreAppDisplayLanguage, useStoreAppShowUnsymbolizedFeatures } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { DateMgt } from '@/core/utils/date-mgt';
 import linkifyHtml from 'linkify-html';
 import { isImage, delay, sanitizeHtmlContent, enhanceLinksAccessibility } from '@/core/utils/utilities';
 import { debounce } from '@/core/utils/debounce';
 import { logger } from '@/core/utils/logger';
 import type { TypeFeatureInfoEntry } from '@/api/types/map-schema-types';
-import { useFilterRows, useToolbarActionMessage, useGlobalFilter } from './hooks';
+import { useFilterRows, useGlobalFilter } from './hooks';
 import { getSxClasses } from './data-table-style';
 import { useLightBox } from '@/core/components/common';
 import { NUMBER_FILTER, DATE_FILTER, STRING_FILTER } from '@/core/utils/constant';
@@ -108,7 +108,6 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
   const mapId = useStoreGeoViewMapId();
   const language = useStoreAppDisplayLanguage();
   const datatableSettings = useStoreDataTableLayerSettings();
-  const showUnsymbolizedFeatures = useStoreAppShowUnsymbolizedFeatures();
   const layerClassFilter = useStoreLayerFilterClass(layerPath);
   const layerTimeFilter = useStoreTimeSliderFilter(layerPath);
   const layerDateTemporalMode = useStoreLayerDateTemporalMode(layerPath);
@@ -630,17 +629,17 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
       (props: { table: MRTTableInstance<ColumnsType> }): ReactNode => (
         <TopToolbar
           sxClasses={sxClasses}
-          datatableSettings={datatableSettings}
           layerPath={layerPath}
           t={t}
           globalFilter={globalFilter}
-          useTable={useTable}
+          useTable={props.table}
           columns={memoColumns}
           data={data}
           table={props.table}
+          unfilteredFeaturesCount={unfilteredFeaturesCount}
         />
       ),
-      [datatableSettings, layerPath, globalFilter, memoColumns, data, sxClasses, t, useTable] // Include dependencies
+      [sxClasses, layerPath, t, globalFilter, memoColumns, data, unfilteredFeaturesCount] // Include dependencies
     ),
     enableFilterMatchHighlighting: true,
     enableColumnResizing: true,
@@ -923,15 +922,15 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
   }, [globalFilter]);
 
   // set toolbar custom action message in store.
-  useToolbarActionMessage({
-    data,
-    columnFilters,
-    globalFilter,
-    layerPath,
-    tableInstance: useTable,
-    showUnsymbolizedFeatures,
-    unfilteredFeaturesCount,
-  });
+  // useToolbarActionMessage({
+  //   data,
+  //   columnFilters,
+  //   globalFilter,
+  //   layerPath,
+  //   tableInstance: useTable,
+  //   showUnsymbolizedFeatures,
+  //   unfilteredFeaturesCount,
+  // });
 
   return (
     <Box ref={dataTableWrapperRef} sx={sxClasses.dataTableWrapper} className="data-table-wrapper">

--- a/packages/geoview-core/src/core/components/data-table/filter-data-extent.tsx
+++ b/packages/geoview-core/src/core/components/data-table/filter-data-extent.tsx
@@ -3,8 +3,11 @@ import { useTheme } from '@mui/material/styles';
 
 import { getSxClasses } from './data-table-style';
 import { Switch } from '@/ui';
-import { useDataTableLayerSettings, setStoreFilterDataToExtent } from '@/core/stores/store-interface-and-intial-values/data-table-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import {
+  useStoreDataTableLayerSettings,
+  setStoreFilterDataToExtent,
+} from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 
 import { logger } from '@/core/utils/logger';
 
@@ -28,8 +31,8 @@ function FilterDataToExtent(props: FilterDataToExtentProps): JSX.Element {
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
 
-  const mapId = useGeoViewMapId();
-  const datatableSettings = useDataTableLayerSettings();
+  const mapId = useStoreGeoViewMapId();
+  const datatableSettings = useStoreDataTableLayerSettings();
 
   return (
     <Switch

--- a/packages/geoview-core/src/core/components/data-table/filter-data-extent.tsx
+++ b/packages/geoview-core/src/core/components/data-table/filter-data-extent.tsx
@@ -8,16 +8,16 @@ import { useGeoViewMapId } from '@/core/stores/geoview-store';
 
 import { logger } from '@/core/utils/logger';
 
-/**
- * Custom Filter map toggle button.
- * @param props - The props for the filter map component
- * @returns The filter switch
- *
- */
 interface FilterDataToExtentProps {
   layerPath: string;
 }
 
+/**
+ * Custom Filter map toggle button.
+ *
+ * @param props - The props for the filter map component
+ * @returns The filter switch
+ */
 function FilterDataToExtent(props: FilterDataToExtentProps): JSX.Element {
   const { layerPath } = props;
   // Log

--- a/packages/geoview-core/src/core/components/data-table/filter-data-extent.tsx
+++ b/packages/geoview-core/src/core/components/data-table/filter-data-extent.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
+import { useCallback } from 'react';
 
 import { getSxClasses } from './data-table-style';
 import { Switch } from '@/ui';
@@ -8,6 +9,7 @@ import {
   setStoreFilterDataToExtent,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
+import { useMapController } from '@/core/controllers/use-controllers';
 
 import { logger } from '@/core/utils/logger';
 
@@ -33,11 +35,28 @@ function FilterDataToExtent(props: FilterDataToExtentProps): JSX.Element {
 
   const mapId = useStoreGeoViewMapId();
   const datatableSettings = useStoreDataTableLayerSettings();
+  const mapController = useMapController();
+
+  /**
+   * Handles when the filter toggle is changed.
+   *
+   * Toggles the filter state and very slightly nudges the map extent to trigger data-table filtering.
+   */
+  const handleFilterToggle = useCallback((): void => {
+    // Toggle the filter state
+    const newFilterState = !datatableSettings[layerPath].filterDataToExtent;
+    setStoreFilterDataToExtent(mapId, newFilterState, layerPath);
+
+    // Very slightly nudge the map center to trigger extent-based filtering
+    // Alternate direction to prevent long-term drift
+    const offset = newFilterState ? 0.00001 : -0.00001;
+    mapController.nudgeMapCenter(offset, 0);
+  }, [mapId, layerPath, datatableSettings, mapController]);
 
   return (
     <Switch
       size="medium"
-      onChange={() => setStoreFilterDataToExtent(mapId, !datatableSettings[layerPath].filterDataToExtent, layerPath)}
+      onChange={handleFilterToggle}
       checked={datatableSettings[layerPath].filterDataToExtent}
       sx={sxClasses.filterMap}
       label={t('dataTable.filterDataToExtent')}

--- a/packages/geoview-core/src/core/components/data-table/filter-data-extent.tsx
+++ b/packages/geoview-core/src/core/components/data-table/filter-data-extent.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '@mui/material/styles';
+
+import { getSxClasses } from './data-table-style';
+import { Switch } from '@/ui';
+import { useDataTableLayerSettings, setStoreFilterDataToExtent } from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { useGeoViewMapId } from '@/core/stores/geoview-store';
+
+import { logger } from '@/core/utils/logger';
+
+/**
+ * Custom Filter map toggle button.
+ * @param props - The props for the filter map component
+ * @returns The filter switch
+ *
+ */
+interface FilterDataToExtentProps {
+  layerPath: string;
+}
+
+function FilterDataToExtent(props: FilterDataToExtentProps): JSX.Element {
+  const { layerPath } = props;
+  // Log
+  logger.logTraceRender('components/data-table/filter-map');
+
+  // Hook
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const sxClasses = getSxClasses(theme);
+
+  const mapId = useGeoViewMapId();
+  const datatableSettings = useDataTableLayerSettings();
+
+  return (
+    <Switch
+      size="medium"
+      onChange={() => setStoreFilterDataToExtent(mapId, !datatableSettings[layerPath].filterDataToExtent, layerPath)}
+      checked={datatableSettings[layerPath].filterDataToExtent}
+      sx={sxClasses.filterMap}
+      label={t('dataTable.filterDataToExtent')}
+    />
+  );
+}
+
+export default FilterDataToExtent;

--- a/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useMemo } from 'react';
 import type { MRT_TableInstance as MRTTableInstance, MRT_ColumnFiltersState as MRTColumnFiltersState } from 'material-react-table';
 import { useTranslation } from 'react-i18next';
 import {
@@ -40,11 +40,11 @@ export function useToolbarActionMessage({
   const mapId = useStoreGeoViewMapId();
 
   /**
-   * Updates the toolbar message when filters or feature data change.
+   * Computes the toolbar message based on current filters and feature data.
    */
-  useEffect(() => {
+  const memoToolbarMessage = useMemo(() => {
     // Log
-    logger.logTraceUseEffect('USETOOLBARACTIONMESSAGE - combined', { columnFilters, globalFilter });
+    logger.logTraceUseMemo('USETOOLBARACTIONMESSAGE - combined', { columnFilters, globalFilter });
 
     let message = '';
     let length = 0;
@@ -55,14 +55,14 @@ export function useToolbarActionMessage({
       const filteredRows = tableInstance.getFilteredRowModel().rows.length;
 
       if (filteredRows !== visibleFeatures) {
-        // Table has additional filtering applied (column filters or global filter)
+        // Table has additional filtering applied
         length = filteredRows;
         message = t('dataTable.rowsFiltered')
           .replace('{rowsFiltered}', filteredRows.toString())
           .replace('{totalRows}', visibleFeatures.toString() ?? '');
         message += !showUnsymbolizedFeatures ? ` (${unfilteredFeaturesCount} ${t('dataTable.total')})` : '';
       } else if (!showUnsymbolizedFeatures && visibleFeatures !== unfilteredFeaturesCount) {
-        // No table filtering, but some features are hidden due to missing icons
+        // Some features hidden due to missing icons
         message = `${visibleFeatures} ${t('dataTable.features')} ${t('dataTable.showing')} (${unfilteredFeaturesCount} ${t('dataTable.total')})`;
         length = 0;
       } else {
@@ -70,10 +70,12 @@ export function useToolbarActionMessage({
         message = `${data.features?.length} ${t('dataTable.features')}`;
         length = 0;
       }
-
-      setStoreRowsFilteredEntry(mapId, length, layerPath);
     }
 
-    setStoreToolbarRowSelectedMessageEntry(mapId, message, layerPath);
-  }, [mapId, columnFilters, data.features, globalFilter, showUnsymbolizedFeatures, tableInstance, layerPath, t, unfilteredFeaturesCount]);
+    return { message, length };
+  }, [columnFilters, data.features, globalFilter, showUnsymbolizedFeatures, tableInstance, t, unfilteredFeaturesCount]);
+
+  // Update store
+  setStoreRowsFilteredEntry(mapId, memoToolbarMessage.length, layerPath);
+  setStoreToolbarRowSelectedMessageEntry(mapId, memoToolbarMessage.message, layerPath);
 }

--- a/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
@@ -1,17 +1,17 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { MRT_TableInstance as MRTTableInstance, MRT_ColumnFiltersState as MRTColumnFiltersState } from 'material-react-table';
 import { useTranslation } from 'react-i18next';
-import {
-  setStoreRowsFilteredEntry,
-  setStoreToolbarRowSelectedMessageEntry,
-} from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { setStoreRowsFilteredEntry } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { logger } from '@/core/utils/logger';
-import type { MappedLayerDataType, ColumnsType } from '@/core/components/data-table/data-table-types';
+import type { ColumnsType } from '@/core/components/data-table/data-table-types';
+import type { TypeFeatureInfoEntry } from '@/api/types/map-schema-types';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 
 /** Properties for the useToolbarActionMessage hook. */
 interface UseSelectedRowMessageProps {
-  data: MappedLayerDataType;
+  data: {
+    features?: TypeFeatureInfoEntry[] | null;
+  };
   layerPath: string;
   tableInstance: MRTTableInstance<ColumnsType>;
   columnFilters: MRTColumnFiltersState;
@@ -33,7 +33,7 @@ export function useToolbarActionMessage({
   tableInstance,
   showUnsymbolizedFeatures,
   unfilteredFeaturesCount,
-}: UseSelectedRowMessageProps): void {
+}: UseSelectedRowMessageProps): string {
   const { t } = useTranslation();
 
   // Get store values
@@ -72,10 +72,16 @@ export function useToolbarActionMessage({
       }
     }
 
-    return { message, length };
-  }, [columnFilters, data.features, globalFilter, showUnsymbolizedFeatures, tableInstance, t, unfilteredFeaturesCount]);
+    return { message, filteredRowCount: length };
+  }, [columnFilters, globalFilter, data.features?.length, tableInstance, showUnsymbolizedFeatures, unfilteredFeaturesCount, t]);
 
-  // Update store
-  setStoreRowsFilteredEntry(mapId, memoToolbarMessage.length, layerPath);
-  setStoreToolbarRowSelectedMessageEntry(mapId, memoToolbarMessage.message, layerPath);
+  useEffect(() => {
+    // Log
+    logger.logTraceUseEffect('USETOOLBARACTIONMESSAGE - set store toolbar message', memoToolbarMessage.filteredRowCount);
+
+    // Update the store with the current filtered row count for the layer
+    setStoreRowsFilteredEntry(mapId, memoToolbarMessage.filteredRowCount, layerPath);
+  }, [mapId, layerPath, memoToolbarMessage.filteredRowCount, memoToolbarMessage.message]);
+
+  return memoToolbarMessage.message;
 }

--- a/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
@@ -17,6 +17,7 @@ interface UseSelectedRowMessageProps {
   columnFilters: MRTColumnFiltersState;
   globalFilter: string;
   showUnsymbolizedFeatures: boolean;
+  unfilteredFeaturesCount: number;
 }
 
 /**
@@ -31,6 +32,7 @@ export function useToolbarActionMessage({
   layerPath,
   tableInstance,
   showUnsymbolizedFeatures,
+  unfilteredFeaturesCount,
 }: UseSelectedRowMessageProps): void {
   const { t } = useTranslation();
 
@@ -47,8 +49,7 @@ export function useToolbarActionMessage({
     let message = '';
     let length = 0;
 
-    const totalFeatures = data.features?.length ?? 0;
-    const visibleFeatures = showUnsymbolizedFeatures ? totalFeatures : data.features?.filter((feature) => feature.featureIcon)?.length || 0;
+    const visibleFeatures = data.features?.length ?? 0;
 
     if (tableInstance) {
       const filteredRows = tableInstance.getFilteredRowModel().rows.length;
@@ -59,10 +60,10 @@ export function useToolbarActionMessage({
         message = t('dataTable.rowsFiltered')
           .replace('{rowsFiltered}', filteredRows.toString())
           .replace('{totalRows}', visibleFeatures.toString() ?? '');
-        message += !showUnsymbolizedFeatures ? ` (${totalFeatures} ${t('dataTable.total')})` : '';
-      } else if (!showUnsymbolizedFeatures && visibleFeatures !== totalFeatures) {
+        message += !showUnsymbolizedFeatures ? ` (${unfilteredFeaturesCount} ${t('dataTable.total')})` : '';
+      } else if (!showUnsymbolizedFeatures && visibleFeatures !== unfilteredFeaturesCount) {
         // No table filtering, but some features are hidden due to missing icons
-        message = `${visibleFeatures} ${t('dataTable.features')} ${t('dataTable.showing')} (${totalFeatures} ${t('dataTable.total')})`;
+        message = `${visibleFeatures} ${t('dataTable.features')} ${t('dataTable.showing')} (${unfilteredFeaturesCount} ${t('dataTable.total')})`;
         length = 0;
       } else {
         // No filtering
@@ -74,5 +75,5 @@ export function useToolbarActionMessage({
     }
 
     setStoreToolbarRowSelectedMessageEntry(mapId, message, layerPath);
-  }, [mapId, columnFilters, data.features, globalFilter, showUnsymbolizedFeatures, tableInstance, layerPath, t]);
+  }, [mapId, columnFilters, data.features, globalFilter, showUnsymbolizedFeatures, tableInstance, layerPath, t, unfilteredFeaturesCount]);
 }

--- a/packages/geoview-core/src/core/components/data-table/top-toolbar.tsx
+++ b/packages/geoview-core/src/core/components/data-table/top-toolbar.tsx
@@ -14,10 +14,12 @@ import JSONExportButton from './json-export-button';
 import FilterMap from './filter-map';
 import FilterDataToExtent from './filter-data-extent';
 import type { ColumnsType } from './data-table-types';
+import { useToolbarActionMessage } from './hooks/useToolbarActionMessage';
 import type { TypeFeatureInfoEntry } from '@/api/types/map-schema-types';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import type { SxStyles } from '@/ui/style/types';
 import { ClearFiltersIcon } from '@/ui/icons';
+import { useStoreAppShowUnsymbolizedFeatures } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { logger } from '@/core/utils/logger';
 
 /** Properties for the TopToolbar component. */
@@ -25,9 +27,6 @@ import { logger } from '@/core/utils/logger';
 interface TopToolbarProps<TData extends ColumnsType> {
   /** Classes or styles for the component. */
   sxClasses: SxStyles;
-
-  /** Settings for the datatable, indexed by layerPath. */
-  datatableSettings: Record<string, { toolbarRowSelectedMessageRecord: string }>;
 
   /** The path for the current layer being processed. */
   layerPath: string;
@@ -54,6 +53,8 @@ interface TopToolbarProps<TData extends ColumnsType> {
 
   /** The Material React Table instance. */
   table: MRTTableInstance<ColumnsType>;
+
+  unfilteredFeaturesCount?: number;
 }
 
 /**
@@ -66,7 +67,20 @@ function TopToolbar(props: TopToolbarProps<ColumnsType>): JSX.Element {
   // Log
   logger.logTraceRender('components/data-table/top-toolbar');
 
-  const { sxClasses, datatableSettings, layerPath, t, globalFilter, useTable, columns, data, table } = props;
+  const { sxClasses, layerPath, t, globalFilter, useTable, columns, data, table, unfilteredFeaturesCount } = props;
+
+  const showUnsymbolizedFeatures = useStoreAppShowUnsymbolizedFeatures();
+
+  // Get toolbar message
+  const toolbarMessage = useToolbarActionMessage({
+    data: data,
+    layerPath,
+    tableInstance: table,
+    columnFilters: table.getState().columnFilters,
+    globalFilter: table.getState().globalFilter ?? '',
+    showUnsymbolizedFeatures: showUnsymbolizedFeatures, // Need to pass this prop
+    unfilteredFeaturesCount: unfilteredFeaturesCount || 0, // Need to pass this prop
+  });
 
   // ESRI Dynamic layer data does not include geometry and can't be filtered to extent
   const isEsriDynamic = data.features?.[0]?.geoviewLayerType === CONST_LAYER_TYPES.ESRI_DYNAMIC;
@@ -82,7 +96,7 @@ function TopToolbar(props: TopToolbarProps<ColumnsType>): JSX.Element {
     >
       <Box display="flex" sx={{ flexDirection: 'column', justifyContent: 'space-evenly' }}>
         <Box component="p" role="status" className="filter-results-summary" sx={sxClasses.selectedRows} aria-live="polite">
-          {datatableSettings[layerPath].toolbarRowSelectedMessageRecord}
+          {toolbarMessage}
         </Box>
         <Box display="flex">
           <FilterMap layerPath={layerPath} isGlobalFilterOn={!!globalFilter?.length} />

--- a/packages/geoview-core/src/core/components/data-table/top-toolbar.tsx
+++ b/packages/geoview-core/src/core/components/data-table/top-toolbar.tsx
@@ -54,6 +54,7 @@ interface TopToolbarProps<TData extends ColumnsType> {
   /** The Material React Table instance. */
   table: MRTTableInstance<ColumnsType>;
 
+  /** The count of features before any filters are applied. */
   unfilteredFeaturesCount?: number;
 }
 
@@ -78,8 +79,8 @@ function TopToolbar(props: TopToolbarProps<ColumnsType>): JSX.Element {
     tableInstance: table,
     columnFilters: table.getState().columnFilters,
     globalFilter: table.getState().globalFilter ?? '',
-    showUnsymbolizedFeatures: showUnsymbolizedFeatures, // Need to pass this prop
-    unfilteredFeaturesCount: unfilteredFeaturesCount || 0, // Need to pass this prop
+    showUnsymbolizedFeatures: showUnsymbolizedFeatures,
+    unfilteredFeaturesCount: unfilteredFeaturesCount || 0,
   });
 
   // ESRI Dynamic layer data does not include geometry and can't be filtered to extent

--- a/packages/geoview-core/src/core/components/data-table/top-toolbar.tsx
+++ b/packages/geoview-core/src/core/components/data-table/top-toolbar.tsx
@@ -12,8 +12,10 @@ import { Box, IconButton, Switch } from '@/ui';
 import ExportButton from './export-button';
 import JSONExportButton from './json-export-button';
 import FilterMap from './filter-map';
+import FilterDataToExtent from './filter-data-extent';
 import type { ColumnsType } from './data-table-types';
 import type { TypeFeatureInfoEntry } from '@/api/types/map-schema-types';
+import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import type { SxStyles } from '@/ui/style/types';
 import { ClearFiltersIcon } from '@/ui/icons';
 import { logger } from '@/core/utils/logger';
@@ -65,6 +67,10 @@ function TopToolbar(props: TopToolbarProps<ColumnsType>): JSX.Element {
   logger.logTraceRender('components/data-table/top-toolbar');
 
   const { sxClasses, datatableSettings, layerPath, t, globalFilter, useTable, columns, data, table } = props;
+
+  // ESRI Dynamic layer data does not include geometry and can't be filtered to extent
+  const isEsriDynamic = data.features?.[0]?.geoviewLayerType === CONST_LAYER_TYPES.ESRI_DYNAMIC;
+
   return (
     <Box
       className="data-table-top-toolbar"
@@ -80,6 +86,7 @@ function TopToolbar(props: TopToolbarProps<ColumnsType>): JSX.Element {
         </Box>
         <Box display="flex">
           <FilterMap layerPath={layerPath} isGlobalFilterOn={!!globalFilter?.length} />
+          {!isEsriDynamic && <FilterDataToExtent layerPath={layerPath} />}
         </Box>
       </Box>
       <Box display="flex" sx={{ flexDirection: 'column' }}>

--- a/packages/geoview-core/src/core/controllers/map-controller.ts
+++ b/packages/geoview-core/src/core/controllers/map-controller.ts
@@ -684,6 +684,27 @@ export class MapController extends AbstractMapViewerController {
   }
 
   /**
+   * Nudges the map center by an imperceptible amount to trigger extent change events.
+   *
+   * Useful for triggering extent-based listeners without visible map movement.
+   * The store is updated automatically via the MapViewer move-end event.
+   *
+   * @param offsetX - The horizontal offset in map units (default: 0.00001)
+   * @param offsetY - The vertical offset in map units (default: 0)
+   */
+  nudgeMapCenter(offsetX: number = 0.00001, offsetY: number = 0): void {
+    const view = this.getMapViewer().map.getView();
+    const currentCenter = view.getCenter()!;
+
+    // Shift center by imperceptible amount
+    const newCenter: Coordinate = [currentCenter[0] + offsetX, currentCenter[1] + offsetY];
+
+    // Set center without animation
+    view.setCenter(newCenter);
+    // GV No need to Save to the store, because this will trigger an event on MapViewer which will take care of updating the store
+  }
+
+  /**
    * Rotates the map to the specified angle.
    *
    * The store is updated automatically via the MapViewer move-end event.
@@ -1197,7 +1218,7 @@ export class MapController extends AbstractMapViewerController {
     else listOfLayerEntryConfig.push(this.#createLayerEntryConfig(layerPath, isGeocore, overrideGeocoreServiceNames));
 
     // Get initial settings
-    const initialSettings = MapController.#getInitialSettings(layerEntryConfig, orderedLayerInfo, legendLayerInfo!);
+    const initialSettings = MapController.#getInitialSettings(layerEntryConfig, orderedLayerInfo, legendLayerInfo);
 
     // Construct geoview layer config
     const newGeoviewLayerConfig: MapConfigLayerEntry =
@@ -1281,7 +1302,7 @@ export class MapController extends AbstractMapViewerController {
     }
 
     // Get initial settings
-    const initialSettings = MapController.#getInitialSettings(layerEntryConfig, orderedLayerInfo, legendLayerInfo!);
+    const initialSettings = MapController.#getInitialSettings(layerEntryConfig, orderedLayerInfo, legendLayerInfo);
 
     // Clone the source object
     let source;
@@ -1409,12 +1430,12 @@ export class MapController extends AbstractMapViewerController {
   static #getInitialSettings(
     layerEntryConfig: ConfigBaseClass,
     orderedLayerInfo: TypeOrderedLayerInfo,
-    legendLayerInfo: TypeLegendLayer
+    legendLayerInfo: TypeLegendLayer | undefined
   ): TypeLayerInitialSettings {
     return {
       states: {
         visible: orderedLayerInfo.visible,
-        opacity: legendLayerInfo.opacity,
+        opacity: legendLayerInfo?.opacity ?? 1,
         legendCollapsed: orderedLayerInfo.legendCollapsed,
         queryable: orderedLayerInfo.queryableState,
         hoverable: orderedLayerInfo.hoverable,

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
@@ -56,7 +56,6 @@ export interface IDataTableState {
     setSelectedFeature: (feature: TypeFeatureInfoEntry) => void;
     setSelectedLayerPath: (layerPath: string) => void;
     setTableFilters(newTableFilters: Record<string, string>): void;
-    setToolbarRowSelectedMessageEntry: (message: string, layerPath: string) => void;
   };
 }
 
@@ -247,24 +246,6 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
           dataTableState: {
             ...get().dataTableState,
             tableFilters: newTableFilters,
-          },
-        });
-      },
-
-      /**
-       * Sets the toolbar row-selected message for the specified layer.
-       *
-       * @param message - The message to display in the toolbar.
-       * @param layerPath - The target layer path.
-       */
-      setToolbarRowSelectedMessageEntry: (message: string, layerPath: string): void => {
-        const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
-        layerSettings.toolbarRowSelectedMessageRecord = message;
-
-        set({
-          dataTableState: {
-            ...get().dataTableState,
-            layersDataTableSetting: { ...get().dataTableState.layersDataTableSetting, [layerPath]: layerSettings },
           },
         });
       },
@@ -568,17 +549,6 @@ export const setStoreRowsFilteredEntry = (mapId: string, rows: number, layerPath
 };
 
 /**
- * Sets the toolbar row-selected message for a specific layer in the store.
- *
- * @param mapId - The map identifier.
- * @param message - The message to display.
- * @param layerPath - The target layer path.
- */
-export const setStoreToolbarRowSelectedMessageEntry = (mapId: string, message: string, layerPath: string): void => {
-  getStoreDataTableState(mapId).actions.setToolbarRowSelectedMessageEntry(message, layerPath);
-};
-
-/**
  * Adds or updates a table filter for a specific layer in the store.
  *
  * Merges the provided filter with existing filters, overwriting
@@ -689,9 +659,6 @@ export interface IDataTableSettings {
 
   /** The number of rows matching the current filters. */
   rowsFilteredRecord: number;
-
-  /** The toolbar message shown when rows are selected. */
-  toolbarRowSelectedMessageRecord: string;
 
   /** The current global filter string applied across all columns. */
   globalFilterRecord: string;

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
@@ -51,6 +51,7 @@ export interface IDataTableState {
     setInitiallayerDataTableSetting: (layerPath: string) => void;
     setGlobalFilteredEntry: (globalFilterValue: string, layerPath: string) => void;
     setMapFilteredEntry: (mapFiltered: boolean, layerPath: string) => void;
+    setFilterDataToExtent: (filterDataToExtent: boolean, layerPath: string) => void;
     setRowsFilteredEntry: (rows: number, layerPath: string) => void;
     setSelectedFeature: (feature: TypeFeatureInfoEntry) => void;
     setSelectedLayerPath: (layerPath: string) => void;
@@ -132,6 +133,7 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
           columnFilterModesRecord: {},
           columnsFiltersVisibility: false,
           mapFilteredRecord: true,
+          filterDataToExtent: false,
           rowsFilteredRecord: 0,
           toolbarRowSelectedMessageRecord: '',
           globalFilterRecord: '',
@@ -299,6 +301,18 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
         });
       },
 
+      setFilterDataToExtent: (filterDataToExtent: boolean, layerPath: string) => {
+        const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
+        layerSettings.filterDataToExtent = filterDataToExtent;
+
+        set({
+          dataTableState: {
+            ...get().dataTableState,
+            layersDataTableSetting: { ...get().dataTableState.layersDataTableSetting, [layerPath]: layerSettings },
+          },
+        });
+      },
+
       /**
        * Sets the currently selected feature in the data table.
        *
@@ -419,6 +433,17 @@ export const useStoreDataTableLayerSettings = (): Record<string, IDataTableSetti
 export const useStoreDataTableSelectedFeature = (): TypeFeatureInfoEntry | null =>
   useStore(useGeoViewStore(), (state) => state.dataTableState.selectedFeature);
 
+/**
+ * Gets whether the data table is filtered to the current map extent for a specific layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to check.
+ * @returns True if map extent filtering is enabled, or undefined if the layer has no settings.
+ */
+export const getStoreDataTableFilterDataToExtent = (mapId: string, layerPath: string): boolean | undefined => {
+  return getStoreDataTableState(mapId)?.layersDataTableSetting?.[layerPath]?.filterDataToExtent;
+};
+
 // #endregion STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
 
 // #region STATE ADAPTORS
@@ -509,7 +534,7 @@ export const setStoreGlobalFilteredEntry = (mapId: string, globalFilterValue: st
 };
 
 /**
- * Sets whether the data table is filtered to the current map extent for a layer in the store.
+ * Sets whether the map feature is filtered to the data table filters for a specific layer in the store.
  *
  * @param mapId - The map identifier.
  * @param mapFiltered - Whether map extent filtering is enabled.
@@ -517,6 +542,17 @@ export const setStoreGlobalFilteredEntry = (mapId: string, globalFilterValue: st
  */
 export const setStoreMapFilteredEntry = (mapId: string, mapFiltered: boolean, layerPath: string): void => {
   getStoreDataTableState(mapId).actions.setMapFilteredEntry(mapFiltered, layerPath);
+};
+
+/**
+ * Sets whether the data table is filtered to the current map extent for a layer in the store.
+ *
+ * @param mapId - The map identifier.
+ * @param filterDataToExtent - Whether filtering data to extent is enabled.
+ * @param layerPath - The target layer path.
+ */
+export const setStoreFilterDataToExtent = (mapId: string, filterDataToExtent: boolean, layerPath: string): void => {
+  getStoreDataTableState(mapId).actions.setFilterDataToExtent(filterDataToExtent, layerPath);
 };
 
 /**
@@ -644,8 +680,11 @@ export interface IDataTableSettings {
   /** Whether column filter inputs are visible. */
   columnsFiltersVisibility: boolean;
 
-  /** Whether the table is filtered to the current map extent. */
+  /** Whether the features in the map should reflect the filters applied in the data table. */
   mapFilteredRecord: boolean;
+
+  /** Whether the data table is filtered to the current map extent. */
+  filterDataToExtent: boolean;
 
   /** The number of rows matching the current filters. */
   rowsFilteredRecord: number;

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
@@ -1,7 +1,7 @@
 import { useStore } from 'zustand';
 
 import type { TypeFeatureInfoEntry, TypeLayerData, TypeResultSet, TypeResultSetEntry } from '@/api/types/map-schema-types';
-import type { TypeSetStore, TypeGetStore } from '@/core/stores/geoview-store';
+import { type TypeSetStore, type TypeGetStore, useStableSelector } from '@/core/stores/geoview-store';
 import { getGeoViewStore, helperDeleteFromArray, useGeoViewStore } from '@/core/stores/stores-managers';
 import type { TypeMapFeaturesConfig } from '@/core/types/global-types';
 import { logger } from '@/core/utils/logger';
@@ -426,8 +426,9 @@ export const getStoreMapFilteredRecord = (mapId: string, layerPath: string): boo
 };
 
 /** Hook that returns the per-layer data table settings record. */
-export const useStoreDataTableLayerSettings = (): Record<string, IDataTableSettings> =>
-  useStore(useGeoViewStore(), (state) => state.dataTableState.layersDataTableSetting);
+export const useStoreDataTableLayerSettings = (): Record<string, IDataTableSettings> => {
+  return useStableSelector(useGeoViewStore(), (state) => state.dataTableState.layersDataTableSetting);
+};
 
 /** Hook that returns the currently selected feature in the data table. */
 export const useStoreDataTableSelectedFeature = (): TypeFeatureInfoEntry | null =>

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
@@ -46,9 +46,6 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
   /** Callback delegates for the text visible changed event */
   #onTextVisibleChangedHandlers: TextVisibleChangedDelegate[] = [];
 
-  /** Cache for feature styles keyed by feature ID */
-  #styleCache: Map<string, Style | undefined> = new Map();
-
   /** Maximum number of styles to cache */
   static readonly STYLE_CACHE_SIZE_LIMIT = 1000;
 
@@ -68,9 +65,14 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
     const layerOptions: VectorLayerOptions<VectorSource<Feature<Geometry>>> = {
       properties: { layerConfig },
       source: olSource,
-      style: (feature, resolution) => {
+      style: (feature) => {
         // Get or create cached style
-        const style = this.#getOrCreateCachedStyle(feature, resolution, label);
+        const style = AbstractGVVector.calculateStyleForFeature(
+          this as AbstractGVLayer,
+          feature,
+          label,
+          this.getLayerFilters()?.getFilterEquation()
+        );
 
         // Set the style applied, throwing a style applied event in the process
         this.setStyleApplied(true);
@@ -78,20 +80,10 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
         // Return the style
         return style;
       },
-      // TODO: (SEE ISSUE 3227) For layers with text, in order for declutterMode options to work, declutter at the layer level must be true
-      // TO.DOCONT: If true though, this will cause the features themselves to be decluttered, which we don't want
-      // TO.DOCONT: Instead, the best solution would be to create a second text only layer that uses the same source.
-      // TO.DOCONT: Could both layers be accessed by the same GeoView Layer? So that only the text layer or both layer's visibility can be toggled?
-      // TO.DOCONT: If two separate layers, could we remove the text from the sublayers? Could have separate categories for the text, although
-      // TO.DOCONT: then we wouldn't be able to turn off the individual text categories in the UI. Would be all or nothing at the main layer level.
-      // declutter: true,
     };
 
     // Init the layer options with initial settings
     AbstractGVVector.initOptionsWithInitialSettings(layerOptions, layerConfig);
-
-    // Clear cache when filters are updated.
-    this.onLayerFilterApplied(() => this.#clearStyleCache());
 
     // Keep the subscription clean and readable
     this.onLayerFirstLoaded(this.#handleLayerFirstLoaded.bind(this));
@@ -421,73 +413,11 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
   // #region METHODS
 
   /**
-   * Gets or creates a cached style for a feature at a given resolution.
-   *
-   * Resolution is rounded to 2 decimal places to prevent cache thrashing during smooth zoom animations.
-   * This avoids recreating Style objects for every tiny resolution change.
-   *
-   * @param feature - The feature to calculate style for.
-   * @param resolution - The current map resolution.
-   * @param label - Style label for fallback styling.
-   * @returns The cached or newly calculated style.
-   */
-  #getOrCreateCachedStyle(feature: FeatureLike, resolution: number, label: string): Style | undefined {
-    // Round resolution to 1 decimal place as cache key component to reduce style churn at zoom boundaries.
-    const roundedResolution = Math.round(resolution * 10) / 10;
-
-    // Calculate new style and cache it
-    const featureStyle = AbstractGVVector.calculateStyleForFeature(
-      this as AbstractGVLayer,
-      feature,
-      resolution,
-      label,
-      this.getLayerFilters()?.getFilterEquation()
-    );
-
-    // If no feature style generated
-    if (!featureStyle) {
-      // No style
-      return undefined;
-    }
-
-    // Clone the style
-    const styleClone = featureStyle.clone();
-    // Eliminate geometry from the style clone to prevent cache misses due to different geometries on features
-    styleClone.setGeometry('');
-    // Create a cache key based on the rounded resolution and the stringified style (without geometry)
-    const styleKey = `${roundedResolution}${JSON.stringify(styleClone)}`;
-
-    // Cache the style if not already cached
-    if (!this.#styleCache.has(styleKey)) {
-      this.#styleCache.set(styleKey, featureStyle);
-
-      // Limit cache size to prevent memory bloat
-      if (this.#styleCache.size > AbstractGVVector.STYLE_CACHE_SIZE_LIMIT) {
-        const firstKey = this.#styleCache.keys().next().value;
-        if (firstKey) {
-          this.#styleCache.delete(firstKey);
-        }
-      }
-    }
-
-    return this.#styleCache.get(styleKey);
-  }
-
-  /**
-   * Clears the style cache. Call this when layer style, filters, or visibility changes to ensure fresh styles are recalculated.
-   */
-  #clearStyleCache(): void {
-    this.#styleCache.clear();
-  }
-
-  /**
    * Sets the layer style.
    *
    * @param style - The layer style
    */
   override setStyle(style: TypeLayerStyleConfig): void {
-    // Clear the style cache to ensure new styles are calculated with the updated style configuration
-    this.#clearStyleCache();
     super.setStyle(style);
     // Trigger a refresh to apply the new style to all features
     this.refresh(undefined);
@@ -668,7 +598,6 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
   static calculateStyleForFeature(
     layer: AbstractGVLayer,
     feature: FeatureLike,
-    resolution: number,
     label: string,
     filterEquation?: FilterNodeType[]
   ): Style | undefined {
@@ -676,7 +605,7 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
     const style = layer.getStyle() || {};
 
     // Get and create Feature style if necessary
-    return GeoviewRenderer.getAndCreateFeatureStyle(feature, resolution, style, label, filterEquation, (geometryType, theStyle) => {
+    return GeoviewRenderer.getAndCreateFeatureStyle(feature, style, label, filterEquation, (geometryType, theStyle) => {
       // A new style has been created
       logger.logDebug('A new style has been created on-the-fly', geometryType, layer);
 

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
@@ -46,6 +46,9 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
   /** Callback delegates for the text visible changed event */
   #onTextVisibleChangedHandlers: TextVisibleChangedDelegate[] = [];
 
+  /** Cache for feature styles keyed by feature ID */
+  #styleCache: Map<string, Style | undefined> = new Map();
+
   /** Maximum number of styles to cache */
   static readonly STYLE_CACHE_SIZE_LIMIT = 1000;
 
@@ -67,12 +70,15 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
       source: olSource,
       style: (feature) => {
         // Get or create cached style
-        const style = AbstractGVVector.calculateStyleForFeature(
-          this as AbstractGVLayer,
-          feature,
-          label,
-          this.getLayerFilters()?.getFilterEquation()
-        );
+        const style =
+          feature.getGeometry()?.getType() === 'Point'
+            ? this.#getOrCreateCachedStyle(feature, label)
+            : AbstractGVVector.calculateStyleForFeature(
+                this as AbstractGVLayer,
+                feature,
+                label,
+                this.getLayerFilters()?.getFilterEquation()
+              );
 
         // Set the style applied, throwing a style applied event in the process
         this.setStyleApplied(true);
@@ -84,6 +90,9 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
 
     // Init the layer options with initial settings
     AbstractGVVector.initOptionsWithInitialSettings(layerOptions, layerConfig);
+
+    // Clear cache when filters are updated.
+    this.onLayerFilterApplied(() => this.#clearStyleCache());
 
     // Keep the subscription clean and readable
     this.onLayerFirstLoaded(this.#handleLayerFirstLoaded.bind(this));
@@ -413,11 +422,65 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
   // #region METHODS
 
   /**
+   * Gets or creates a cached style for a feature.
+   *
+   * @param feature - The feature to calculate style for.
+   * @param label - Style label for fallback styling.
+   * @returns The cached or newly calculated style.
+   */
+  #getOrCreateCachedStyle(feature: FeatureLike, label: string): Style | undefined {
+    // Calculate new style and cache it
+    const featureStyle = AbstractGVVector.calculateStyleForFeature(
+      this as AbstractGVLayer,
+      feature,
+      label,
+      this.getLayerFilters()?.getFilterEquation()
+    );
+
+    // If no feature style generated
+    if (!featureStyle) {
+      // No style
+      return undefined;
+    }
+
+    // Clone the style
+    const styleClone = featureStyle.clone();
+    // Eliminate geometry from the style clone to prevent cache misses due to different geometries on features
+    styleClone.setGeometry('');
+    // Create a cache key based on the stringified style (without geometry)
+    const styleKey = JSON.stringify(styleClone);
+
+    // Cache the style if not already cached
+    if (!this.#styleCache.has(styleKey)) {
+      this.#styleCache.set(styleKey, featureStyle);
+
+      // Limit cache size to prevent memory bloat
+      if (this.#styleCache.size > AbstractGVVector.STYLE_CACHE_SIZE_LIMIT) {
+        const firstKey = this.#styleCache.keys().next().value;
+        if (firstKey) {
+          this.#styleCache.delete(firstKey);
+        }
+      }
+    }
+
+    return this.#styleCache.get(styleKey);
+  }
+
+  /**
+   * Clears the style cache. Call this when layer style, filters, or visibility changes to ensure fresh styles are recalculated.
+   */
+  #clearStyleCache(): void {
+    this.#styleCache.clear();
+  }
+
+  /**
    * Sets the layer style.
    *
    * @param style - The layer style
    */
   override setStyle(style: TypeLayerStyleConfig): void {
+    // Clear the style cache to ensure new styles are calculated with the updated style configuration
+    this.#clearStyleCache();
     super.setStyle(style);
     // Trigger a refresh to apply the new style to all features
     this.refresh(undefined);

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
@@ -103,9 +103,9 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
       const textLayerOptions: VectorLayerOptions<VectorSource<Feature<Geometry>>> = {
         properties: { layerConfig, isAuxiliaryLayer: true },
         source: olSource, // Share the same source
-        style: (feature, resolution) => {
+        style: (feature) => {
           // Calculate text-only style for the feature
-          const style = AbstractGVVector.calculateTextStyleForFeature(this as AbstractGVLayer, feature, resolution);
+          const style = AbstractGVVector.calculateTextStyleForFeature(this as AbstractGVLayer, feature);
           return style;
         },
         // Enable declutter based on layerText.declutterMode
@@ -693,10 +693,9 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
    *
    * @param layer - The layer on which to work for the style.
    * @param feature - Feature that needs its style defined.
-   * @param resolution - The map resolution.
    * @returns The text-only style or undefined if no text style could be calculated.
    */
-  static calculateTextStyleForFeature(layer: AbstractGVLayer, feature: FeatureLike, resolution: number): Style | undefined {
+  static calculateTextStyleForFeature(layer: AbstractGVLayer, feature: FeatureLike): Style | undefined {
     // Get the layer config and style
     const style = layer.getStyle() || {};
     const outfields = layer.getLayerConfig().getOutfields();
@@ -714,7 +713,7 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
     if (!styleSettings) return undefined;
 
     // Get the text style
-    const textStyle = GeoviewTextRenderer.getTextStyle(feature, resolution, styleSettings, layerText, aliasLookup);
+    const textStyle = GeoviewTextRenderer.getTextStyle(feature, styleSettings, layerText, aliasLookup);
 
     // If no text style, return undefined
     if (!textStyle) return undefined;

--- a/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
@@ -2251,7 +2251,6 @@ export abstract class GeoviewRenderer {
    * If the style does not exist for the geometryType, create it using the default style strategy.
    *
    * @param feature - Feature that need its style to be defined
-   * @param resolution - The resolution of the map
    * @param layerStyle - The style to use
    * @param label - The style label when one has to be created
    * @param filterEquation - Optional filter equation associated to the layer
@@ -2260,7 +2259,6 @@ export abstract class GeoviewRenderer {
    */
   static getAndCreateFeatureStyle(
     feature: FeatureLike,
-    resolution: number,
     layerStyle: TypeLayerStyleConfig,
     label: string,
     filterEquation?: FilterNodeType[],

--- a/packages/geoview-core/src/geo/utils/renderer/geoview-text-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/geoview-text-renderer.ts
@@ -52,7 +52,6 @@ export class GeoviewTextRenderer {
    * Method for getting the text style
    *
    * @param feature - The feature to get the text style for
-   * @param resolution - The resolution of the map
    * @param styleSettings - The style settings
    * @param layerText - The layer text configuration
    * @param aliasLookup - The alias lookup
@@ -60,7 +59,6 @@ export class GeoviewTextRenderer {
    */
   static getTextStyle = (
     feature: FeatureLike,
-    resolution: number,
     styleSettings: TypeLayerStyleSettings,
     layerText?: TypeLayerTextConfig,
     aliasLookup?: TypeAliasLookup


### PR DESCRIPTION
# Description

Added a switch in the data-table that allows a user to filter the rows in the table to just those that are visible in the current map view.

Fixes #1929 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
### Hosted on 2026-04-23 @ 10:10PM

Open a config with the data table enabled. Turn on the filter to extent and then zoom / pan around the map.

[ESRI Feature Navigator](https://matthewmuehlhausernrcan.github.io/geoview/layers-navigator.html?config=./configs/navigator/layers/esri-feature.json)

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3356)
<!-- Reviewable:end -->
