### PR TITLE
bug(Text Layers): Update how text layer max and min zoom works to avoid errors

### DIFF
--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -528,7 +528,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
     if (activeView === 'settings') {
       return (
         <IconButton
-          ref={settingsButtonRef}
+          iconRef={settingsButtonRef}
           aria-label={t('layers.settings.back')}
           className="buttonOutline"
           onClick={handleSettingsBackToDetails}
@@ -541,7 +541,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
 
     return (
       <IconButton
-        ref={settingsButtonRef}
+        iconRef={settingsButtonRef}
         aria-label={t('layers.settings.title')}
         className="buttonOutline"
         onClick={handleOpenSettings}
@@ -556,7 +556,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
     if (activeView === 'info') {
       return (
         <IconButton
-          ref={infoButtonRef}
+          iconRef={infoButtonRef}
           aria-label={t('layers.settings.back')}
           className="buttonOutline"
           onClick={handleInfoBackToDetails}
@@ -569,7 +569,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
 
     return (
       <IconButton
-        ref={infoButtonRef}
+        iconRef={infoButtonRef}
         aria-label={t('layers.moreInfo')}
         className="buttonOutline"
         onClick={handleOpenInfo}

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
@@ -112,6 +112,9 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
         },
         // Enable declutter based on layerText.declutterMode
         declutter: layerConfig.getLayerText()?.declutterMode !== 'none',
+        // set zoom constraints
+        minZoom: layerConfig.getLayerText()?.minZoomLevel || -Infinity,
+        maxZoom: layerConfig.getLayerText()?.maxZoomLevel || Infinity,
       };
 
       // Set declutterMode on layer options if specified
@@ -184,7 +187,22 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
     super.onSetOpacity(opacity, emitOpacityChanged);
 
     // Sync text layer opacity if it exists
-    this.#textOLLayer?.setOpacity(opacity);
+    if (this.#textOLLayer) {
+      // Check if renderer exists and is ready before setting opacity
+      const layerWithRenderer = this.#textOLLayer;
+      const hasRenderer =
+        layerWithRenderer.getRenderer && typeof layerWithRenderer.getRenderer === 'function' && layerWithRenderer.getRenderer();
+
+      if (hasRenderer) {
+        // Renderer exists, safe to set opacity
+        this.#textOLLayer.setOpacity(opacity);
+      } else {
+        // Renderer doesn't exist yet - set up handler for when layer first renders
+        this.#textOLLayer.once('postrender', () => {
+          this.#textOLLayer?.setOpacity(opacity);
+        });
+      }
+    }
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
@@ -112,14 +112,24 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
         },
         // Enable declutter based on layerText.declutterMode
         declutter: layerConfig.getLayerText()?.declutterMode !== 'none',
-        // set zoom constraints
-        minZoom: layerConfig.getLayerText()?.minZoomLevel || -Infinity,
-        maxZoom: layerConfig.getLayerText()?.maxZoomLevel || Infinity,
       };
 
       // Set declutterMode on layer options if specified
-      if (layerConfig.getLayerText()?.declutterMode) {
-        textLayerOptions.declutter = layerConfig.getLayerText()?.declutterMode;
+      const declutterMode = layerConfig.getLayerText()?.declutterMode;
+      if (declutterMode) {
+        textLayerOptions.declutter = declutterMode;
+      }
+
+      // Set minZoom for text layer if specified in layerText config
+      const textMinZoom = layerConfig.getLayerText()?.minZoomLevel;
+      if (textMinZoom) {
+        textLayerOptions.minZoom = textMinZoom;
+      }
+
+      // Set maxZoom for text layer if specified in layerText config
+      const textMaxZoom = layerConfig.getLayerText()?.maxZoomLevel;
+      if (textMaxZoom) {
+        textLayerOptions.maxZoom = textMaxZoom;
       }
 
       // Init the text layer options with initial settings

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
@@ -186,23 +186,8 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
     // Call parent to handle geometry layer
     super.onSetOpacity(opacity, emitOpacityChanged);
 
-    // Sync text layer opacity if it exists
-    if (this.#textOLLayer) {
-      // Check if renderer exists and is ready before setting opacity
-      const layerWithRenderer = this.#textOLLayer;
-      const hasRenderer =
-        layerWithRenderer.getRenderer && typeof layerWithRenderer.getRenderer === 'function' && layerWithRenderer.getRenderer();
-
-      if (hasRenderer) {
-        // Renderer exists, safe to set opacity
-        this.#textOLLayer.setOpacity(opacity);
-      } else {
-        // Renderer doesn't exist yet - set up handler for when layer first renders
-        this.#textOLLayer.once('postrender', () => {
-          this.#textOLLayer?.setOpacity(opacity);
-        });
-      }
-    }
+    // Set opacity for text layer if it exists
+    this.#textOLLayer?.setOpacity(opacity);
   }
 
   /**

--- a/packages/geoview-core/src/geo/utils/renderer/geoview-text-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/geoview-text-renderer.ts
@@ -2,17 +2,12 @@ import { Stroke, Fill, Text } from 'ol/style';
 import type { FeatureLike } from 'ol/Feature';
 import type Feature from 'ol/Feature';
 
-import type {
-  TypeLayerStyleSettings,
-  TypeLayerStyleConfig,
-  TypeLayerTextConfig,
-  TypeAliasLookup,
-  TypeValidMapProjectionCodes,
-} from '@/api/types/map-schema-types';
+import type { TypeLayerStyleSettings, TypeLayerStyleConfig, TypeLayerTextConfig, TypeAliasLookup } from '@/api/types/map-schema-types';
 import { logger } from '@/core/utils/logger';
 import { DateMgt } from '@/core/utils/date-mgt';
 import { GeoviewRenderer } from '@/geo/utils/renderer/geoview-renderer';
 import type { VectorLayerEntryConfig } from '@/api/config/validation-classes/vector-layer-entry-config';
+
 export class GeoviewTextRenderer {
   /**
    * This method returns true if a style config has a text configuration
@@ -98,10 +93,6 @@ export class GeoviewTextRenderer {
 
     const textSettings = symbolText || layerText;
     if (!textSettings) return undefined;
-    if (textSettings.minZoomLevel !== undefined && resolution > GeoviewTextRenderer.getApproximateResolution(textSettings.minZoomLevel))
-      return undefined;
-    if (textSettings.maxZoomLevel !== undefined && resolution < GeoviewTextRenderer.getApproximateResolution(textSettings.maxZoomLevel))
-      return undefined;
 
     return GeoviewTextRenderer.createTextStyle(feature, textSettings);
   };
@@ -206,27 +197,6 @@ export class GeoviewTextRenderer {
       declutterMode,
     });
   };
-
-  /**
-   * Get approximate resolution for common zoom levels by projection
-   *
-   * @param zoom - The zoom level (0-20)
-   * @param projection - The map projection (3857 for Web Mercator, 3978 for Canada Lambert)
-   * @returns Approximate resolution for the given zoom and projection
-   */
-  static getApproximateResolution(zoom: number, projection: TypeValidMapProjectionCodes = 3857): number {
-    if (projection === 3978) {
-      // Lambert Conformal Conic Canada: resolution ≈ 38364.660062653464 / (2^zoom)
-      return 38364.660062653464 / Math.pow(2, zoom);
-    }
-    if (projection === 3573) {
-      // TODO: Update this value when there's an active service
-      // North Pole LAEA Canada: resolution ≈ 38364.660062653464 / (2^zoom)
-      return 38364.660062653464 / Math.pow(2, zoom);
-    }
-    // Default to Web Mercator: resolution ≈ 156543.03392804097 / (2^zoom)
-    return 156543.03392804097 / Math.pow(2, zoom);
-  }
 
   /**
    * Wrap text to fit within specified constraints


### PR DESCRIPTION
# Description

Clicking the highlight button was causing the setOpacity to run on layers which was causing any textLayers which weren't currently "visible" on the map to throw an error. This is mainly because the geometry and text layers were split and the text layer had it's visibility handled inside the style. The max and minZoomLevel properties are now set at the layer level for the text layers which is then able to properly handle opacity and other rendering changes when the layer isn't visible.

Fixes #3359 

## Type of change
### Host updated 2026-03-20 @ 10:50am

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Go to a configuration with text layers enabled. Try highlighting one of the layers or changing the opacity when the text is not visible. No errors should occur in the console or on the screen and the behaviour should be correct.

[__Add the URL for your deploy!__](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/demos/24-configured-feature-labels.json)

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3360)
<!-- Reviewable:end -->
