### PR TITLE
fix(date): filter undefined/null before formatting date

### DIFF
--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -321,7 +321,7 @@ function DataTable({ data, layerPath, containerType }: DataTableProps): JSX.Elem
 
         // Spread in more properties if dataType is date
         ...(value.dataType === 'date' && {
-          accessorFn: (row) => DateMgt.createDayjs(row[key].value as string),
+          accessorFn: (row) => (row[key].value ? DateMgt.createDayjs(row[key].value as string) : undefined),
           Cell: ({ cell }) => getCellContentDate(cell.getValue<Dayjs>()),
           muiFilterDatePickerProps: {
             timezone: displayDateTimezoneUniversal,

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -1938,7 +1938,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     inputTemporalMode: TemporalMode | undefined
   ): unknown {
     const fieldValue = feature.get(fieldName);
-    if (fieldType === 'date') {
+    if (fieldType === 'date' && fieldValue) {
       // Read the date
       return DateMgt.createDate(fieldValue, inputFormat, inputTimezone, inputTemporalMode);
     }


### PR DESCRIPTION
# Description

Fixes issue with data table not being populated when some date fields are undefined or null.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Major projects data table here:
https://damonu2.github.io/geoview/outlier-metadata.html

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3378)
<!-- Reviewable:end -->
