### PR TITLE
fix(hover-dates) Quick fix for the hover when displaying date values

### DIFF
--- a/packages/geoview-core/public/configs/navigator/demos/12-package-time-slider-custom.json
+++ b/packages/geoview-core/public/configs/navigator/demos/12-package-time-slider-custom.json
@@ -34,15 +34,15 @@
         ]
       },
       {
-        "geoviewLayerId": "MSI",
-        "geoviewLayerName": "MSI",
-        "metadataAccessPath": "https://datacube.services.geo.ca/ows/msi",
-        "geoviewLayerType": "ogcWms",
+        "geoviewLayerId": "fire_progression",
+        "geoviewLayerName": "fire_progression_20230915",
+        "geoviewLayerType": "esriDynamic",
         "listOfLayerEntryConfig": [
           {
-            "layerId": "msi-94-or-more"
+            "layerId": "0"
           }
-        ]
+        ],
+        "metadataAccessPath": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/NRCAN/FireCreepPerimeter_20230915/MapServer/"
       },
       {
         "geoviewLayerId": "fire_perimeters",
@@ -51,17 +51,6 @@
         "listOfLayerEntryConfig": [
           {
             "layerId": "1"
-          }
-        ],
-        "metadataAccessPath": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/NRCAN/FireCreepPerimeter_20230915/MapServer/"
-      },
-      {
-        "geoviewLayerId": "fire_progression",
-        "geoviewLayerName": "fire_progression_20230915",
-        "geoviewLayerType": "esriDynamic",
-        "listOfLayerEntryConfig": [
-          {
-            "layerId": "0"
           }
         ],
         "metadataAccessPath": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/NRCAN/FireCreepPerimeter_20230915/MapServer/"
@@ -76,6 +65,17 @@
           }
         ],
         "metadataAccessPath": "https://maps-cartes.services.geo.ca/egs_sgu/rest/services/Flood_Inondation/EGS_Flood_Product_Current_en/MapServer"
+      },
+      {
+        "geoviewLayerId": "MSI",
+        "geoviewLayerName": "MSI",
+        "metadataAccessPath": "https://datacube.services.geo.ca/ows/msi",
+        "geoviewLayerType": "ogcWms",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "msi-94-or-more"
+          }
+        ]
       },
       {
         "geoviewLayerId": "df168bcf-4abc-4756",

--- a/packages/geoview-core/src/core/components/hover-tooltip/hover-tooltip.tsx
+++ b/packages/geoview-core/src/core/components/hover-tooltip/hover-tooltip.tsx
@@ -11,8 +11,14 @@ import {
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { getSxClasses } from './hover-tooltip-styles';
 import { useGeoViewMapId } from '@/core/stores/geoview-store';
-import { useAppGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useAppDisplayLanguage, useAppGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { logger } from '@/core/utils/logger';
+import { DateMgt } from '@/core/utils/date-mgt';
+import {
+  useLayerDateTemporalModes,
+  useLayerDisplayDateFormats,
+  useLayerDisplayDateTimezones,
+} from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 export const HoverTooltip = memo(function HoverTooltip(): JSX.Element | null {
   // Log
@@ -34,6 +40,30 @@ export const HoverTooltip = memo(function HoverTooltip(): JSX.Element | null {
   const hoverFeatureInfo = useMapHoverFeatureInfo();
   const isMouseouseInMap = useMapIsMouseInsideMap();
   const mapElem = useAppGeoviewHTMLElement().querySelector(`[id^="mapTargetElement-${useGeoViewMapId()}"]`) as HTMLElement;
+  const language = useAppDisplayLanguage();
+  const layerDateTemporalModes = useLayerDateTemporalModes();
+  const displayDateFormats = useLayerDisplayDateFormats();
+  const displayDateTimezones = useLayerDisplayDateTimezones();
+
+  const memoValue = useMemo(() => {
+    logger.logTraceUseMemo('HOVER TOOLTIP - memoValue', hoverFeatureInfo?.fieldInfo?.value);
+
+    const valueRaw = hoverFeatureInfo?.fieldInfo?.value;
+    let valueString = valueRaw !== undefined ? (valueRaw as string) : undefined;
+
+    // If the value is a date
+    if (valueRaw instanceof Date) {
+      const layerDateTemporalMode = layerDateTemporalModes[hoverFeatureInfo!.layerPath];
+      valueString = DateMgt.formatDate(
+        valueRaw,
+        displayDateFormats[hoverFeatureInfo!.layerPath][language],
+        language,
+        displayDateTimezones[hoverFeatureInfo!.layerPath],
+        layerDateTemporalMode
+      );
+    }
+    return valueString;
+  }, [hoverFeatureInfo, displayDateFormats, displayDateTimezones, language, layerDateTemporalModes]);
 
   // Calculate position with boundary checks
   const position = useMemo(() => {
@@ -42,7 +72,7 @@ export const HoverTooltip = memo(function HoverTooltip(): JSX.Element | null {
 
     // Early return in memo
     // Check for all required conditions upfront
-    if (!pointerPosition?.pixel || !mapElem || !hoverFeatureInfo?.fieldInfo?.value || !isMouseouseInMap) {
+    if (!pointerPosition?.pixel || !mapElem || memoValue === undefined || !isMouseouseInMap) {
       return { left: '0px', top: '0px', isValid: false };
     }
     logger.logTraceUseMemo('HOVER TOOLTIP - position', pointerPosition);
@@ -52,7 +82,7 @@ export const HoverTooltip = memo(function HoverTooltip(): JSX.Element | null {
 
     // Approximate width calculation (50px for empty tooltip)
     // Assuming average character width of 10px and adding padding/margins
-    let approximateWidth = 25 + String(hoverFeatureInfo.fieldInfo?.value).length * 10;
+    let approximateWidth = 25 + memoValue.length * 10;
 
     // After a certain length, the string is cut off with ellipsis in the tooltip, so we have a max width.
     if (approximateWidth > 370) approximateWidth = 370; // Cap to max width
@@ -71,7 +101,7 @@ export const HoverTooltip = memo(function HoverTooltip(): JSX.Element | null {
     if (tooltipY < mapRectRef.current.top) tooltipY = pointerPosition.pixel[1] + 10;
 
     return { left: `${tooltipX}px`, top: `${tooltipY}px`, isValid: true };
-  }, [hoverFeatureInfo, isMouseouseInMap, mapElem, mapId]);
+  }, [mapId, mapElem, memoValue, isMouseouseInMap]);
 
   // Compute tooltip content and visibility
   const tooltipContent = useMemo(() => {
@@ -83,14 +113,15 @@ export const HoverTooltip = memo(function HoverTooltip(): JSX.Element | null {
     }
 
     logger.logTraceUseMemo('HOVER TOOLTIP - tooltipContent', hoverFeatureInfo);
+
     return {
       content: {
-        value: (hoverFeatureInfo.fieldInfo?.value as string) || '',
+        value: memoValue,
         icon: hoverFeatureInfo.featureIcon ? hoverFeatureInfo.featureIcon : '',
       },
       isVisible: true,
     };
-  }, [hoverFeatureInfo, position.isValid]);
+  }, [hoverFeatureInfo, memoValue, position.isValid]);
 
   return (
     <Box
@@ -109,7 +140,7 @@ export const HoverTooltip = memo(function HoverTooltip(): JSX.Element | null {
           <BrowserNotSupportedIcon />
         </Box>
       )}
-      {tooltipContent.content.value && <Box sx={sxClasses.tooltipText}>{tooltipContent.content.value}</Box>}
+      {tooltipContent.content.value !== undefined && <Box sx={sxClasses.tooltipText}>{tooltipContent.content.value}</Box>}
     </Box>
   );
 });

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
@@ -197,6 +197,7 @@ export type TypeFeatureInfoResultSet = TypeResultSet<TypeFeatureInfoResultSetEnt
 
 export type TypeHoverFeatureInfo =
   | {
+      layerPath: string;
       geoviewLayerType: TypeGeoviewLayerType;
       featureIcon?: string;
       fieldInfo?: TypeFieldEntry;

--- a/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
@@ -156,6 +156,7 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
             const fieldInfo = nameField ? arrayOfRecords[0].fieldInfo[nameField] : undefined;
 
             this.resultSet[layerPath].feature = {
+              layerPath,
               featureIcon: arrayOfRecords[0].featureIcon,
               fieldInfo,
               geoviewLayerType: arrayOfRecords[0].geoviewLayerType,

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -143,11 +143,6 @@ import type { TypeFeatureInfoResultSet } from '@/core/stores/store-interface-and
  * A class to get the layer from layer type. Layer type can be esriFeature, esriDynamic and ogcWMS
  */
 export class LayerApi {
-  /** A zoom level buffer to guarantee that the calculations being done via the resolutions, inches per meter, dpi are more strict than not enough */
-  /** The value 0.21 seems rather specific, but it was the value giving us the best result during testing on layer National Forest Inventory Photo Plot Summary */
-  /** It could be increased slightly if ever we need to, but it might offer worse precision depending on various layers */
-  static readonly MIN_MAX_ZOOM_LEVEL_BUFFER = 0.21;
-
   /** The opacity ratio to use when highlighting a layer vs the other layers */
   static readonly HIGHLIGHT_OPACITY_RATIO = 4;
 
@@ -2493,10 +2488,7 @@ export class LayerApi {
     // be handled in the map-viewer's handleMapZoomEnd by checking the children visibility
     if ((layerConfig.getInitialSettings()?.maxZoom || layerConfig.getMaxScale()) && !(gvLayer instanceof GVGroupLayer)) {
       // Calculate the map zoom for the corresponding max scale
-      let scaleZoomLevel = this.mapViewer.getMapZoomFromScale(layerConfig.getMaxScale()) ?? Infinity;
-
-      // Add a buffer, because the calculations are sometimes a bit off
-      scaleZoomLevel -= LayerApi.MIN_MAX_ZOOM_LEVEL_BUFFER;
+      const scaleZoomLevel = this.mapViewer.getMapZoomFromScale(layerConfig.getMaxScale()) ?? Infinity;
 
       const maxZoom = Math.min(layerConfig.getInitialSettings()?.maxZoom ?? Infinity, scaleZoomLevel);
       gvLayer.setMaxZoom(maxZoom);
@@ -2504,10 +2496,7 @@ export class LayerApi {
 
     if ((layerConfig.getInitialSettings()?.minZoom || layerConfig.getMinScale()) && !(gvLayer instanceof GVGroupLayer)) {
       // Calculate the map zoom for the corresponding min scale
-      let scaleZoomLevel = this.mapViewer.getMapZoomFromScale(layerConfig.getMinScale()) ?? -Infinity;
-
-      // Add a buffer, because the calculations are sometimes a bit off
-      scaleZoomLevel += LayerApi.MIN_MAX_ZOOM_LEVEL_BUFFER;
+      const scaleZoomLevel = this.mapViewer.getMapZoomFromScale(layerConfig.getMinScale()) ?? -Infinity;
 
       const minZoom = Math.max(layerConfig.getInitialSettings()?.minZoom ?? -Infinity, scaleZoomLevel);
       gvLayer.setMinZoom(minZoom);

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -83,6 +83,12 @@ import type { AbstractPlugin } from '@/api/plugin/abstract-plugin';
  * Class used to manage created maps.
  */
 export class MapViewer {
+  /** A zoom level buffer to guarantee that the calculations being done via the resolutions, inches per meter, dpi are more strict than not enough
+   * The value 0.21 seems rather specific, but it was the value giving us the best result during testing on layer
+   * National Forest Inventory Photo Plot Summary (6433173f-bca8-44e6-be8e-3e8a19d3c299) at zoom level 3.78 +/- 0.25
+   * It could be increased slightly if ever we need to, but it might offer worse precision depending on various layers */
+  static readonly ZOOM_LEVEL_FROM_SCALE_BUFFER = 0.21;
+
   /** Minimum delay (in milliseconds) for map to be in loading state */
   static readonly #MIN_DELAY_LOADING = 2000; // 2 seconds
 
@@ -795,9 +801,16 @@ export class MapViewer {
    * @returns The OpenLayers zoom level corresponding to the scale, or `undefined` if `targetScale` is not provided.
    */
   getMapZoomFromScale(targetScale: number | undefined, dpiValue: number = MapViewer.DEFAULT_DPI): number | undefined {
+    // Get the resolution from the scale
     const resolution = this.getMapResolutionFromScale(targetScale, dpiValue);
     if (!resolution) return undefined;
-    return this.getView().getZoomForResolution(resolution);
+
+    // Calculate the zoom level from the resolution
+    const zoomLevel = this.getView().getZoomForResolution(resolution);
+    if (!zoomLevel) return undefined;
+
+    // Add a buffer, because the calculations are sometimes a bit off
+    return zoomLevel + MapViewer.ZOOM_LEVEL_FROM_SCALE_BUFFER;
   }
 
   /**


### PR DESCRIPTION
# Description

- Quick fix for the hover when displaying date values.
- Also fixing a calculation issue with the min/max zoom level for the layers with restrictive min/max scales.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Host March 24 @ 12h30

- Go here: https://alex-nrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/demos/12-package-time-slider-custom.json and hover on the perimeters layer features, the map doesn't crash anymore and a date is shown following the layer display date format setting.
- Add the layer ae385105-e48c-4b54-bd0f-dfb7303301cb and zoom in and out between the visibility scales of layers: small-scale and smaller-scale (layer paths: ae385105-e48c-4b54-bd0f-dfb7303301cb/0/2/7 and ae385105-e48c-4b54-bd0f-dfb7303301cb/0/2/8)

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3373)
<!-- Reviewable:end -->
