### PR TITLE
fix(TimeSlider): Skip layers with undefined timeSliderLayer state

### DIFF
--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/time-slider-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/time-slider-state.ts
@@ -130,8 +130,11 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
       },
 
       setFiltering(layerPath: string, filtering: boolean): void {
+        const timeSliderLayer = get().timeSliderState.timeSliderLayers[layerPath];
+        if (!timeSliderLayer) return; // This can happen if there are no features in the service
+
         // Redirect to TimeSliderEventProcessor
-        const { field, minAndMax, values, additionalLayerpaths } = get().timeSliderState.timeSliderLayers[layerPath];
+        const { field, minAndMax, values, additionalLayerpaths } = timeSliderLayer;
 
         // Update the filters
         TimeSliderEventProcessor.updateFilters(get().mapId, layerPath, field, filtering, minAndMax, values);
@@ -157,8 +160,10 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
         get().timeSliderState.setterActions.setStep(layerPath, step);
       },
       setValues(layerPath: string, values: number[]): void {
-        // Redirect to TimeSliderEventProcessor
-        const { field, minAndMax, filtering, additionalLayerpaths } = get().timeSliderState.timeSliderLayers[layerPath];
+        const timeSliderLayer = get().timeSliderState.timeSliderLayers[layerPath];
+        if (!timeSliderLayer) return; // This can happen if there are no features in the service
+
+        const { field, minAndMax, filtering, additionalLayerpaths } = timeSliderLayer;
 
         // Update the filters
         TimeSliderEventProcessor.updateFilters(get().mapId, layerPath, field, filtering, minAndMax, values);


### PR DESCRIPTION
# Description

Services with no features were causing the timeSliderState.timeSliderLayers[layerPath] to be undefined, which was causing an error when trying to unpack the state, since the values didn't exist.

Specifically, this was happening in the custom time slider because of the "Floods in Canada" layer which the service seems to have no features at the moment.

Fixes #

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Go to the custom time slider navigator page and then turn on time filtering for the "Progression and Perimeters of Fires and Floods" time slider layer. Then play the time slider or change the handles. This would throw an error previously.

[_Custom Time Slider Navigator__](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/demos/12-package-time-slider-custom.json)

# Checklist:

- [X] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3384)
<!-- Reviewable:end -->
