### PR TITLE
fix(store-naming-convention) - Improved some store getters/hooks names and started improving UI performance

### DIFF
--- a/packages/eslint.config.js
+++ b/packages/eslint.config.js
@@ -103,6 +103,7 @@ export default [
           fixStyle: 'separate-type-imports',
         },
       ],
+      '@typescript-eslint/no-import-type-side-effects': 'error',
       'no-useless-constructor': 'off',
       '@typescript-eslint/no-useless-constructor': 'error',
       'no-unused-vars': 'off',

--- a/packages/geoview-about-panel/src/about-panel.tsx
+++ b/packages/geoview-about-panel/src/about-panel.tsx
@@ -1,6 +1,6 @@
 import type { TypeWindow } from 'geoview-core/core/types/global-types';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import { logger } from 'geoview-core/core/utils/logger';
 
 import { getSxClasses } from './about-panel-style';
@@ -30,7 +30,7 @@ function MarkdownFromPath(props: TypeMarkdownFromPathProps): JSX.Element {
   const { useEffect, useState } = react;
   const { Box, Typography } = ui.elements;
 
-  const displayLanguage = useAppDisplayLanguage();
+  const displayLanguage = useStoreAppDisplayLanguage();
 
   const [content, setContent] = useState<string>('');
   const [error, setError] = useState<string | null>(null);

--- a/packages/geoview-aoi-panel/src/aoi-panel.tsx
+++ b/packages/geoview-aoi-panel/src/aoi-panel.tsx
@@ -1,7 +1,7 @@
 import type { TypeWindow } from 'geoview-core/core/types/global-types';
 import type { Extent } from 'geoview-core/api/types/map-schema-types';
 import { Projection } from 'geoview-core/geo/utils/projection';
-import { useMapProjectionEPSG } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapCurrentProjectionEPSG } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from 'geoview-core/core/utils/logger';
 import { getSxClasses } from './area-of-interest-style';
 import { useMapController } from 'geoview-core/core/controllers/map-controller';
@@ -51,7 +51,8 @@ export function AoiPanel(props: AoiPanelProps): JSX.Element {
   const theme = ui.useTheme();
   const sxClasses = getSxClasses(theme);
 
-  const mapProjectionEPSG = useMapProjectionEPSG();
+  // Store
+  const mapProjectionEPSG = useStoreMapCurrentProjectionEPSG();
   const mapController = useMapController();
 
   /**

--- a/packages/geoview-core/public/configs/navigator/layers/esri-dynamic.json
+++ b/packages/geoview-core/public/configs/navigator/layers/esri-dynamic.json
@@ -249,5 +249,8 @@
     "tabs": {
       "core": ["geolocator", "legend", "details", "export"]
     }
+  },
+  "globalSettings": {
+    "coordinateInfoEnabled": false
   }
 }

--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -303,7 +303,6 @@
     "nullValue": "Null",
     "toggleCoordinateInfo": "Toggle coordinate info tool",
     "showCoordinateInfo": "Show coordinate info",
-    "noCoordinateInfo": "No Coordinate Info",
     "coordinateInfoTitle": "Coordinate Info",
     "geographicCoordinates": "Geographic Coordinates",
     "degreesDecimal": "Decimal Degrees",
@@ -490,7 +489,8 @@
       "basemapLayerCreationError": "Error creating __param__ basemap.",
       "kmlLayerWarning": "KML layers will not have proper symbols in the panels or have entries in the data table.",
       "layerCRSNotSupported": "The spatial reference of the map '__param__' is not officially supported by the layer '__param__'. GeoView will still attempt to load the layer on the map, but it might be misaligned.",
-      "invalidGeometry": "The '__param__' layer contains features with invalid geometries that will not show on the map."
+      "invalidGeometry": "The '__param__' layer contains features with invalid geometries that will not show on the map.",
+      "slowCoordinateInfo": "The coordinate info for the clicked coordinates is taking longer than expected to fetch..."
     }
   },
   "error": {

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -303,7 +303,6 @@
     "nullValue": "Nul",
     "toggleCoordinateInfo": "Basculer l'outil d'informations sur les coordonnées",
     "showCoordinateInfo": "Afficher les informations sur les coordonnées",
-    "noCoordinateInfo": "Aucune information sur les coordonnées",
     "coordinateInfoTitle": "Informations sur les coordonnées",
     "geographicCoordinates": "Coordonnée géographique",
     "degreesDecimal": "Degrés décimaux",
@@ -490,7 +489,8 @@
       "basemapLayerCreationError": "Erreur lors de la création de la couche de base __param__.",
       "kmlLayerWarning": "Les couches KML n'afficheront pas les symboles appropriés dans les panneaux et ne comporteront pas d'entrées dans le tableau de données.",
       "layerCRSNotSupported": "La référence spatiale de la carte '__param__' n'est pas officiellement supportée par la couche '__param__'. GeoView va tout de même tenté d'afficher la couche, mais celle-ci risque d'être désalignée..",
-      "invalidGeometry": "La couche '__param__' contient des entités dont la géométrie est invalide et qui ne s'afficheront pas sur la carte."
+      "invalidGeometry": "La couche '__param__' contient des entités dont la géométrie est invalide et qui ne s'afficheront pas sur la carte.",
+      "slowCoordinateInfo": "Les informations de coordonnées pour le point cliqué prennent plus de temps que prévu à être récupérées..."
     }
   },
   "error": {

--- a/packages/geoview-core/public/templates/codedoc.js
+++ b/packages/geoview-core/public/templates/codedoc.js
@@ -193,14 +193,19 @@ function addRectangle(map, groupKey) {
 }
 
 function listenToLegendLayerSetChanges(elementId, mapViewer) {
-  mapViewer.layer.legendsLayerSet.onLayerSetUpdated((sender, payload) => {
+  const displayField = document.getElementById(elementId);
 
-    const { resultSet } = payload;
+  // Listen on the layer status changes
+  const allResults = {};
+  displayField.innerHTML = '';
+  mapViewer.layer.onLayerStatusChanged((sender, payload) => {
+    const layerPath = payload.config.layerPath;
+    const layerStatus = payload.status;
+    allResults[layerPath] = layerStatus;
+
     const outputHeader = '<table class="state"><tr class="state"><th class="state">Name</th><th class="state">Status</th></tr>';
-    const displayField = document.getElementById(elementId);
-    const output = Object.keys(resultSet).reduce((outputValue, layerPath) => {
-      const { layerStatus } = resultSet[layerPath];
-      return `${outputValue}<tr class="state"><td class="state">${layerPath}</td><td class="state">${layerStatus}</td></tr>`;
+    const output = Object.keys(allResults).reduce((outputValue, layerPath) => {
+      return `${outputValue}<tr class="state"><td class="state">${layerPath}</td><td class="state">${allResults[layerPath]}</td></tr>`;
     }, outputHeader);
     displayField.innerHTML = output && output !== outputHeader ? `${output}</table>` : '';
   });
@@ -225,7 +230,7 @@ async function onConfigChange(mapId, e) {
 
   // create map
   try {
-    const mapViewer = await cgpv.api.createMapFromConfig(mapId, e.target.value, 800);
+    const mapViewer = await cgpv.api.createMapFromConfigFast(mapId, e.target.value, 800);
     listenToLegendLayerSetChanges('sandboxMap-state', mapViewer);
   } catch (error) {
     console.error('Failed to create map from config', error);

--- a/packages/geoview-core/public/templates/default-config.html
+++ b/packages/geoview-core/public/templates/default-config.html
@@ -224,7 +224,7 @@
       insertPageHeader();
 
       cgpv.api
-        .createMapFromConfig(
+        .createMapFromConfigFast(
           'map7',
           JSON.stringify({
             map: {

--- a/packages/geoview-core/public/templates/demos/demo-app-geo-v2.html
+++ b/packages/geoview-core/public/templates/demos/demo-app-geo-v2.html
@@ -106,7 +106,7 @@
         cgpv.api.hasMapViewer(mapId) && (await cgpv.api.deleteMapViewer(mapId, false));
 
         // Create the map
-        await cgpv.api.createMapFromConfig(mapId, configString);
+        await cgpv.api.createMapFromConfigFast(mapId, configString);
 
         // Add the geoview layer by geocore id
         cgpv.api.getMapViewer(mapId).layer.addGeoviewLayerByGeoCoreUUID(id);

--- a/packages/geoview-core/public/templates/demos/demo-osdp-integration.html
+++ b/packages/geoview-core/public/templates/demos/demo-osdp-integration.html
@@ -224,7 +224,7 @@ function addLayers(layers) {
                 await removeMap('Map1');
 
                 // Create map from config
-                await cgpv.api.createMapFromConfig('Map1', JSON.stringify(mapConfig), 800).then((mapViewer) => {
+                await cgpv.api.createMapFromConfigFast('Map1', JSON.stringify(mapConfig), 800).then((mapViewer) => {
                   if (langSwitch) {
                       mapViewer.notifications.showWarning('Map language changed', []);
                       mapViewer.notifications.addNotificationWarning(`MapViewer: Map language changed to ${lang}`);
@@ -429,7 +429,7 @@ cgpv.api.getMapViewer('Map1').replaceMapConfigLayerNames(pairs, mapConfig, true)
           await removeMap('Map1');
 
           // Create map from config
-          await cgpv.api.createMapFromConfig('Map1', JSON.stringify(mapConfig), 800).then((mapViewer) => {
+          await cgpv.api.createMapFromConfigFast('Map1', JSON.stringify(mapConfig), 800).then((mapViewer) => {
             if (langSwitch) {
               mapViewer.notifications.showWarning('Map language changed', []);
               mapViewer.notifications.addNotificationWarning(`MapViewer: Map language changed to ${lang}`);

--- a/packages/geoview-core/public/templates/package-swiper.html
+++ b/packages/geoview-core/public/templates/package-swiper.html
@@ -47,27 +47,6 @@
     <script>
       insertPageHeader();
 
-      // Register handler when map has been initialized
-      cgpv.onMapInit((mapViewer) => {
-        if (mapViewer.mapId === 'map1') {
-          // Hook when the layers will be loaded
-          mapViewer.onMapLayersLoaded(() => {
-            // TODO: Check - Why delay it here? Safe to remove?
-            window.setInterval(() => {
-              const displayField1 = document.getElementById('HUC3-state');
-              const featureInfoLayerSet = mapViewer.layer.featureInfoLayerSet.resultSet;
-              if (featureInfoLayerSet) {
-                const output = Object.keys(featureInfoLayerSet).reduce((outputValue, layerId) => {
-                  const { layerStatus } = featureInfoLayerSet[layerId];
-                  return `${outputValue}${layerId.split('/')[layerId.split('/').length - 1]} - status: ${layerStatus}, `;
-                }, '(');
-                displayField1.textContent = output && output !== '(' ? `${output.slice(0, -2)})` : '(undefined)';
-              } else displayField1.textContent = '(undefined)';
-            }, 250);
-          });
-        }
-      });
-
       // initialize cgpv
       cgpv.init();
 

--- a/packages/geoview-core/public/templates/sandbox.html
+++ b/packages/geoview-core/public/templates/sandbox.html
@@ -1070,7 +1070,7 @@
           const configArea = document.getElementById('configGeoview');
           // Use centralized config parser
           const configText = configArea.value.replace(getSingleQuoteRegex(), '"');
-          const mapViewer = await cgpv.api.createMapFromConfig('map1', configText);
+          const mapViewer = await cgpv.api.createMapFromConfigFast('map1', configText);
           listenToLegendLayerSetChanges('sandboxMap-state', mapViewer);
         } catch (error) {
           console.error('Failed to create map from config', error);

--- a/packages/geoview-core/src/api/api.ts
+++ b/packages/geoview-core/src/api/api.ts
@@ -173,10 +173,11 @@ export class API {
    * @param divId - Id of the div to create map in (becomes the mapId)
    * @param mapConfig - Config passed in from the function call (string or url of a config path)
    * @param divHeight - Optional height of the div to inject the map in (mandatory if the map reloads)
+   * @param waitOnMapReady - Optional flag to wait for the map to be ready before resolving the promise
    * @returns A promise that resolves with the MapViewer (after the onMapReady is triggered) which will be created from the configuration
    */
   // This function is called by the template, and since the template use the instance of the object from cgpv.api, this function has to be on the instance, not static. Refactor this?
-  async createMapFromConfig(divId: string, mapConfig: string, divHeight?: number): Promise<MapViewer> {
+  async createMapFromConfig(divId: string, mapConfig: string, divHeight?: number, waitOnMapReady: boolean = true): Promise<MapViewer> {
     // Get the map div
     const mapDiv = document.getElementById(divId);
     if (!mapDiv) throw new InitDivNotExistError(divId);
@@ -190,12 +191,35 @@ export class API {
     // Init by function call
     const mapViewer = await initMapDivFromFunctionCall(mapDiv, mapConfig);
 
-    // Wait for onMapReady to be triggered
-    await new Promise<void>((resolve) => {
-      mapViewer.onMapReady(() => resolve());
-    });
+    // If waiting on the map ready.
+    // GV Keep in mind that doing so will make you skip some layer entry config processing happening in parallel.
+    // GV The waitOnMapReady parameter was added as an extra parameter for legacy support. The better solution would be
+    // GV to get rid of the parameter and never wait for the map to be ready before returning the MapViewer. Have the caller
+    // GV call 'waitForMapReady' themselves if they need to, because the default scenario should be to not wait.
+    if (waitOnMapReady) {
+      // Wait for map to be ready
+      await mapViewer.waitForMapReady();
+    }
 
+    // Return the map viewer in a 'ready' or 'not ready' state depending on the waitOnMapReady parameter
     return mapViewer;
+  }
+
+  /**
+   * Creates a new map in a given div id.
+   *
+   * GV The div MUST NOT have a geoview-map class or a warning will be shown when initMapDivFromFunctionCall is called.
+   * If is present, the div will be created with a default config.
+   *
+   * @param divId - Id of the div to create map in (becomes the mapId)
+   * @param mapConfig - Config passed in from the function call (string or url of a config path)
+   * @param divHeight - Optional height of the div to inject the map in (mandatory if the map reloads)
+   * @returns A promise that resolves with the MapViewer (after the onMapReady is triggered) which will be created from the configuration
+   */
+  // This function is called by the template, and since the template use the instance of the object from cgpv.api, this function has to be on the instance, not static. Refactor this?
+  createMapFromConfigFast(divId: string, mapConfig: string, divHeight?: number): Promise<MapViewer> {
+    // Redirect
+    return this.createMapFromConfig(divId, mapConfig, divHeight, false);
   }
 
   /**
@@ -222,7 +246,7 @@ export class API {
     await this.deleteMapViewer(mapId, false);
 
     // TODO: There is still a problem with bad config schema value and layers loading... should be refactor when config is done
-    return this.createMapFromConfig(mapId, JSON.stringify(config), height);
+    return this.createMapFromConfigFast(mapId, JSON.stringify(config), height);
   }
 
   /**

--- a/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
@@ -15,7 +15,8 @@ import type {
 } from '@/api/types/layer-schema-types';
 import type { ConfigBaseClassProps } from '@/api/config/validation-classes/config-base-class';
 import { ConfigBaseClass } from '@/api/config/validation-classes/config-base-class';
-import { DateMgt, type TemporalMode, type TimeDimension, type TimeIANA, type TypeDisplayDateFormat } from '@/core/utils/date-mgt';
+import { DateMgt } from '@/core/utils/date-mgt';
+import type { TemporalMode, TimeDimension, TimeIANA, TypeDisplayDateFormat } from '@/core/utils/date-mgt';
 import { LayerDataAccessPathMandatoryError } from '@/core/exceptions/layer-exceptions';
 import { NoPrimaryKeyFieldError } from '@/core/exceptions/geoview-exceptions';
 import { GeoUtilities } from '@/geo/utils/utilities';

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wmts-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wmts-layer-entry-config.ts
@@ -1,6 +1,6 @@
 import type { ConfigClassOrType, TypeGeoviewLayerConfig } from '@/api/types/layer-schema-types';
 import { CONST_LAYER_ENTRY_TYPES, CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
-import { type AbstractBaseLayerEntryConfigProps } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
+import type { AbstractBaseLayerEntryConfigProps } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
 import { TileLayerEntryConfig } from '@/api/config/validation-classes/tile-layer-entry-config';
 import type { TypeSourceImageWMTSInitialConfig, TypeWmtsLayerConfig } from '@/geo/layer/geoview-layers/raster/wmts';
 

--- a/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/wfs-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/vector-validation-classes/wfs-layer-entry-config.ts
@@ -7,7 +7,7 @@ import type {
 } from '@/api/types/layer-schema-types';
 import type { TypeOutfields } from '@/api/types/map-schema-types';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
-import { type TypeWFSLayerConfig } from '@/geo/layer/geoview-layers/vector/wfs';
+import type { TypeWFSLayerConfig } from '@/geo/layer/geoview-layers/vector/wfs';
 import type { VectorLayerEntryConfigProps } from '@/api/config/validation-classes/vector-layer-entry-config';
 import { VectorLayerEntryConfig } from '@/api/config/validation-classes/vector-layer-entry-config';
 import { LayerEntryConfigLayerIdNotFoundError } from '@/core/exceptions/layer-entry-config-exceptions';

--- a/packages/geoview-core/src/api/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/types/map-schema-types.ts
@@ -650,7 +650,7 @@ export type TypeLayerStyleConfigInfo = {
   /** Flag used to show/hide features associated to the label (default: true). */
   visible: boolean;
   /** The label to display for the field. */
-  label: string;
+  label?: string;
   /** The OpenLayers Text style to apply to the label (will override the global feature text) */
   text?: TypeLayerTextConfig;
   /**

--- a/packages/geoview-core/src/app.tsx
+++ b/packages/geoview-core/src/app.tsx
@@ -278,7 +278,7 @@ export function initMapDivFromFunctionCall(mapDiv: HTMLElement, mapConfig: strin
   mapDiv.classList.add('geoview-map');
 
   // Add a compatibility flag on the div so that when a map is loaded via function call, it's subsequently ignored in eventual init() calls.
-  // This is useful in case that a html first calls for example `cgpv.api.createMapFromConfig('LNG1', config, divHeight);` and then
+  // This is useful in case that a html first calls for example `cgpv.api.createMapFromConfigFast('LNG1', config, divHeight);` and then
   // calls `cgpv.init()` (let's say for other maps on the page), the map LNG1 isn't being initialized twice.
   // Remember that init() grabs all maps with geoview-map class and we just added that class manually above, so we need that flag.
   mapDiv.classList.add('geoview-map-func-call');

--- a/packages/geoview-core/src/core/app-start.tsx
+++ b/packages/geoview-core/src/core/app-start.tsx
@@ -9,7 +9,7 @@ import { ScopedCssBaseline } from '@mui/material';
 import { Shell } from '@/core/containers/shell';
 import { getTheme } from '@/ui/style/theme';
 import { logger } from '@/core/utils/logger';
-import { useAppDisplayThemeById } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayThemeById } from '@/core/stores/store-interface-and-intial-values/app-state';
 import type { TypeDisplayLanguage } from '@/api/types/map-schema-types';
 import type { MapViewer } from '@/geo/map/map-viewer';
 import { ControllerContext } from '@/core/controllers/base/controller-manager';
@@ -98,7 +98,7 @@ function AppStart(props: AppStartProps): JSX.Element {
 
   // GV get store values by id because context is not set.... it is the only atomic selector by id
   // once context is define, map id is available
-  const theme = useAppDisplayThemeById(mapViewer.mapId);
+  const theme = useStoreAppDisplayThemeById(mapViewer.mapId);
 
   return (
     <ErrorBoundary language={(i18nLang.language as TypeDisplayLanguage) || 'en'}>

--- a/packages/geoview-core/src/core/components/app-bar/app-bar-api.ts
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar-api.ts
@@ -5,7 +5,7 @@ import type { IconButtonPropsExtend } from '@/ui/icon-button/icon-button';
 import { generateId } from '@/core/utils/utilities';
 import type { EventDelegateBase } from '@/api/events/event-helper';
 import EventHelper from '@/api/events/event-helper';
-import { type ActiveAppBarTabType } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { getStoreUIActiveAppBarTab, type ActiveAppBarTabType } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import type { UIController } from '@/core/controllers/ui-controller';
 import { logger } from '@/core/utils/logger';
 
@@ -159,10 +159,10 @@ export class AppBarApi {
    * Gets the active app bar tab.
    *
    * @returns The active app bar tab info.
-   * @deprecated Legacy support. Should use uiController.getActiveAppBarTab directly instead.
+   * @deprecated Legacy support. Should be removed.
    */
   getActiveAppBarTab(): ActiveAppBarTabType {
-    return this.#uiController.getActiveAppBarTab();
+    return getStoreUIActiveAppBarTab(this.#uiController.getMapId());
   }
 
   /**

--- a/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
@@ -22,15 +22,15 @@ import { Geolocator } from '@/core/components/geolocator/geolocator';
 import type { TypeButtonPanel, TypePanelProps } from '@/ui/panel/panel-types';
 import ExportButton from '@/core/components/export/export-modal-button';
 import {
-  useUIActiveFocusItem,
-  useUIActiveTrapGeoView,
-  useUIAppbarComponents,
-  useUIActiveAppBarTab,
-  useUIHiddenTabs,
+  useStoreUIActiveFocusItem,
+  useStoreUIActiveTrapGeoView,
+  useStoreUIAppbarComponents,
+  useStoreUIActiveAppBarTab,
+  useStoreUIHiddenTabs,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import { useMapInteraction, setStoreMapClickMarkerIconHide } from '@/core/stores/store-interface-and-intial-values/map-state';
-import { useAppGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { useGeoViewConfig, useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreMapInteraction, setStoreMapClickMarkerIconHide } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreAppGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreGeoViewConfig, useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
 import type { AppBarApi, AppBarCreatedEvent, AppBarRemovedEvent } from '@/core/components';
 import { Guide, Legend, DetailsPanel, Datapanel, LayersPanel } from '@/core/components';
@@ -73,7 +73,6 @@ export function AppBar(props: AppBarProps): JSX.Element {
   const { api: appBarApi, onScrollShellIntoView } = props;
 
   // Hooks
-  const mapId = useGeoViewMapId();
   const { t } = useTranslation();
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
@@ -82,21 +81,21 @@ export function AppBar(props: AppBarProps): JSX.Element {
   const [buttonPanels, setButtonPanels] = useState<ButtonPanelType>({});
 
   // get store values and action
-  const activeModalId = useUIActiveFocusItem().activeElementId;
-  const interaction = useMapInteraction();
-  const appBarComponents = useUIAppbarComponents();
-  const { tabId, isOpen, isFocusTrapped } = useUIActiveAppBarTab();
-  const hiddenTabs = useUIHiddenTabs();
-  const activeTrapGeoView = useUIActiveTrapGeoView();
+  const mapId = useStoreGeoViewMapId();
+  const activeModalId = useStoreUIActiveFocusItem().activeElementId;
+  const interaction = useStoreMapInteraction();
+  const appBarComponents = useStoreUIAppbarComponents();
+  const { tabId, isOpen, isFocusTrapped } = useStoreUIActiveAppBarTab();
+  const hiddenTabs = useStoreUIHiddenTabs();
+  const activeTrapGeoView = useStoreUIActiveTrapGeoView();
   const pluginController = usePluginController();
-
-  const geoviewElement = useAppGeoviewHTMLElement().querySelector('[id^="mapTargetElement-"]') as HTMLElement;
-
   const uiController = useUIController();
 
+  const geoviewElement = useStoreAppGeoviewHTMLElement().querySelector('[id^="mapTargetElement-"]') as HTMLElement;
+
   // get store config for app bar to add (similar logic as in footer-bar)
-  const appBarConfig = useGeoViewConfig()?.appBar;
-  const footerBarConfig = useGeoViewConfig()?.footerBar;
+  const appBarConfig = useStoreGeoViewConfig()?.appBar;
+  const footerBarConfig = useStoreGeoViewConfig()?.footerBar;
 
   // #region REACT HOOKS
 

--- a/packages/geoview-core/src/core/components/app-bar/buttons/share.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/buttons/share.tsx
@@ -2,14 +2,14 @@ import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ShareIcon, IconButton, Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Box } from '@/ui';
-import { useGeoViewMapId, useGeoViewSharedMode } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId, useStoreGeoViewSharedMode } from '@/core/stores/geoview-store';
 import {
-  useMapInteraction,
-  useMapZoom,
-  useMapCenterCoordinates,
-  useMapProjection,
-  useMapCurrentBasemapOptions,
-  useMapOrderedLayers,
+  useStoreMapInteraction,
+  useStoreMapZoom,
+  useStoreMapCenterCoordinates,
+  useStoreMapCurrentProjection,
+  useStoreMapCurrentBasemapOptions,
+  useStoreMapOrderedLayers,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { Projection } from '@/geo/utils/projection';
 
@@ -98,14 +98,14 @@ export default function Share(): JSX.Element | null {
   const { t } = useTranslation<string>();
 
   // Store
-  const mapId = useGeoViewMapId();
-  const sharedMode = useGeoViewSharedMode();
-  const interaction = useMapInteraction();
-  const zoom = useMapZoom();
-  const center = useMapCenterCoordinates();
-  const projection = useMapProjection();
-  const basemap = useMapCurrentBasemapOptions();
-  const layers = useMapOrderedLayers();
+  const mapId = useStoreGeoViewMapId();
+  const sharedMode = useStoreGeoViewSharedMode();
+  const interaction = useStoreMapInteraction();
+  const zoom = useStoreMapZoom();
+  const center = useStoreMapCenterCoordinates();
+  const projection = useStoreMapCurrentProjection();
+  const basemap = useStoreMapCurrentBasemapOptions();
+  const layers = useStoreMapOrderedLayers();
 
   // State
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/buttons/version.tsx
@@ -6,12 +6,12 @@ import { Typography, Box, Link, SvgIcon, ClickAwayListener, List, Paper, useThem
 import { useUIController } from '@/core/controllers/ui-controller';
 import { GITHUB_REPO, GEO_URL_TEXT, CONTAINER_TYPE } from '@/core/utils/constant';
 import { GeoCaIcon, IconButton, Popper, CloseIcon } from '@/ui';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
-import { useMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { GitHubIcon } from '@/ui/icons';
 import { handleEscapeKey } from '@/core/utils/utilities';
 import { FocusTrapContainer } from '@/core/components/common/focus-trap-container';
-import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { DateMgt } from '@/core/utils/date-mgt';
 import type { SxStyles } from '@/ui/style/types';
 import { visuallyHidden } from '@/ui/style/default';
@@ -87,12 +87,12 @@ export default function Version(): JSX.Element {
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // Store
-  const interaction = useMapInteraction();
-  const activeTrapGeoView = useUIActiveTrapGeoView();
+  const mapId = useStoreGeoViewMapId();
+  const interaction = useStoreMapInteraction();
+  const activeTrapGeoView = useStoreUIActiveTrapGeoView();
   const uiController = useUIController();
 
   // Get container
-  const mapId = useGeoViewMapId();
   const mapElem = document.getElementById(`shell-${mapId}`);
 
   // State

--- a/packages/geoview-core/src/core/components/attribution/attribution.tsx
+++ b/packages/geoview-core/src/core/components/attribution/attribution.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
 
 import { Box, CopyrightIcon, Popover, IconButton, Typography } from '@/ui';
-import { useMapAttribution, useMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreMapAttribution, useStoreMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
 
 /** Popover anchor and transform origin positions. */
@@ -45,14 +45,14 @@ export const Attribution = memo(function Attribution(): JSX.Element {
   const theme = useTheme();
 
   // State
-  const interaction = useMapInteraction();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
   const open = Boolean(anchorEl);
 
   // Store
-  const mapAttribution = useMapAttribution();
+  const mapId = useStoreGeoViewMapId();
+  const interaction = useStoreMapInteraction();
+  const mapAttribution = useStoreMapAttribution();
 
-  const mapId = useGeoViewMapId();
   const mapElem = document.getElementById(`shell-${mapId}`);
 
   const buttonStyles = {

--- a/packages/geoview-core/src/core/components/click-marker/click-marker.tsx
+++ b/packages/geoview-core/src/core/components/click-marker/click-marker.tsx
@@ -4,12 +4,12 @@ import type { Coordinate } from 'ol/coordinate';
 import { Box, ClickMapMarker } from '@/ui';
 
 import {
-  useMapClickMarker,
-  useMapClickCoordinates,
+  useStoreMapClickMarker,
+  useStoreMapClickCoordinates,
   setStoreMapOverlayClickMarkerRef,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { useMapController } from '@/core/controllers/map-controller';
 
 /** Represents a click marker placed on the map at the user's click location. */
@@ -27,13 +27,13 @@ export const ClickMarker = memo(function ClickMarker(): JSX.Element {
   logger.logTraceRender('components/click-marker/click-marker');
 
   // State
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
   const clickMarkerRef = useRef<HTMLDivElement>(null);
   const clickMarkerId = `${mapId}-clickmarker`;
 
   // Store
-  const clickMarker = useMapClickMarker();
-  const clickCoordinates = useMapClickCoordinates();
+  const clickMarker = useStoreMapClickMarker();
+  const clickCoordinates = useStoreMapClickCoordinates();
   const mapController = useMapController();
 
   /**

--- a/packages/geoview-core/src/core/components/common/focus-trap-container.tsx
+++ b/packages/geoview-core/src/core/components/common/focus-trap-container.tsx
@@ -4,10 +4,10 @@ import { useTranslation } from 'react-i18next';
 import { FocusTrap, Box, Button } from '@/ui';
 
 import { useUIController } from '@/core/controllers/ui-controller';
-import { useUIActiveFocusItem, useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreUIActiveFocusItem, useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { CONTAINER_TYPE, TIMEOUT } from '@/core/utils/constant';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
 
 /** Properties for the FocusTrapContainer component. */
@@ -43,10 +43,10 @@ export const FocusTrapContainer = memo(function FocusTrapContainer({
   const { t } = useTranslation<string>();
 
   // Store
+  const mapId = useStoreGeoViewMapId();
   const uiController = useUIController();
-  const activeTrapGeoView = useUIActiveTrapGeoView();
-  const focusItem = useUIActiveFocusItem();
-  const mapId = useGeoViewMapId();
+  const activeTrapGeoView = useStoreUIActiveTrapGeoView();
+  const focusItem = useStoreUIActiveFocusItem();
 
   /**
    * Handles closing the focus trap and restoring focus.

--- a/packages/geoview-core/src/core/components/common/hooks/use-light-box.tsx
+++ b/packages/geoview-core/src/core/components/common/hooks/use-light-box.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useState } from 'react';
 import { Box } from '@/ui';
 import type { LightBoxSlides } from '@/core/components/lightbox/lightbox';
 import { LightboxImg } from '@/core/components/lightbox/lightbox';
-import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { logger } from '@/core/utils/logger';
 import { TIMEOUT } from '@/core/utils/constant';
 
@@ -41,7 +41,7 @@ const BaseLightBoxComponent = memo(function BaseLightBoxComponent({
 }: BaseLightBoxProps) {
   logger.logTraceRender('components/common/use-lightbox (BaseLightBoxComponent)');
 
-  const activeTrapGeoView = useUIActiveTrapGeoView();
+  const activeTrapGeoView = useStoreUIActiveTrapGeoView();
 
   /**
    * Handles when the user changes slides in the lightbox.

--- a/packages/geoview-core/src/core/components/common/hooks/use-navigate-to-tab.ts
+++ b/packages/geoview-core/src/core/components/common/hooks/use-navigate-to-tab.ts
@@ -1,15 +1,15 @@
 import { useCallback } from 'react';
 import {
-  useUIActiveFooterBarTab,
-  useUIFooterBarComponents,
-  useUIAppbarComponents,
+  useStoreUIActiveFooterBarTab,
+  useStoreUIFooterBarComponents,
+  useStoreUIAppbarComponents,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { scrollIfNotVisible } from '@/core/utils/utilities';
 import { logger } from '@/core/utils/logger';
 import type { TypeValidAppBarCoreProps, TypeValidFooterBarTabsCoreProps } from '@/api/types/map-schema-types';
 import { TIMEOUT } from '@/core/utils/constant';
 import { useUIController } from '@/core/controllers/ui-controller';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 
 /** Options for navigating to a tab. */
 interface NavigateToTabOptions {
@@ -26,11 +26,11 @@ interface NavigateToTabOptions {
  */
 export function useNavigateToTab(tabId: string, onNavigate?: (mapId: string, layerPath: string) => void): (options?: NavigateToTabOptions) => void {
   // Store
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
   const uiController = useUIController();
-  const { isOpen: isFooterOpen } = useUIActiveFooterBarTab();
-  const footerBarComponents = useUIFooterBarComponents();
-  const appBarComponents = useUIAppbarComponents();
+  const { isOpen: isFooterOpen } = useStoreUIActiveFooterBarTab();
+  const footerBarComponents = useStoreUIFooterBarComponents();
+  const appBarComponents = useStoreUIAppbarComponents();
 
   // Check if tab exists in footer or appbar
   const hasFooterTab = footerBarComponents.includes(tabId as TypeValidFooterBarTabsCoreProps);

--- a/packages/geoview-core/src/core/components/common/layer-icon.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-icon.tsx
@@ -4,10 +4,10 @@ import { Box, CircularProgressBase, ErrorIcon, Icon, BrowserNotSupportedIcon, La
 
 import { getSxClasses } from '@/core/components/common/layer-icon-style';
 import {
-  useLayerIconLayerSet,
-  useLayerSelectorChildren,
-  useLayerSelectorLegendQueryStatus,
-  useLayerSelectorStatus,
+  useStoreLayerIconLayerSet,
+  useStoreLayerChildPaths,
+  useStoreLayerLegendQueryStatus,
+  useStoreLayerStatus,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { logger } from '@/core/utils/logger';
 
@@ -46,7 +46,7 @@ function IconStack({ layerPath }: TypeIconStackProps): JSX.Element | null {
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // Store
-  const iconData = useLayerIconLayerSet(layerPath);
+  const iconData = useStoreLayerIconLayerSet(layerPath);
 
   const { iconImage, iconImageStacked, numOfIcons } = useMemo(
     () => ({
@@ -131,12 +131,12 @@ export function LayerIcon({ layerPath }: LayerIconProps): JSX.Element {
   logger.logTraceRenderDetailed('components/common/layer-icon', layerPath);
 
   // Hooks
-  const layerStatus = useLayerSelectorStatus(layerPath);
-  const legendQueryStatus = useLayerSelectorLegendQueryStatus(layerPath);
-  const layerChildren = useLayerSelectorChildren(layerPath);
+  const layerStatus = useStoreLayerStatus(layerPath);
+  const legendQueryStatus = useStoreLayerLegendQueryStatus(layerPath);
+  const layerChildPaths = useStoreLayerChildPaths(layerPath);
 
   // If has children (is a group layer)
-  const hasChildren = layerChildren && layerChildren.length;
+  const hasChildren = layerChildPaths && layerChildPaths.length;
 
   // If there is an error in layer or query status, flag it and show icon error
   const isError = layerStatus === 'error' || (legendQueryStatus && legendQueryStatus === 'error');

--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -10,6 +10,7 @@ import { getSxClasses } from './layer-list-style';
 import { LayerIcon } from './layer-icon';
 import { useStoreLayerStatus } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { logger } from '@/core/utils/logger';
+import { LAYER_PATH_COORDINATE_INFO, useStoreDetailsQueryStatus } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 
 /** Represents an entry in the layer list. */
 export interface LayerListEntry {
@@ -60,31 +61,40 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // Store
-  const layerStatus = useStoreLayerStatus(layer.layerPath);
+  // TODO: REFACTOR - The whole 'layer' parameter received in the component parameters list should be reviewed and turned obsolete.
+  // TO.DOCONT: It should all be using store selector hooks instead. Fallback to layer query status if details query status is not available for now.
+  const layerStatus = useStoreLayerStatus(layer.layerPath) ?? layer.layerStatus;
+  const layerQueryStatus = useStoreDetailsQueryStatus(layer.layerPath) ?? layer.queryStatus;
 
   // Style
   const containerClass = [
     'layer-panel',
     'bordered',
-    layer.layerStatus ?? '',
-    `query-${layer.queryStatus}`,
+    layerStatus ?? '',
+    `query-${layerQueryStatus}`,
     isSelected ? 'selectedLayer bordered-primary' : '',
   ]
     .join(' ')
     .trim();
 
   // Constant for state
-  const isDisabled = layer?.numOffeatures === 0 || layer?.isDisabled;
-  const isLoading = layer.queryStatus === 'processing' || layer.layerStatus === 'loading' || layer.layerStatus === 'processing';
+  const isLoading = layerQueryStatus === 'processing' || layerStatus === 'loading' || layerStatus === 'processing';
+  const isLayerCoordinateInfo = layer.layerPath === LAYER_PATH_COORDINATE_INFO;
+
+  // Default disabled state
+  let isDisabled = isLoading || layer?.isDisabled || layer?.numOffeatures === 0;
+
+  // If it's the layer coordinate info, it's never disabled, because it always at least have the clicked map coordinates information
+  if (isLayerCoordinateInfo) isDisabled = false;
 
   /**
    * Gets the layer status label based on query and layer status.
    */
   const getLayerStatus = useCallback((): JSX.Element | string => {
-    if (layer.layerStatus === 'error' || layer?.queryStatus === 'error') {
+    if (layerStatus === 'error' || layerQueryStatus === 'error') {
       return `${t('legend.layerError')}`;
     }
-    if (['processing'].includes(layer.queryStatus)) {
+    if (['processing'].includes(layerQueryStatus)) {
       return `${t('layers.querying')}...`;
     }
     return (
@@ -92,7 +102,7 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
         {layer.layerFeatures ?? ''} {layer?.mapFilteredIcon ?? ''}
       </>
     );
-  }, [layer.layerFeatures, layer.layerStatus, layer?.mapFilteredIcon, layer.queryStatus, t]);
+  }, [layer.layerFeatures, layerStatus, layer?.mapFilteredIcon, layerQueryStatus, t]);
 
   /**
    * Handles layer selection with keyboard (Enter or Spacebar).
@@ -137,10 +147,9 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
           onKeyDown={(e) => handleLayerKeyDown(e, layer)}
           onClick={() => onListItemClick(layer)}
           selected={isSelected}
-          // disable when layer features has null value.
-          disabled={isDisabled || isLoading}
+          disabled={isDisabled}
         >
-          {layer.layerPath === 'coordinate-info' ? (
+          {layer.layerPath === LAYER_PATH_COORDINATE_INFO ? (
             // Treat
             <LocationSearchingIcon />
           ) : (
@@ -156,7 +165,7 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
               </Typography>
             </Box>
           </Box>
-          {layer.layerPath !== 'coordinate-info' && (layer.numOffeatures ?? 0) > 0 && (
+          {layer.layerPath !== LAYER_PATH_COORDINATE_INFO && (layer.numOffeatures ?? 0) > 0 && (
             <Badge badgeContent={layer.numOffeatures} max={99} color="info" sx={sxClasses.layerCount} className="layer-count" aria-hidden="true"></Badge>
           )}
         </ListItemButton>

--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -8,7 +8,7 @@ import type { TypeFeatureInfoEntry, TypeQueryStatus } from '@/api/types/map-sche
 import type { TypeLayerStatus } from '@/api/types/layer-schema-types';
 import { getSxClasses } from './layer-list-style';
 import { LayerIcon } from './layer-icon';
-import { useLayerSelectorStatus } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerStatus } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { logger } from '@/core/utils/logger';
 
 /** Represents an entry in the layer list. */
@@ -60,7 +60,7 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // Store
-  const layerStatus = useLayerSelectorStatus(layer.layerPath);
+  const layerStatus = useStoreLayerStatus(layer.layerPath);
 
   // Style
   const containerClass = [

--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -84,7 +84,8 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
   // Default disabled state
   let isDisabled = isLoading || layer?.isDisabled || layer?.numOffeatures === 0;
 
-  // If it's the layer coordinate info, it's never disabled, because it always at least have the clicked map coordinates information
+  // If it's the layer coordinate info, it's never disabled, because it always at least have the clicked map coordinates information.
+  // However, if "coordinateInfoEnabled" is true, and no map click has been done,the layer coord info will show zero-ed out coordinates in the UI.
   if (isLayerCoordinateInfo) isDisabled = false;
 
   /**

--- a/packages/geoview-core/src/core/components/common/layout.tsx
+++ b/packages/geoview-core/src/core/components/common/layout.tsx
@@ -9,7 +9,7 @@ import { ResponsiveGridLayout } from './responsive-grid-layout';
 import { Typography } from '@/ui';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { CONTAINER_TYPE } from '@/core/utils/constant';
-import { useLayerSelectorName } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerName } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 /** Properties for the Layout component. */
 interface LayoutProps {
@@ -71,7 +71,7 @@ const Layout = forwardRef(
     // Hooks
     const responsiveLayoutRef = useRef<ResponsiveGridLayoutExposedMethods>(null);
     const theme = useTheme();
-    const layerName = useLayerSelectorName(selectedLayerPath!);
+    const layerName = useStoreLayerName(selectedLayerPath!);
 
     /**
      * Handles clicks to layers in left panel and shows the right panel.

--- a/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
@@ -23,6 +23,14 @@ import { useStoreUIActiveTrapGeoView, useStoreUIActiveFocusItem } from '@/core/s
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { CONTAINER_TYPE, TIMEOUT, LIGHTBOX_SELECTORS } from '@/core/utils/constant';
 
+/** SxProps for the main row root container. */
+// TODO: To prevent the right panel toolbar to be hidden on first click og group layer. There is still a jump on first selection
+const MAIN_ROW_SX: SxProps = {
+  flexGrow: 1,
+  overflow: 'hidden',
+  paddingTop: '30px',
+};
+
 
 /** Properties for the ResponsiveGridLayout component. */
 interface ResponsiveGridLayoutProps {
@@ -125,6 +133,30 @@ const ResponsiveGridLayout = forwardRef(
     // sxClasses
     const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
     const guideSxClasses = useMemo(() => getGuideSxClasses(theme), [theme]);
+
+    /** Memoized sxProps for the left-top panel. */
+    const memoLeftTopSxProps = useMemo(() => ({ zIndex: isFullScreen ? 'unset' : 200 }), [isFullScreen]);
+
+    /** Memoized sxProps for the right-top panel. */
+    const memoRightTopSxProps = useMemo(() => ({ zIndex: isFullScreen ? 'unset' : 100, alignContent: 'flex-end' }), [isFullScreen]);
+
+    /** Memoized sx for the right-top content box layout. */
+    const memoRightTopContentSx = useMemo(
+      () => ({
+        display: 'flex',
+        alignItems: containerType === CONTAINER_TYPE.APP_BAR ? 'end' : 'center',
+        flexDirection: containerType === CONTAINER_TYPE.APP_BAR ? 'column' : 'row',
+        gap: containerType === CONTAINER_TYPE.APP_BAR ? '10px' : '0',
+        [theme.breakpoints.up('sm')]: {
+          justifyContent: containerType === CONTAINER_TYPE.APP_BAR ? 'space-between' : 'right',
+        },
+        [theme.breakpoints.down('sm')]: {
+          justifyContent: 'space-between',
+        },
+        width: '100%',
+      }),
+      [containerType, theme.breakpoints]
+    );
 
     // Expose imperative methods to parent component
     useImperativeHandle(
@@ -231,8 +263,8 @@ const ResponsiveGridLayout = forwardRef(
      * Toggles the guide panel open or closed.
      */
     const handleOpenGuide = useCallback((): void => {
-      setIsGuideOpen(!isGuideOpen);
-    }, [isGuideOpen]);
+      setIsGuideOpen((prev) => !prev);
+    }, []);
 
     /**
      * Focus management for the guide close button using requestAnimationFrame.
@@ -293,9 +325,9 @@ const ResponsiveGridLayout = forwardRef(
     /**
      * Toggles fullscreen mode for the right panel.
      */
-    const handleToggleFullScreen = useCallback(() => {
-      setIsFullScreen(!isFullScreen);
-    }, [isFullScreen]);
+    const handleToggleFullScreen = useCallback((): void => {
+      setIsFullScreen((prev) => !prev);
+    }, []);
 
     /**
      * Handles keyboard events within the guide container.
@@ -339,6 +371,8 @@ const ResponsiveGridLayout = forwardRef(
     );
 
     // If we're on mobile
+    // TODO: CHECK - theme.breakpoints.down('md') returns a CSS media query string which is always truthy
+    // TO.DOCONT: in a boolean context. This should probably use isMobile or useMediaQuery for proper responsive behavior?
     if (theme.breakpoints.down('md')) {
       if (!(leftMain || leftTop) && !isRightPanelVisible) {
         setIsRightPanelVisible(true);
@@ -637,9 +671,9 @@ const ResponsiveGridLayout = forwardRef(
           <ResponsiveGrid.Left
             isRightPanelVisible={isRightPanelVisible}
             isEnlarged={isEnlarged}
-            aria-hidden={!isRightPanelVisible}
+            ariaHidden={!isRightPanelVisible}
             toggleMode={toggleMode}
-            sxProps={{ zIndex: isFullScreen ? 'unset' : 200 }}
+            sxProps={memoLeftTopSxProps}
             className="responsive-layout-left-top"
           >
             {/* This panel is hidden from screen readers when not visible */}
@@ -649,41 +683,20 @@ const ResponsiveGridLayout = forwardRef(
             isRightPanelVisible={isRightPanelVisible}
             isEnlarged={isEnlarged}
             toggleMode={toggleMode}
-            sxProps={{ zIndex: isFullScreen ? 'unset' : 100, alignContent: 'flex-end' }}
+            sxProps={memoRightTopSxProps}
             className="responsive-layout-right-top"
           >
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: containerType === CONTAINER_TYPE.APP_BAR ? 'end' : 'center',
-                flexDirection: containerType === CONTAINER_TYPE.APP_BAR ? 'column' : 'row',
-                gap: containerType === CONTAINER_TYPE.APP_BAR ? '10px' : '0',
-                [theme.breakpoints.up('sm')]: {
-                  justifyContent: containerType === CONTAINER_TYPE.APP_BAR ? 'space-between' : 'right',
-                },
-                [theme.breakpoints.down('sm')]: {
-                  justifyContent: 'space-between',
-                },
-                width: '100%',
-              }}
-            >
+            <Box sx={memoRightTopContentSx}>
               {rightTop ?? <Box />}
             </Box>
           </ResponsiveGrid.Right>
         </ResponsiveGrid.Root>
-        <ResponsiveGrid.Root
-          className="responsive-layout-main-row"
-          sx={{
-            flexGrow: 1,
-            overflow: 'hidden',
-            paddingTop: '30px', // TODO: To prevent the right panel toolbar to be hidden on first click og group layer. There is still a jump onn first selection
-          }}
-        >
+        <ResponsiveGrid.Root className="responsive-layout-main-row" sx={MAIN_ROW_SX}>
           <ResponsiveGrid.Left
             isEnlarged={isEnlarged}
             isRightPanelVisible={isRightPanelVisible}
             toggleMode={toggleMode}
-            aria-hidden={!isRightPanelVisible}
+            ariaHidden={!isRightPanelVisible}
             sxProps={sxClasses.gridLeftMain as SxProps}
             className="responsive-layout-left-main"
           >

--- a/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
@@ -17,9 +17,9 @@ import { getSxClasses as getGuideSxClasses } from '@/core/components/guide/guide
 import { FullScreenDialog } from './full-screen-dialog';
 import { logger } from '@/core/utils/logger';
 import { ArrowBackIcon, ArrowForwardIcon, CloseIcon, QuestionMarkIcon } from '@/ui/icons';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
-import { useAppGuide, useAppFullscreenActive, useAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { useUIActiveTrapGeoView, useUIActiveFocusItem } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreAppGuide, useStoreAppIsFullscreenActive, useStoreAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreUIActiveTrapGeoView, useStoreUIActiveFocusItem } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { CONTAINER_TYPE, TIMEOUT, LIGHTBOX_SELECTORS } from '@/core/utils/constant';
 
@@ -88,7 +88,6 @@ const ResponsiveGridLayout = forwardRef(
     // Hooks
     const { t } = useTranslation<string>();
     const theme = useTheme();
-    const isMapFullScreen = useAppFullscreenActive();
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     // Derive whether we have content (vs guide-only) from rightMain prop
     const hasContent = !!rightMain;
@@ -103,11 +102,12 @@ const ResponsiveGridLayout = forwardRef(
     const closeBtnRef = useRef<HTMLButtonElement>(null);
 
     // Store
-    const mapId = useGeoViewMapId();
-    const guide = useAppGuide();
-    const isFocusTrap = useUIActiveTrapGeoView();
-    const focusItem = useUIActiveFocusItem();
-    const shellContainer = useAppShellContainer();
+    const mapId = useStoreGeoViewMapId();
+    const guide = useStoreAppGuide();
+    const isFocusTrap = useStoreUIActiveTrapGeoView();
+    const isMapFullScreen = useStoreAppIsFullscreenActive();
+    const focusItem = useStoreUIActiveFocusItem();
+    const shellContainer = useStoreAppShellContainer();
 
     // States
     const [isRightPanelVisible, setIsRightPanelVisible] = useState(false);

--- a/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
@@ -24,7 +24,7 @@ import type { TypeContainerBox } from '@/core/types/global-types';
 import { CONTAINER_TYPE, TIMEOUT, LIGHTBOX_SELECTORS } from '@/core/utils/constant';
 
 /** SxProps for the main row root container. */
-// TODO: To prevent the right panel toolbar to be hidden on first click og group layer. There is still a jump on first selection
+// TODO: To prevent the right panel toolbar to be hidden on first click of group layer. There is still a jump on first selection
 const MAIN_ROW_SX: SxProps = {
   flexGrow: 1,
   overflow: 'hidden',

--- a/packages/geoview-core/src/core/components/common/responsive-grid.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode} from 'react';
+import type { ReactNode, ForwardedRef } from 'react';
 import { forwardRef, useMemo } from 'react';
 import { useTheme } from '@mui/material/styles';
 import type { GridProps, SxProps } from '@/ui';
@@ -18,10 +18,14 @@ interface ResponsiveGridPanelProps extends GridProps {
   isEnlarged: boolean;
   className?: string;
   toggleMode?: boolean;
+  ariaHidden?: boolean;
 }
 
 /** Grid container padding. */
 const PADDING = '0 6px';
+
+/** Default empty sx props to avoid new object reference on every render. */
+const EMPTY_SX_PROPS: SxProps = {};
 
 /** Base breakpoint sizes without xs since it's common. */
 type BaseBreakpointSize = 'sm' | 'md' | 'lg' | 'xl';
@@ -127,18 +131,18 @@ ResponsiveGridRoot.displayName = 'ResponsiveGridRoot';
  * @param ref - Forwarded ref for the Grid element
  * @returns The responsive grid panel element
  */
-const ResponsiveGridPanel = forwardRef(
+const ResponsiveGridPanel = forwardRef<HTMLDivElement, ResponsiveGridPanelProps & { isLeftPanel: boolean }>(
   (
     {
       children,
       className = '',
       isRightPanelVisible = false,
-      sxProps = {},
+      sxProps = EMPTY_SX_PROPS,
       isEnlarged,
       isLeftPanel,
       toggleMode = false,
-      ...rest
-    }: ResponsiveGridPanelProps & { isLeftPanel: boolean },
+      ariaHidden,
+    },
     ref
   ) => {
     // Log
@@ -178,7 +182,7 @@ const ResponsiveGridPanel = forwardRef(
         }}
         component="div"
         ref={ref}
-        {...rest}
+        aria-hidden={ariaHidden}
       >
         {children}
       </Grid>
@@ -194,7 +198,7 @@ ResponsiveGridPanel.displayName = 'ResponsiveRightPanel';
  * @param ref - Forwarded ref
  * @returns The left panel element
  */
-const ResponsiveGridLeftPanel = forwardRef((props: ResponsiveGridPanelProps, ref) => (
+const ResponsiveGridLeftPanel = forwardRef<HTMLDivElement, ResponsiveGridPanelProps>((props, ref: ForwardedRef<HTMLDivElement>) => (
   <ResponsiveGridPanel {...props} isLeftPanel ref={ref} />
 ));
 ResponsiveGridLeftPanel.displayName = 'ResponsiveGridLeftPanel';
@@ -206,7 +210,7 @@ ResponsiveGridLeftPanel.displayName = 'ResponsiveGridLeftPanel';
  * @param ref - Forwarded ref
  * @returns The right panel element
  */
-const ResponsiveGridRightPanel = forwardRef((props: ResponsiveGridPanelProps, ref) => (
+const ResponsiveGridRightPanel = forwardRef<HTMLDivElement, ResponsiveGridPanelProps>((props, ref: ForwardedRef<HTMLDivElement>) => (
   <ResponsiveGridPanel {...props} isLeftPanel={false} ref={ref} />
 ));
 ResponsiveGridRightPanel.displayName = 'ResponsiveGridRightPanel';

--- a/packages/geoview-core/src/core/components/crosshair/crosshair.tsx
+++ b/packages/geoview-core/src/core/components/crosshair/crosshair.tsx
@@ -5,11 +5,11 @@ import { Box, Fade, Typography } from '@/ui';
 
 import { getSxClasses } from './crosshair-style';
 import { CrosshairIcon } from './crosshair-icon';
-import { useAppCrosshairsActive } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppIsCrosshairsActive } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { getStoreMapPointerPosition } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
 import { useEventListener } from '@/core/components/common/hooks/use-event-listener';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { useUIController } from '@/core/controllers/ui-controller';
 import { useMapController } from '@/core/controllers/map-controller';
 
@@ -38,8 +38,8 @@ export const Crosshair = memo(function Crosshair({ mapTargetElement }: Crosshair
   const panDelta = useRef(128);
 
   //  Store
-  const isCrosshairsActive = useAppCrosshairsActive();
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
+  const isCrosshairsActive = useStoreAppIsCrosshairsActive();
   const uiController = useUIController();
   const mapController = useMapController();
 

--- a/packages/geoview-core/src/core/components/crosshair/crosshair.tsx
+++ b/packages/geoview-core/src/core/components/crosshair/crosshair.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { Box, Fade, Typography } from '@/ui';
@@ -43,6 +43,9 @@ export const Crosshair = memo(function Crosshair({ mapTargetElement }: Crosshair
   const uiController = useUIController();
   const mapController = useMapController();
 
+  // AbortController ref - aborts any in-flight coordinate info fetch on re-click
+  const abortControllerRef = useRef<AbortController | null>(null);
+
   /**
    * Simulates a map mouse click to trigger the details panel.
    */
@@ -55,7 +58,15 @@ export const Crosshair = memo(function Crosshair({ mapTargetElement }: Crosshair
       // Use store getter, we do not subcribe to modification
       const currentPointerPosition = getStoreMapPointerPosition(mapId);
       if (currentPointerPosition) {
-        mapController.setClickCoordinates(currentPointerPosition);
+        // Abort any previous in-flight request
+        abortControllerRef.current?.abort();
+
+        // Create a new AbortController for this click
+        const controller = new AbortController();
+        abortControllerRef.current = controller;
+
+        // Set the click coordinates
+        mapController.setClickCoordinates(currentPointerPosition, controller.signal);
       }
     },
     [isCrosshairsActive, mapId, mapController]
@@ -78,6 +89,15 @@ export const Crosshair = memo(function Crosshair({ mapTargetElement }: Crosshair
     },
     [isCrosshairsActive, uiController]
   );
+
+  /**
+   * Aborts any in-flight coordinate info request on unmount.
+   */
+  useEffect(() => {
+    return (): void => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
 
   // Use custom hook for event listeners
   useEventListener<HTMLElement>('keydown', simulateClick, mapTargetElement, isCrosshairsActive);

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -6,20 +6,23 @@ import DataTable from './data-table';
 
 import { useUIController } from '@/core/controllers/ui-controller';
 import {
-  useDataTableSelectedLayerPath,
-  useDataTableAllFeaturesDataArray,
-  useDataTableLayerSettings,
+  useStoreDataTableSelectedLayerPath,
+  useStoreDataTableAllFeaturesDataArray,
+  useStoreDataTableLayerSettings,
   setStoreSelectedLayerPath,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
-import { useAppShowUnsymbolizedFeatures } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { useMapAllVisibleandInRangeLayers, getStoreMapIsLayerHiddenOnMap } from '@/core/stores/store-interface-and-intial-values/map-state';
-import { useLayerNames, useLayerStatuses } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreAppShowUnsymbolizedFeatures } from '@/core/stores/store-interface-and-intial-values/app-state';
 import {
-  useUIActiveAppBarTab,
-  useUIActiveFooterBarTab,
-  useUIAppbarComponents,
+  useStoreMapAllVisibleandInRangeLayers,
+  useStoreMapIsLayerHiddenOnMapSet,
+} from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreLayerNameSet, useStoreLayerStatusSet } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import {
+  useStoreUIActiveAppBarTab,
+  useStoreUIActiveFooterBarTab,
+  useStoreUIAppbarComponents,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import type { LayerListEntry } from '@/core/components/common';
 import { Layout } from '@/core/components/common';
 import { logger } from '@/core/utils/logger';
@@ -53,19 +56,20 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
   const [isLoading, setIsLoading] = useState(false);
   const isFirstLoad = useRef<Record<string, boolean>>({});
 
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
   const uiController = useUIController();
   const layerSetController = useLayerSetController();
-  const layerData = useDataTableAllFeaturesDataArray();
-  const selectedLayerPath = useDataTableSelectedLayerPath();
-  const datatableSettings = useDataTableLayerSettings();
-  const visibleInRangeLayers = useMapAllVisibleandInRangeLayers();
-  const activeFooterBarTab = useUIActiveFooterBarTab();
-  const activeAppBarTab = useUIActiveAppBarTab();
-  const appBarComponents = useUIAppbarComponents();
-  const showUnsymbolizedFeatures = useAppShowUnsymbolizedFeatures();
-  const layerNames = useLayerNames();
-  const layerStatuses = useLayerStatuses();
+  const layerData = useStoreDataTableAllFeaturesDataArray();
+  const selectedLayerPath = useStoreDataTableSelectedLayerPath();
+  const datatableSettings = useStoreDataTableLayerSettings();
+  const visibleInRangeLayers = useStoreMapAllVisibleandInRangeLayers();
+  const activeFooterBarTab = useStoreUIActiveFooterBarTab();
+  const activeAppBarTab = useStoreUIActiveAppBarTab();
+  const appBarComponents = useStoreUIAppbarComponents();
+  const showUnsymbolizedFeatures = useStoreAppShowUnsymbolizedFeatures();
+  const layerNames = useStoreLayerNameSet();
+  const layerStatuses = useStoreLayerStatusSet();
+  const layerHiddenSet = useStoreMapIsLayerHiddenOnMapSet();
 
   // Create columns for data table.
   const mappedLayerData = useFeatureFieldInfos(layerData);
@@ -76,9 +80,8 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
   const memoOrderedLayerData = useMemo(() => {
     return visibleInRangeLayers
       .map((layerPath) => mappedLayerData.filter((data) => data.layerPath === layerPath)[0])
-      .filter((layer) => layer !== undefined && !getStoreMapIsLayerHiddenOnMap(mapId, layer.layerPath));
-    // TODO: CHECK -This should likely go through a Zustand hook instead of a state getter (line above).
-  }, [mappedLayerData, visibleInRangeLayers, mapId]);
+      .filter((layer) => layer !== undefined && !layerHiddenSet[layer.layerPath]);
+  }, [mappedLayerData, visibleInRangeLayers, layerHiddenSet]);
 
   /**
    * Handles layer selection change from the layer list.

--- a/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
@@ -8,21 +8,21 @@ import { MRT_Localization_EN as MRTLocalizationEN } from 'material-react-table/l
 import { Modal, MRTTable as Table, type MRT_ColumnDef as MRTColumnDef, Box, CircularProgress, Button } from '@/ui';
 import { useUIController } from '@/core/controllers/ui-controller';
 import {
-  useUIActiveFocusItem,
-  useUIFooterBarComponents,
-  useUIAppbarComponents,
-  useUIActiveTrapGeoView,
+  useStoreUIActiveFocusItem,
+  useStoreUIFooterBarComponents,
+  useStoreUIAppbarComponents,
+  useStoreUIActiveTrapGeoView,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import { useLayerNames, useLayerSelectedLayerPath } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerNameSet, useStoreLayerSelectedLayerPath } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { getSxClasses } from './data-table-style';
 import { logger } from '@/core/utils/logger';
 import {
   setStoreSelectedLayerPath,
-  useDataTableAllFeaturesDataArray,
+  useStoreDataTableAllFeaturesDataArray,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { useFeatureFieldInfos } from './hooks';
 import type { TypeFieldEntry } from '@/api/types/map-schema-types';
-import { useAppDisplayLanguage, useAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage, useStoreAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { TableViewIcon } from '@/ui/icons';
 import { useNavigateToTab } from '@/core/components/common/hooks/use-navigate-to-tab';
 
@@ -44,15 +44,15 @@ export default function DataTableModal(): JSX.Element {
 
   // get store function
   const uiController = useUIController();
-  const activeModalId = useUIActiveFocusItem().activeElementId;
-  const selectedLayerPath = useLayerSelectedLayerPath();
-  const layersData = useDataTableAllFeaturesDataArray();
-  const language = useAppDisplayLanguage();
-  const shellContainer = useAppShellContainer();
-  const footerBarComponents = useUIFooterBarComponents();
-  const appBarComponents = useUIAppbarComponents();
-  const isFocusTrap = useUIActiveTrapGeoView();
-  const layerNames = useLayerNames();
+  const activeModalId = useStoreUIActiveFocusItem().activeElementId;
+  const selectedLayerPath = useStoreLayerSelectedLayerPath();
+  const layersData = useStoreDataTableAllFeaturesDataArray();
+  const language = useStoreAppDisplayLanguage();
+  const shellContainer = useStoreAppShellContainer();
+  const footerBarComponents = useStoreUIFooterBarComponents();
+  const appBarComponents = useStoreUIAppbarComponents();
+  const isFocusTrap = useStoreUIActiveTrapGeoView();
+  const layerNames = useStoreLayerNameSet();
 
   const dataTableLocalization = language === 'fr' ? MRTLocalizationFR : MRTLocalizationEN;
 

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -38,20 +38,20 @@ import TopToolbar from './top-toolbar';
 import { useUIController } from '@/core/controllers/ui-controller';
 import { getStoreMapCurrentProjectionEPSG } from '@/core/stores/store-interface-and-intial-values/map-state';
 import {
-  useLayerDateTemporalMode,
-  useLayerDisplayDateFormat,
-  useLayerDisplayDateTimezone,
-  useLayerSelectorFilterClass,
-  useLayerSelectorName,
+  useStoreLayerDateTemporalMode,
+  useStoreLayerDisplayDateFormat,
+  useStoreLayerDisplayDateTimezone,
+  useStoreLayerFilterClass,
+  useStoreLayerName,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import {
-  useDataTableLayerSettings,
+  useStoreDataTableLayerSettings,
   setStoreColumnFilterModesEntry,
   setStoreColumnsFiltersVisibility,
   setStoreSelectedFeature,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
-import { useTimeSliderFiltersSelector } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
-import { useAppDisplayLanguage, useAppShowUnsymbolizedFeatures } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreTimeSliderFilter } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
+import { useStoreAppDisplayLanguage, useStoreAppShowUnsymbolizedFeatures } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { DateMgt } from '@/core/utils/date-mgt';
 import linkifyHtml from 'linkify-html';
 import { isImage, delay, sanitizeHtmlContent, enhanceLinksAccessibility } from '@/core/utils/utilities';
@@ -63,7 +63,7 @@ import { getSxClasses } from './data-table-style';
 import { useLightBox } from '@/core/components/common';
 import { NUMBER_FILTER, DATE_FILTER, STRING_FILTER } from '@/core/utils/constant';
 import type { DataTableProps, ColumnsType } from './data-table-types';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { GeoviewRenderer } from '@/geo/utils/renderer/geoview-renderer';
 import { LayerFilters } from '@/geo/layer/gv-layers/layer-filters';
 import { Projection } from '@/geo/utils/projection';
@@ -108,19 +108,21 @@ function DataTable({ data, layerPath, containerType }: DataTableProps): JSX.Elem
   const sxClasses = getSxClasses(sxtheme);
 
   // get store actions and values
-  const language = useAppDisplayLanguage();
-  const datatableSettings = useDataTableLayerSettings();
-  const showUnsymbolizedFeatures = useAppShowUnsymbolizedFeatures();
-  const layerClassFilter = useLayerSelectorFilterClass(layerPath);
-  const layerTimeFilter = useTimeSliderFiltersSelector(layerPath);
-  const layerDateTemporalMode = useLayerDateTemporalMode(layerPath);
-  const displayDateFormat = useLayerDisplayDateFormat(layerPath);
-  const displayDateTimezone = useLayerDisplayDateTimezone(layerPath);
+  const mapId = useStoreGeoViewMapId();
+  const language = useStoreAppDisplayLanguage();
+  const datatableSettings = useStoreDataTableLayerSettings();
+  const showUnsymbolizedFeatures = useStoreAppShowUnsymbolizedFeatures();
+  const layerClassFilter = useStoreLayerFilterClass(layerPath);
+  const layerTimeFilter = useStoreTimeSliderFilter(layerPath);
+  const layerDateTemporalMode = useStoreLayerDateTemporalMode(layerPath);
+  const displayDateFormat = useStoreLayerDisplayDateFormat(layerPath);
+  const displayDateTimezone = useStoreLayerDisplayDateTimezone(layerPath);
   const displayDateTimezoneUniversal = displayDateTimezone === 'local' ? DateMgt.TIME_IANA_LOCAL : displayDateTimezone;
-  const layerName = useLayerSelectorName(layerPath);
+  const layerName = useStoreLayerName(layerPath);
   const dataTableController = useDataTableController();
   const layerController = useLayerController();
   const mapController = useMapController();
+  const uiController = useUIController();
 
   // internal state
   const [density, setDensity] = useState<MRTDensityState>('compact');
@@ -145,10 +147,6 @@ function DataTable({ data, layerPath, containerType }: DataTableProps): JSX.Elem
   const { columnFilters, setColumnFilters } = useFilterRows({ layerPath });
   const { globalFilter, setGlobalFilter } = useGlobalFilter({ layerPath });
   // #endregion
-
-  const uiController = useUIController();
-
-  const mapId = useGeoViewMapId();
 
   // #region Handlers
 
@@ -478,7 +476,7 @@ function DataTable({ data, layerPath, containerType }: DataTableProps): JSX.Elem
       if (extent) {
         // Project
         const center = getCenter(extent);
-        // TODO: CHECK -This should likely go through a Zustand hook instead of a state getter
+        // Transform the coordinate and use a state getter here, because we don't need to hook on value changes in this callback function.
         const newCenter = Projection.transformPoints([center], getStoreMapCurrentProjectionEPSG(mapId), `EPSG:4326`)[0];
 
         // Zoom to extent and wait for it to finish

--- a/packages/geoview-core/src/core/components/data-table/export-button.tsx
+++ b/packages/geoview-core/src/core/components/data-table/export-button.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import type { Options } from 'export-to-csv';
 import { ExportToCsv } from 'export-to-csv';
 
-import { type MRT_ColumnDef as MRTColumnDef } from 'material-react-table';
+import type { MRT_ColumnDef as MRTColumnDef } from 'material-react-table';
 
 import { IconButton, DownloadIcon, Menu, MenuItem } from '@/ui';
 import { logger } from '@/core/utils/logger';

--- a/packages/geoview-core/src/core/components/data-table/export-button.tsx
+++ b/packages/geoview-core/src/core/components/data-table/export-button.tsx
@@ -11,7 +11,7 @@ import { type MRT_ColumnDef as MRTColumnDef } from 'material-react-table';
 import { IconButton, DownloadIcon, Menu, MenuItem } from '@/ui';
 import { logger } from '@/core/utils/logger';
 import type { ColumnsType } from './data-table-types';
-import { useLayerSelectorName } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerName } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 /** Properties for the ExportButton component. */
 interface ExportButtonProps {
@@ -35,7 +35,7 @@ function ExportButton({ layerPath, rows, columns, children }: ExportButtonProps)
   logger.logTraceRender('components/data-table/export-button');
 
   const { t } = useTranslation<string>();
-  const layerName = useLayerSelectorName(layerPath) ?? '';
+  const layerName = useStoreLayerName(layerPath) ?? '';
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);

--- a/packages/geoview-core/src/core/components/data-table/filter-map.tsx
+++ b/packages/geoview-core/src/core/components/data-table/filter-map.tsx
@@ -3,8 +3,8 @@ import { useTheme } from '@mui/material/styles';
 
 import { getSxClasses } from './data-table-style';
 import { Switch } from '@/ui';
-import { useDataTableLayerSettings, setStoreMapFilteredEntry } from '@/core/stores/store-interface-and-intial-values/data-table-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreDataTableLayerSettings, setStoreMapFilteredEntry } from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
 
 /** Properties for the FilterMap component. */
@@ -28,8 +28,8 @@ function FilterMap({ layerPath, isGlobalFilterOn }: FilterMapProps): JSX.Element
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
 
-  const mapId = useGeoViewMapId();
-  const datatableSettings = useDataTableLayerSettings();
+  const mapId = useStoreGeoViewMapId();
+  const datatableSettings = useStoreDataTableLayerSettings();
 
   return (
     <Switch

--- a/packages/geoview-core/src/core/components/data-table/hooks/useFilterRows.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useFilterRows.tsx
@@ -1,8 +1,11 @@
 import type { Dispatch, SetStateAction } from 'react';
 import { useEffect, useState } from 'react';
 import type { TypeColumnFiltersState } from '@/core/stores/store-interface-and-intial-values/data-table-state';
-import { useDataTableLayerSettings, setStoreColumnFiltersEntry } from '@/core/stores/store-interface-and-intial-values/data-table-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import {
+  useStoreDataTableLayerSettings,
+  setStoreColumnFiltersEntry,
+} from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
 
 /** Properties for the useFilterRows hook. */
@@ -20,8 +23,8 @@ export function useFilterRows({ layerPath }: UseFilterRowsProps): {
   columnFilters: TypeColumnFiltersState;
   setColumnFilters: Dispatch<SetStateAction<TypeColumnFiltersState>>;
 } {
-  const mapId = useGeoViewMapId();
-  const datatableSettings = useDataTableLayerSettings();
+  const mapId = useStoreGeoViewMapId();
+  const datatableSettings = useStoreDataTableLayerSettings();
 
   const [columnFilters, setColumnFilters] = useState<TypeColumnFiltersState>(datatableSettings[layerPath].columnFiltersRecord || []);
 

--- a/packages/geoview-core/src/core/components/data-table/hooks/useGlobalFilter.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useGlobalFilter.tsx
@@ -1,8 +1,11 @@
 import type { Dispatch, SetStateAction } from 'react';
 import { useEffect, useState } from 'react';
-import { useDataTableLayerSettings, setStoreGlobalFilteredEntry } from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import {
+  useStoreDataTableLayerSettings,
+  setStoreGlobalFilteredEntry,
+} from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { logger } from '@/core/utils/logger';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 
 /** Properties for the useGlobalFilter hook. */
 export interface UseGlobalFilterProps {
@@ -19,9 +22,9 @@ export function useGlobalFilter({ layerPath }: UseGlobalFilterProps): {
   globalFilter: string;
   setGlobalFilter: Dispatch<SetStateAction<string>>;
 } {
-  const datatableSettings = useDataTableLayerSettings();
+  const datatableSettings = useStoreDataTableLayerSettings();
 
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
   const [globalFilter, setGlobalFilter] = useState(datatableSettings[layerPath].globalFilterRecord ?? '');
 
   /**

--- a/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { type MRT_TableInstance as MRTTableInstance, type MRT_ColumnFiltersState as MRTColumnFiltersState } from 'material-react-table';
+import type { MRT_TableInstance as MRTTableInstance, MRT_ColumnFiltersState as MRTColumnFiltersState } from 'material-react-table';
 import { useTranslation } from 'react-i18next';
 import {
   setStoreRowsFilteredEntry,

--- a/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { logger } from '@/core/utils/logger';
 import type { MappedLayerDataType, ColumnsType } from '@/core/components/data-table/data-table-types';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 
 /** Properties for the useToolbarActionMessage hook. */
 interface UseSelectedRowMessageProps {
@@ -35,7 +35,7 @@ export function useToolbarActionMessage({
   const { t } = useTranslation();
 
   // Get store values
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
 
   /**
    * Updates the toolbar message when filters or feature data change.

--- a/packages/geoview-core/src/core/components/data-table/json-export-button.tsx
+++ b/packages/geoview-core/src/core/components/data-table/json-export-button.tsx
@@ -6,8 +6,8 @@ import { MenuItem } from '@/ui';
 
 import { JsonExportWorker } from '@/core/workers/json-export-worker';
 import type { SerializedGeometry, TypeFeatureInfoEntry } from '@/api/types/map-schema-types';
-import { useLayerSelectorName, useLayerSelectorSchemaTag } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import { useMapProjectionEPSG } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreLayerName, useStoreLayerSchemaTag } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreMapCurrentProjectionEPSG } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { GeometryApi } from '@/geo/layer/geometry/geometry';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import { TIMEOUT } from '@/core/utils/constant';
@@ -36,9 +36,9 @@ function JSONExportButton({ rows, features, layerPath }: JSONExportButtonProps):
 
   // get store action and map projection
   const uiController = useUIController();
-  const mapProjectionEPSG = useMapProjectionEPSG();
-  const layerName = useLayerSelectorName(layerPath) ?? '';
-  const schemaTag = useLayerSelectorSchemaTag(layerPath);
+  const mapProjectionEPSG = useStoreMapCurrentProjectionEPSG();
+  const layerName = useStoreLayerName(layerPath) ?? '';
+  const schemaTag = useStoreLayerSchemaTag(layerPath);
   const layerController = useLayerController();
 
   // Keep exporting state

--- a/packages/geoview-core/src/core/components/details/coordinate-info.tsx
+++ b/packages/geoview-core/src/core/components/details/coordinate-info.tsx
@@ -1,17 +1,20 @@
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTheme, useMediaQuery } from '@mui/material';
 import { getSxClasses } from './details-style';
 
 import { List, ListItem, Box, Typography, Switch, Tooltip } from '@/ui';
+import { CircularProgressBase } from '@/ui/circular-progress/circular-progress-base';
 import {
-  useStoreDetailsLayerDataArray,
+  useStoreDetailsLayerDataArrayFeature,
   useStoreDetailsCoordinateInfoEnabled,
-  toggleStoreDetailsCoordinateInfoEnabled,
+  useStoreDetailsQueryStatus,
+  LAYER_PATH_COORDINATE_INFO,
 } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
-import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreMapClickCoordinates } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { GeoUtilities } from '@/geo/utils/utilities';
 import { logger } from '@/core/utils/logger';
+import { useMapController } from '@/core/controllers/map-controller';
 
 /** Coordinate data extracted from the feature info. */
 type CoordinateData = {
@@ -49,18 +52,38 @@ export function CoordinateInfoSwitch({ disabled }: CoordinateInfoSwitchProps): J
 
   const { t } = useTranslation();
   const theme = useTheme();
-  const mapId = useStoreGeoViewMapId();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
+  // Store
   const coordinateInfoEnabled = useStoreDetailsCoordinateInfoEnabled();
+  const mapController = useMapController();
+
+  // AbortController ref — aborts any in-flight coordinate info fetch on unmount or re-toggle
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   /**
    * Handles toggling the coordinate info switch.
    */
   const handleCoordinateInfoToggle = useCallback((): void => {
+    // Abort any in-flight request
+    abortControllerRef.current?.abort();
+
+    // Create a new AbortController for this toggle
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
     // Toggle the state
-    toggleStoreDetailsCoordinateInfoEnabled(mapId);
-  }, [mapId]);
+    mapController.toggleCoordinateInfoEnabled(controller.signal);
+  }, [mapController]);
+
+  /**
+   * Aborts the previous coordinate info request on unmount.
+   */
+  useEffect(() => {
+    return (): void => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
 
   return (
     <Tooltip title={t('details.toggleCoordinateInfo')} placement="top">
@@ -87,32 +110,26 @@ export function CoordinateInfo(): JSX.Element {
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
-  const layerDataArray = useStoreDetailsLayerDataArray();
-
-  // Find the coordinate info layer
-  const coordinateInfoLayer = layerDataArray.find((layer) => layer.layerPath === 'coordinate-info');
-  const feature = coordinateInfoLayer?.features?.[0];
+  // Store
+  const clickCoordinates = useStoreMapClickCoordinates();
+  const feature = useStoreDetailsLayerDataArrayFeature();
+  const layerQueryStatus = useStoreDetailsQueryStatus(LAYER_PATH_COORDINATE_INFO);
+  const spinning = layerQueryStatus === 'processing';
 
   /**
    * Memoizes the parsed coordinate data from the feature.
    */
-  const memoCoordinateData = useMemo((): CoordinateData | undefined => {
-    if (!feature?.fieldInfo) return undefined;
-
+  const memoCoordinateData = useMemo((): CoordinateData => {
     return {
-      lat: parseFloat(feature.fieldInfo.latitude?.value?.toString() || '0'),
-      lng: parseFloat(feature.fieldInfo.longitude?.value?.toString() || '0'),
-      utmZone: feature.fieldInfo.utmZone?.value?.toString(),
-      easting: feature.fieldInfo.easting?.value?.toString(),
-      northing: feature.fieldInfo.northing?.value?.toString(),
-      ntsMapsheet: feature.fieldInfo.ntsMapsheet?.value?.toString(),
-      elevation: feature.fieldInfo.elevation?.value?.toString(),
+      lat: parseFloat(clickCoordinates?.lonlat[1]?.toString() || '0'),
+      lng: parseFloat(clickCoordinates?.lonlat[0]?.toString() || '0'),
+      utmZone: feature?.fieldInfo.utmZone?.value?.toString(),
+      easting: feature?.fieldInfo.easting?.value?.toString(),
+      northing: feature?.fieldInfo.northing?.value?.toString(),
+      ntsMapsheet: feature?.fieldInfo.ntsMapsheet?.value?.toString(),
+      elevation: feature?.fieldInfo.elevation?.value?.toString(),
     };
-  }, [feature]);
-
-  if (!memoCoordinateData) {
-    return <Typography>{t('details.noCoordinateInfo')}</Typography>;
-  }
+  }, [feature, clickCoordinates]);
 
   const { lat, lng, utmZone, easting, northing, ntsMapsheet, elevation } = memoCoordinateData;
 
@@ -150,11 +167,12 @@ export function CoordinateInfo(): JSX.Element {
             </Box>
           </ListItem>
 
-          {utmZone && (
-            <ListItem sx={sxClasses.coordinateInfoSection} disablePadding>
-              <Typography variant="subtitle1" sx={sxClasses.coordinateInfoSectionTitle}>
-                {t('details.utmCoordinates')}
-              </Typography>
+          <ListItem sx={sxClasses.coordinateInfoSection} disablePadding>
+            <Typography variant="subtitle1" sx={sxClasses.coordinateInfoSectionTitle}>
+              {t('details.utmCoordinates')}
+            </Typography>
+            {spinning && <CircularProgressBase size={20} />}
+            {!spinning && utmZone && (
               <Box sx={sxClasses.coordinateInfoContent}>
                 <Typography>
                   {t('details.zone')}: {utmZone}
@@ -166,32 +184,34 @@ export function CoordinateInfo(): JSX.Element {
                   {t('details.northing')}: {northing}
                 </Typography>
               </Box>
-            </ListItem>
-          )}
+            )}
+          </ListItem>
 
-          {ntsMapsheet && (
-            <ListItem sx={sxClasses.coordinateInfoSection} disablePadding>
-              <Typography variant="subtitle1" sx={sxClasses.coordinateInfoSectionTitle}>
-                {t('details.ntsMapsheet')}
-              </Typography>
+          <ListItem sx={sxClasses.coordinateInfoSection} disablePadding>
+            <Typography variant="subtitle1" sx={sxClasses.coordinateInfoSectionTitle}>
+              {t('details.ntsMapsheet')}
+            </Typography>
+            {spinning && <CircularProgressBase size={20} />}
+            {!spinning && ntsMapsheet && (
               <Box sx={sxClasses.coordinateInfoContent}>
                 {ntsMapsheet.split('\n').map((line) => (
                   <Typography key={line}>{line}</Typography>
                 ))}
               </Box>
-            </ListItem>
-          )}
+            )}
+          </ListItem>
 
-          {elevation && (
-            <ListItem sx={sxClasses.coordinateInfoSection} disablePadding>
-              <Typography variant="subtitle1" sx={sxClasses.coordinateInfoSectionTitle}>
-                {t('details.elevation')}
-              </Typography>
+          <ListItem sx={sxClasses.coordinateInfoSection} disablePadding>
+            <Typography variant="subtitle1" sx={sxClasses.coordinateInfoSectionTitle}>
+              {t('details.elevation')}
+            </Typography>
+            {spinning && <CircularProgressBase size={20} />}
+            {!spinning && elevation && (
               <Box sx={sxClasses.coordinateInfoContent}>
                 <Typography>{elevation}</Typography>
               </Box>
-            </ListItem>
-          )}
+            )}
+          </ListItem>
 
           {/* {declination && (
             <ListItem sx={{ flexDirection: 'column', alignItems: 'flex-start' }}>

--- a/packages/geoview-core/src/core/components/details/coordinate-info.tsx
+++ b/packages/geoview-core/src/core/components/details/coordinate-info.tsx
@@ -5,11 +5,11 @@ import { getSxClasses } from './details-style';
 
 import { List, ListItem, Box, Typography, Switch, Tooltip } from '@/ui';
 import {
-  useDetailsLayerDataArray,
-  useDetailsCoordinateInfoEnabled,
+  useStoreDetailsLayerDataArray,
+  useStoreDetailsCoordinateInfoEnabled,
   toggleStoreDetailsCoordinateInfoEnabled,
 } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { GeoUtilities } from '@/geo/utils/utilities';
 import { logger } from '@/core/utils/logger';
 
@@ -49,10 +49,10 @@ export function CoordinateInfoSwitch({ disabled }: CoordinateInfoSwitchProps): J
 
   const { t } = useTranslation();
   const theme = useTheme();
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
-  const coordinateInfoEnabled = useDetailsCoordinateInfoEnabled();
+  const coordinateInfoEnabled = useStoreDetailsCoordinateInfoEnabled();
 
   /**
    * Handles toggling the coordinate info switch.
@@ -87,7 +87,7 @@ export function CoordinateInfo(): JSX.Element {
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
-  const layerDataArray = useDetailsLayerDataArray();
+  const layerDataArray = useStoreDetailsLayerDataArray();
 
   // Find the coordinate info layer
   const coordinateInfoLayer = layerDataArray.find((layer) => layer.layerPath === 'coordinate-info');

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -7,25 +7,25 @@ import { IconButton, Grid, ArrowForwardIosOutlinedIcon, ArrowBackIosOutlinedIcon
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { useUIController } from '@/core/controllers/ui-controller';
 import {
-  useDetailsCheckedFeatures,
-  useDetailsLayerDataArrayBatch,
-  useDetailsSelectedLayerPath,
-  useDetailsCoordinateInfoEnabled,
-  useMapHideCoordinateInfoSwitch,
+  useStoreDetailsCheckedFeatures,
+  useStoreDetailsLayerDataArrayBatch,
+  useStoreDetailsSelectedLayerPath,
+  useStoreDetailsCoordinateInfoEnabled,
+  useStoreDetailsHideCoordinateInfoSwitch,
   setStoreDetailsLayerDataArrayBatchLayerPathBypass,
   setStoreDetailsSelectedLayerPath,
   removeStoreDetailsCheckedFeature,
 } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
-import { useUIActiveAppBarTab, useUIActiveFooterBarTab } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import { useLayerNames, useLayerStatuses } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreUIActiveAppBarTab, useStoreUIActiveFooterBarTab } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreLayerNameSet, useStoreLayerStatusSet } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import {
-  useMapClickCoordinates,
-  useMapAllVisibleandInRangeLayers,
-  useMapOrderedLayers,
-  useMapSelectorLayerQueryable,
-  getStoreMapLayerParentHidden, // TODO: CHECK -This should likely go through a Zustand hook instead of a state getter
-  getStoreMapIsLayerHiddenOnMap, // TODO: CHECK - This should likely go through a Zustand hook instead of a state getter
+  useStoreMapClickCoordinates,
+  useStoreMapAllVisibleandInRangeLayers,
+  useStoreMapOrderedLayers,
+  useStoreMapLayerQueryable,
+  useStoreMapIsParentLayerHiddenOnMapSet,
+  useStoreMapIsLayerHiddenOnMapSet,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import type { TypeFeatureInfoEntry, TypeLayerData, TypeMapMouseInfo } from '@/api/types/map-schema-types';
 
@@ -61,21 +61,23 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // Store
-  const mapId = useGeoViewMapId();
-  const selectedLayerPath = useDetailsSelectedLayerPath();
-  const arrayOfLayerDataBatch = useDetailsLayerDataArrayBatch();
-  const checkedFeatures = useDetailsCheckedFeatures();
-  const coordinateInfoEnabled = useDetailsCoordinateInfoEnabled();
-  const hideCoordinateInfoSwitch = useMapHideCoordinateInfoSwitch();
-  const visibleInRangeLayers = useMapAllVisibleandInRangeLayers();
-  const orderedLayers = useMapOrderedLayers();
-  const mapClickCoordinates = useMapClickCoordinates();
-  const activeAppBarTab = useUIActiveAppBarTab();
-  const activeFooterBarTab = useUIActiveFooterBarTab();
-  const queryableByLayerPath = useMapSelectorLayerQueryable(visibleInRangeLayers);
+  const mapId = useStoreGeoViewMapId();
+  const selectedLayerPath = useStoreDetailsSelectedLayerPath();
+  const arrayOfLayerDataBatch = useStoreDetailsLayerDataArrayBatch();
+  const checkedFeatures = useStoreDetailsCheckedFeatures();
+  const coordinateInfoEnabled = useStoreDetailsCoordinateInfoEnabled();
+  const hideCoordinateInfoSwitch = useStoreDetailsHideCoordinateInfoSwitch();
+  const visibleInRangeLayers = useStoreMapAllVisibleandInRangeLayers();
+  const orderedLayers = useStoreMapOrderedLayers();
+  const mapClickCoordinates = useStoreMapClickCoordinates();
+  const activeAppBarTab = useStoreUIActiveAppBarTab();
+  const activeFooterBarTab = useStoreUIActiveFooterBarTab();
+  const queryableByLayerPath = useStoreMapLayerQueryable(visibleInRangeLayers);
+  const layerNames = useStoreLayerNameSet();
+  const layerStatuses = useStoreLayerStatusSet();
+  const layerHiddenSet = useStoreMapIsLayerHiddenOnMapSet();
+  const layerParentHiddenSet = useStoreMapIsParentLayerHiddenOnMapSet();
   const uiController = useUIController();
-  const layerNames = useLayerNames();
-  const layerStatuses = useLayerStatuses();
   const mapController = useMapController();
 
   // States
@@ -184,7 +186,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
     // Set the layers list (filter: visible - visible in range and isQueryable)
     const layerListEntries = visibleInRangeLayers
       .map((layerPath) => arrayOfLayerDataBatch.find((layerData) => layerData.layerPath === layerPath))
-      .filter((layer) => layer && !getStoreMapIsLayerHiddenOnMap(mapId, layer.layerPath))
+      .filter((layer) => layer && !layerHiddenSet[layer.layerPath])
       .filter((layer) => layer && queryableByLayerPath[layer.layerPath])
       .map(
         (layer) =>
@@ -209,7 +211,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
         (layer.features?.length ?? 0) > 0 &&
         !existingLayerPaths.has(layer.layerPath) &&
         layer.layerPath !== 'coordinate-info' &&
-        !getStoreMapLayerParentHidden(mapId, layer.layerPath)
+        !layerParentHiddenSet[layer.layerPath]
       ) {
         layerListEntries.push({
           layerName: layerNames[layer.layerPath] ?? '',
@@ -266,6 +268,8 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
     queryableByLayerPath,
     layerNames,
     layerStatuses,
+    layerHiddenSet,
+    layerParentHiddenSet,
     getNumFeaturesLabel,
     mapId,
     orderedLayers,

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -15,6 +15,7 @@ import {
   setStoreDetailsLayerDataArrayBatchLayerPathBypass,
   setStoreDetailsSelectedLayerPath,
   removeStoreDetailsCheckedFeature,
+  LAYER_PATH_COORDINATE_INFO,
 } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import { useStoreUIActiveAppBarTab, useStoreUIActiveFooterBarTab } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { useStoreLayerNameSet, useStoreLayerStatusSet } from '@/core/stores/store-interface-and-intial-values/layer-state';
@@ -70,8 +71,8 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
   const visibleInRangeLayers = useStoreMapAllVisibleandInRangeLayers();
   const orderedLayers = useStoreMapOrderedLayers();
   const mapClickCoordinates = useStoreMapClickCoordinates();
-  const activeAppBarTab = useStoreUIActiveAppBarTab();
-  const activeFooterBarTab = useStoreUIActiveFooterBarTab();
+  const { tabId: appBarTabId, isOpen: appBarIsOpen } = useStoreUIActiveAppBarTab();
+  const { tabId: footerBarTabId, isOpen: footerBarIsOpen } = useStoreUIActiveFooterBarTab();
   const queryableByLayerPath = useStoreMapLayerQueryable(visibleInRangeLayers);
   const layerNames = useStoreLayerNameSet();
   const layerStatuses = useStoreLayerStatusSet();
@@ -168,13 +169,13 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
    */
   const memoIsPanelOpen = useMemo(() => {
     if (containerType === CONTAINER_TYPE.FOOTER_BAR) {
-      return activeFooterBarTab.tabId === TABS.DETAILS && activeFooterBarTab.isOpen && isRightPanelVisible;
+      return footerBarTabId === TABS.DETAILS && footerBarIsOpen && isRightPanelVisible;
     }
     if (containerType === CONTAINER_TYPE.APP_BAR) {
-      return activeAppBarTab.tabId === 'details' && activeAppBarTab.isOpen && isRightPanelVisible;
+      return appBarTabId === TABS.DETAILS && appBarIsOpen && isRightPanelVisible;
     }
     return false;
-  }, [containerType, activeFooterBarTab, activeAppBarTab, isRightPanelVisible]);
+  }, [containerType, footerBarTabId, footerBarIsOpen, appBarTabId, appBarIsOpen, isRightPanelVisible]);
 
   /**
    * Memoizes the layers list for the LayerList component and centralizing indexing purposes.
@@ -210,7 +211,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
       if (
         (layer.features?.length ?? 0) > 0 &&
         !existingLayerPaths.has(layer.layerPath) &&
-        layer.layerPath !== 'coordinate-info' &&
+        layer.layerPath !== LAYER_PATH_COORDINATE_INFO &&
         !layerParentHiddenSet[layer.layerPath]
       ) {
         layerListEntries.push({
@@ -228,9 +229,11 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
 
     // Split the layers list into two groups while preserving order (exclude coordinate-info from sorting)
     const layersWithFeatures = layerListEntries.filter(
-      (layer) => layer.numOffeatures && layer.numOffeatures > 0 && layer.layerPath !== 'coordinate-info'
+      (layer) => layer.numOffeatures && layer.numOffeatures > 0 && layer.layerPath !== LAYER_PATH_COORDINATE_INFO
     );
-    const layersWithoutFeatures = layerListEntries.filter((layer) => layer.numOffeatures === 0 && layer.layerPath !== 'coordinate-info');
+    const layersWithoutFeatures = layerListEntries.filter(
+      (layer) => layer.numOffeatures === 0 && layer.layerPath !== LAYER_PATH_COORDINATE_INFO
+    );
 
     // Sort layersWithFeatures according to orderedLayers
     layersWithFeatures.sort((a, b) => {
@@ -246,16 +249,16 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
     const orderedLayerListEntries = [...layersWithFeatures, ...layersWithoutFeatures];
 
     // Add coordinate info layer at the beginning if it exists and is enabled
-    const coordinateInfoLayer = arrayOfLayerDataBatch.find((layer) => layer.layerPath === 'coordinate-info');
+    const coordinateInfoLayer = arrayOfLayerDataBatch.find((layer) => layer.layerPath === LAYER_PATH_COORDINATE_INFO);
     if (coordinateInfoLayer && coordinateInfoEnabled) {
       orderedLayerListEntries.unshift({
-        layerName: layerNames[coordinateInfoLayer.layerPath] ?? 'Coordinate Information',
+        layerName: t('details.coordinateInfoTitle'),
         layerPath: coordinateInfoLayer.layerPath,
         layerStatus: layerStatuses[coordinateInfoLayer.layerPath],
         queryStatus: coordinateInfoLayer.queryStatus,
         numOffeatures: coordinateInfoLayer.features?.length ?? 0,
         layerFeatures: getNumFeaturesLabel(coordinateInfoLayer),
-        tooltip: t('layers.selectLayer', { layerName: layerNames[coordinateInfoLayer.layerPath] ?? '' }) ?? '',
+        tooltip: t('layers.selectLayer', { layerName: t('details.coordinateInfoTitle') }) ?? '',
         layerUniqueId: `${mapId}-${TABS.DETAILS}-${coordinateInfoLayer.layerPath}`,
       });
     }
@@ -638,16 +641,16 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
    */
   useEffect(() => {
     // Log
-    logger.logTraceUseEffect('DETAILS-PANEL - panel closed check', activeFooterBarTab, activeAppBarTab, containerType);
+    logger.logTraceUseEffect('DETAILS-PANEL - panel closed check', containerType);
 
     let shouldClear = false;
 
     if (containerType === CONTAINER_TYPE.FOOTER_BAR) {
       // For footer bar: clear when not on details tab or footer is collapsed
-      shouldClear = activeFooterBarTab.tabId !== TABS.DETAILS || !activeFooterBarTab.isOpen;
+      shouldClear = footerBarTabId !== TABS.DETAILS || !footerBarIsOpen;
     } else if (containerType === CONTAINER_TYPE.APP_BAR) {
       // For app bar: clear when details panel is closed (tabId === 'details' and isOpen === false)
-      shouldClear = activeAppBarTab.tabId === TABS.DETAILS && !activeAppBarTab.isOpen;
+      shouldClear = appBarTabId === TABS.DETAILS && !appBarIsOpen;
     }
 
     if (shouldClear) {
@@ -658,7 +661,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
       // Clear all checked features
       removeStoreDetailsCheckedFeature(mapId, 'all');
     }
-  }, [mapId, mapController, activeFooterBarTab, activeAppBarTab, containerType]);
+  }, [mapId, mapController, footerBarTabId, footerBarIsOpen, appBarTabId, appBarIsOpen, containerType]);
 
   /**
    * Checks if all layers query status is processed.
@@ -677,25 +680,31 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
    */
   useEffect(() => {
     // Log
-    logger.logTraceUseEffect('DETAILS-PANEL - check for auto-guide display', activeAppBarTab, activeFooterBarTab, arrayOfLayerDataBatch);
+    logger.logTraceUseEffect('DETAILS-PANEL - check for auto-guide display', arrayOfLayerDataBatch);
 
     // Check if details panel just opened (from AppBar or Footer)
     const isDetailsActive =
-      (containerType === CONTAINER_TYPE.FOOTER_BAR && activeFooterBarTab.tabId === TABS.DETAILS && activeFooterBarTab.isOpen) ||
-      (containerType === CONTAINER_TYPE.APP_BAR && activeAppBarTab.tabId === TABS.DETAILS && activeAppBarTab.isOpen);
+      (containerType === CONTAINER_TYPE.FOOTER_BAR && footerBarTabId === TABS.DETAILS && footerBarIsOpen) ||
+      (containerType === CONTAINER_TYPE.APP_BAR && appBarTabId === TABS.DETAILS && appBarIsOpen);
 
     // Only run when details is active
     if (isDetailsActive && arrayOfLayerDataBatch && arrayOfLayerDataBatch.length > 0) {
       // Check if all layers have no features (excluding coordinate-info)
       const allLayersHaveNoFeatures = arrayOfLayerDataBatch.every(
-        (layer) => layer.layerPath === 'coordinate-info' || !layer.features || layer.features.length === 0
+        (layer) => layer.layerPath === LAYER_PATH_COORDINATE_INFO || !layer.features || layer.features.length === 0
       );
 
-      // If all layers have no features and queries are processed
-      if (allLayersHaveNoFeatures && memoIsAllLayersQueryStatusProcessed()) {
-        logger.logTraceUseEffect('DETAILS-PANEL - All layers have no features, showing right panel with guide');
+      // Check if we should clear the selected layer
+      const shouldClearSelectedLayer = allLayersHaveNoFeatures && !coordinateInfoEnabled;
+
+      // If should clear the selected layer and queries are processed
+      if (shouldClearSelectedLayer && memoIsAllLayersQueryStatusProcessed()) {
+        // Log
+        logger.logDebug('DETAILS-PANEL - All layers have no features and coordinate info is disabled, showing right panel with guide');
+
         // Clear selection to show the guide
         setStoreDetailsSelectedLayerPath(mapId, '');
+
         // Make sure the right panel is visible
         if (!isRightPanelVisible) {
           layoutRef.current?.showRightPanel(true);
@@ -704,8 +713,11 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
     }
   }, [
     mapId,
-    activeAppBarTab,
-    activeFooterBarTab,
+    appBarTabId,
+    appBarIsOpen,
+    footerBarTabId,
+    footerBarIsOpen,
+    coordinateInfoEnabled,
     containerType,
     arrayOfLayerDataBatch,
     memoIsAllLayersQueryStatusProcessed,
@@ -722,7 +734,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
    * @returns The right panel content, or null to show the guide
    */
   const renderContent = (): JSX.Element | null => {
-    if (selectedLayerPath === 'coordinate-info') {
+    if (selectedLayerPath === LAYER_PATH_COORDINATE_INFO) {
       return <CoordinateInfo />;
     }
 
@@ -830,7 +842,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
       onLayerListClicked={(layerEntry) => handleLayerChange(layerEntry)}
       onRightPanelClosed={handleRightPanelClosed}
       onRightPanelVisibilityChanged={handleRightPanelVisibilityChanged}
-      guideContentIds={['details']}
+      guideContentIds={[TABS.DETAILS]}
       hideEnlargeBtn={containerType === CONTAINER_TYPE.APP_BAR}
       toggleMode={containerType === CONTAINER_TYPE.APP_BAR}
     >

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -839,7 +839,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
       }
       selectedLayerPath={selectedLayerPath}
       layerList={memoLayersList}
-      onLayerListClicked={(layerEntry) => handleLayerChange(layerEntry)}
+      onLayerListClicked={handleLayerChange}
       onRightPanelClosed={handleRightPanelClosed}
       onRightPanelVisibilityChanged={handleRightPanelVisibilityChanged}
       guideContentIds={[TABS.DETAILS]}

--- a/packages/geoview-core/src/core/components/details/feature-detail-modal.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-detail-modal.tsx
@@ -2,9 +2,9 @@ import { useMemo, useState } from 'react';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 
-import { useDataTableSelectedFeature } from '@/core/stores/store-interface-and-intial-values/data-table-state';
-import { useUIActiveFocusItem, useUIActiveAppBarTab } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import { useAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreDataTableSelectedFeature } from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { useStoreUIActiveFocusItem, useStoreUIActiveAppBarTab } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
 
 import { Modal, List, Box, Typography, BrowserNotSupportedIcon } from '@/ui';
 
@@ -31,13 +31,13 @@ export default function FeatureDetailModal(): JSX.Element {
 
   // get store function
   const uiController = useUIController();
-  const activeModalId = useUIActiveFocusItem().activeElementId;
-  const feature = useDataTableSelectedFeature()!;
+  const activeModalId = useStoreUIActiveFocusItem().activeElementId;
+  const feature = useStoreDataTableSelectedFeature()!;
   const [nameFieldValue, setNameFieldValue] = useState('');
-  const shellContainer = useAppShellContainer();
+  const shellContainer = useStoreAppShellContainer();
 
   // Determine which container (appBar or footerBar) the modal is rendered in
-  const activeAppBarTab = useUIActiveAppBarTab();
+  const activeAppBarTab = useStoreUIActiveAppBarTab();
   const containerType = activeAppBarTab.tabId === TABS.DATA_TABLE && activeAppBarTab.isOpen ? 'appBar' : 'footerBar';
 
   /**

--- a/packages/geoview-core/src/core/components/details/feature-info-table.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info-table.tsx
@@ -15,7 +15,8 @@ import {
 import { logger } from '@/core/utils/logger';
 import type { TypeDisplayLanguage, TypeFieldEntry } from '@/api/types/map-schema-types';
 import type { TypeContainerBox } from '@/core/types/global-types';
-import { DateMgt, type TemporalMode, type TimeIANA, type TypeDisplayDateFormat } from '@/core/utils/date-mgt';
+import { DateMgt } from '@/core/utils/date-mgt';
+import type { TemporalMode, TimeIANA, TypeDisplayDateFormat } from '@/core/utils/date-mgt';
 import { useLightBox } from '@/core/components/common';
 import { getSxClasses } from './details-style';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';

--- a/packages/geoview-core/src/core/components/details/feature-info-table.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info-table.tsx
@@ -6,11 +6,11 @@ import linkifyHtml from 'linkify-html';
 import { Box, Button, Table, TableHead, TableBody, TableRow, TableCell, TableContainer } from '@/ui';
 import { isImage, stringify, sanitizeHtmlContent, enhanceLinksAccessibility } from '@/core/utils/utilities';
 import { UseHtmlToReact } from '@/core/components/common/hooks/use-html-to-react';
-import { useAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
 import {
-  useLayerDateTemporalMode,
-  useLayerDisplayDateFormat,
-  useLayerDisplayDateTimezone,
+  useStoreLayerDateTemporalMode,
+  useStoreLayerDisplayDateFormat,
+  useStoreLayerDisplayDateTimezone,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { logger } from '@/core/utils/logger';
 import type { TypeDisplayLanguage, TypeFieldEntry } from '@/api/types/map-schema-types';
@@ -18,7 +18,7 @@ import type { TypeContainerBox } from '@/core/types/global-types';
 import { DateMgt, type TemporalMode, type TimeIANA, type TypeDisplayDateFormat } from '@/core/utils/date-mgt';
 import { useLightBox } from '@/core/components/common';
 import { getSxClasses } from './details-style';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 
 /** Properties for the FeatureInfoTable component. */
 interface FeatureInfoTableProps {
@@ -171,7 +171,7 @@ export const FeatureRow = memo(function FeatureRow({
   displayDateTimezone,
   containerType,
 }: FeatureRowProps): JSX.Element {
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
   const { alias, value } = featureInfoItem;
@@ -268,10 +268,10 @@ export const FeatureInfoTable = memo(function FeatureInfoTable({
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // Store hooks
-  const language = useAppDisplayLanguage();
-  const layerDateTemporalMode = useLayerDateTemporalMode(layerPath);
-  const displayDateFormat = useLayerDisplayDateFormat(layerPath);
-  const displayDateTimezone = useLayerDisplayDateTimezone(layerPath);
+  const language = useStoreAppDisplayLanguage();
+  const layerDateTemporalMode = useStoreLayerDateTemporalMode(layerPath);
+  const displayDateFormat = useStoreLayerDisplayDateFormat(layerPath);
+  const displayDateTimezone = useStoreLayerDisplayDateTimezone(layerPath);
 
   // Store
   const { initLightBox, LightBoxComponent } = useLightBox();

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -15,12 +15,12 @@ import {
 import {
   addStoreDetailsCheckedFeature,
   removeStoreDetailsCheckedFeature,
-  useDetailsCheckedFeatures,
+  useStoreDetailsCheckedFeatures,
 } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import {
   setStoreGeochartSelectedLayerPath,
-  useGeochartConfigs,
-  useGeochartLayerDataArrayBatch,
+  useStoreGeochartChartsConfig,
+  useStoreGeochartLayerDataArrayBatch,
 } from '@/core/stores/store-interface-and-intial-values/geochart-state';
 import { useNavigateToTab } from '@/core/components/common/hooks/use-navigate-to-tab';
 import { logger } from '@/core/utils/logger';
@@ -29,8 +29,8 @@ import type { TypeFeatureInfoEntry, TypeFieldEntry } from '@/api/types/map-schem
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { FeatureInfoTable } from './feature-info-table';
 import { getSxClasses } from './details-style';
-import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { useMapController } from '@/core/controllers/map-controller';
 
 /** Properties for the FeatureInfo component. */
@@ -113,7 +113,7 @@ const FeatureHeader = memo(function FeatureHeader({
   const { t } = useTranslation();
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const isFocusTrap = useUIActiveTrapGeoView();
+  const isFocusTrap = useStoreUIActiveTrapGeoView();
 
   /**
    * Handles when the checked button is toggled.
@@ -211,10 +211,10 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
   const [checked, setChecked] = useState<boolean>(false);
 
   // Store
-  const mapId = useGeoViewMapId();
-  const checkedFeatures = useDetailsCheckedFeatures();
-  const geochartLayerDataArrayBatch = useGeochartLayerDataArrayBatch();
-  const geochartConfigs = useGeochartConfigs();
+  const mapId = useStoreGeoViewMapId();
+  const checkedFeatures = useStoreDetailsCheckedFeatures();
+  const geochartLayerDataArrayBatch = useStoreGeochartLayerDataArrayBatch();
+  const geochartConfigs = useStoreGeochartChartsConfig();
   const mapController = useMapController();
 
   // Use navigate hook for geochart (only if geochart state exists)

--- a/packages/geoview-core/src/core/components/export/canvas-layout.tsx
+++ b/packages/geoview-core/src/core/components/export/canvas-layout.tsx
@@ -1,7 +1,7 @@
 import { renderToString } from 'react-dom/server';
 import * as html2canvas from '@html2canvas/html2canvas';
 
-import { type TemporalMode, type TypeDisplayDateFormat } from '@/core/utils/date-mgt';
+import type { TemporalMode, TypeDisplayDateFormat } from '@/core/utils/date-mgt';
 import type { FileExportProps } from '@/core/components/export/export-modal';
 import type { FlattenedLegendItem, ElementFactory, NorthArrowSVG } from '@/core/components/export/utilities';
 import { ExportUtilities, EXPORT_CONSTANTS } from '@/core/components/export/utilities';

--- a/packages/geoview-core/src/core/components/export/export-modal-button.tsx
+++ b/packages/geoview-core/src/core/components/export/export-modal-button.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@mui/material/styles';
 import { IconButton } from '@/ui/icon-button/icon-button';
 import { DownloadIcon } from '@/ui/icons';
 import { useUIController } from '@/core/controllers/ui-controller';
-import { useLayerAreLayersLoading } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerAreLayersLoading } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 /** Props for the ExportButton component. */
 interface ExportProps {
@@ -30,7 +30,7 @@ export default function ExportButton({ id, className = '', sxDetails }: ExportPr
 
   // get store function
   const uiController = useUIController();
-  const layersAreLoading = useLayerAreLayersLoading();
+  const layersAreLoading = useStoreLayerAreLayersLoading();
 
   return (
     <IconButton

--- a/packages/geoview-core/src/core/components/export/export-modal.tsx
+++ b/packages/geoview-core/src/core/components/export/export-modal.tsx
@@ -27,14 +27,17 @@ import { useTheme } from '@mui/material/styles';
 
 import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, LoadingButton, Skeleton, TextField, Menu, MenuItem } from '@/ui';
 import type { TypeDisplayLanguage } from '@/api/types/map-schema-types';
-import { useUIActiveFocusItem } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreUIActiveFocusItem } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import {
-  useAppDisplayLanguage,
-  useAppGeoviewHTMLElement,
-  useAppShellContainer,
+  useStoreAppDisplayLanguage,
+  useStoreAppGeoviewHTMLElement,
+  useStoreAppShellContainer,
 } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { useLayerDateTemporalModes, useLayerDisplayDateFormats } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import {
+  useStoreLayerDateTemporalModeSet,
+  useStoreLayerDisplayDateFormatSet,
+} from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { exportFile } from '@/core/utils/utilities';
 
 import { useUIController } from '@/core/controllers/ui-controller';
@@ -86,14 +89,14 @@ export default function ExportModal(): JSX.Element {
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // Store
-  const mapId = useGeoViewMapId();
-  const mapElement = useAppGeoviewHTMLElement();
+  const mapId = useStoreGeoViewMapId();
+  const mapElement = useStoreAppGeoviewHTMLElement();
   const uiController = useUIController();
-  const activeModalId = useUIActiveFocusItem().activeElementId;
-  const shellContainer = useAppShellContainer();
-  const language = useAppDisplayLanguage();
-  const layerDateFormats = useLayerDisplayDateFormats();
-  const layerDateTemporalModes = useLayerDateTemporalModes();
+  const activeModalId = useStoreUIActiveFocusItem().activeElementId;
+  const shellContainer = useStoreAppShellContainer();
+  const language = useStoreAppDisplayLanguage();
+  const layerDateFormats = useStoreLayerDisplayDateFormatSet();
+  const layerDateTemporalModes = useStoreLayerDateTemporalModeSet();
 
   // State & refs
   const [isMapLoading, setIsMapLoading] = useState(true);

--- a/packages/geoview-core/src/core/components/export/pdf-layout.tsx
+++ b/packages/geoview-core/src/core/components/export/pdf-layout.tsx
@@ -1,7 +1,7 @@
 import { pdf } from '@react-pdf/renderer';
 
 import { Document, Page, Text, View, Image, Svg, Path } from '@react-pdf/renderer';
-import { type TemporalMode, type TypeDisplayDateFormat } from '@/core/utils/date-mgt';
+import type { TemporalMode, TypeDisplayDateFormat } from '@/core/utils/date-mgt';
 import type { FlattenedLegendItem, ElementFactory, NorthArrowSVG } from '@/core/components/export/utilities';
 import { ExportUtilities } from '@/core/components/export/utilities';
 import type { FileExportProps } from '@/core/components/export/export-modal';

--- a/packages/geoview-core/src/core/components/export/utilities.ts
+++ b/packages/geoview-core/src/core/components/export/utilities.ts
@@ -12,8 +12,8 @@ import {
   isStoreTimeSliderInitialized,
 } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
 import { getStoreMapOrderedLayerInfo, getStoreMapStateForExportLayout } from '@/core/stores/store-interface-and-intial-values/map-state';
-import { getStoreGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { getStoreLayerStateLegendLayers } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { getStoreAppGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { getStoreLayerLegendLayers } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 import { logger } from '@/core/utils/logger';
 import { getLocalizedMessage } from '@/core/utils/utilities';
@@ -912,7 +912,7 @@ export class ExportUtilities {
     layerDateTemporalModes: Record<string, TemporalMode>
   ): Promise<TypeMapInfoResult> {
     // Get all needed data from store state
-    const mapElement = getStoreGeoviewHTMLElement(mapId);
+    const mapElement = getStoreAppGeoviewHTMLElement(mapId);
     const mapState = getStoreMapStateForExportLayout(mapId);
     const { northArrow, northArrowElement, attribution, mapRotation, mapScale, currentProjection } = mapState;
 
@@ -993,7 +993,7 @@ export class ExportUtilities {
     const scaleLineWidth = `${pdfScaleWidth}px`;
 
     // Get all other state data
-    const legendLayers = getStoreLayerStateLegendLayers(mapId).filter(
+    const legendLayers = getStoreLayerLegendLayers(mapId).filter(
       (layer) => layer.layerStatus === 'loaded' && (layer.items.length === 0 || layer.items.some((item) => item.isVisible))
     );
     const orderedLayerInfo = getStoreMapOrderedLayerInfo(mapId);

--- a/packages/geoview-core/src/core/components/export/utilities.ts
+++ b/packages/geoview-core/src/core/components/export/utilities.ts
@@ -17,7 +17,8 @@ import { getStoreLayerLegendLayers } from '@/core/stores/store-interface-and-int
 
 import { logger } from '@/core/utils/logger';
 import { getLocalizedMessage } from '@/core/utils/utilities';
-import { DateMgt, type TemporalMode, type TypeDisplayDateFormat } from '@/core/utils/date-mgt';
+import { DateMgt } from '@/core/utils/date-mgt';
+import type { TemporalMode, TypeDisplayDateFormat } from '@/core/utils/date-mgt';
 import { NorthArrowIcon } from '@/core/components/north-arrow/north-arrow-icon';
 
 import { SHARED_STYLES, getScaledCanvasStyles } from '@/core/components/export/layout-styles';

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import type { FooterBarApi, FooterTabCreatedEvent, FooterTabRemovedEvent } from '@/core/components';
 import { DEFAULT_FOOTER_TABS_ORDER } from '@/api/types/map-schema-types';
+import { CONTAINER_TYPE, TABS } from '@/core/utils/constant';
 import { useStoreGeoViewConfig, useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { UseHtmlToReact } from '@/core/components/common/hooks/use-html-to-react';
 import { Legend } from '@/core/components/legend/legend';
@@ -35,7 +36,6 @@ import { camelCase, delay, scrollIfNotVisible } from '@/core/utils/utilities';
 import { logger } from '@/core/utils/logger';
 import { Guide } from '@/core/components/guide/guide';
 import { FooterPlugin } from '@/api/plugin/footer-plugin';
-import { CONTAINER_TYPE } from '@/core/utils/constant';
 
 /** Tab definition with icon, content, and optional label. */
 interface Tab {
@@ -238,10 +238,10 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
     logger.logTraceUseEffect('FOOTER-TABS - arrayOfLayerDataBatch', arrayOfLayerDataBatch, activeFooterBarTab);
 
     // If the details tab is not in the footer bar tabs config, return
-    if (footerBarTabsConfig && !footerBarTabsConfig.tabs.core.includes('details')) return;
+    if (footerBarTabsConfig && !footerBarTabsConfig.tabs.core.includes(TABS.DETAILS)) return;
 
     // If we're on the details panel and the footer is collapsed
-    if (activeFooterBarTab.tabId === 'details' && !activeFooterBarTab.isOpen) {
+    if (activeFooterBarTab.tabId === TABS.DETAILS && !activeFooterBarTab.isOpen) {
       // Uncollapse it
       uiController.setFooterBarIsOpen(true);
     }

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -11,17 +11,21 @@ import { useUIController } from '@/core/controllers/ui-controller';
 import { usePluginController } from '@/core/controllers/plugin-controller';
 import { getSxClasses } from './footer-bar-style';
 import { ResizeFooterPanel } from '@/core/components/footer-bar/hooks/resize-footer-panel';
-import { useAppFullscreenActive, useAppHeight, useAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { useDetailsLayerDataArrayBatch } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import {
-  useUIActiveFooterBarTab,
-  useUIFooterPanelResizeValue,
-  useUIActiveTrapGeoView,
-  useUIHiddenTabs,
+  useStoreAppIsFullscreenActive,
+  useStoreAppHeight,
+  useStoreAppShellContainer,
+} from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreDetailsLayerDataArrayBatch } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
+import {
+  useStoreUIActiveFooterBarTab,
+  useStoreUIFooterPanelResizeValue,
+  useStoreUIActiveTrapGeoView,
+  useStoreUIHiddenTabs,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import type { FooterBarApi, FooterTabCreatedEvent, FooterTabRemovedEvent } from '@/core/components';
 import { DEFAULT_FOOTER_TABS_ORDER } from '@/api/types/map-schema-types';
-import { useGeoViewConfig, useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewConfig, useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { UseHtmlToReact } from '@/core/components/common/hooks/use-html-to-react';
 import { Legend } from '@/core/components/legend/legend';
 import { LayersPanel } from '@/core/components/layers/layers-panel';
@@ -63,8 +67,6 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
   const { api: footerBarApi } = props;
 
   // Hooks
-  const isMapFullScreen = useAppFullscreenActive();
-  const footerPanelResizeValue = useUIFooterPanelResizeValue();
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
@@ -72,19 +74,21 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
   const tabsContainerRef = useRef<HTMLDivElement>();
 
   // Store
-  const mapId = useGeoViewMapId();
-  const arrayOfLayerDataBatch = useDetailsLayerDataArrayBatch();
-  const activeFooterBarTab = useUIActiveFooterBarTab();
-  const activeTrapGeoView = useUIActiveTrapGeoView();
-  const shellContainer = useAppShellContainer();
-  const uiController = useUIController();
-  const backupAppHeight: number = useAppHeight();
+  const mapId = useStoreGeoViewMapId();
+  const isMapFullScreen = useStoreAppIsFullscreenActive();
+  const footerPanelResizeValue = useStoreUIFooterPanelResizeValue();
+  const arrayOfLayerDataBatch = useStoreDetailsLayerDataArrayBatch();
+  const activeFooterBarTab = useStoreUIActiveFooterBarTab();
+  const activeTrapGeoView = useStoreUIActiveTrapGeoView();
+  const shellContainer = useStoreAppShellContainer();
+  const backupAppHeight: number = useStoreAppHeight();
   const appHeight = document.getElementById(mapId)?.getAttribute('data-footer-height') ?? `${backupAppHeight}px`;
-  const hiddenTabs: string[] = useUIHiddenTabs();
+  const hiddenTabs: string[] = useStoreUIHiddenTabs();
+  const uiController = useUIController();
   const pluginController = usePluginController();
 
   // get store config for footer bar tabs to add (similar logic as in app-bar)
-  const footerBarTabsConfig = useGeoViewConfig()?.footerBar;
+  const footerBarTabsConfig = useStoreGeoViewConfig()?.footerBar;
 
   /**
    * Builds the footer bar tab keys from configuration.

--- a/packages/geoview-core/src/core/components/footer-bar/hooks/resize-footer-panel.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/hooks/resize-footer-panel.tsx
@@ -5,9 +5,9 @@ import Slider from '@mui/material/Slider';
 import { Box, HeightIcon, IconButton, Popover } from '@/ui';
 
 import { useUIController } from '@/core/controllers/ui-controller';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { getSxClasses } from './resize-footer-panel-style';
-import { useUIFooterPanelResizeValue } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreUIFooterPanelResizeValue } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { logger } from '@/core/utils/logger';
 
 /** Slider input styles for vertical orientation. */
@@ -48,14 +48,14 @@ export const ResizeFooterPanel = memo(function ResizeFooterPanel(): JSX.Element 
   const sxClasses = useMemo(() => getSxClasses(), []);
 
   // Store
-  const footerPanelResizeValue = useUIFooterPanelResizeValue();
+  const footerPanelResizeValue = useStoreUIFooterPanelResizeValue();
   const uiController = useUIController();
 
   // States
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
   // Get container
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
   const mapElem = document.getElementById(`shell-${mapId}`);
 
   // Marks calculation

--- a/packages/geoview-core/src/core/components/geolocator/geolocator-result.tsx
+++ b/packages/geoview-core/src/core/components/geolocator/geolocator-result.tsx
@@ -8,10 +8,10 @@ import type { GeoListItem } from '@/core/components/geolocator/geolocator';
 import { GeoList } from '@/core/components/geolocator/geo-list';
 import { createMenuItems } from '@/core/components/geolocator/utilities';
 import { getSxClasses } from '@/core/components/geolocator/geolocator-style';
-import { useMapSize } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapSize } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
-import { useAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 
 /** Props for the GeolocatorResult component. */
 interface GeolocatorFiltersType {
@@ -37,10 +37,10 @@ export function GeolocatorResult({ geoLocationData, searchValue, error }: Geoloc
   const { t } = useTranslation();
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
 
   // Store
-  const shellContainer = useAppShellContainer();
+  const shellContainer = useStoreAppShellContainer();
 
   // State
   const [province, setProvince] = useState<string>('');
@@ -55,7 +55,7 @@ export function GeolocatorResult({ geoLocationData, searchValue, error }: Geoloc
 
   // Store
   // TODO: style - we should not base length on map size value, parent should adjust
-  const mapSize = useMapSize();
+  const mapSize = useStoreMapSize();
 
   /**
    * Clears all filters.

--- a/packages/geoview-core/src/core/components/geolocator/geolocator-result.tsx
+++ b/packages/geoview-core/src/core/components/geolocator/geolocator-result.tsx
@@ -37,9 +37,9 @@ export function GeolocatorResult({ geoLocationData, searchValue, error }: Geoloc
   const { t } = useTranslation();
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const mapId = useStoreGeoViewMapId();
 
   // Store
+  const mapId = useStoreGeoViewMapId();
   const shellContainer = useStoreAppShellContainer();
 
   // State

--- a/packages/geoview-core/src/core/components/geolocator/geolocator.tsx
+++ b/packages/geoview-core/src/core/components/geolocator/geolocator.tsx
@@ -9,7 +9,7 @@ import { debounce } from '@/core/utils/debounce';
 import { Box, ProgressBar, Typography } from '@/ui';
 
 import { useUIController } from '@/core/controllers/ui-controller';
-import { useUIActiveAppBarTab, useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreUIActiveAppBarTab, useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { GeolocatorResult } from '@/core/components/geolocator/geolocator-result';
 import { getSxClasses } from '@/core/components/geolocator/geolocator-style';
 import { DEFAULT_APPBAR_CORE } from '@/api/types/map-schema-types';
@@ -18,7 +18,7 @@ import { logger } from '@/core/utils/logger';
 import { useGeolocator } from '@/core/components/geolocator/hooks/use-geolocator';
 import { GeolocatorBar } from '@/core/components/geolocator/geolocator-bar';
 import { handleEscapeKey } from '@/core/utils/utilities';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { CONTAINER_TYPE, TIMEOUT } from '@/core/utils/constant';
 
 /** Geolocation search result item. */
@@ -59,12 +59,12 @@ export function Geolocator(): JSX.Element {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
-  const mapId = useGeoViewMapId();
 
   // Store
+  const mapId = useStoreGeoViewMapId();
   const uiController = useUIController();
-  const { tabId, isOpen } = useUIActiveAppBarTab();
-  const activeTrapGeoView = useUIActiveTrapGeoView();
+  const { tabId, isOpen } = useStoreUIActiveAppBarTab();
+  const activeTrapGeoView = useStoreUIActiveTrapGeoView();
 
   // Derived values
   const isPanelOpen = tabId === DEFAULT_APPBAR_CORE.GEOLOCATOR && isOpen;

--- a/packages/geoview-core/src/core/components/geolocator/hooks/use-geolocator.ts
+++ b/packages/geoview-core/src/core/components/geolocator/hooks/use-geolocator.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useAppGeolocatorServiceURL, useAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppGeolocatorServiceURL, useStoreAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { cleanPostalCode, getDecimalDegreeItem } from '@/core/components/geolocator/utilities';
 import type { GeoListItem } from '@/core/components/geolocator/geolocator';
 import { logger } from '@/core/utils/logger';
@@ -40,8 +40,8 @@ export const useGeolocator = (): UseGeolocatorReturn => {
   const [searchValue, setSearchValue] = useState<string>('');
 
   // Store
-  const displayLanguage = useAppDisplayLanguage();
-  const geolocatorServiceURL = useAppGeolocatorServiceURL();
+  const displayLanguage = useStoreAppDisplayLanguage();
+  const geolocatorServiceURL = useStoreAppGeolocatorServiceURL();
 
   // Refs
   const displayLanguageRef = useRef(displayLanguage);

--- a/packages/geoview-core/src/core/components/guide/guide.tsx
+++ b/packages/geoview-core/src/core/components/guide/guide.tsx
@@ -5,12 +5,12 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
 import { Box } from '@/ui';
-import { useAppGuide } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppGuide } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { logger } from '@/core/utils/logger';
 import { getSxClasses } from './guide-style';
 import type { LayerListEntry } from '@/core/components/common';
 import { Layout } from '@/core/components/common';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { TABS } from '@/core/utils/constant';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { GuideSearch } from './guide-search';
@@ -50,8 +50,8 @@ export const Guide = memo(function GuidePanel({ containerType }: GuideType): JSX
   );
 
   // Store
-  const guide = useAppGuide();
-  const mapId = useGeoViewMapId();
+  const guide = useStoreAppGuide();
+  const mapId = useStoreGeoViewMapId();
 
   // Callbacks & Memoize values
   /**

--- a/packages/geoview-core/src/core/components/hover-tooltip/hover-tooltip.tsx
+++ b/packages/geoview-core/src/core/components/hover-tooltip/hover-tooltip.tsx
@@ -5,19 +5,19 @@ import { useTheme } from '@mui/material/styles';
 import { Box, BrowserNotSupportedIcon } from '@/ui';
 
 import {
-  getStoreMapPointerPosition,
-  useMapHoverFeatureInfo,
-  useMapIsMouseInsideMap,
+  useStoreMapHoverFeatureInfo,
+  useStoreMapIsMouseInsideMap,
+  useStoreMapPointerPosition,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { getSxClasses } from './hover-tooltip-styles';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
-import { useAppDisplayLanguage, useAppGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreAppDisplayLanguage, useStoreAppGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { logger } from '@/core/utils/logger';
 import { DateMgt } from '@/core/utils/date-mgt';
 import {
-  useLayerDateTemporalModes,
-  useLayerDisplayDateFormats,
-  useLayerDisplayDateTimezones,
+  useStoreLayerDateTemporalModeSet,
+  useStoreLayerDisplayDateFormatSet,
+  useStoreLayerDisplayDateTimezoneSet,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 /**
@@ -43,14 +43,15 @@ export const HoverTooltip = memo(function HoverTooltip(): JSX.Element | null {
   const mapRectRef = useRef<DOMRect | null>(null);
 
   // Store values
-  const mapId = useGeoViewMapId();
-  const hoverFeatureInfo = useMapHoverFeatureInfo();
-  const isMouseouseInMap = useMapIsMouseInsideMap();
-  const mapElem = useAppGeoviewHTMLElement().querySelector(`[id^="mapTargetElement-${useGeoViewMapId()}"]`) as HTMLElement;
-  const language = useAppDisplayLanguage();
-  const layerDateTemporalModes = useLayerDateTemporalModes();
-  const displayDateFormats = useLayerDisplayDateFormats();
-  const displayDateTimezones = useLayerDisplayDateTimezones();
+  const mapId = useStoreGeoViewMapId();
+  const hoverFeatureInfo = useStoreMapHoverFeatureInfo();
+  const isMouseouseInMap = useStoreMapIsMouseInsideMap();
+  const mapElem = useStoreAppGeoviewHTMLElement().querySelector(`[id^="mapTargetElement-${mapId}"]`) as HTMLElement;
+  const language = useStoreAppDisplayLanguage();
+  const layerDateTemporalModes = useStoreLayerDateTemporalModeSet();
+  const displayDateFormats = useStoreLayerDisplayDateFormatSet();
+  const displayDateTimezones = useStoreLayerDisplayDateTimezoneSet();
+  const pointerPosition = useStoreMapPointerPosition();
 
   /**
    * Formats the hovered feature value for display.
@@ -79,11 +80,6 @@ export const HoverTooltip = memo(function HoverTooltip(): JSX.Element | null {
    * Calculates the tooltip position with boundary checks.
    */
   const memoPosition = useMemo(() => {
-    // TODO: CHECK - This should likely go through a Zustand hook instead of a state getter.
-    // TO.DOCONT: Or write down why we do an exception here (other than 'use it only when needed')
-    // Use store getter, we do not subcribe to modification and use it only when needed
-    const pointerPosition = getStoreMapPointerPosition(mapId);
-
     // Early return in memo
     // Check for all required conditions upfront
     if (!pointerPosition?.pixel || !mapElem || memoValue === undefined || !isMouseouseInMap) {
@@ -115,7 +111,7 @@ export const HoverTooltip = memo(function HoverTooltip(): JSX.Element | null {
     if (tooltipY < mapRectRef.current.top) tooltipY = pointerPosition.pixel[1] + 10;
 
     return { left: `${tooltipX}px`, top: `${tooltipY}px`, isValid: true };
-  }, [mapId, mapElem, memoValue, isMouseouseInMap]);
+  }, [mapElem, memoValue, isMouseouseInMap, pointerPosition]);
 
   /**
    * Computes the tooltip content and visibility state.

--- a/packages/geoview-core/src/core/components/layers/delete-undo-button.tsx
+++ b/packages/geoview-core/src/core/components/layers/delete-undo-button.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box, CircularProgressBase, DeleteOutlineIcon, IconButton, UndoIcon } from '@/ui';
-import { useLayerSelectorDeletionStartTime } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerDeletionStartTime } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { logger } from '@/core/utils/logger';
 import { TIMEOUT } from '@/core/utils/constant';
 import { useLayerController } from '@/core/controllers/layer-controller';
@@ -74,7 +74,7 @@ export function DeleteUndoButton(props: DeleteUndoButtonProps): JSX.Element {
   const undoButtonRef = useRef<HTMLButtonElement>(null);
 
   // Store hooks
-  const layerDeletionStartTime = useLayerSelectorDeletionStartTime(layerPath);
+  const layerDeletionStartTime = useStoreLayerDeletionStartTime(layerPath);
   const layerController = useLayerController();
 
   // state

--- a/packages/geoview-core/src/core/components/layers/layers-panel.tsx
+++ b/packages/geoview-core/src/core/components/layers/layers-panel.tsx
@@ -7,7 +7,7 @@ import { useTheme } from '@mui/material';
 import { Box } from '@/ui';
 
 import { useUIController } from '@/core/controllers/ui-controller';
-import { useLayerDisplayState, useSelectedLayer } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerDisplayState, useStoreSelectedLayer } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { LayersToolbar } from './layers-toolbar';
 import { LayerDetails } from './right-panel/layer-details';
 import { LeftPanel } from './left-panel/left-panel';
@@ -17,7 +17,7 @@ import { ResponsiveGridLayout } from '@/core/components/common/responsive-grid-l
 import { Typography } from '@/ui/typography/typography';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { TABS } from '@/core/utils/constant';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 
 interface TypeLayersPanel {
   containerType: TypeContainerBox;
@@ -30,14 +30,14 @@ export function LayersPanel({ containerType }: TypeLayersPanel): JSX.Element {
 
   const { t } = useTranslation();
 
-  const selectedLayer = useSelectedLayer(); // get store value
-  const displayState = useLayerDisplayState();
-  const [isLayoutEnlarged, setIsLayoutEnlarged] = useState<boolean>(false);
+  const mapId = useStoreGeoViewMapId();
+  const selectedLayer = useStoreSelectedLayer();
+  const displayState = useStoreLayerDisplayState();
 
   const uiController = useUIController();
 
   const responsiveLayoutRef = useRef<ResponsiveGridLayoutExposedMethods>(null);
-  const mapId = useGeoViewMapId();
+  const [isLayoutEnlarged, setIsLayoutEnlarged] = useState<boolean>(false);
 
   const showLayerDetailsPanel = useCallback((): void => {
     // Just set visibility - focus will be handled automatically by useEffect

--- a/packages/geoview-core/src/core/components/layers/layers-panel.tsx
+++ b/packages/geoview-core/src/core/components/layers/layers-panel.tsx
@@ -7,7 +7,11 @@ import { useTheme } from '@mui/material';
 import { Box } from '@/ui';
 
 import { useUIController } from '@/core/controllers/ui-controller';
-import { useStoreLayerDisplayState, useStoreSelectedLayer } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import {
+  useStoreLayerDisplayState,
+  useStoreLayerSelectedLayerPath,
+  useStoreLayerSelectedLayerName,
+} from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { LayersToolbar } from './layers-toolbar';
 import { LayerDetails } from './right-panel/layer-details';
 import { LeftPanel } from './left-panel/left-panel';
@@ -31,7 +35,8 @@ export function LayersPanel({ containerType }: TypeLayersPanel): JSX.Element {
   const { t } = useTranslation();
 
   const mapId = useStoreGeoViewMapId();
-  const selectedLayer = useStoreSelectedLayer();
+  const selectedLayerPath = useStoreLayerSelectedLayerPath();
+  const selectedLayerName = useStoreLayerSelectedLayerName();
   const displayState = useStoreLayerDisplayState();
 
   const uiController = useUIController();
@@ -65,8 +70,8 @@ export function LayersPanel({ containerType }: TypeLayersPanel): JSX.Element {
   };
 
   const rightPanel = (): JSX.Element | null => {
-    if (selectedLayer && displayState === 'view') {
-      return <LayerDetails layerDetails={selectedLayer} containerType={containerType} />;
+    if (selectedLayerPath && displayState === 'view') {
+      return <LayerDetails layerPath={selectedLayerPath} containerType={containerType} />;
     }
     return null;
   };
@@ -83,7 +88,7 @@ export function LayersPanel({ containerType }: TypeLayersPanel): JSX.Element {
         }}
         component="div"
       >
-        {selectedLayer?.layerName ?? ''}
+        {selectedLayerName ?? ''}
       </Typography>
     );
   };
@@ -100,13 +105,13 @@ export function LayersPanel({ containerType }: TypeLayersPanel): JSX.Element {
    */
   const handleRightPanelClosed = useCallback((): void => {
     // If we have a selected layer, tell disableFocusTrap to focus it
-    if (selectedLayer?.layerPath) {
-      const layerListItemId = `${mapId}-${containerType}-${TABS.LAYERS}-${selectedLayer.layerPath}`;
+    if (selectedLayerPath) {
+      const layerListItemId = `${mapId}-${containerType}-${TABS.LAYERS}-${selectedLayerPath}`;
       uiController.disableFocusTrap(layerListItemId);
     } else {
       uiController.disableFocusTrap('no-focus');
     }
-  }, [mapId, selectedLayer, uiController, containerType]);
+  }, [mapId, selectedLayerPath, uiController, containerType]);
 
   return (
     <ResponsiveGridLayout

--- a/packages/geoview-core/src/core/components/layers/layers-toolbar.tsx
+++ b/packages/geoview-core/src/core/components/layers/layers-toolbar.tsx
@@ -7,14 +7,14 @@ import { useTheme } from '@mui/material';
 import { Box, AddCircleOutlineIcon, Button } from '@/ui';
 import { ToggleAll } from '@/core/components/toggle-all/toggle-all';
 import {
-  useLayerDisplayState,
-  useLayerLegendLayers,
+  useStoreLayerDisplayState,
+  useStoreLayerLayerPaths,
   setStoreLayerDisplayState,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import type { TypeLayersViewDisplayState } from './types';
 import { logger } from '@/core/utils/logger';
 import type { TypeContainerBox } from '@/core/types/global-types';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 
 interface TypeLayersToolbar {
   containerType: TypeContainerBox;
@@ -39,9 +39,9 @@ export function LayersToolbar({ containerType }: TypeLayersToolbar): JSX.Element
   };
 
   // Store
-  const mapId = useGeoViewMapId();
-  const displayState = useLayerDisplayState();
-  const legendLayers = useLayerLegendLayers();
+  const mapId = useStoreGeoViewMapId();
+  const displayState = useStoreLayerDisplayState();
+  const layerPaths = useStoreLayerLayerPaths();
 
   // State
   const lastDisplayState = useRef<TypeLayersViewDisplayState | null>(null);
@@ -73,7 +73,7 @@ export function LayersToolbar({ containerType }: TypeLayersToolbar): JSX.Element
    */
   useEffect(() => {
     // Always show 'add' panel when there are no layers
-    if (legendLayers.length === 0 && displayState !== 'add') {
+    if (layerPaths.length === 0 && displayState !== 'add') {
       setStoreLayerDisplayState(mapId, 'add');
     }
 
@@ -93,7 +93,7 @@ export function LayersToolbar({ containerType }: TypeLayersToolbar): JSX.Element
         userClickedAdd.current = false;
       }
     }
-  }, [displayState, legendLayers.length, mapId]);
+  }, [displayState, layerPaths.length, mapId]);
 
   /**
    * Secondary effect specifically for auto-switching to view mode.
@@ -104,11 +104,11 @@ export function LayersToolbar({ containerType }: TypeLayersToolbar): JSX.Element
    * 3. User didn't explicitly click the Add button
    */
   useEffect(() => {
-    if (legendLayers.length > 0 && displayState === 'add' && !userClickedAdd.current) {
+    if (layerPaths.length > 0 && displayState === 'add' && !userClickedAdd.current) {
       setStoreLayerDisplayState(mapId, 'view');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [legendLayers.length, mapId]); // Only depend on legendLayers.length and mapId
+  }, [layerPaths.length, mapId]); // Only depend on layerPaths.length and mapId
 
   return (
     <Box id={`${mapId}-${containerType}-layers-toolbar`} sx={layerToolbarStyle}>

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -4,12 +4,12 @@ import { useTranslation } from 'react-i18next';
 import type { SelectChangeEvent } from '@mui/material';
 import type { ButtonPropsLayerPanel } from '@/ui';
 import { Box, Button, IconButton, ButtonGroup, CircularProgressBase, FileUploadIcon, Paper, Select, Stepper, TextField } from '@/ui';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { setStoreLayerDisplayState } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import {
-  useAppDisabledLayerTypes,
-  useAppDisplayLanguage,
-  useAppShellContainer,
+  useStoreAppDisabledLayerTypes,
+  useStoreAppDisplayLanguage,
+  useStoreAppShellContainer,
 } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { ConfigApi } from '@/api/config/config-api';
 import { logger } from '@/core/utils/logger';
@@ -279,11 +279,11 @@ export function AddNewLayer(): JSX.Element {
   const isMultipleTextFieldRef = useRef<HTMLDivElement>(null);
 
   // Store
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
+  const disabledLayerTypes = useStoreAppDisabledLayerTypes();
+  const language = useStoreAppDisplayLanguage();
+  const shellContainer = useStoreAppShellContainer();
   const uiController = useUIController();
-  const disabledLayerTypes = useAppDisabledLayerTypes();
-  const language = useAppDisplayLanguage();
-  const shellContainer = useAppShellContainer();
   const mapController = useMapController();
   const layerCreatorController = useLayerCreatorController();
 

--- a/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
@@ -2,30 +2,29 @@ import { useCallback, useMemo } from 'react';
 import { useTheme } from '@mui/material/styles';
 import { List } from '@/ui';
 import { logger } from '@/core/utils/logger';
-import type { TypeLegendLayer } from '@/core/components/layers/types';
 import { SingleLayer } from './single-layer';
 import { getSxClasses } from './left-panel-styles';
 import type { TypeContainerBox } from '@/core/types/global-types';
-import { useMapOrderedLayers } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapOrderedLayers } from '@/core/stores/store-interface-and-intial-values/map-state';
 
 interface LayerListProps {
   depth: number;
-  layersList: TypeLegendLayer[];
+  layerPaths: string[];
   showLayerDetailsPanel: (layerId: string) => void;
   isLayoutEnlarged: boolean;
   containerType: TypeContainerBox;
 }
 
-export function LayersList({ layersList, showLayerDetailsPanel, isLayoutEnlarged, depth, containerType }: LayerListProps): JSX.Element {
+export function LayersList({ layerPaths, showLayerDetailsPanel, isLayoutEnlarged, depth, containerType }: LayerListProps): JSX.Element {
   // Log
-  logger.logTraceRender('components/layers/left-panel/layers-list', `Count ${layersList.length}`);
+  logger.logTraceRender('components/layers/left-panel/layers-list', `Count ${layerPaths.length}`);
 
   // Hook
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // Store
-  const layerPathOrder = useMapOrderedLayers();
+  const layerPathOrder = useStoreMapOrderedLayers();
 
   // ? I doubt we want to define an explicit type for style properties?
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -39,20 +38,20 @@ export function LayersList({ layersList, showLayerDetailsPanel, isLayoutEnlarged
   // Memoize the legend items
   const memoLegendItems = useMemo(() => {
     // Log
-    logger.logTraceUseMemo('LAYERS-LIST - memoLegendItems', layersList);
+    logger.logTraceUseMemo('LAYERS-LIST - memoLegendItems', layerPaths);
 
-    const sortedLayers = layersList.sort((a, b) => {
-      return layerPathOrder.indexOf(a.layerPath) - layerPathOrder.indexOf(b.layerPath);
+    const sortedPaths = [...layerPaths].sort((a, b) => {
+      return layerPathOrder.indexOf(a) - layerPathOrder.indexOf(b);
     });
 
-    return sortedLayers.map((layer, index) => {
+    return sortedPaths.map((layerPath, index) => {
       const isFirst = index === 0;
-      const isLast = index === sortedLayers.length - 1;
+      const isLast = index === sortedPaths.length - 1;
 
       return (
         <SingleLayer
-          key={layer.layerPath}
-          layerPath={layer.layerPath}
+          key={layerPath}
+          layerPath={layerPath}
           depth={depth}
           showLayerDetailsPanel={showLayerDetailsPanel}
           isFirst={isFirst}
@@ -62,7 +61,7 @@ export function LayersList({ layersList, showLayerDetailsPanel, isLayoutEnlarged
         />
       );
     });
-  }, [depth, isLayoutEnlarged, showLayerDetailsPanel, layersList, layerPathOrder, containerType]);
+  }, [depth, isLayoutEnlarged, showLayerDetailsPanel, layerPaths, layerPathOrder, containerType]);
 
   return <List sx={getListClass()}>{memoLegendItems}</List>;
 }

--- a/packages/geoview-core/src/core/components/layers/left-panel/left-panel.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/left-panel.tsx
@@ -1,4 +1,4 @@
-import { useLayerDisplayState, useLayerLegendLayers } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerDisplayState, useStoreLayerLayerPaths } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { LayersList } from './layers-list';
 import { AddNewLayer } from './add-new-layer/add-new-layer';
 import { logger } from '@/core/utils/logger';
@@ -15,8 +15,8 @@ export function LeftPanel({ showLayerDetailsPanel, isLayoutEnlarged, containerTy
   logger.logTraceRender('components/layers/left-panel/left-panel');
 
   // get from the store
-  const legendLayers = useLayerLegendLayers();
-  const displayState = useLayerDisplayState();
+  const layerPaths = useStoreLayerLayerPaths();
+  const displayState = useStoreLayerDisplayState();
 
   if (displayState === 'add') {
     return <AddNewLayer />;
@@ -24,7 +24,7 @@ export function LeftPanel({ showLayerDetailsPanel, isLayoutEnlarged, containerTy
 
   return (
     <LayersList
-      layersList={legendLayers}
+      layerPaths={layerPaths}
       depth={0}
       showLayerDetailsPanel={showLayerDetailsPanel}
       isLayoutEnlarged={isLayoutEnlarged}

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -16,24 +16,24 @@ import {
   VisibilityOffOutlinedIcon,
   VisibilityOutlinedIcon,
 } from '@/ui';
-import type { TypeLegendLayer } from '@/core/components/layers/types';
 import {
-  useLayerDisplayState,
-  useLayerSelectedLayerPath,
-  useLayerSelectorName,
-  useLayerSelectorId,
-  useLayerSelectorStatus,
-  useLayerSelectorEntryType,
-  useLayerSelectorControls,
-  useLayerSelectorChildren,
-  useLayerSelectorItems,
+  useStoreLayerDisplayState,
+  useStoreLayerSelectedLayerPath,
+  useStoreLayerName,
+  useStoreLayerId,
+  useStoreLayerStatus,
+  useStoreLayerEntryType,
+  useStoreLayerControls,
+  useStoreLayerChildPaths,
+  useStoreLayerItems,
+  useStoreLayerHasDisabledVisibility,
   setStoreLayerSelectedLayersTabLayer,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import {
-  useMapSelectorLayerLegendCollapsed,
-  useMapSelectorLayerVisibility,
-  useMapSelectorLayerInVisibleRange,
-  useMapSelectorLayerParentHidden,
+  useStoreMapLegendCollapsedByPath,
+  useStoreMapLayerVisibility,
+  useStoreMapLayerInVisibleRange,
+  useStoreMapIsParentLayerHiddenOnMap,
   setStoreMapToggleLegendCollapsed,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { DeleteUndoButton } from '@/core/components/layers/delete-undo-button';
@@ -42,12 +42,11 @@ import { LayerIcon } from '@/core/components/common/layer-icon';
 import { logger } from '@/core/utils/logger';
 import { ArrowDownwardIcon, ArrowUpIcon, CenterFocusScaleIcon, LoopIcon } from '@/ui/icons';
 import { Divider } from '@/ui/divider/divider';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
-import type { TypeLayerControls } from '@/api/types/layer-schema-types';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { scrollListItemIntoView } from '@/core/utils/utilities';
 import { TIMEOUT, TABS } from '@/core/utils/constant';
 import type { TypeContainerBox } from '@/core/types/global-types';
-import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { useMapController } from '@/core/controllers/map-controller';
 import { useLayerCreatorController } from '@/core/controllers/layer-creator-controller';
 
@@ -85,24 +84,24 @@ export function SingleLayer({
   const reloadRequestedRef = useRef<boolean>(false);
 
   // Get store states
-  const mapId = useGeoViewMapId();
-  const selectedLayerPath = useLayerSelectedLayerPath();
-  const displayState = useLayerDisplayState();
+  const mapId = useStoreGeoViewMapId();
+  const selectedLayerPath = useStoreLayerSelectedLayerPath();
+  const displayState = useStoreLayerDisplayState();
   const layerIsSelected = layerPath === selectedLayerPath && displayState === 'view';
-  const isKeyboardNavigationMode = useUIActiveTrapGeoView();
+  const isKeyboardNavigationMode = useStoreUIActiveTrapGeoView();
 
-  const isVisible = useMapSelectorLayerVisibility(layerPath);
-  const inVisibleRange = useMapSelectorLayerInVisibleRange(layerPath);
-  const legendExpanded = !useMapSelectorLayerLegendCollapsed(layerPath);
-  const parentHidden = useMapSelectorLayerParentHidden(layerPath);
+  const isVisible = useStoreMapLayerVisibility(layerPath);
+  const inVisibleRange = useStoreMapLayerInVisibleRange(layerPath);
+  const legendExpanded = !useStoreMapLegendCollapsedByPath(layerPath);
+  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layerPath);
 
-  const layerId = useLayerSelectorId(layerPath);
-  const layerName = useLayerSelectorName(layerPath);
-  const layerStatus = useLayerSelectorStatus(layerPath);
-  const layerEntryType = useLayerSelectorEntryType(layerPath);
-  const layerControls = useLayerSelectorControls(layerPath);
-  const layerChildren = useLayerSelectorChildren(layerPath);
-  const layerItems = useLayerSelectorItems(layerPath);
+  const layerId = useStoreLayerId(layerPath);
+  const layerName = useStoreLayerName(layerPath);
+  const layerStatus = useStoreLayerStatus(layerPath);
+  const layerEntryType = useStoreLayerEntryType(layerPath);
+  const layerControls = useStoreLayerControls(layerPath);
+  const layerChildPaths = useStoreLayerChildPaths(layerPath);
+  const layerItems = useStoreLayerItems(layerPath);
   const mapController = useMapController();
   const layerCreatorController = useLayerCreatorController();
 
@@ -148,43 +147,11 @@ export function SingleLayer({
     }
   }, [layerIsSelected, layerId]);
 
-  // if any of the child layers is selected return true
-  const isLayerChildSelected = useCallback(
-    (children: TypeLegendLayer[] | undefined): boolean => {
-      if (displayState !== 'view') {
-        return false;
-      }
-      if (children && children.length > 0) {
-        if (children.filter((child) => child.layerPath === selectedLayerPath).length > 0) {
-          return true;
-        }
+  // Check if any descendant layer is selected — layer paths are hierarchical so startsWith works
+  const layerChildIsSelected = displayState === 'view' && !!selectedLayerPath && selectedLayerPath.startsWith(`${layerPath}/`);
 
-        return children.some((child) => isLayerChildSelected(child.children));
-      }
-      return false;
-    },
-    [displayState, selectedLayerPath]
-  );
-
-  const layerChildIsSelected = isLayerChildSelected(layerChildren);
-
-  // returns true if any of the layer children has visibility of false
-  const layerHasDisabledVisibility = useCallback(
-    (children: TypeLegendLayer[] | undefined, controls: TypeLayerControls | undefined): boolean => {
-      if (controls?.visibility === false) {
-        return true;
-      }
-      let childrenHasAlways = false;
-      if (children && children.length > 0) {
-        childrenHasAlways = children.some((child) => layerHasDisabledVisibility(child.children, child.controls));
-      }
-
-      return childrenHasAlways;
-    },
-    []
-  );
-
-  const isLayerAlwaysVisible = layerHasDisabledVisibility(layerChildren, layerControls);
+  // Check if any layer in the subtree has visibility disabled
+  const isLayerAlwaysVisible = useStoreLayerHasDisabledVisibility(layerPath);
 
   // #region HANDLERS
 
@@ -447,8 +414,8 @@ export function SingleLayer({
 
     if (parentHidden) return t('layers.parentHidden');
 
-    if (layerChildren && layerChildren.length > 0) {
-      return t('legend.subLayersCount').replace('{count}', layerChildren.length.toString());
+    if (layerChildPaths && layerChildPaths.length > 0) {
+      return t('legend.subLayersCount').replace('{count}', layerChildPaths.length.toString());
     }
 
     const count = layerItems?.filter((d) => d.isVisible !== false).length || 0;
@@ -461,7 +428,7 @@ export function SingleLayer({
     }
 
     return itemsLengthDesc;
-  }, [layerPath, layerStatus, parentHidden, t, layerChildren, layerItems]);
+  }, [layerPath, layerStatus, parentHidden, t, layerChildPaths, layerItems]);
 
   // Memoize the EditModeButtons component section
 
@@ -551,7 +518,7 @@ export function SingleLayer({
             id={reloadButtonId}
             edge="end"
             size="small"
-            aria-label={layerChildren && layerChildren.length > 0 ? t('layers.reloadSublayers') : t('layers.reloadLayer')}
+            aria-label={layerChildPaths && layerChildPaths.length > 0 ? t('layers.reloadSublayers') : t('layers.reloadLayer')}
             className="buttonOutline"
             onClick={handleReload}
             onKeyDown={handleReloadKeyDown}
@@ -631,7 +598,7 @@ export function SingleLayer({
     handleToggleVisibility,
     handleToggleVisibilityKeyDown,
     isVisible,
-    layerChildren,
+    layerChildPaths,
     handleReload,
     handleReloadKeyDown,
     parentHidden,
@@ -645,7 +612,7 @@ export function SingleLayer({
     // Log
     logger.logTraceUseMemo('SINGLE-LAYER - memoArrowButtons');
 
-    if (layerChildren?.length) {
+    if (layerChildPaths?.length) {
       return (
         <IconButton
           color="primary"
@@ -662,14 +629,14 @@ export function SingleLayer({
     }
 
     return null;
-  }, [handleExpandGroupClick, handleExpandGroupKeyDown, layerChildren, legendExpanded, t]);
+  }, [handleExpandGroupClick, handleExpandGroupKeyDown, layerChildPaths, legendExpanded, t]);
 
   // Memoize the collapse component section
   const memoCollapse = useMemo((): JSX.Element | null => {
     // Log
-    logger.logTraceUseMemo('SINGLE-LAYER - memoCollapse', layerChildren);
+    logger.logTraceUseMemo('SINGLE-LAYER - memoCollapse', layerChildPaths);
 
-    if (!(layerChildren && layerChildren.length)) {
+    if (!layerChildPaths?.length) {
       return null;
     }
 
@@ -677,14 +644,14 @@ export function SingleLayer({
       <Collapse in={legendExpanded} timeout="auto">
         <LayersList
           depth={1 + depth}
-          layersList={layerChildren}
+          layerPaths={layerChildPaths}
           isLayoutEnlarged={isLayoutEnlarged}
           showLayerDetailsPanel={showLayerDetailsPanel}
           containerType={containerType}
         />
       </Collapse>
     );
-  }, [depth, isLayoutEnlarged, layerChildren, legendExpanded, showLayerDetailsPanel, containerType]);
+  }, [depth, isLayoutEnlarged, layerChildPaths, legendExpanded, showLayerDetailsPanel, containerType]);
 
   // Memoize the container class section
   const memoContainerClass = useMemo(() => {

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -50,6 +50,20 @@ import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-i
 import { useMapController } from '@/core/controllers/map-controller';
 import { useLayerCreatorController } from '@/core/controllers/layer-creator-controller';
 
+/** Static Tooltip slotProps — offset popper by [0, -8]. */
+const TOOLTIP_SLOT_PROPS = {
+  popper: {
+    modifiers: [
+      {
+        name: 'offset',
+        options: {
+          offset: [0, -8],
+        },
+      },
+    ],
+  },
+};
+
 interface SingleLayerProps {
   layerPath: string;
   depth: number;
@@ -168,6 +182,7 @@ export function SingleLayer({
 
   /**
    * Select the layer if not already selected and status is valid.
+   *
    * @param openPanel - Whether to open the details panel (default: true)
    */
   const selectLayerIfNeeded = useCallback(
@@ -707,6 +722,15 @@ export function SingleLayer({
     }
   }, [layerStatus, layerPath, reloadButtonId, layerListItemButtonId]);
 
+  /** Memoized sx for the list item button. */
+  const memoListItemButtonSx = useMemo(
+    () => ({
+      minHeight: '4.51rem',
+      ...(!inVisibleRange || parentHidden || !isVisible || layerStatus === 'error' ? sxClasses.outOfRange : {}),
+    }),
+    [inVisibleRange, parentHidden, isVisible, layerStatus, sxClasses.outOfRange]
+  );
+
   return (
     <ListItem
       ref={layerListItemRef}
@@ -724,27 +748,13 @@ export function SingleLayer({
           enterDelay={theme.transitions.duration.tooltipDelay}
           enterNextDelay={theme.transitions.duration.tooltipDelay}
           arrow
-          slotProps={{
-            popper: {
-              modifiers: [
-                {
-                  name: 'offset',
-                  options: {
-                    offset: [0, -8],
-                  },
-                },
-              ],
-            },
-          }}
+          slotProps={TOOLTIP_SLOT_PROPS}
         >
           <ListItemButton
             id={layerListItemButtonId}
             onClick={handleLayerClick}
             selected={layerIsSelected || (layerChildIsSelected && !legendExpanded)}
-            sx={{
-              minHeight: '4.51rem',
-              ...(!inVisibleRange || parentHidden || !isVisible || layerStatus === 'error' ? sxClasses.outOfRange : {}),
-            }}
+            sx={memoListItemButtonSx}
             className={!inVisibleRange ? 'out-of-range' : ''}
           >
             <LayerIcon layerPath={layerPath} />

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -694,7 +694,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
                       <IconButton
                         role="checkbox"
                         aria-label={allSublayersVisible ? t('layers.hideAllLayers') : t('layers.showAllLayers')}
-                        aria-checked={allSublayersVisible === true}
+                        aria-checked={allSublayersVisible}
                         tooltipPlacement="left"
                         color="primary"
                         onClick={handleToggleAllVisibility}

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -30,6 +30,7 @@ import { useUIController } from '@/core/controllers/ui-controller';
 import type { TypeLegendLayer, TypeLegendItem } from '@/core/components/layers/types';
 import { getSxClasses } from './layer-details-style';
 import {
+  useStoreLayerByPath,
   useStoreLayerHighlightedLayer,
   useStoreLayerBounds,
   useStoreLayerHasText,
@@ -71,7 +72,7 @@ import { useMapController } from '@/core/controllers/map-controller';
 // TODO: WCAG Issue #3108 - Check all icon buttons for "state related" aria values (i.e aria-checked, aria-disabled, etc.)
 
 interface LayerDetailsProps {
-  layerDetails: TypeLegendLayer;
+  layerPath: string;
   containerType: TypeContainerBox;
 }
 
@@ -121,11 +122,11 @@ const Sublayer = memo(({ layer }: SubLayerProps): JSX.Element => {
 
 Sublayer.displayName = 'Sublayer';
 
-export function LayerDetails(props: LayerDetailsProps): JSX.Element {
+export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   // Log
   logger.logTraceRender('components/layers/right-panel/layer-details');
 
-  const { layerDetails, containerType } = props;
+  const { layerPath, containerType } = props;
 
   const { t } = useTranslation<string>();
 
@@ -140,19 +141,20 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   // Ref for settings button focus restoration
   const settingsButtonRef = useRef<HTMLButtonElement>(null);
   const infoButtonRef = useRef<HTMLButtonElement>(null);
-  const mapId = useStoreGeoViewMapId();
 
-  // get store actions
+  // get store state
+  const mapId = useStoreGeoViewMapId();
+  const layerDetails = useStoreLayerByPath(layerPath);
   const highlightedLayer = useStoreLayerHighlightedLayer();
-  const hasText = useStoreLayerHasText(layerDetails.layerPath);
+  const hasText = useStoreLayerHasText(layerPath);
   const visibleLayers = useStoreMapVisibleLayers();
   const datatableSettings = useStoreDataTableLayerSettings();
   const layersData = useStoreDataTableAllFeaturesDataArray();
-  const bounds = useStoreLayerBounds(layerDetails.layerPath);
-  const layerVisible = useStoreMapLayerVisibility(layerDetails.layerPath);
-  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layerDetails.layerPath);
-  const layerHidden = useStoreMapIsLayerHiddenOnMap(layerDetails.layerPath);
-  const availableSettings = useStoreLayerStyleSettings(layerDetails.layerPath);
+  const bounds = useStoreLayerBounds(layerPath);
+  const layerVisible = useStoreMapLayerVisibility(layerPath);
+  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layerPath);
+  const layerHidden = useStoreMapIsLayerHiddenOnMap(layerPath);
+  const availableSettings = useStoreLayerStyleSettings(layerPath);
   const timeSliderLayers = useStoreTimeSliderLayers();
   const isFocusTrap = useStoreUIActiveTrapGeoView();
   const uiController = useUIController();
@@ -164,10 +166,10 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   const navigateToTimeSlider = useNavigateToTab('time-slider', setStoreTimeSliderSelectedLayerPath);
 
   // Is highlight button disabled?
-  const isLayerHighlightCapable = layerDetails.controls?.highlight;
+  const isLayerHighlightCapable = layerDetails?.controls?.highlight;
 
   // Is zoom to extent button disabled?
-  const isLayerZoomToExtentCapable = layerDetails.controls?.zoom;
+  const isLayerZoomToExtentCapable = layerDetails?.controls?.zoom;
 
   // Generate unique table details button ID
   const tableDetailsButtonId = `table-details-${containerType}-${mapId}`;
@@ -175,9 +177,9 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   // Reset view to details when layer changes
   useEffect(() => {
     // Log
-    logger.logTraceUseEffect('LAYER DETAILS - reset activeView on layer change', layerDetails.layerPath);
+    logger.logTraceUseEffect('LAYER DETAILS - reset activeView on layer change', layerPath);
     setActiveView('details');
-  }, [layerDetails.layerPath]);
+  }, [layerPath]);
 
   /**
    * Recursively checks if all children of a layer are visible.
@@ -199,31 +201,33 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   }, []);
 
   useEffect(() => {
+    if (!layerDetails) return;
     const allChildrenVisible = legendLayersChildrenVisible(layerDetails, visibleLayers);
     if (allChildrenVisible !== allSublayersVisible) setAllSublayersVisible(allChildrenVisible);
-  }, [allSublayersVisible, layerDetails, layerDetails.children, legendLayersChildrenVisible, visibleLayers]);
+  }, [allSublayersVisible, layerDetails, layerDetails?.children, legendLayersChildrenVisible, visibleLayers]);
 
   const handleRefreshLayer = (): void => {
-    layerController.resetLayer(layerDetails.layerPath).catch((error: unknown) => {
+    layerController.resetLayer(layerPath).catch((error: unknown) => {
       // Log
       logger.logPromiseFailed('in layerController.resetLayer in layer-details.handleRefreshLayer', error);
     });
   };
 
   const handleZoomTo = (): void => {
-    mapController.zoomToLayerExtent(layerDetails.layerPath).catch((error: unknown) => {
+    mapController.zoomToLayerExtent(layerPath).catch((error: unknown) => {
       // Log
       logger.logPromiseFailed('in zoomToLayerExtent in layer-details.handleZoomTo', error);
     });
   };
 
   const handleOpenTable = (): void => {
+    if (!layerDetails) return;
     // trigger the fetching of the features when not available OR when layer status is in error
     if (
-      !layersData.filter((layers) => layers.layerPath === layerDetails.layerPath && !!layers?.features?.length).length ||
+      !layersData.filter((layers) => layers.layerPath === layerPath && !!layers?.features?.length).length ||
       layerDetails.layerStatus === LAYER_STATUS.ERROR
     ) {
-      layerSetController.triggerGetAllFeatureInfo(layerDetails.layerPath).catch((error: unknown) => {
+      layerSetController.triggerGetAllFeatureInfo(layerPath).catch((error: unknown) => {
         // Log
         logger.logPromiseFailed('Failed to triggerGetAllFeatureInfo in single-layer.handleLayerClick', error);
       });
@@ -232,7 +236,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   };
 
   const handleHighlightLayer = (): void => {
-    layerController.setHighlightLayer(layerDetails.layerPath);
+    layerController.setHighlightLayer(layerPath);
   };
 
   /**
@@ -310,18 +314,17 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
    * Sets visibility for all children of the layer.
    */
   const handleToggleAllVisibility = useCallback((): void => {
+    if (!layerDetails) return;
     setVisibilityForAllSublayers(layerDetails, !allSublayersVisible);
   }, [allSublayersVisible, layerDetails, setVisibilityForAllSublayers]);
 
   const allItemsChecked = (): boolean => {
+    if (!layerDetails) return false;
     return layerDetails.items.every((i) => i.isVisible !== false);
   };
 
-  function renderItemCheckbox(item: TypeLegendItem): JSX.Element | null {
-    // First check if styleConfig exists
-    if (!layerDetails.styleConfig) {
-      return null;
-    }
+  const renderItemCheckbox = (item: TypeLegendItem): JSX.Element | null => {
+    if (!layerDetails || !layerDetails.styleConfig) return null;
 
     // No checkbox for simple style layers
     if (layerDetails.styleConfig[item.geometryType]?.type === 'simple') return null;
@@ -345,16 +348,16 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
         aria-label={item.isVisible ? t('layers.hideClass', { name: item.name }) : t('layers.showClass', { name: item.name })}
         aria-checked={item.isVisible === true}
         tooltipPlacement="left"
-        onClick={() => layerController.toggleItemVisibilityAndForget(layerDetails.layerPath, item)}
+        onClick={() => layerController.toggleItemVisibilityAndForget(layerPath, item)}
         disabled={layerHidden}
       >
         {item.isVisible === true ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
       </IconButton>
     );
-  }
+  };
 
-  function renderHeaderCheckbox(): JSX.Element {
-    if (!layerDetails.canToggle) {
+  const renderHeaderCheckbox = (): JSX.Element => {
+    if (!layerDetails?.canToggle) {
       return (
         <IconButton disabled role="checkbox" aria-label={t('layers.visibilityIsAlways')} aria-checked={false} tooltipPlacement="left">
           <CheckBoxIcon color="disabled" />
@@ -369,15 +372,15 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
         aria-label={allItemsChecked() ? t('layers.hideAllLayers') : t('layers.showAllLayers')}
         aria-checked={allItemsChecked() === true}
         tooltipPlacement="left"
-        onClick={() => layerController.setAllItemsVisibilityAndForget(layerDetails.layerPath, !allItemsChecked())}
+        onClick={() => layerController.setAllItemsVisibilityAndForget(layerPath, !allItemsChecked())}
         disabled={layerHidden}
       >
         {allItemsChecked() ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
       </IconButton>
     );
-  }
+  };
 
-  function renderItems(): JSX.Element {
+  const renderItems = (): JSX.Element => {
     return (
       <Grid
         className="layer-details-panel"
@@ -388,7 +391,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
         justifyContent="left"
         justifyItems="stretch"
       >
-        {layerDetails.items.map((item) => (
+        {layerDetails?.items.map((item) => (
           <Grid
             container
             direction="row"
@@ -412,9 +415,9 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
         ))}
       </Grid>
     );
-  }
+  };
 
-  function renderSubLayers(startLayer: TypeLegendLayer): JSX.Element {
+  const renderSubLayers = (startLayer: TypeLegendLayer): JSX.Element => {
     return (
       <List>
         {startLayer.children.map((layer) => (
@@ -425,10 +428,10 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
         ))}
       </List>
     );
-  }
+  };
 
-  function renderDetailsButton(): JSX.Element {
-    const isDisabled = layerDetails.controls?.table === false || layerHidden || parentHidden;
+  const renderDetailsButton = (): JSX.Element => {
+    const isDisabled = layerDetails?.controls?.table === false || layerHidden || parentHidden;
 
     return (
       <IconButton
@@ -441,11 +444,11 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
         <TableViewIcon color={isDisabled ? 'disabled' : 'inherit'} />
       </IconButton>
     );
-  }
+  };
 
-  function renderTimeSliderButton(): JSX.Element | null {
+  const renderTimeSliderButton = (): JSX.Element | null => {
     // Check if layer is in time slider
-    const isLayerInTimeSlider = timeSliderLayers && timeSliderLayers[layerDetails.layerPath];
+    const isLayerInTimeSlider = timeSliderLayers && timeSliderLayers[layerPath];
     const isDisabled = layerHidden || parentHidden;
 
     // Button to navigate to Time Slider panel and select this layer
@@ -458,7 +461,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
           className="buttonOutline"
           onClick={(event) => {
             event.stopPropagation();
-            navigateToTimeSlider({ layerPath: layerDetails.layerPath });
+            navigateToTimeSlider({ layerPath });
           }}
           disabled={isDisabled}
         >
@@ -467,19 +470,19 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
       );
     }
     return null;
-  }
+  };
 
-  function renderHighlightButton(): JSX.Element | null {
+  const renderHighlightButton = (): JSX.Element | null => {
     if (isLayerHighlightCapable)
       return (
         <IconButton aria-label={t('legend.highlightLayer')} onClick={handleHighlightLayer} className="buttonOutline" disabled={layerHidden}>
-          {highlightedLayer === layerDetails.layerPath ? <HighlightIcon /> : <HighlightOutlinedIcon />}
+          {highlightedLayer === layerPath ? <HighlightIcon /> : <HighlightOutlinedIcon />}
         </IconButton>
       );
     return null;
-  }
+  };
 
-  function renderZoomButton(): JSX.Element | null {
+  const renderZoomButton = (): JSX.Element | null => {
     if (isLayerZoomToExtentCapable)
       return (
         <IconButton
@@ -492,25 +495,25 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
         </IconButton>
       );
     return null;
-  }
+  };
 
-  function renderDeleteButton(): JSX.Element | null {
+  const renderDeleteButton = (): JSX.Element | null => {
     // Only render delete button if layer is removable (controls.remove must be explicitly true)
-    const isRemovable = layerDetails.controls?.remove ?? false;
+    const isRemovable = layerDetails?.controls?.remove ?? false;
     if (!isRemovable) return null;
 
     return (
       <DeleteUndoButton
-        key={`delete-undo-${layerDetails.layerPath}`}
-        layerPath={layerDetails.layerPath}
+        key={`delete-undo-${layerPath}`}
+        layerPath={layerPath}
         layerRemovable={isRemovable}
         focusTargetIdAfterDelete={`${mapId}-${containerType}-${TABS.LAYERS}-panel-close-btn`}
       />
     );
-  }
+  };
 
-  function renderSettingsButton(): JSX.Element | null {
-    const hasInteraction = layerDetails.controls?.hover || layerDetails.controls?.query;
+  const renderSettingsButton = (): JSX.Element | null => {
+    const hasInteraction = layerDetails?.controls?.hover || layerDetails?.controls?.query;
     if (!availableSettings?.length && !hasInteraction && !hasText) return null;
 
     if (activeView === 'settings') {
@@ -538,9 +541,9 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
         <SettingsIcon />
       </IconButton>
     );
-  }
+  };
 
-  function renderInfoButton(): JSX.Element {
+  const renderInfoButton = (): JSX.Element => {
     if (activeView === 'info') {
       return (
         <IconButton
@@ -566,11 +569,11 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
         <InfoOutlinedIcon />
       </IconButton>
     );
-  }
+  };
 
-  function renderLayerButtons(): JSX.Element {
+  const renderLayerButtons = (): JSX.Element => {
     const timeSliderButton = renderTimeSliderButton();
-    const hasDataTable = datatableSettings[layerDetails.layerPath];
+    const hasDataTable = datatableSettings[layerPath];
     const deleteButton = renderDeleteButton();
     const showDivider = hasDataTable || timeSliderButton;
 
@@ -588,9 +591,10 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
         {deleteButton}
       </Box>
     );
-  }
+  };
 
   const getSubTitle = (): string | null => {
+    if (!layerDetails) return null;
     if (parentHidden) return t('layers.parentHidden');
     if (!layerVisible) return t('layers.hidden');
     if (layerDetails.children.length > 0) {
@@ -606,6 +610,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   };
 
   const renderWMSImage = (): JSX.Element | null => {
+    if (!layerDetails) return null;
     if (
       layerDetails.schemaTag === CONST_LAYER_TYPES.WMS &&
       layerDetails.icons.length &&
@@ -624,123 +629,121 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
     return null;
   };
 
+  if (!layerDetails) return null;
+
   // TODO: WCAG Issue #3116 - Consider using CSS rather than Divider for cleaner HTML structure
   // Render
   return (
     <Paper sx={sxClasses.layerDetails}>
-      {layerDetails !== undefined && (
-        <>
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'row',
-              justifyContent: 'space-between',
-              width: '100%',
-              alignItems: 'center',
-              gap: '15px',
-            }}
-          >
-            <Box sx={{ textAlign: 'left', flex: 1, minWidth: 0, [theme.breakpoints.down('sm')]: { display: 'none' } }}>
-              <Typography sx={{ ...sxClasses.categoryTitle, ...(layerHidden && hiddenStyle) }} title={layerDetails.layerName}>
-                {layerDetails.layerName}
-              </Typography>
-              {(() => {
-                const subTitle = getSubTitle();
-                return (
-                  subTitle && (
-                    <Typography
-                      sx={{
-                        fontSize: theme.palette.geoViewFontSize.sm,
-                        ...(layerHidden && hiddenStyle),
-                      }}
-                    >
-                      {' '}
-                      {subTitle}{' '}
-                    </Typography>
-                  )
-                );
-              })()}
-            </Box>
-            {renderSettingsButton()}
-            {renderInfoButton()}
-          </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          width: '100%',
+          alignItems: 'center',
+          gap: '15px',
+        }}
+      >
+        <Box sx={{ textAlign: 'left', flex: 1, minWidth: 0, [theme.breakpoints.down('sm')]: { display: 'none' } }}>
+          <Typography sx={{ ...sxClasses.categoryTitle, ...(layerHidden && hiddenStyle) }} title={layerDetails.layerName}>
+            {layerDetails.layerName}
+          </Typography>
+          {(() => {
+            const subTitle = getSubTitle();
+            return (
+              subTitle && (
+                <Typography
+                  sx={{
+                    fontSize: theme.palette.geoViewFontSize.sm,
+                    ...(layerHidden && hiddenStyle),
+                  }}
+                >
+                  {' '}
+                  {subTitle}{' '}
+                </Typography>
+              )
+            );
+          })()}
+        </Box>
+        {renderSettingsButton()}
+        {renderInfoButton()}
+      </Box>
 
-          {/* Sequential crossfade: fade out → swap content → fade in */}
-          <Fade in={contentVisible} timeout={TIMEOUT.fadingPanelDuration}>
-            <Box>
-              {activeView === 'details' && (
-                <>
-                  {renderLayerButtons()}
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap-reverse' }}>
-                    {layerDetails.items.length > 1 &&
-                      layerDetails.items.some((item) => layerDetails.styleConfig?.[item.geometryType]?.fields[0] !== undefined) && (
-                        <Grid container direction="row" alignItems="center" justifyItems="stretch">
-                          <Grid size={{ xs: 'auto' }}>{renderHeaderCheckbox()}</Grid>
-                          <Grid size={{ xs: 'auto' }}>
-                            <Box component="span" sx={{ fontWeight: 'bold', ...(layerHidden && hiddenStyle) }}>
-                              {t('layers.toggleItemsVisibility')}
-                            </Box>
-                          </Grid>
-                        </Grid>
-                      )}
-                    {layerDetails.children.length > 0 && (
-                      <Grid container direction="row" alignItems="center" justifyItems="stretch">
-                        <Grid size={{ xs: 'auto' }}>
-                          <IconButton
-                            role="checkbox"
-                            aria-label={allSublayersVisible ? t('layers.hideAllLayers') : t('layers.showAllLayers')}
-                            aria-checked={allSublayersVisible === true}
-                            tooltipPlacement="left"
-                            color="primary"
-                            onClick={handleToggleAllVisibility}
-                            disabled={layerHidden}
-                          >
-                            {allSublayersVisible ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
-                          </IconButton>
-                        </Grid>
-                        <Grid size={{ xs: 'auto' }}>
-                          <Box component="span" sx={{ fontWeight: 'bold', ...(layerHidden && hiddenStyle) }}>
-                            {t('layers.toggleSublayersVisibility')}
-                          </Box>
-                        </Grid>
+      {/* Sequential crossfade: fade out → swap content → fade in */}
+      <Fade in={contentVisible} timeout={TIMEOUT.fadingPanelDuration}>
+        <Box>
+          {activeView === 'details' && (
+            <>
+              {renderLayerButtons()}
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap-reverse' }}>
+                {layerDetails.items.length > 1 &&
+                  layerDetails.items.some((item) => layerDetails.styleConfig?.[item.geometryType]?.fields[0] !== undefined) && (
+                    <Grid container direction="row" alignItems="center" justifyItems="stretch">
+                      <Grid size={{ xs: 'auto' }}>{renderHeaderCheckbox()}</Grid>
+                      <Grid size={{ xs: 'auto' }}>
+                        <Box component="span" sx={{ fontWeight: 'bold', ...(layerHidden && hiddenStyle) }}>
+                          {t('layers.toggleItemsVisibility')}
+                        </Box>
                       </Grid>
-                    )}
-                    {layerDetails.controls?.opacity !== false && <LayerOpacityControl layerDetails={layerDetails} />}
-                  </Box>
-                  <Divider sx={{ height: 'auto', marginTop: '10px', marginBottom: '10px' }} variant="middle" />
-                  {renderWMSImage()}
-                  <Box>
-                    {layerDetails.items?.length > 0 && renderItems()}
-                    {layerDetails.children.length > 0 && renderSubLayers(layerDetails)}
-                  </Box>
-                  <Divider sx={{ height: 'auto', marginTop: '10px', marginBottom: '10px' }} variant="middle" />
-                  {layerDetails.layerAttribution &&
-                    layerDetails.layerAttribution.map((attribution) => {
-                      if (attribution) {
-                        return (
-                          <Typography
-                            sx={{
-                              marginTop: '10px',
-                              color: theme.palette.geoViewColor.textColor.light[200],
-                              fontSize: theme.palette.geoViewFontSize.sm,
-                              textAlign: 'center',
-                            }}
-                            key={attribution}
-                          >
-                            {attribution.indexOf('©') === -1 ? `© ${attribution}` : attribution}
-                          </Typography>
-                        );
-                      }
-                      return null;
-                    })}
-                </>
-              )}
-              {activeView === 'settings' && <LayerSettingsPanel layerDetails={layerDetails} />}
-              {activeView === 'info' && <LayerInfoPanel layerDetails={layerDetails} />}
-            </Box>
-          </Fade>
-        </>
-      )}
+                    </Grid>
+                  )}
+                {layerDetails.children.length > 0 && (
+                  <Grid container direction="row" alignItems="center" justifyItems="stretch">
+                    <Grid size={{ xs: 'auto' }}>
+                      <IconButton
+                        role="checkbox"
+                        aria-label={allSublayersVisible ? t('layers.hideAllLayers') : t('layers.showAllLayers')}
+                        aria-checked={allSublayersVisible === true}
+                        tooltipPlacement="left"
+                        color="primary"
+                        onClick={handleToggleAllVisibility}
+                        disabled={layerHidden}
+                      >
+                        {allSublayersVisible ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
+                      </IconButton>
+                    </Grid>
+                    <Grid size={{ xs: 'auto' }}>
+                      <Box component="span" sx={{ fontWeight: 'bold', ...(layerHidden && hiddenStyle) }}>
+                        {t('layers.toggleSublayersVisibility')}
+                      </Box>
+                    </Grid>
+                  </Grid>
+                )}
+                {layerDetails.controls?.opacity !== false && <LayerOpacityControl layerDetails={layerDetails} />}
+              </Box>
+              <Divider sx={{ height: 'auto', marginTop: '10px', marginBottom: '10px' }} variant="middle" />
+              {renderWMSImage()}
+              <Box>
+                {layerDetails.items?.length > 0 && renderItems()}
+                {layerDetails.children.length > 0 && renderSubLayers(layerDetails)}
+              </Box>
+              <Divider sx={{ height: 'auto', marginTop: '10px', marginBottom: '10px' }} variant="middle" />
+              {layerDetails.layerAttribution &&
+                layerDetails.layerAttribution.map((attribution) => {
+                  if (attribution) {
+                    return (
+                      <Typography
+                        sx={{
+                          marginTop: '10px',
+                          color: theme.palette.geoViewColor.textColor.light[200],
+                          fontSize: theme.palette.geoViewFontSize.sm,
+                          textAlign: 'center',
+                        }}
+                        key={attribution}
+                      >
+                        {attribution.indexOf('©') === -1 ? `© ${attribution}` : attribution}
+                      </Typography>
+                    );
+                  }
+                  return null;
+                })}
+            </>
+          )}
+          {activeView === 'settings' && <LayerSettingsPanel layerDetails={layerDetails} />}
+          {activeView === 'info' && <LayerInfoPanel layerDetails={layerDetails} />}
+        </Box>
+      </Fade>
     </Paper>
   );
 }

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -30,15 +30,15 @@ import { useUIController } from '@/core/controllers/ui-controller';
 import type { TypeLegendLayer, TypeLegendItem } from '@/core/components/layers/types';
 import { getSxClasses } from './layer-details-style';
 import {
-  getStoreLayerStyleSettings,
-  useLayerHighlightedLayer,
-  useLayerSelectorBounds,
-  useLayerSelectorHasText,
+  useStoreLayerHighlightedLayer,
+  useStoreLayerBounds,
+  useStoreLayerHasText,
+  useStoreLayerStyleSettings,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import {
-  useDataTableAllFeaturesDataArray,
-  useDataTableLayerSettings,
+  useStoreDataTableAllFeaturesDataArray,
+  useStoreDataTableLayerSettings,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { LayerIcon } from '@/core/components/common/layer-icon';
 import { LayerOpacityControl } from './layer-opacity-control/layer-opacity-control';
@@ -49,17 +49,17 @@ import { LAYER_STATUS, TABS, TIMEOUT } from '@/core/utils/constant';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 
 import {
-  useMapVisibleLayers,
-  useMapSelectorIsLayerHiddenOnMap,
-  useMapSelectorLayerVisibility,
-  useMapSelectorLayerParentHidden,
+  useStoreMapVisibleLayers,
+  useStoreMapIsLayerHiddenOnMap,
+  useStoreMapLayerVisibility,
+  useStoreMapIsParentLayerHiddenOnMap,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import {
-  useTimeSliderLayers,
+  useStoreTimeSliderLayers,
   setStoreTimeSliderSelectedLayerPath,
 } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
 import { useNavigateToTab } from '@/core/components/common/hooks/use-navigate-to-tab';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { DeleteUndoButton } from '@/core/components/layers/delete-undo-button';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { useLayerController } from '@/core/controllers/layer-controller';
@@ -89,9 +89,9 @@ const Sublayer = memo(({ layer }: SubLayerProps): JSX.Element => {
   const { t } = useTranslation<string>();
 
   // Hooks
-  const layerHidden = useMapSelectorIsLayerHiddenOnMap(layer.layerPath);
-  const parentHidden = useMapSelectorLayerParentHidden(layer.layerPath);
-  const layerVisible = useMapSelectorLayerVisibility(layer.layerPath);
+  const layerHidden = useStoreMapIsLayerHiddenOnMap(layer.layerPath);
+  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layer.layerPath);
+  const layerVisible = useStoreMapLayerVisibility(layer.layerPath);
   const mapController = useMapController();
 
   // Return the ui
@@ -140,27 +140,25 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element {
   // Ref for settings button focus restoration
   const settingsButtonRef = useRef<HTMLButtonElement>(null);
   const infoButtonRef = useRef<HTMLButtonElement>(null);
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
 
   // get store actions
-  const highlightedLayer = useLayerHighlightedLayer();
-  const hasText = useLayerSelectorHasText(layerDetails.layerPath);
+  const highlightedLayer = useStoreLayerHighlightedLayer();
+  const hasText = useStoreLayerHasText(layerDetails.layerPath);
+  const visibleLayers = useStoreMapVisibleLayers();
+  const datatableSettings = useStoreDataTableLayerSettings();
+  const layersData = useStoreDataTableAllFeaturesDataArray();
+  const bounds = useStoreLayerBounds(layerDetails.layerPath);
+  const layerVisible = useStoreMapLayerVisibility(layerDetails.layerPath);
+  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layerDetails.layerPath);
+  const layerHidden = useStoreMapIsLayerHiddenOnMap(layerDetails.layerPath);
+  const availableSettings = useStoreLayerStyleSettings(layerDetails.layerPath);
+  const timeSliderLayers = useStoreTimeSliderLayers();
+  const isFocusTrap = useStoreUIActiveTrapGeoView();
   const uiController = useUIController();
-  const visibleLayers = useMapVisibleLayers();
-  const datatableSettings = useDataTableLayerSettings();
-  const layersData = useDataTableAllFeaturesDataArray();
-  const bounds = useLayerSelectorBounds(layerDetails.layerPath);
-  const layerVisible = useMapSelectorLayerVisibility(layerDetails.layerPath);
-  const parentHidden = useMapSelectorLayerParentHidden(layerDetails.layerPath);
-  const layerHidden = useMapSelectorIsLayerHiddenOnMap(layerDetails.layerPath);
-  const timeSliderLayers = useTimeSliderLayers();
-  const isFocusTrap = useUIActiveTrapGeoView();
   const layerController = useLayerController();
   const layerSetController = useLayerSetController();
   const mapController = useMapController();
-
-  // TODO: CHECK - This should likely go through a Zustand hook instead of a state getter
-  const availableSettings = getStoreLayerStyleSettings(mapId, layerDetails.layerPath);
 
   // Use navigate hook for time slider (only if time slider state exists)
   const navigateToTimeSlider = useNavigateToTab('time-slider', setStoreTimeSliderSelectedLayerPath);

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
 import { delay } from '@/core/utils/utilities';
@@ -27,14 +27,25 @@ import {
 import { ArrowBackIcon } from '@/ui/icons';
 
 import { useUIController } from '@/core/controllers/ui-controller';
-import type { TypeLegendLayer, TypeLegendItem } from '@/core/components/layers/types';
+import type { TypeLegendItem } from '@/core/components/layers/types';
 import { getSxClasses } from './layer-details-style';
 import {
-  useStoreLayerByPath,
+  getStoreLayerLegendLayerByPath,
   useStoreLayerHighlightedLayer,
   useStoreLayerBounds,
   useStoreLayerHasText,
   useStoreLayerStyleSettings,
+  useStoreLayerAllChildrenVisible,
+  useStoreLayerChildPaths,
+  useStoreLayerControls,
+  useStoreLayerStatus,
+  useStoreLayerItems,
+  useStoreLayerStyleConfig,
+  useStoreLayerCanToggle,
+  useStoreLayerName,
+  useStoreLayerSchemaTag,
+  useStoreLayerIcons,
+  useStoreLayerAttribution,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import {
@@ -77,11 +88,16 @@ interface LayerDetailsProps {
 }
 
 interface SubLayerProps {
-  layer: TypeLegendLayer;
+  layerPath: string;
 }
 
-// Memoized Sublayer Component
-const Sublayer = memo(({ layer }: SubLayerProps): JSX.Element => {
+/**
+ * Renders a single sublayer item with visibility toggle.
+ *
+ * Memoized to avoid re-rendering all sublayer items when only one changes.
+ * Self-recursive: renders its own children if present.
+ */
+const Sublayer = memo(function Sublayer({ layerPath }: SubLayerProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/right-panel/Sublayer');
 
@@ -90,33 +106,46 @@ const Sublayer = memo(({ layer }: SubLayerProps): JSX.Element => {
   const { t } = useTranslation<string>();
 
   // Hooks
-  const layerHidden = useStoreMapIsLayerHiddenOnMap(layer.layerPath);
-  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layer.layerPath);
-  const layerVisible = useStoreMapLayerVisibility(layer.layerPath);
+  const layerName = useStoreLayerName(layerPath);
+  const childPaths = useStoreLayerChildPaths(layerPath);
+  const layerHidden = useStoreMapIsLayerHiddenOnMap(layerPath);
+  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layerPath);
+  const layerVisible = useStoreMapLayerVisibility(layerPath);
   const mapController = useMapController();
 
   // Return the ui
   return (
-    <ListItem>
-      <IconButton
-        color="primary"
-        role="checkbox"
-        onClick={() => mapController.setOrToggleMapLayerVisibility(layer.layerPath)}
-        disabled={parentHidden}
-        aria-checked={layerVisible === true}
-        aria-label={layerVisible ? t('layers.hideLayer', { name: layer.layerName }) : t('layers.showLayer', { name: layer.layerName })}
-        tooltipPlacement="left"
-      >
-        {layerVisible ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
-      </IconButton>
-      <LayerIcon layerPath={layer.layerPath} />
-      <Box
-        component="span"
-        sx={{ ...sxClasses.tableIconLabel, ...(layerHidden && { color: theme.palette.grey[600], fontStyle: 'italic' }) }}
-      >
-        {layer.layerName}
-      </Box>
-    </ListItem>
+    <>
+      <ListItem>
+        <IconButton
+          color="primary"
+          role="checkbox"
+          onClick={() => mapController.setOrToggleMapLayerVisibility(layerPath)}
+          disabled={parentHidden}
+          aria-checked={layerVisible === true}
+          aria-label={layerVisible ? t('layers.hideLayer', { name: layerName }) : t('layers.showLayer', { name: layerName })}
+          tooltipPlacement="left"
+        >
+          {layerVisible ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
+        </IconButton>
+        <LayerIcon layerPath={layerPath} />
+        <Box
+          component="span"
+          sx={{ ...sxClasses.tableIconLabel, ...(layerHidden && { color: theme.palette.grey[600], fontStyle: 'italic' }) }}
+        >
+          {layerName}
+        </Box>
+      </ListItem>
+      {childPaths && (
+        <Box sx={{ paddingLeft: '30px', width: '100%' }}>
+          <List>
+            {childPaths.map((childPath) => (
+              <Sublayer key={childPath} layerPath={childPath} />
+            ))}
+          </List>
+        </Box>
+      )}
+    </>
   );
 });
 
@@ -134,7 +163,6 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   const sxClasses = getSxClasses(theme);
   const hiddenStyle = { color: theme.palette.grey[600], fontStyle: 'italic' };
 
-  const [allSublayersVisible, setAllSublayersVisible] = useState(true);
   const [contentVisible, setContentVisible] = useState(true);
   const [activeView, setActiveView] = useState<'details' | 'settings' | 'info'>('details');
 
@@ -142,9 +170,19 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   const settingsButtonRef = useRef<HTMLButtonElement>(null);
   const infoButtonRef = useRef<HTMLButtonElement>(null);
 
-  // get store state
+  // get store state — individual hooks for precise reactivity
   const mapId = useStoreGeoViewMapId();
-  const layerDetails = useStoreLayerByPath(layerPath);
+  const layerName = useStoreLayerName(layerPath);
+  const layerControls = useStoreLayerControls(layerPath);
+  const layerStatus = useStoreLayerStatus(layerPath);
+  const layerItems = useStoreLayerItems(layerPath);
+  const layerStyleConfig = useStoreLayerStyleConfig(layerPath);
+  const layerCanToggle = useStoreLayerCanToggle(layerPath);
+  const layerSchemaTag = useStoreLayerSchemaTag(layerPath);
+  const layerIcons = useStoreLayerIcons(layerPath);
+  const layerAttribution = useStoreLayerAttribution(layerPath);
+  const layerChildPaths = useStoreLayerChildPaths(layerPath);
+  const allSublayersVisible = useStoreLayerAllChildrenVisible(layerPath);
   const highlightedLayer = useStoreLayerHighlightedLayer();
   const hasText = useStoreLayerHasText(layerPath);
   const visibleLayers = useStoreMapVisibleLayers();
@@ -166,10 +204,10 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   const navigateToTimeSlider = useNavigateToTab('time-slider', setStoreTimeSliderSelectedLayerPath);
 
   // Is highlight button disabled?
-  const isLayerHighlightCapable = layerDetails?.controls?.highlight;
+  const isLayerHighlightCapable = layerControls?.highlight;
 
   // Is zoom to extent button disabled?
-  const isLayerZoomToExtentCapable = layerDetails?.controls?.zoom;
+  const isLayerZoomToExtentCapable = layerControls?.zoom;
 
   // Generate unique table details button ID
   const tableDetailsButtonId = `table-details-${containerType}-${mapId}`;
@@ -180,31 +218,6 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
     logger.logTraceUseEffect('LAYER DETAILS - reset activeView on layer change', layerPath);
     setActiveView('details');
   }, [layerPath]);
-
-  /**
-   * Recursively checks if all children of a layer are visible.
-   * @param legendLayer - The legend layer to check
-   * @param curVisibleLayers - The visible layers array
-   * @returns Whether the children are visible
-   */
-  const legendLayersChildrenVisible = useCallback((legendLayer: TypeLegendLayer, curVisibleLayers: string[]): boolean => {
-    // Check if any children are not visible
-    if (legendLayer.children.find((child) => !curVisibleLayers.includes(child.layerPath))) return false;
-
-    // Check if any of the children have a child that is not visible
-    const invisibleChildren = legendLayer.children.find((child) => {
-      return child.children?.length && !legendLayersChildrenVisible(child, curVisibleLayers);
-    });
-
-    if (invisibleChildren) return false;
-    return true;
-  }, []);
-
-  useEffect(() => {
-    if (!layerDetails) return;
-    const allChildrenVisible = legendLayersChildrenVisible(layerDetails, visibleLayers);
-    if (allChildrenVisible !== allSublayersVisible) setAllSublayersVisible(allChildrenVisible);
-  }, [allSublayersVisible, layerDetails, layerDetails?.children, legendLayersChildrenVisible, visibleLayers]);
 
   const handleRefreshLayer = (): void => {
     layerController.resetLayer(layerPath).catch((error: unknown) => {
@@ -221,11 +234,10 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   };
 
   const handleOpenTable = (): void => {
-    if (!layerDetails) return;
     // trigger the fetching of the features when not available OR when layer status is in error
     if (
       !layersData.filter((layers) => layers.layerPath === layerPath && !!layers?.features?.length).length ||
-      layerDetails.layerStatus === LAYER_STATUS.ERROR
+      layerStatus === LAYER_STATUS.ERROR
     ) {
       layerSetController.triggerGetAllFeatureInfo(layerPath).catch((error: unknown) => {
         // Log
@@ -294,46 +306,37 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   }, []);
 
   /**
-   * Recursively sets child layer visibility.
-   * @param legendLayer - The legend layer to set the child visibility of
-   * @param newVisibility - The new visibility to set
+   * Sets visibility for all children of the layer.
    */
-  const setVisibilityForAllSublayers = useCallback(
-    (legendLayer: TypeLegendLayer, newVisibility: boolean): void => {
+  const handleToggleAllVisibility = useCallback((): void => {
+    // Use the non-reactive getter to walk the tree — only needed at click time
+    const layer = getStoreLayerLegendLayerByPath(mapId, layerPath);
+    if (!layer) return;
+
+    const setRecursive = (legendLayer: typeof layer, newVisibility: boolean): void => {
       legendLayer.children.forEach((child) => {
         if (newVisibility) {
           if (!visibleLayers.includes(child.layerPath)) mapController.setOrToggleMapLayerVisibility(child.layerPath, true);
         } else if (visibleLayers.includes(child.layerPath)) mapController.setOrToggleMapLayerVisibility(child.layerPath, false);
-        if (child.children.length) setVisibilityForAllSublayers(child, newVisibility);
+        if (child.children.length) setRecursive(child, newVisibility);
       });
-    },
-    [mapController, visibleLayers]
-  );
+    };
+    setRecursive(layer, !allSublayersVisible);
+  }, [allSublayersVisible, mapId, layerPath, mapController, visibleLayers]);
 
-  /**
-   * Sets visibility for all children of the layer.
-   */
-  const handleToggleAllVisibility = useCallback((): void => {
-    if (!layerDetails) return;
-    setVisibilityForAllSublayers(layerDetails, !allSublayersVisible);
-  }, [allSublayersVisible, layerDetails, setVisibilityForAllSublayers]);
-
-  const allItemsChecked = (): boolean => {
-    if (!layerDetails) return false;
-    return layerDetails.items.every((i) => i.isVisible !== false);
-  };
+  const allItemsChecked = !!(layerItems && layerItems.every((i) => i.isVisible !== false));
 
   const renderItemCheckbox = (item: TypeLegendItem): JSX.Element | null => {
-    if (!layerDetails || !layerDetails.styleConfig) return null;
+    if (!layerStyleConfig) return null;
 
     // No checkbox for simple style layers
-    if (layerDetails.styleConfig[item.geometryType]?.type === 'simple') return null;
+    if (layerStyleConfig[item.geometryType]?.type === 'simple') return null;
 
     // GV: Some esri layer has uniqueValue renderer but there is no field defined in their metadata (i.e. e2424b6c-db0c-4996-9bc0-2ca2e6714d71).
     // For these layers, we need to disable checkboxes
-    if (layerDetails.styleConfig[item.geometryType]?.fields[0] === undefined) return null;
+    if (layerStyleConfig[item.geometryType]?.fields[0] === undefined) return null;
 
-    if (!layerDetails.canToggle) {
+    if (!layerCanToggle) {
       return (
         <IconButton disabled role="checkbox" aria-label={t('layers.visibilityIsAlways')} aria-checked={false} tooltipPlacement="left">
           <CheckBoxIcon color="disabled" />
@@ -357,7 +360,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   };
 
   const renderHeaderCheckbox = (): JSX.Element => {
-    if (!layerDetails?.canToggle) {
+    if (!layerCanToggle) {
       return (
         <IconButton disabled role="checkbox" aria-label={t('layers.visibilityIsAlways')} aria-checked={false} tooltipPlacement="left">
           <CheckBoxIcon color="disabled" />
@@ -369,13 +372,13 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
       <IconButton
         color="primary"
         role="checkbox"
-        aria-label={allItemsChecked() ? t('layers.hideAllLayers') : t('layers.showAllLayers')}
-        aria-checked={allItemsChecked() === true}
+        aria-label={allItemsChecked ? t('layers.hideAllLayers') : t('layers.showAllLayers')}
+        aria-checked={allItemsChecked}
         tooltipPlacement="left"
-        onClick={() => layerController.setAllItemsVisibilityAndForget(layerPath, !allItemsChecked())}
+        onClick={() => layerController.setAllItemsVisibilityAndForget(layerPath, !allItemsChecked)}
         disabled={layerHidden}
       >
-        {allItemsChecked() ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
+        {allItemsChecked ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
       </IconButton>
     );
   };
@@ -391,11 +394,11 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
         justifyContent="left"
         justifyItems="stretch"
       >
-        {layerDetails?.items.map((item) => (
+        {layerItems?.map((item) => (
           <Grid
             container
             direction="row"
-            key={`${item.name}/${layerDetails.items.indexOf(item)}`}
+            key={`${layerPath}/${item.name}`}
             alignItems="center"
             justifyItems="stretch"
             sx={{ display: 'flex', flexWrap: 'nowrap', marginBottom: '5px' }}
@@ -417,21 +420,8 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
     );
   };
 
-  const renderSubLayers = (startLayer: TypeLegendLayer): JSX.Element => {
-    return (
-      <List>
-        {startLayer.children.map((layer) => (
-          <Fragment key={layer.layerId}>
-            <Sublayer layer={layer} />
-            {layer.children.length > 0 && <Box sx={{ paddingLeft: '30px', width: '100%' }}>{renderSubLayers(layer)}</Box>}
-          </Fragment>
-        ))}
-      </List>
-    );
-  };
-
   const renderDetailsButton = (): JSX.Element => {
-    const isDisabled = layerDetails?.controls?.table === false || layerHidden || parentHidden;
+    const isDisabled = layerControls?.table === false || layerHidden || parentHidden;
 
     return (
       <IconButton
@@ -499,7 +489,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
 
   const renderDeleteButton = (): JSX.Element | null => {
     // Only render delete button if layer is removable (controls.remove must be explicitly true)
-    const isRemovable = layerDetails?.controls?.remove ?? false;
+    const isRemovable = layerControls?.remove ?? false;
     if (!isRemovable) return null;
 
     return (
@@ -513,7 +503,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   };
 
   const renderSettingsButton = (): JSX.Element | null => {
-    const hasInteraction = layerDetails?.controls?.hover || layerDetails?.controls?.query;
+    const hasInteraction = layerControls?.hover || layerControls?.query;
     if (!availableSettings?.length && !hasInteraction && !hasText) return null;
 
     if (activeView === 'settings') {
@@ -593,34 +583,32 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
     );
   };
 
-  const getSubTitle = (): string | null => {
-    if (!layerDetails) return null;
+  const subTitle = ((): string | null => {
     if (parentHidden) return t('layers.parentHidden');
     if (!layerVisible) return t('layers.hidden');
-    if (layerDetails.children.length > 0) {
-      return t('legend.subLayersCount').replace('{count}', layerDetails.children.length.toString());
+    if (layerChildPaths && layerChildPaths.length > 0) {
+      return t('legend.subLayersCount').replace('{count}', layerChildPaths.length.toString());
     }
-    const count = layerDetails.items.filter((d) => d.isVisible !== false).length;
-    const totalCount = layerDetails.items.length;
+    const count = layerItems?.filter((d) => d.isVisible !== false).length ?? 0;
+    const totalCount = layerItems?.length ?? 0;
 
     if (totalCount <= 1) {
       return null;
     }
     return t('legend.itemsCount').replace('{count}', count.toString()).replace('{totalCount}', totalCount.toString());
-  };
+  })();
 
   const renderWMSImage = (): JSX.Element | null => {
-    if (!layerDetails) return null;
     if (
-      layerDetails.schemaTag === CONST_LAYER_TYPES.WMS &&
-      layerDetails.icons.length &&
-      layerDetails.icons[0].iconImage &&
-      layerDetails.icons[0].iconImage !== 'no data'
+      layerSchemaTag === CONST_LAYER_TYPES.WMS &&
+      layerIcons?.length &&
+      layerIcons[0].iconImage &&
+      layerIcons[0].iconImage !== 'no data'
     ) {
       return (
         <Grid sx={sxClasses.itemsGrid}>
           <Grid container pt={6} pb={6}>
-            <Box component="img" alt="" src={layerDetails.icons[0].iconImage} sx={sxClasses.wmsImage} />
+            <Box component="img" alt="" src={layerIcons[0].iconImage} sx={sxClasses.wmsImage} />
           </Grid>
         </Grid>
       );
@@ -628,8 +616,6 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
 
     return null;
   };
-
-  if (!layerDetails) return null;
 
   // TODO: WCAG Issue #3116 - Consider using CSS rather than Divider for cleaner HTML structure
   // Render
@@ -646,25 +632,19 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
         }}
       >
         <Box sx={{ textAlign: 'left', flex: 1, minWidth: 0, [theme.breakpoints.down('sm')]: { display: 'none' } }}>
-          <Typography sx={{ ...sxClasses.categoryTitle, ...(layerHidden && hiddenStyle) }} title={layerDetails.layerName}>
-            {layerDetails.layerName}
+          <Typography sx={{ ...sxClasses.categoryTitle, ...(layerHidden && hiddenStyle) }} title={layerName}>
+            {layerName}
           </Typography>
-          {(() => {
-            const subTitle = getSubTitle();
-            return (
-              subTitle && (
-                <Typography
-                  sx={{
-                    fontSize: theme.palette.geoViewFontSize.sm,
-                    ...(layerHidden && hiddenStyle),
-                  }}
-                >
-                  {' '}
-                  {subTitle}{' '}
-                </Typography>
-              )
-            );
-          })()}
+          {subTitle && (
+            <Typography
+              sx={{
+                fontSize: theme.palette.geoViewFontSize.sm,
+                ...(layerHidden && hiddenStyle),
+              }}
+            >
+              {subTitle}
+            </Typography>
+          )}
         </Box>
         {renderSettingsButton()}
         {renderInfoButton()}
@@ -677,8 +657,9 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
             <>
               {renderLayerButtons()}
               <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap-reverse' }}>
-                {layerDetails.items.length > 1 &&
-                  layerDetails.items.some((item) => layerDetails.styleConfig?.[item.geometryType]?.fields[0] !== undefined) && (
+                {layerItems &&
+                  layerItems.length > 1 &&
+                  layerItems.some((item) => layerStyleConfig?.[item.geometryType]?.fields[0] !== undefined) && (
                     <Grid container direction="row" alignItems="center" justifyItems="stretch">
                       <Grid size={{ xs: 'auto' }}>{renderHeaderCheckbox()}</Grid>
                       <Grid size={{ xs: 'auto' }}>
@@ -688,7 +669,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
                       </Grid>
                     </Grid>
                   )}
-                {layerDetails.children.length > 0 && (
+                {layerChildPaths && layerChildPaths.length > 0 && (
                   <Grid container direction="row" alignItems="center" justifyItems="stretch">
                     <Grid size={{ xs: 'auto' }}>
                       <IconButton
@@ -710,17 +691,23 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
                     </Grid>
                   </Grid>
                 )}
-                {layerDetails.controls?.opacity !== false && <LayerOpacityControl layerDetails={layerDetails} />}
+                {layerControls?.opacity !== false && <LayerOpacityControl layerPath={layerPath} />}
               </Box>
               <Divider sx={{ height: 'auto', marginTop: '10px', marginBottom: '10px' }} variant="middle" />
               {renderWMSImage()}
               <Box>
-                {layerDetails.items?.length > 0 && renderItems()}
-                {layerDetails.children.length > 0 && renderSubLayers(layerDetails)}
+                {layerItems && layerItems.length > 0 && renderItems()}
+                {layerChildPaths && layerChildPaths.length > 0 && (
+                  <List>
+                    {layerChildPaths.map((childPath) => (
+                      <Sublayer key={childPath} layerPath={childPath} />
+                    ))}
+                  </List>
+                )}
               </Box>
               <Divider sx={{ height: 'auto', marginTop: '10px', marginBottom: '10px' }} variant="middle" />
-              {layerDetails.layerAttribution &&
-                layerDetails.layerAttribution.map((attribution) => {
+              {layerAttribution &&
+                layerAttribution.map((attribution) => {
                   if (attribution) {
                     return (
                       <Typography
@@ -740,8 +727,8 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
                 })}
             </>
           )}
-          {activeView === 'settings' && <LayerSettingsPanel layerDetails={layerDetails} />}
-          {activeView === 'info' && <LayerInfoPanel layerDetails={layerDetails} />}
+          {activeView === 'settings' && <LayerSettingsPanel layerPath={layerPath} />}
+          {activeView === 'info' && <LayerInfoPanel layerPath={layerPath} />}
         </Box>
       </Fade>
     </Paper>

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -673,7 +673,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
       {/* Sequential crossfade: fade out → swap content → fade in */}
       <Fade in={contentVisible} timeout={TIMEOUT.fadingPanelDuration}>
         <Box>
-          {activeView === 'details' && (
+          {activeView === TABS.DETAILS && (
             <>
               {renderLayerButtons()}
               <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap-reverse' }}>

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-info/layer-info.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-info/layer-info.tsx
@@ -11,23 +11,23 @@ import { logger } from '@/core/utils/logger';
 import { getLocalizedMessage, isValidUUID } from '@/core/utils/utilities';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import { UtilAddLayer } from '@/core/components/layers/left-panel/add-new-layer/add-layer-utils';
-import { useAppDisplayLanguage, useAppMetadataServiceURL } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { useMapProjectionEPSG } from '@/core/stores/store-interface-and-intial-values/map-state';
-import { useDataTableFilterSelector } from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { useStoreAppDisplayLanguage, useStoreAppMetadataServiceURL } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreMapCurrentProjectionEPSG } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreTableFilter } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import {
-  useLayerDateTemporalMode,
-  useLayerDisplayDateFormat,
-  useLayerDisplayDateFormatShort,
-  useLayerDisplayDateTimezone,
-  useLayerSelectorBounds,
-  useLayerSelectorBounds4326,
-  useLayerSelectorFilter,
-  useLayerSelectorFilterClass,
-  useLayerTimeDimension,
+  useStoreLayerDateTemporalMode,
+  useStoreLayerDisplayDateFormat,
+  useStoreLayerDisplayDateFormatShort,
+  useStoreLayerDisplayDateTimezone,
+  useStoreLayerBounds,
+  useStoreLayerBounds4326,
+  useStoreLayerFilter,
+  useStoreLayerFilterClass,
+  useStoreLayerTimeDimension,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import {
-  useTimeSliderFiltersSelector,
-  useTimeSliderLayersSelector,
+  useStoreTimeSliderFilter,
+  useStoreTimeSliderLayer,
 } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
 import { useLayerController } from '@/core/controllers/layer-controller';
 
@@ -58,21 +58,21 @@ export function LayerInfoPanel({ layerDetails }: LayerInfoPanelProps): JSX.Eleme
   const sxClasses = getSxClasses(theme);
 
   // Store hooks
-  const language = useAppDisplayLanguage();
-  const metadataUrl = useAppMetadataServiceURL();
-  const mapProjectionEPSG = useMapProjectionEPSG();
-  const layerFilter = useLayerSelectorFilter(layerDetails.layerPath);
-  const classFilter = useLayerSelectorFilterClass(layerDetails.layerPath);
-  const dataFilter = useDataTableFilterSelector(layerDetails.layerPath);
-  const timeFilter = useTimeSliderFiltersSelector(layerDetails.layerPath);
-  const bounds = useLayerSelectorBounds(layerDetails.layerPath);
-  const bounds4326 = useLayerSelectorBounds4326(layerDetails.layerPath);
-  const layerDisplayDateFormat = useLayerDisplayDateFormat(layerDetails.layerPath);
-  const layerDisplayDateFormatShort = useLayerDisplayDateFormatShort(layerDetails.layerPath);
-  const layerDateTemporalMode = useLayerDateTemporalMode(layerDetails.layerPath);
-  const layerDisplayDateTimezone = useLayerDisplayDateTimezone(layerDetails.layerPath);
-  const layerTimeDimension = useLayerTimeDimension(layerDetails.layerPath);
-  const timeSliderDimension = useTimeSliderLayersSelector(layerDetails.layerPath);
+  const language = useStoreAppDisplayLanguage();
+  const metadataUrl = useStoreAppMetadataServiceURL();
+  const mapProjectionEPSG = useStoreMapCurrentProjectionEPSG();
+  const layerFilter = useStoreLayerFilter(layerDetails.layerPath);
+  const classFilter = useStoreLayerFilterClass(layerDetails.layerPath);
+  const dataFilter = useStoreTableFilter(layerDetails.layerPath);
+  const timeFilter = useStoreTimeSliderFilter(layerDetails.layerPath);
+  const bounds = useStoreLayerBounds(layerDetails.layerPath);
+  const bounds4326 = useStoreLayerBounds4326(layerDetails.layerPath);
+  const layerDisplayDateFormat = useStoreLayerDisplayDateFormat(layerDetails.layerPath);
+  const layerDisplayDateFormatShort = useStoreLayerDisplayDateFormatShort(layerDetails.layerPath);
+  const layerDateTemporalMode = useStoreLayerDateTemporalMode(layerDetails.layerPath);
+  const layerDisplayDateTimezone = useStoreLayerDisplayDateTimezone(layerDetails.layerPath);
+  const layerTimeDimension = useStoreLayerTimeDimension(layerDetails.layerPath);
+  const timeSliderDimension = useStoreTimeSliderLayer(layerDetails.layerPath);
   const layerController = useLayerController();
 
   // TODO: CHECK - This should probably be a Zustand store hook instead of a controller getter?

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-info/layer-info.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-info/layer-info.tsx
@@ -25,10 +25,7 @@ import {
   useStoreLayerFilterClass,
   useStoreLayerTimeDimension,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import {
-  useStoreTimeSliderFilter,
-  useStoreTimeSliderLayer,
-} from '@/core/stores/store-interface-and-intial-values/time-slider-state';
+import { useStoreTimeSliderFilter, useStoreTimeSliderLayer } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
 import { useLayerController } from '@/core/controllers/layer-controller';
 
 // OGC/ESRI service capability request suffixes

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-info/layer-info.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-info/layer-info.tsx
@@ -6,7 +6,6 @@ import { Box, Divider, List, ListItem, Typography } from '@/ui';
 import { ListItemText } from '@/ui/list';
 
 import { getSxClasses } from '../layer-details-style';
-import type { TypeLegendLayer } from '@/core/components/layers/types';
 import { logger } from '@/core/utils/logger';
 import { getLocalizedMessage, isValidUUID } from '@/core/utils/utilities';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
@@ -24,6 +23,8 @@ import {
   useStoreLayerFilter,
   useStoreLayerFilterClass,
   useStoreLayerTimeDimension,
+  useStoreLayerSchemaTag,
+  useStoreLayerUrl,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { useStoreTimeSliderFilter, useStoreTimeSliderLayer } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
 import { useLayerController } from '@/core/controllers/layer-controller';
@@ -33,7 +34,8 @@ const WFS_PARAMS = '?service=WFS&version=2.0.0&request=GetCapabilities';
 const WMS_PARAMS = '?service=WMS&version=1.3.0&request=GetCapabilities';
 
 interface LayerInfoPanelProps {
-  layerDetails: TypeLegendLayer;
+  /** The layer path to display information for. */
+  layerPath: string;
 }
 
 /**
@@ -43,9 +45,9 @@ interface LayerInfoPanelProps {
  * resource links, and metadata links. The header and back navigation are
  * handled by the parent.
  *
- * @param layerDetails - The legend layer to display information for.
+ * @param layerPath - The layer path to display information for.
  */
-export function LayerInfoPanel({ layerDetails }: LayerInfoPanelProps): JSX.Element | null {
+export function LayerInfoPanel({ layerPath }: LayerInfoPanelProps): JSX.Element | null {
   // Log
   logger.logTraceRender('components/layers/right-panel/layer-info/layer-info');
 
@@ -58,30 +60,29 @@ export function LayerInfoPanel({ layerDetails }: LayerInfoPanelProps): JSX.Eleme
   const language = useStoreAppDisplayLanguage();
   const metadataUrl = useStoreAppMetadataServiceURL();
   const mapProjectionEPSG = useStoreMapCurrentProjectionEPSG();
-  const layerFilter = useStoreLayerFilter(layerDetails.layerPath);
-  const classFilter = useStoreLayerFilterClass(layerDetails.layerPath);
-  const dataFilter = useStoreTableFilter(layerDetails.layerPath);
-  const timeFilter = useStoreTimeSliderFilter(layerDetails.layerPath);
-  const bounds = useStoreLayerBounds(layerDetails.layerPath);
-  const bounds4326 = useStoreLayerBounds4326(layerDetails.layerPath);
-  const layerDisplayDateFormat = useStoreLayerDisplayDateFormat(layerDetails.layerPath);
-  const layerDisplayDateFormatShort = useStoreLayerDisplayDateFormatShort(layerDetails.layerPath);
-  const layerDateTemporalMode = useStoreLayerDateTemporalMode(layerDetails.layerPath);
-  const layerDisplayDateTimezone = useStoreLayerDisplayDateTimezone(layerDetails.layerPath);
-  const layerTimeDimension = useStoreLayerTimeDimension(layerDetails.layerPath);
-  const timeSliderDimension = useStoreTimeSliderLayer(layerDetails.layerPath);
+  const layerFilter = useStoreLayerFilter(layerPath);
+  const classFilter = useStoreLayerFilterClass(layerPath);
+  const dataFilter = useStoreTableFilter(layerPath);
+  const timeFilter = useStoreTimeSliderFilter(layerPath);
+  const schemaTag = useStoreLayerSchemaTag(layerPath);
+  const url = useStoreLayerUrl(layerPath);
+  const bounds = useStoreLayerBounds(layerPath);
+  const bounds4326 = useStoreLayerBounds4326(layerPath);
+  const layerDisplayDateFormat = useStoreLayerDisplayDateFormat(layerPath);
+  const layerDisplayDateFormatShort = useStoreLayerDisplayDateFormatShort(layerPath);
+  const layerDateTemporalMode = useStoreLayerDateTemporalMode(layerPath);
+  const layerDisplayDateTimezone = useStoreLayerDisplayDateTimezone(layerPath);
+  const layerTimeDimension = useStoreLayerTimeDimension(layerPath);
+  const timeSliderDimension = useStoreTimeSliderLayer(layerPath);
   const layerController = useLayerController();
 
   // TODO: CHECK - This should probably be a Zustand store hook instead of a controller getter?
-  const layerNativeProjection = layerController.getLayerMetatadaProjectionEPSG(layerDetails.layerPath);
+  const layerNativeProjection = layerController.getLayerMetatadaProjectionEPSG(layerPath);
 
   // Derived values
   const memoLocalizedLayerType = useMemo(() => UtilAddLayer.getLocalizeLayerType(language, true), [language]);
   const boundsRounded = bounds?.map((value) => Math.round(value));
   const boundsRounded4326 = bounds4326?.map((value) => Math.round(value * 100) / 100);
-
-  // Props
-  const { schemaTag, url, layerPath } = layerDetails;
 
   // Build resource URL based on layer type
   const memoResources = useMemo((): string => {
@@ -112,7 +113,7 @@ export function LayerInfoPanel({ layerDetails }: LayerInfoPanelProps): JSX.Eleme
   }, [url, schemaTag, layerPath]);
 
   // Check if we can set the metadata from layerPath
-  const id = layerDetails.layerPath.split('/')[0].split(':')[0];
+  const id = layerPath.split('/')[0].split(':')[0];
   const validId = isValidUUID(id) && metadataUrl !== '';
 
   // Find the localized name for the current layer type
@@ -121,11 +122,11 @@ export function LayerInfoPanel({ layerDetails }: LayerInfoPanelProps): JSX.Eleme
     let name = localizedTypeEntry ? localizedTypeEntry[1] : t('layers.serviceGroup');
 
     // Special case if type is GeoJSON and url end by zip or shp. It is a GeoJSON format derived from a shapefile
-    if (name === CONST_LAYER_TYPES.GEOJSON && (layerDetails.url?.includes('.zip') || layerDetails.url?.includes('.shp'))) {
+    if (name === CONST_LAYER_TYPES.GEOJSON && (url?.includes('.zip') || url?.includes('.shp'))) {
       name = `${name} - ${t('layers.serviceEsriShapefile')}`;
     }
     return name;
-  }, [memoLocalizedLayerType, schemaTag, layerDetails.url, t]);
+  }, [memoLocalizedLayerType, schemaTag, url, t]);
 
   return (
     <Box sx={sxClasses.layerInfo}>

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-opacity-control/layer-opacity-control.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-opacity-control/layer-opacity-control.tsx
@@ -25,6 +25,8 @@ export function LayerOpacityControl(props: LayerOpacityControlProps): JSX.Elemen
   const { t } = useTranslation<string>();
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
+
+  // Store
   const layerHidden = useStoreMapIsLayerHiddenOnMap(layerDetails.layerPath);
   const layerController = useLayerController();
 

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-opacity-control/layer-opacity-control.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-opacity-control/layer-opacity-control.tsx
@@ -4,22 +4,22 @@ import { useTheme } from '@mui/material/styles';
 import type { Mark } from '@mui/base';
 import { getSxClasses } from './layer-opacity-control-styles';
 import { Box, Slider, Typography } from '@/ui';
-import type { TypeLegendLayer } from '@/core/components/layers/types';
+import { useStoreLayerOpacity, useStoreLayerOpacityMaxFromParent } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { useStoreMapIsLayerHiddenOnMap } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
 import { useLayerController } from '@/core/controllers/layer-controller';
 
 interface LayerOpacityControlProps {
-  layerDetails: TypeLegendLayer;
+  /** The layer path to control opacity for. */
+  layerPath: string;
 }
 
-export function LayerOpacityControl(props: LayerOpacityControlProps): JSX.Element {
+export function LayerOpacityControl({ layerPath }: LayerOpacityControlProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/right-panel/layer-opacity-control/layer-opacity-control');
 
-  const { layerDetails } = props;
-  const layerOpacity = layerDetails.opacity ?? 1;
-  const layerParentOpacity = layerDetails.opacityMaxFromParent ?? 1;
+  const layerOpacity = useStoreLayerOpacity(layerPath) ?? 1;
+  const layerParentOpacity = useStoreLayerOpacityMaxFromParent(layerPath) ?? 1;
 
   // Hook
   const { t } = useTranslation<string>();
@@ -27,7 +27,7 @@ export function LayerOpacityControl(props: LayerOpacityControlProps): JSX.Elemen
   const sxClasses = getSxClasses(theme);
 
   // Store
-  const layerHidden = useStoreMapIsLayerHiddenOnMap(layerDetails.layerPath);
+  const layerHidden = useStoreMapIsLayerHiddenOnMap(layerPath);
   const layerController = useLayerController();
 
   // State
@@ -70,9 +70,9 @@ export function LayerOpacityControl(props: LayerOpacityControlProps): JSX.Elemen
 
       // Necessary to keep the handle from exceeding the max from parent
       setLocalOpacity(newValue);
-      layerController.setLayerOpacity(layerDetails.layerPath, newValue, updateStore);
+      layerController.setLayerOpacity(layerPath, newValue, updateStore);
     },
-    [layerDetails.layerPath, layerParentOpacity, layerController]
+    [layerPath, layerParentOpacity, layerController]
   );
 
   return (

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-opacity-control/layer-opacity-control.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-opacity-control/layer-opacity-control.tsx
@@ -5,7 +5,7 @@ import type { Mark } from '@mui/base';
 import { getSxClasses } from './layer-opacity-control-styles';
 import { Box, Slider, Typography } from '@/ui';
 import type { TypeLegendLayer } from '@/core/components/layers/types';
-import { useMapSelectorIsLayerHiddenOnMap } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapIsLayerHiddenOnMap } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
 import { useLayerController } from '@/core/controllers/layer-controller';
 
@@ -25,7 +25,7 @@ export function LayerOpacityControl(props: LayerOpacityControlProps): JSX.Elemen
   const { t } = useTranslation<string>();
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
-  const layerHidden = useMapSelectorIsLayerHiddenOnMap(layerDetails.layerPath);
+  const layerHidden = useStoreMapIsLayerHiddenOnMap(layerDetails.layerPath);
   const layerController = useLayerController();
 
   // State

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/layer-settings.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/layer-settings.tsx
@@ -9,18 +9,21 @@ import {
   useStoreLayerHasText,
   useStoreLayerTextVisibility,
   useStoreLayerStyleSettings,
+  useStoreLayerControls,
+  useStoreLayerHoverable,
+  useStoreLayerQueryable,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 import { getSxClasses } from '../layer-details-style';
 import { RasterFunctionPanel } from './raster-function-selector';
 import { MosaicRulePanel } from './mosaic-rule-selector';
 import { WmsStylePanel } from './wms-style-selector';
-import type { TypeLegendLayer } from '@/core/components/layers/types';
 import { useLayerController } from '@/core/controllers/layer-controller';
 import { logger } from '@/core/utils/logger';
 
 interface LayerSettingsPanelProps {
-  layerDetails: TypeLegendLayer;
+  /** The layer path to configure settings for. */
+  layerPath: string;
 }
 
 /**
@@ -30,9 +33,9 @@ interface LayerSettingsPanelProps {
  * interaction toggles) as inline collapsible sections. The header and
  * back navigation are handled by the parent.
  *
- * @param layerDetails - The legend layer to configure.
+ * @param layerPath - The layer path to configure.
  */
-export function LayerSettingsPanel({ layerDetails }: LayerSettingsPanelProps): JSX.Element {
+export function LayerSettingsPanel({ layerPath }: LayerSettingsPanelProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/right-panel/layer-settings/layer-settings');
 
@@ -43,26 +46,31 @@ export function LayerSettingsPanel({ layerDetails }: LayerSettingsPanelProps): J
 
   // Store
   const layerController = useLayerController();
-  const hasText = useStoreLayerHasText(layerDetails.layerPath);
-  const textVisible = useStoreLayerTextVisibility(layerDetails.layerPath);
-  const availableSettings = useStoreLayerStyleSettings(layerDetails.layerPath);
+  const hasText = useStoreLayerHasText(layerPath);
+  const textVisible = useStoreLayerTextVisibility(layerPath);
+  const availableSettings = useStoreLayerStyleSettings(layerPath);
+  const layerControls = useStoreLayerControls(layerPath);
+  const hoverable = useStoreLayerHoverable(layerPath);
+  const queryable = useStoreLayerQueryable(layerPath);
 
   // Derived values
-  const isLayerHoverable = layerDetails.controls?.hover;
-  const isLayerQueryable = layerDetails.controls?.query;
+  const isLayerHoverable = layerControls?.hover;
+  const isLayerQueryable = layerControls?.query;
+
+  // TODO: CHECK - Change the use of hooks in those callbacks to use state getters instead?
 
   // Stable handlers for hover/query toggles
   const handleToggleHoverable = useCallback((): void => {
-    layerController.setLayerHoverable(layerDetails.layerPath, !layerDetails.hoverable!);
-  }, [layerDetails.layerPath, layerDetails.hoverable, layerController]);
+    layerController.setLayerHoverable(layerPath, !hoverable!);
+  }, [layerPath, hoverable, layerController]);
 
   const handleToggleQueryable = useCallback((): void => {
-    layerController.setLayerQueryable(layerDetails.layerPath, !layerDetails.queryable!);
-  }, [layerDetails.layerPath, layerDetails.queryable, layerController]);
+    layerController.setLayerQueryable(layerPath, !queryable!);
+  }, [layerPath, queryable, layerController]);
 
   const handleToggleText = useCallback((): void => {
-    layerController.setLayerTextVisibility(layerDetails.layerPath, !textVisible);
-  }, [layerDetails.layerPath, textVisible, layerController]);
+    layerController.setLayerTextVisibility(layerPath, !textVisible);
+  }, [layerPath, textVisible, layerController]);
 
   function renderToggleTextButton(): JSX.Element {
     return (
@@ -85,10 +93,10 @@ export function LayerSettingsPanel({ layerDetails }: LayerSettingsPanelProps): J
         <Typography sx={sxClasses.infoSectionTitle}>{t('layers.layerInfoInteraction')}</Typography>
         <Box sx={sxClasses.infoSectionContent}>
           {isLayerHoverable && (
-            <Switch size="small" onChange={handleToggleHoverable} label={t('layers.layerHoverable')} checked={layerDetails.hoverable} />
+            <Switch size="small" onChange={handleToggleHoverable} label={t('layers.layerHoverable')} checked={hoverable} />
           )}
           {isLayerQueryable && (
-            <Switch size="small" onChange={handleToggleQueryable} label={t('layers.layerQueryable')} checked={layerDetails.queryable} />
+            <Switch size="small" onChange={handleToggleQueryable} label={t('layers.layerQueryable')} checked={queryable} />
           )}
           {hasText && renderToggleTextButton()}
         </Box>
@@ -100,9 +108,9 @@ export function LayerSettingsPanel({ layerDetails }: LayerSettingsPanelProps): J
     <Box>
       <Divider sx={{ height: 'auto', marginTop: '10px', marginBottom: '10px' }} variant="middle" />
 
-      {availableSettings?.includes('rasterFunction') && <RasterFunctionPanel layerDetails={layerDetails} />}
-      {availableSettings?.includes('mosaicRule') && <MosaicRulePanel layerDetails={layerDetails} />}
-      {availableSettings?.includes('wmsStyles') && <WmsStylePanel layerDetails={layerDetails} />}
+      {availableSettings?.includes('rasterFunction') && <RasterFunctionPanel layerPath={layerPath} />}
+      {availableSettings?.includes('mosaicRule') && <MosaicRulePanel layerPath={layerPath} />}
+      {availableSettings?.includes('wmsStyles') && <WmsStylePanel layerPath={layerPath} />}
 
       {renderInteractionSection()}
     </Box>

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/layer-settings.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/layer-settings.tsx
@@ -6,9 +6,9 @@ import { Box, Divider, Typography } from '@/ui';
 import { Switch } from '@/ui/switch/switch';
 
 import {
-  getStoreLayerStyleSettings,
-  useLayerSelectorHasText,
-  useLayerSelectorTextVisibility,
+  useStoreLayerHasText,
+  useStoreLayerTextVisibility,
+  useStoreLayerStyleSettings,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 import { getSxClasses } from '../layer-details-style';
@@ -17,7 +17,6 @@ import { MosaicRulePanel } from './mosaic-rule-selector';
 import { WmsStylePanel } from './wms-style-selector';
 import type { TypeLegendLayer } from '@/core/components/layers/types';
 import { useLayerController } from '@/core/controllers/layer-controller';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
 
 interface LayerSettingsPanelProps {
@@ -43,13 +42,10 @@ export function LayerSettingsPanel({ layerDetails }: LayerSettingsPanelProps): J
   const sxClasses = getSxClasses(theme);
 
   // Store
-  const mapId = useGeoViewMapId();
   const layerController = useLayerController();
-  const hasText = useLayerSelectorHasText(layerDetails.layerPath);
-  const textVisible = useLayerSelectorTextVisibility(layerDetails.layerPath);
-
-  // TODO: CHECK - This should likely go through a Zustand hook instead of a state getter
-  const availableSettings = getStoreLayerStyleSettings(mapId, layerDetails.layerPath);
+  const hasText = useStoreLayerHasText(layerDetails.layerPath);
+  const textVisible = useStoreLayerTextVisibility(layerDetails.layerPath);
+  const availableSettings = useStoreLayerStyleSettings(layerDetails.layerPath);
 
   // Derived values
   const isLayerHoverable = layerDetails.controls?.hover;

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/mosaic-rule-selector.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/mosaic-rule-selector.tsx
@@ -8,7 +8,6 @@ import { CollectionsIcon, ExpandMoreIcon, ExpandLessIcon } from '@/ui';
 import { getSxClasses } from './layer-settings-style';
 import { useStoreLayerMosaicRule, useStoreLayerAllowedMosaicMethods } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
-import type { TypeLegendLayer } from '../../types';
 import type { TypeMosaicMethod, TypeMosaicOperation } from '@/api/types/layer-schema-types';
 import { logger } from '@/core/utils/logger';
 import { useLayerController } from '@/core/controllers/layer-controller';
@@ -37,7 +36,8 @@ const OPERATION_ENTRIES: Record<string, string> = {
 };
 
 interface MosaicRulePanelProps {
-  layerDetails: TypeLegendLayer;
+  /** The layer path to configure mosaic rules for. */
+  layerPath: string;
 }
 
 /**
@@ -52,10 +52,10 @@ interface MosaicRulePanelProps {
  * and how overlapping pixels are resolved (e.g., via blending, maximum, or minimum values).
  *
  * @see {@link https://developers.arcgis.com/javascript/latest/references/core/layers/support/MosaicRule}
- * @param layerDetails - The legend layer to configure mosaic rules for.
+ * @param layerPath - The layer path to configure mosaic rules for.
  * @returns A JSX element representing the MosaicRulePanel component.
  */
-export function MosaicRulePanel({ layerDetails }: MosaicRulePanelProps): JSX.Element {
+export function MosaicRulePanel({ layerPath }: MosaicRulePanelProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/right-panel/layer-settings/mosaic-rule-selector > MosaicRulePanel');
 
@@ -65,8 +65,8 @@ export function MosaicRulePanel({ layerDetails }: MosaicRulePanelProps): JSX.Ele
   const { t } = useTranslation();
 
   // Store hooks
-  const mosaicRule = useStoreLayerMosaicRule(layerDetails.layerPath);
-  const allowedMosaicMethods = useStoreLayerAllowedMosaicMethods(layerDetails.layerPath);
+  const mosaicRule = useStoreLayerMosaicRule(layerPath);
+  const allowedMosaicMethods = useStoreLayerAllowedMosaicMethods(layerPath);
   const layerController = useLayerController();
 
   // State
@@ -87,23 +87,23 @@ export function MosaicRulePanel({ layerDetails }: MosaicRulePanelProps): JSX.Ele
   // Handlers with stable references
   const handleChangeMethod = useCallback(
     (event: React.ChangeEvent<HTMLInputElement> | (Event & { target: { value: unknown; name: string } })): void => {
-      layerController.setLayerMosaicRuleMethod(layerDetails.layerPath, event.target.value as TypeMosaicMethod);
+      layerController.setLayerMosaicRuleMethod(layerPath, event.target.value as TypeMosaicMethod);
     },
-    [layerDetails.layerPath, layerController]
+    [layerPath, layerController]
   );
 
   const handleChangeOperation = useCallback(
     (event: React.ChangeEvent<HTMLInputElement> | (Event & { target: { value: unknown; name: string } })): void => {
-      layerController.setLayerMosaicRuleOperation(layerDetails.layerPath, event.target.value as TypeMosaicOperation);
+      layerController.setLayerMosaicRuleOperation(layerPath, event.target.value as TypeMosaicOperation);
     },
-    [layerDetails.layerPath, layerController]
+    [layerPath, layerController]
   );
 
   const handleChangeAscending = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>): void => {
-      layerController.setLayerMosaicRuleAscending(layerDetails.layerPath, event.target.checked);
+      layerController.setLayerMosaicRuleAscending(layerPath, event.target.checked);
     },
-    [layerDetails.layerPath, layerController]
+    [layerPath, layerController]
   );
 
   // Menu items derived from the module-level entry maps

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/mosaic-rule-selector.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/mosaic-rule-selector.tsx
@@ -6,10 +6,7 @@ import { Box, Checkbox, Collapse, FormControl, Select, Typography } from '@/ui';
 import { CollectionsIcon, ExpandMoreIcon, ExpandLessIcon } from '@/ui';
 
 import { getSxClasses } from './layer-settings-style';
-import {
-  useLayerSelectorMosaicRule,
-  useLayerSelectorAllowedMosaicMethods,
-} from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerMosaicRule, useStoreLayerAllowedMosaicMethods } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 import type { TypeLegendLayer } from '../../types';
 import type { TypeMosaicMethod, TypeMosaicOperation } from '@/api/types/layer-schema-types';
@@ -68,8 +65,8 @@ export function MosaicRulePanel({ layerDetails }: MosaicRulePanelProps): JSX.Ele
   const { t } = useTranslation();
 
   // Store hooks
-  const mosaicRule = useLayerSelectorMosaicRule(layerDetails.layerPath);
-  const allowedMosaicMethods = useLayerSelectorAllowedMosaicMethods(layerDetails.layerPath);
+  const mosaicRule = useStoreLayerMosaicRule(layerDetails.layerPath);
+  const allowedMosaicMethods = useStoreLayerAllowedMosaicMethods(layerDetails.layerPath);
   const layerController = useLayerController();
 
   // State

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/raster-function-selector.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/raster-function-selector.tsx
@@ -7,10 +7,7 @@ import { Box, CircularProgress, Collapse, Typography } from '@/ui';
 import { ImageNotSupportedIcon, FunctionsIcon, ExpandMoreIcon, ExpandLessIcon } from '@/ui';
 
 import { getSxClasses } from './layer-settings-style';
-import {
-  useLayerSelectorRasterFunctionInfos,
-  useLayerSelectorRasterFunction,
-} from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerRasterFunctionInfos, useStoreLayerRasterFunction } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import type { TypeLegendLayer } from '@/core/components/layers/types';
 import type { TypeMetadataEsriRasterFunctionInfos } from '@/api/types/layer-schema-types';
 import { logger } from '@/core/utils/logger';
@@ -146,9 +143,9 @@ export function RasterFunctionPanel({ layerDetails }: RasterFunctionPanelProps):
   const sxClasses = getSxClasses(theme);
 
   // Store hooks
-  const storeRasterFunctionInfos = useLayerSelectorRasterFunctionInfos(layerDetails.layerPath);
+  const storeRasterFunctionInfos = useStoreLayerRasterFunctionInfos(layerDetails.layerPath);
   const memoRasterFunctionInfos = useMemo(() => storeRasterFunctionInfos || [], [storeRasterFunctionInfos]);
-  const currentRasterFunction = useLayerSelectorRasterFunction(layerDetails.layerPath);
+  const currentRasterFunction = useStoreLayerRasterFunction(layerDetails.layerPath);
   const layerController = useLayerController();
 
   // State

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/raster-function-selector.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/raster-function-selector.tsx
@@ -8,7 +8,6 @@ import { ImageNotSupportedIcon, FunctionsIcon, ExpandMoreIcon, ExpandLessIcon } 
 
 import { getSxClasses } from './layer-settings-style';
 import { useStoreLayerRasterFunctionInfos, useStoreLayerRasterFunction } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import type { TypeLegendLayer } from '@/core/components/layers/types';
 import type { TypeMetadataEsriRasterFunctionInfos } from '@/api/types/layer-schema-types';
 import { logger } from '@/core/utils/logger';
 import { useLayerController } from '@/core/controllers/layer-controller';
@@ -21,7 +20,8 @@ interface RasterFunctionItemProps {
 }
 
 interface RasterFunctionPanelProps {
-  layerDetails: TypeLegendLayer;
+  /** The layer path to configure raster functions for. */
+  layerPath: string;
 }
 
 /** Stable empty array reference to avoid re-renders when raster function infos are undefined. */
@@ -133,10 +133,10 @@ function RasterFunctionItem({ info, isSelected, previewPromise, onSelect }: Rast
  * Replaces the previous Menu-based approach with cards displayed
  * directly within the settings panel.
  *
- * @param layerDetails - The legend layer to configure raster functions for.
+ * @param layerPath - The layer path to configure raster functions for.
  * @returns A JSX element representing the RasterFunctionPanel component.
  */
-export function RasterFunctionPanel({ layerDetails }: RasterFunctionPanelProps): JSX.Element {
+export function RasterFunctionPanel({ layerPath }: RasterFunctionPanelProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/right-panel/layer-settings/raster-function-selector > RasterFunctionPanel');
 
@@ -146,8 +146,8 @@ export function RasterFunctionPanel({ layerDetails }: RasterFunctionPanelProps):
   const sxClasses = getSxClasses(theme);
 
   // Store hooks
-  const rasterFunctionInfos = useStoreLayerRasterFunctionInfos(layerDetails.layerPath) ?? EMPTY_RASTER_FUNCTION_INFOS;
-  const currentRasterFunction = useStoreLayerRasterFunction(layerDetails.layerPath);
+  const rasterFunctionInfos = useStoreLayerRasterFunctionInfos(layerPath) ?? EMPTY_RASTER_FUNCTION_INFOS;
+  const currentRasterFunction = useStoreLayerRasterFunction(layerPath);
   const layerController = useLayerController();
 
   // State
@@ -160,16 +160,16 @@ export function RasterFunctionPanel({ layerDetails }: RasterFunctionPanelProps):
 
     if (rasterFunctionInfos.length > 0) {
       // TODO: CHECK - Verify if that's the intent here? - Use a hook?
-      const promises = layerController.getLayerRasterFunctionPreviews(layerDetails.layerPath);
+      const promises = layerController.getLayerRasterFunctionPreviews(layerPath);
       setPreviewPromises(promises);
     }
-  }, [layerDetails.layerPath, rasterFunctionInfos, layerController]);
+  }, [layerPath, rasterFunctionInfos, layerController]);
 
   const handleSelect = useCallback(
     (rasterFunctionName: string): void => {
-      layerController.setLayerRasterFunction(layerDetails.layerPath, rasterFunctionName);
+      layerController.setLayerRasterFunction(layerPath, rasterFunctionName);
     },
-    [layerDetails.layerPath, layerController]
+    [layerPath, layerController]
   );
 
   const handleToggle = useCallback((): void => {

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/raster-function-selector.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/raster-function-selector.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
 import type { SxProps } from '@mui/material';
@@ -23,6 +23,9 @@ interface RasterFunctionItemProps {
 interface RasterFunctionPanelProps {
   layerDetails: TypeLegendLayer;
 }
+
+/** Stable empty array reference to avoid re-renders when raster function infos are undefined. */
+const EMPTY_RASTER_FUNCTION_INFOS: TypeMetadataEsriRasterFunctionInfos[] = [];
 
 /**
  * Card component displaying a raster function option with image preview.
@@ -143,8 +146,7 @@ export function RasterFunctionPanel({ layerDetails }: RasterFunctionPanelProps):
   const sxClasses = getSxClasses(theme);
 
   // Store hooks
-  const storeRasterFunctionInfos = useStoreLayerRasterFunctionInfos(layerDetails.layerPath);
-  const memoRasterFunctionInfos = useMemo(() => storeRasterFunctionInfos || [], [storeRasterFunctionInfos]);
+  const rasterFunctionInfos = useStoreLayerRasterFunctionInfos(layerDetails.layerPath) ?? EMPTY_RASTER_FUNCTION_INFOS;
   const currentRasterFunction = useStoreLayerRasterFunction(layerDetails.layerPath);
   const layerController = useLayerController();
 
@@ -154,14 +156,14 @@ export function RasterFunctionPanel({ layerDetails }: RasterFunctionPanelProps):
 
   useEffect(() => {
     // Log
-    logger.logTraceUseEffect('RASTER FUNCTION PANEL - Layer Raster Function Infos sync', memoRasterFunctionInfos);
+    logger.logTraceUseEffect('RASTER FUNCTION PANEL - Layer Raster Function Infos sync', rasterFunctionInfos);
 
-    if (memoRasterFunctionInfos.length > 0) {
+    if (rasterFunctionInfos.length > 0) {
       // TODO: CHECK - Verify if that's the intent here? - Use a hook?
       const promises = layerController.getLayerRasterFunctionPreviews(layerDetails.layerPath);
       setPreviewPromises(promises);
     }
-  }, [layerDetails.layerPath, memoRasterFunctionInfos, layerController]);
+  }, [layerDetails.layerPath, rasterFunctionInfos, layerController]);
 
   const handleSelect = useCallback(
     (rasterFunctionName: string): void => {
@@ -200,7 +202,7 @@ export function RasterFunctionPanel({ layerDetails }: RasterFunctionPanelProps):
       </Box>
       <Collapse in={expanded} sx={{ marginTop: expanded ? '12px' : 0 }}>
         <Box sx={sxClasses.settingsCardList}>
-          {memoRasterFunctionInfos.map((info) => (
+          {rasterFunctionInfos.map((info) => (
             <RasterFunctionItem
               key={info.name}
               info={info}

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/wms-style-selector.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/wms-style-selector.tsx
@@ -7,7 +7,7 @@ import { Box, CircularProgress, Collapse, Typography } from '@/ui';
 import { ImageNotSupportedIcon, PaletteIcon, ExpandMoreIcon, ExpandLessIcon } from '@/ui';
 
 import { getSxClasses } from './layer-settings-style';
-import { useLayerSelectorWmsStyle, useLayerSelectorWmsStyles } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerWmsStyle, useStoreLayerWmsStyles } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import type { TypeLegendLayer } from '@/core/components/layers/types';
 import type { TypeMetadataWMSCapabilityLayerStyle } from '@/api/types/layer-schema-types';
 import { logger } from '@/core/utils/logger';
@@ -140,8 +140,8 @@ export function WmsStylePanel({ layerDetails }: WmsStylePanelProps): JSX.Element
   const sxClasses = getSxClasses(theme);
 
   // Store hooks
-  const currentWmsStyle = useLayerSelectorWmsStyle(layerDetails.layerPath);
-  const storeWmsStyles = useLayerSelectorWmsStyles(layerDetails.layerPath);
+  const currentWmsStyle = useStoreLayerWmsStyle(layerDetails.layerPath);
+  const storeWmsStyles = useStoreLayerWmsStyles(layerDetails.layerPath);
   const memoWmsStyleArray = useMemo(() => storeWmsStyles || [], [storeWmsStyles]);
   const layerController = useLayerController();
 

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/wms-style-selector.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/wms-style-selector.tsx
@@ -8,7 +8,6 @@ import { ImageNotSupportedIcon, PaletteIcon, ExpandMoreIcon, ExpandLessIcon } fr
 
 import { getSxClasses } from './layer-settings-style';
 import { useStoreLayerWmsStyle, useStoreLayerWmsStyles } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import type { TypeLegendLayer } from '@/core/components/layers/types';
 import type { TypeMetadataWMSCapabilityLayerStyle } from '@/api/types/layer-schema-types';
 import { logger } from '@/core/utils/logger';
 import { useLayerController } from '@/core/controllers/layer-controller';
@@ -20,7 +19,8 @@ interface WmsStyleItemProps {
 }
 
 interface WmsStylePanelProps {
-  layerDetails: TypeLegendLayer;
+  /** The layer path to configure WMS styles for. */
+  layerPath: string;
 }
 
 /**
@@ -127,10 +127,10 @@ function WmsStyleItem({ style, isSelected, onSelect }: WmsStyleItemProps): JSX.E
  * Displays available styles as cards within a collapsible section,
  * consistent with the raster function panel pattern.
  *
- * @param layerDetails - The legend layer to configure WMS styles for.
+ * @param layerPath - The layer path to configure WMS styles for.
  * @returns A JSX element representing the WMS style panel.
  */
-export function WmsStylePanel({ layerDetails }: WmsStylePanelProps): JSX.Element {
+export function WmsStylePanel({ layerPath }: WmsStylePanelProps): JSX.Element {
   // Log
   logger.logTraceRender('components/layers/right-panel/layer-settings/wms-style-selector > WmsStylePanel');
 
@@ -140,8 +140,8 @@ export function WmsStylePanel({ layerDetails }: WmsStylePanelProps): JSX.Element
   const sxClasses = getSxClasses(theme);
 
   // Store hooks
-  const currentWmsStyle = useStoreLayerWmsStyle(layerDetails.layerPath);
-  const storeWmsStyles = useStoreLayerWmsStyles(layerDetails.layerPath);
+  const currentWmsStyle = useStoreLayerWmsStyle(layerPath);
+  const storeWmsStyles = useStoreLayerWmsStyles(layerPath);
   const memoWmsStyleArray = useMemo(() => storeWmsStyles || [], [storeWmsStyles]);
   const layerController = useLayerController();
 
@@ -150,10 +150,9 @@ export function WmsStylePanel({ layerDetails }: WmsStylePanelProps): JSX.Element
 
   const handleSelect = useCallback(
     (wmsStyleName: string): void => {
-      // TODO: REFACTOR - This setting of styles should be done through a controller, because it affects the domain directly.
-      layerController.setLayerWmsStyle(layerDetails.layerPath, wmsStyleName);
+      layerController.setLayerWmsStyle(layerPath, wmsStyleName);
     },
-    [layerDetails.layerPath, layerController]
+    [layerPath, layerController]
   );
 
   const handleToggle = useCallback((): void => {

--- a/packages/geoview-core/src/core/components/legend/hooks/use-legend-debounce.ts
+++ b/packages/geoview-core/src/core/components/legend/hooks/use-legend-debounce.ts
@@ -1,8 +1,0 @@
-import { useLayerLegendLayers } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import { useDebounceValue } from '@/core/components/common/hooks/use-debounce-value';
-import type { TypeLegendLayer } from '@/core/components/layers/types';
-
-export function useDebounceLayerLegendLayers(delay = 500): TypeLegendLayer[] {
-  const legendLayers = useLayerLegendLayers();
-  return useDebounceValue(legendLayers, delay);
-}

--- a/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
@@ -1,18 +1,17 @@
 import { useTheme } from '@mui/material';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box, List, Typography, IconButton, FullscreenIcon } from '@/ui';
 import { logger } from '@/core/utils/logger';
 import {
-  getStoreMapOrderedLayerInfo,
+  getStoreMapLegendCollapsedSet,
   setStoreMapAllMapLayerCollapsed,
   setStoreMapLegendCollapsed,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 
 import { getSxClasses } from './legend-styles';
 import { LegendLayer } from './legend-layer';
-import type { TypeLegendLayer } from '@/core/components/layers/types';
 import { CONTAINER_TYPE } from '@/core/utils/constant';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { useEventListener } from '@/core/components/common/hooks/use-event-listener';
@@ -22,7 +21,7 @@ import { DEFAULT_APPBAR_CORE } from '@/api/types/map-schema-types';
 /**
  * Properties for the LegendFullscreen component.
  * @interface LegendFullscreenProps
- * @property {TypeLegendLayer[]} layersList - Array of legend layers to display in fullscreen mode.
+ * @property {string[]} layerPaths - Array of layer paths to display in fullscreen mode.
  * @property {string} mapId - The unique identifier of the map.
  * @property {TypeContainerBox} containerType - The type of container where the legend is displayed.
  * @property {boolean} isOpen - Controls whether the fullscreen dialog is open.
@@ -30,7 +29,7 @@ import { DEFAULT_APPBAR_CORE } from '@/api/types/map-schema-types';
  * @property {React.RefObject<HTMLButtonElement>} buttonRef - Reference to the fullscreen button for focus restoration.
  */
 interface LegendFullscreenProps {
-  layersList: TypeLegendLayer[];
+  layerPaths: string[];
   mapId: string;
   containerType: TypeContainerBox;
   isOpen: boolean;
@@ -109,14 +108,14 @@ export function LegendFullscreenButton({ containerType, onClick, buttonRef }: Fu
  * Manages layer collapse state by expanding all layers when entering fullscreen and
  * restoring the previous collapse state when exiting.
  * @param props - The component properties.
- * @param props.layersList - Array of legend layers to display.
+ * @param props.layerPaths - Array of layer paths to display.
  * @param props.mapId - The unique identifier of the map.
  * @param props.containerType - The type of container where the legend is displayed.
  * @param props.isOpen - Controls whether the fullscreen dialog is open.
  * @param props.onClose - Callback function invoked when the dialog is closed.
  * @returns The fullscreen legend dialog component.
  */
-export function LegendFullscreen({ layersList, mapId, containerType, isOpen, onClose, buttonRef }: LegendFullscreenProps): JSX.Element {
+export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onClose, buttonRef }: LegendFullscreenProps): JSX.Element {
   logger.logTraceRender('components/legend/legend-fullscreen');
 
   // Hooks
@@ -125,8 +124,8 @@ export function LegendFullscreen({ layersList, mapId, containerType, isOpen, onC
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // State
-  const [fullscreenLegendLayerList, setFullscreenLegendLayersList] = useState<TypeLegendLayer[][]>([]);
-  const [, setSavedCollapseState] = useState<Record<string, boolean>>({});
+  const [fullscreenLegendLayerList, setFullscreenLegendLayersList] = useState<string[][]>([]);
+  const savedCollapseStateRef = useRef<Record<string, boolean>>({});
 
   // Memoize breakpoint values
   const breakpoints = useMemo(() => {
@@ -161,19 +160,19 @@ export function LegendFullscreen({ layersList, mapId, containerType, isOpen, onC
    * Distributes legend layers across multiple columns for fullscreen display.
    * Uses a round-robin algorithm to evenly distribute layers across the available columns
    * determined by the current window size.
-   * @param layers - Array of legend layers to distribute.
+   * @param paths - Array of layer paths to distribute.
    */
   const updateFullscreenLayerListByWindowSize = useCallback(
-    (layers: TypeLegendLayer[]): void => {
+    (paths: string[]): void => {
       const arrSize = getFullscreenLayerListSize();
-      const list = Array.from({ length: arrSize }, () => []) as Array<TypeLegendLayer[]>;
+      const list = Array.from({ length: arrSize }, () => []) as Array<string[]>;
 
-      layers.forEach((layer, index) => {
-        list[index % arrSize].push(layer);
+      paths.forEach((layerPath, index) => {
+        list[index % arrSize].push(layerPath);
       });
 
       // Format the list only if there is layers
-      setFullscreenLegendLayersList(layers.length === 0 ? [] : list);
+      setFullscreenLegendLayersList(paths.length === 0 ? [] : list);
     },
     [getFullscreenLayerListSize]
   );
@@ -181,8 +180,8 @@ export function LegendFullscreen({ layersList, mapId, containerType, isOpen, onC
   // Memoize the window resize handler and use the hook to add listener to avoid many creation
   const handleWindowResize = useCallback(() => {
     // Update the layer list based on window size
-    updateFullscreenLayerListByWindowSize(layersList);
-  }, [layersList, updateFullscreenLayerListByWindowSize]);
+    updateFullscreenLayerListByWindowSize(layerPaths);
+  }, [layerPaths, updateFullscreenLayerListByWindowSize]);
 
   // Wire a handler using a custom hook on the window resize event
   useEventListener<Window>('resize', handleWindowResize, window);
@@ -190,11 +189,11 @@ export function LegendFullscreen({ layersList, mapId, containerType, isOpen, onC
   // Handle initial layer setup
   useEffect(() => {
     // Log
-    logger.logTraceUseEffect('LEGEND FULLSCREEN - layer setup', layersList);
+    logger.logTraceUseEffect('LEGEND FULLSCREEN - layer setup', layerPaths);
 
     // Update the layer list based on window size
-    updateFullscreenLayerListByWindowSize(layersList);
-  }, [layersList, updateFullscreenLayerListByWindowSize]);
+    updateFullscreenLayerListByWindowSize(layerPaths);
+  }, [layerPaths, updateFullscreenLayerListByWindowSize]);
 
   // Handle fullscreen state changes
   useEffect(() => {
@@ -202,32 +201,21 @@ export function LegendFullscreen({ layersList, mapId, containerType, isOpen, onC
     logger.logTraceUseEffect('LEGEND FULLSCREEN - fullscreen state change', isOpen);
 
     if (isOpen) {
-      // Entering fullscreen: save collapse state and expand all
-      // TODO: CHECK -This should likely go through a Zustand hook instead of a state getter
-      const orderedLayerInfo = getStoreMapOrderedLayerInfo(mapId);
-      const collapseState: Record<string, boolean> = {};
-
-      orderedLayerInfo.forEach((layer) => {
-        collapseState[layer.layerPath] = layer.legendCollapsed;
-      });
-
-      setSavedCollapseState(collapseState);
+      // Entering fullscreen: snapshot collapse state from the store and expand all
+      // GV Here we use a store getter, because we actually want to snapshot the values to reuse them later, we don't want to hook on them
+      savedCollapseStateRef.current = getStoreMapLegendCollapsedSet(mapId);
 
       // Save to the store
       setStoreMapAllMapLayerCollapsed(mapId, false);
     } else {
       // Exiting fullscreen: restore saved collapse state
-      setSavedCollapseState((prevState) => {
-        if (Object.keys(prevState).length > 0) {
-          Object.entries(prevState).forEach(([layerPath, collapsed]) => {
-            // Save to the store
-            setStoreMapLegendCollapsed(mapId, layerPath, collapsed);
-          });
-          // Return empty object to clear state
-          return {};
-        }
-        return prevState;
-      });
+      const savedState = savedCollapseStateRef.current;
+      if (Object.keys(savedState).length > 0) {
+        Object.entries(savedState).forEach(([layerPath, collapsed]) => {
+          // Save to the store
+          setStoreMapLegendCollapsed(mapId, layerPath, collapsed);
+        });
+      }
     }
   }, [isOpen, mapId]);
 
@@ -258,7 +246,7 @@ export function LegendFullscreen({ layersList, mapId, containerType, isOpen, onC
       return noLayersContent;
     }
 
-    return fullscreenLegendLayerList.map((layers, idx) => (
+    return fullscreenLegendLayerList.map((paths, idx) => (
       <List
         className="legendList"
         // eslint-disable-next-line react/no-array-index-key
@@ -268,8 +256,8 @@ export function LegendFullscreen({ layersList, mapId, containerType, isOpen, onC
           ...sxClasses.legendList,
         }}
       >
-        {layers.map((layer) => (
-          <LegendLayer layerPath={layer.layerPath} key={layer.layerPath} showControls={false} containerType={containerType} />
+        {paths.map((layerPath) => (
+          <LegendLayer layerPath={layerPath} key={layerPath} showControls={false} containerType={containerType} />
         ))}
       </List>
     ));

--- a/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
@@ -108,11 +108,6 @@ export function LegendFullscreenButton({ containerType, onClick, buttonRef }: Fu
  * Manages layer collapse state by expanding all layers when entering fullscreen and
  * restoring the previous collapse state when exiting.
  * @param props - The component properties.
- * @param props.layerPaths - Array of layer paths to display.
- * @param props.mapId - The unique identifier of the map.
- * @param props.containerType - The type of container where the legend is displayed.
- * @param props.isOpen - Controls whether the fullscreen dialog is open.
- * @param props.onClose - Callback function invoked when the dialog is closed.
  * @returns The fullscreen legend dialog component.
  */
 export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onClose, buttonRef }: LegendFullscreenProps): JSX.Element {
@@ -160,6 +155,7 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
    * Distributes legend layers across multiple columns for fullscreen display.
    * Uses a round-robin algorithm to evenly distribute layers across the available columns
    * determined by the current window size.
+   *
    * @param paths - Array of layer paths to distribute.
    */
   const updateFullscreenLayerListByWindowSize = useCallback(

--- a/packages/geoview-core/src/core/components/legend/legend-layer-container.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-container.tsx
@@ -10,16 +10,16 @@ import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import { ItemsList } from './legend-layer-items';
 import type { LegendLayerProps } from './legend-layer';
 import {
-  useLayerSelectorChildren,
-  useLayerSelectorIcons,
-  useLayerSelectorItems,
-  useLayerSelectorName,
-  useLayerSelectorStatus,
-  useLayerSelectorSchemaTag,
+  useStoreLayerChildPaths,
+  useStoreLayerIcons,
+  useStoreLayerItems,
+  useStoreLayerName,
+  useStoreLayerStatus,
+  useStoreLayerSchemaTag,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
-import { useMapSelectorLayerLegendCollapsed } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapLegendCollapsedByPath } from '@/core/stores/store-interface-and-intial-values/map-state';
 import type { TypeContainerBox } from '@/core/types/global-types';
 
 interface CollapsibleContentProps {
@@ -90,22 +90,22 @@ export const CollapsibleContent = memo(function CollapsibleContent({
   layerNameId,
 }: CollapsibleContentProps): JSX.Element | null {
   // Hooks
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const isCollapsed = useMapSelectorLayerLegendCollapsed(layerPath);
-  const schemaTag = useLayerSelectorSchemaTag(layerPath);
-  const layerItems = useLayerSelectorItems(layerPath);
-  const layerChildren = useLayerSelectorChildren(layerPath);
-  const layerIcons = useLayerSelectorIcons(layerPath);
-  const layerStatus = useLayerSelectorStatus(layerPath);
-  const layerName = useLayerSelectorName(layerPath);
+  const isCollapsed = useStoreMapLegendCollapsedByPath(layerPath);
+  const schemaTag = useStoreLayerSchemaTag(layerPath);
+  const layerItems = useStoreLayerItems(layerPath);
+  const layerChildPaths = useStoreLayerChildPaths(layerPath);
+  const layerIcons = useStoreLayerIcons(layerPath);
+  const layerStatus = useStoreLayerStatus(layerPath);
+  const layerName = useStoreLayerName(layerPath);
 
   // Log
-  logger.logTraceUseMemo('components/legend/legend-layer-container - CollapsibleContent', layerPath, layerChildren?.length);
+  logger.logTraceUseMemo('components/legend/legend-layer-container - CollapsibleContent', layerPath, layerChildPaths?.length);
 
   // Early returns
-  if ((layerChildren?.length === 0 && layerItems?.length === 1) || layerStatus === 'error') return null;
+  if ((layerChildPaths?.length === 0 && layerItems?.length === 1) || layerStatus === 'error') return null;
 
   const isWMSWithLegend = schemaTag === CONST_LAYER_TYPES.WMS && layerIcons?.[0]?.iconImage && layerIcons[0].iconImage !== 'no data';
 
@@ -136,14 +136,9 @@ export const CollapsibleContent = memo(function CollapsibleContent({
       unmountOnExit
     >
       <List>
-        {layerChildren &&
-          layerChildren.map((item) => (
-            <LegendLayerComponent
-              layerPath={item.layerPath}
-              key={item.layerPath}
-              showControls={showControls}
-              containerType={containerType}
-            />
+        {layerChildPaths &&
+          layerChildPaths.map((childPath) => (
+            <LegendLayerComponent layerPath={childPath} key={childPath} showControls={showControls} containerType={containerType} />
           ))}
       </List>
       <ItemsList items={layerItems || []} layerPath={layerPath} />

--- a/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
@@ -17,33 +17,33 @@ import {
   LayersIcon,
 } from '@/ui';
 import {
-  useLayerHighlightedLayer,
-  useLayerSelectorChildren,
-  useLayerSelectorItems,
-  useLayerSelectorControls,
-  useLayerSelectorStatus,
-  useLayerSelectorEntryType,
-  useLayerSelectorName,
+  useStoreLayerHighlightedLayer,
+  useStoreLayerChildPaths,
+  useStoreLayerItems,
+  useStoreLayerControls,
+  useStoreLayerStatus,
+  useStoreLayerEntryType,
+  useStoreLayerName,
   setStoreLayerSelectedLayersTabLayer,
-  getStoreLayerStateLegendLayerByPath,
+  getStoreLayerLegendLayerByPath,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import {
-  useUIFooterBarComponents,
-  useUIAppbarComponents,
-  useUIActiveTrapGeoView,
+  useStoreUIFooterBarComponents,
+  useStoreUIAppbarComponents,
+  useStoreUIActiveTrapGeoView,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import {
   getStoreMapLayerParentHidden,
   getStoreMapOrderedLayerInfoByPath,
-  useMapSelectorLayerInVisibleRange,
-  useMapSelectorLayerParentHidden,
-  useMapSelectorLayerVisibility,
+  useStoreMapLayerInVisibleRange,
+  useStoreMapIsParentLayerHiddenOnMap,
+  useStoreMapLayerVisibility,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
-import type { TypeLegendItem, TypeLegendLayer } from '@/core/components/layers/types';
+import type { TypeLegendItem } from '@/core/components/layers/types';
 import { getSxClasses } from './legend-styles';
 import { logger } from '@/core/utils/logger';
 import { useNavigateToTab } from '@/core/components/common/hooks/use-navigate-to-tab';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { useLayerController } from '@/core/controllers/layer-controller';
 import { useMapController } from '@/core/controllers/map-controller';
 
@@ -70,17 +70,22 @@ type ControlActions = {
  */
 const useControlActions = (layerPath: string): ControlActions => {
   // Store
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
   const layerController = useLayerController();
   const mapController = useMapController();
 
+  /**
+   * Builds the memoized control action handlers.
+   */
   return useMemo(
     () => ({
+      /**
+       * Handles zooming to the layer's visible scale range.
+       */
       handleZoomToLayerVisibleScale: (event: React.MouseEvent): void => {
         event.stopPropagation();
         // Read current state values when handler executes
-        // TODO: CHECK -This should likely go through a Zustand hook instead of a state getter
-        const layer = getStoreLayerStateLegendLayerByPath(mapId, layerPath);
+        const layer = getStoreLayerLegendLayerByPath(mapId, layerPath);
 
         // Use orderedLayerInfo to check visibility range
         const layerInfo = getStoreMapOrderedLayerInfoByPath(mapId, layerPath);
@@ -92,11 +97,14 @@ const useControlActions = (layerPath: string): ControlActions => {
         }
         mapController.zoomToLayerVisibleScale(layerPath);
       },
+
+      /**
+       * Handles toggling the layer visibility on or off.
+       */
       handleToggleVisibility: (event: React.MouseEvent): boolean => {
         event.stopPropagation();
         // Read current state values when handler executes
-        // TODO: CHECK -This should likely go through a Zustand hook instead of a state getter
-        const layer = getStoreLayerStateLegendLayerByPath(mapId, layerPath);
+        const layer = getStoreLayerLegendLayerByPath(mapId, layerPath);
         const layerInfo = getStoreMapOrderedLayerInfoByPath(mapId, layerPath);
         const isInVisibleRange = layerInfo?.inVisibleRange || false;
         const parentHidden = getStoreMapLayerParentHidden(mapId, layerPath);
@@ -106,11 +114,14 @@ const useControlActions = (layerPath: string): ControlActions => {
         }
         return mapController.setOrToggleMapLayerVisibility(layerPath);
       },
+
+      /**
+       * Handles toggling the layer highlight on or off.
+       */
       handleHighlightLayer: (event: React.MouseEvent): void => {
         event.stopPropagation();
         // Read current state values when handler executes
-        // TODO: CHECK -This should likely go through a Zustand hook instead of a state getter
-        const layer = getStoreLayerStateLegendLayerByPath(mapId, layerPath);
+        const layer = getStoreLayerLegendLayerByPath(mapId, layerPath);
         const layerInfo = getStoreMapOrderedLayerInfoByPath(mapId, layerPath);
         const isInVisibleRange = layerInfo?.inVisibleRange || false;
         const parentHidden = getStoreMapLayerParentHidden(mapId, layerPath);
@@ -121,11 +132,14 @@ const useControlActions = (layerPath: string): ControlActions => {
         }
         layerController.setHighlightLayer(layerPath);
       },
+
+      /**
+       * Handles zooming to the layer's geographic extent.
+       */
       handleZoomTo: (event: React.MouseEvent): void => {
         event.stopPropagation();
         // Read current state values when handler executes
-        // TODO: REFACTOR - This isn't an ideal pattern, review.
-        const layer = getStoreLayerStateLegendLayerByPath(mapId, layerPath);
+        const layer = getStoreLayerLegendLayerByPath(mapId, layerPath);
         const layerInfo = getStoreMapOrderedLayerInfoByPath(mapId, layerPath);
         const isInVisibleRange = layerInfo?.inVisibleRange || false;
         const parentHidden = getStoreMapLayerParentHidden(mapId, layerPath);
@@ -145,16 +159,16 @@ const useControlActions = (layerPath: string): ControlActions => {
 };
 
 // Create subtitle
-const useSubtitle = (layerPath: string, children: TypeLegendLayer[], items: TypeLegendItem[]): string => {
+const useSubtitle = (layerPath: string, childPaths: string[], items: TypeLegendItem[]): string => {
   // Hooks
   const { t } = useTranslation();
-  const parentHidden = useMapSelectorLayerParentHidden(layerPath);
+  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layerPath);
 
   return useMemo(() => {
     if (parentHidden) return t('layers.parentHidden');
 
-    if (children.length) {
-      return t('legend.subLayersCount').replace('{count}', children.length.toString());
+    if (childPaths.length) {
+      return t('legend.subLayersCount').replace('{count}', childPaths.length.toString());
     }
     if (items.length > 1) {
       return t('legend.itemsCount')
@@ -162,14 +176,14 @@ const useSubtitle = (layerPath: string, children: TypeLegendLayer[], items: Type
         .replace('{totalCount}', items.length.toString());
     }
     return '';
-  }, [children.length, items, parentHidden, t]);
+  }, [childPaths.length, items, parentHidden, t]);
 };
 
 // SecondaryControls component (no memo to force re render from layers panel modifications)
 export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.Element {
   // Add store actions for selecting layer and UI
-  const footerBarComponents = useUIFooterBarComponents();
-  const appBarComponents = useUIAppbarComponents();
+  const footerBarComponents = useStoreUIFooterBarComponents();
+  const appBarComponents = useStoreUIAppbarComponents();
   const hasFooterLayersTab = footerBarComponents.includes('layers');
   const hasAppBarLayersTab = appBarComponents.includes('layers');
   const hasLayersTab = hasFooterLayersTab || hasAppBarLayersTab;
@@ -194,17 +208,17 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
   const { t } = useTranslation<string>();
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const layerEntryType = useLayerSelectorEntryType(layerPath);
-  const layerChildren = useLayerSelectorChildren(layerPath);
-  const layerItems = useLayerSelectorItems(layerPath);
-  const layerControls = useLayerSelectorControls(layerPath);
-  const layerStatus = useLayerSelectorStatus(layerPath);
-  const isVisible = useMapSelectorLayerVisibility(layerPath);
-  const isInVisibleRange = useMapSelectorLayerInVisibleRange(layerPath);
-  const parentHidden = useMapSelectorLayerParentHidden(layerPath);
-  const highlightedLayer = useLayerHighlightedLayer();
-  const isFocusTrap = useUIActiveTrapGeoView();
-  const layerName = useLayerSelectorName(layerPath) ?? layerPath;
+  const layerEntryType = useStoreLayerEntryType(layerPath);
+  const layerChildPaths = useStoreLayerChildPaths(layerPath);
+  const layerItems = useStoreLayerItems(layerPath);
+  const layerControls = useStoreLayerControls(layerPath);
+  const layerStatus = useStoreLayerStatus(layerPath);
+  const isVisible = useStoreMapLayerVisibility(layerPath);
+  const isInVisibleRange = useStoreMapLayerInVisibleRange(layerPath);
+  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layerPath);
+  const highlightedLayer = useStoreLayerHighlightedLayer();
+  const isFocusTrap = useStoreUIActiveTrapGeoView();
+  const layerName = useStoreLayerName(layerPath) ?? layerPath;
 
   // Is visibility button disabled?
   const isLayerVisibleCapable = layerControls?.visibility ?? false;
@@ -224,7 +238,7 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
 
   // Component helper
   const controls = useControlActions(layerPath);
-  const subTitle = useSubtitle(layerPath, layerChildren || [], layerItems || []);
+  const subTitle = useSubtitle(layerPath, layerChildPaths || [], layerItems || []);
 
   return (
     <Stack direction="row" alignItems="center" sx={sxClasses.layerStackIcons}>

--- a/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
@@ -4,15 +4,15 @@ import { memo, useCallback, useMemo, useEffect, useRef } from 'react';
 import { Box, ListItem, ListItemButton, ListItemText, ListItemIcon, List, BrowserNotSupportedIcon } from '@/ui';
 import type { TypeLegendItem } from '@/core/components/layers/types';
 import {
-  useLayerSelectorCanToggle,
-  useLayerSelectorControls,
-  useLayerSelectorStyleConfig,
+  useStoreLayerCanToggle,
+  useStoreLayerControls,
+  useStoreLayerStyleConfig,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { getSxClasses } from './legend-styles';
 import { logger } from '@/core/utils/logger';
 import { generateId } from '@/core/utils/utilities';
-import { useMapSelectorIsLayerHiddenOnMap } from '@/core/stores/store-interface-and-intial-values/map-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreMapIsLayerHiddenOnMap } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { useLayerController } from '@/core/controllers/layer-controller';
 
 interface ItemsListProps {
@@ -102,15 +102,16 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
   // Hooks
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const mapId = useGeoViewMapId();
   const lastToggledRef = useRef<string | null>(null);
   const itemIdMapRef = useRef<Map<string, string>>(new Map());
 
-  const layerControls = useLayerSelectorControls(layerPath);
-  const layerHidden = useMapSelectorIsLayerHiddenOnMap(layerPath);
-  const canToggle = useLayerSelectorCanToggle(layerPath);
+  // Store
+  const mapId = useStoreGeoViewMapId();
+  const layerControls = useStoreLayerControls(layerPath);
+  const layerHidden = useStoreMapIsLayerHiddenOnMap(layerPath);
+  const canToggle = useStoreLayerCanToggle(layerPath);
   const canToggleItemVisibility = canToggle && layerControls?.visibility !== false;
-  const styleConfig = useLayerSelectorStyleConfig(layerPath);
+  const styleConfig = useStoreLayerStyleConfig(layerPath);
   const layerController = useLayerController();
 
   /**

--- a/packages/geoview-core/src/core/components/legend/legend-layer.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer.tsx
@@ -4,18 +4,18 @@ import { useTranslation } from 'react-i18next';
 
 import { useTheme } from '@mui/material';
 
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { Box, ListItem, ListItemText, IconButton, KeyboardArrowDownIcon, KeyboardArrowUpIcon, ProgressBar } from '@/ui';
 import {
-  useLayerSelectorChildren,
-  useLayerSelectorItems,
-  useLayerSelectorName,
-  useLayerSelectorStatus,
-  useLayerSelectorSchemaTag,
+  useStoreLayerChildPaths,
+  useStoreLayerItems,
+  useStoreLayerName,
+  useStoreLayerStatus,
+  useStoreLayerSchemaTag,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import {
-  useMapSelectorLayerLegendCollapsed,
-  useMapSelectorIsLayerHiddenOnMap,
+  useStoreMapLegendCollapsedByPath,
+  useStoreMapIsLayerHiddenOnMap,
   setStoreMapToggleLegendCollapsed,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { useLightBox } from '@/core/components/common';
@@ -59,13 +59,13 @@ const LegendLayerHeader = memo(
     logger.logTraceUseMemo('components/legend/legend-layer - LegendLayerHeader', layerPath);
 
     // Hooks
-    const isCollapsed = useMapSelectorLayerLegendCollapsed(layerPath);
-    const layerHidden = useMapSelectorIsLayerHiddenOnMap(layerPath);
-    const layerName = useLayerSelectorName(layerPath) ?? layerPath;
-    const layerItems = useLayerSelectorItems(layerPath);
-    const layerChildren = useLayerSelectorChildren(layerPath);
-    const schemaTag = useLayerSelectorSchemaTag(layerPath);
-    const layerStatus = useLayerSelectorStatus(layerPath);
+    const isCollapsed = useStoreMapLegendCollapsedByPath(layerPath);
+    const layerHidden = useStoreMapIsLayerHiddenOnMap(layerPath);
+    const layerName = useStoreLayerName(layerPath) ?? layerPath;
+    const layerItems = useStoreLayerItems(layerPath);
+    const layerChildPaths = useStoreLayerChildPaths(layerPath);
+    const schemaTag = useStoreLayerSchemaTag(layerPath);
+    const layerStatus = useStoreLayerStatus(layerPath);
 
     // Return the ui
     return (
@@ -87,7 +87,9 @@ const LegendLayerHeader = memo(
           secondary={showControls ? <SecondaryControls layerPath={layerPath} /> : undefined}
         />
         {showControls &&
-          ((layerChildren && layerChildren.length > 0) || (layerItems && layerItems.length > 1) || schemaTag === CONST_LAYER_TYPES.WMS) && (
+          ((layerChildPaths && layerChildPaths.length > 0) ||
+            (layerItems && layerItems.length > 1) ||
+            schemaTag === CONST_LAYER_TYPES.WMS) && (
             <IconButton
               className="buttonOutline"
               onClick={onExpandClick}
@@ -122,14 +124,14 @@ export function LegendLayer({ layerPath, showControls, containerType }: LegendLa
   const { t } = useTranslation<string>();
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const mapId = useGeoViewMapId();
+
+  // Stores
+  const mapId = useStoreGeoViewMapId();
   const id = useId(); // WCAG - Generate a stable unique ID
   const layerNameId = `${mapId}-${containerType}-layer-name-${id}`; // WCAG - IDs to link the layer name to icon buttons related to it (aria-describedby)
   const collapseContainerId = `${mapId}-${containerType}-collapse-${id}`; // WCAG - IDs to link collapse buttons to collapsible content related to it (aria-controls)
-
-  // Stores
-  const layerStatus = useLayerSelectorStatus(layerPath);
-  const layerName = useLayerSelectorName(layerPath) ?? layerPath;
+  const layerStatus = useStoreLayerStatus(layerPath);
+  const layerName = useStoreLayerName(layerPath) ?? layerPath;
   const { initLightBox, LightBoxComponent } = useLightBox();
 
   // Internal state

--- a/packages/geoview-core/src/core/components/legend/legend.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend.tsx
@@ -6,7 +6,6 @@ import { useTheme } from '@mui/material';
 
 import { ToggleAll } from '@/core/components/toggle-all/toggle-all';
 import { Box, List, Typography } from '@/ui';
-import { useStoreGeoViewMapId, useStoreLayerLayerPaths } from '@/core/stores/';
 import { logger } from '@/core/utils/logger';
 
 import { getSxClassesMain, getSxClasses } from './legend-styles';
@@ -15,6 +14,8 @@ import { LegendFullscreen, LegendFullscreenButton } from './legend-fullscreen';
 import { CONTAINER_TYPE } from '@/core/utils/constant';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { useEventListener } from '@/core/components/common/hooks/use-event-listener';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreLayerLayerPaths } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 interface LegendType {
   containerType: TypeContainerBox;
@@ -175,6 +176,10 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
     ));
     // eslint-disable-next-line react-hooks/exhaustive-deps -- sxClasses is memoized from theme which is stable
   }, [formattedLegendLayerList, noLayersContent, containerType]);
+
+  // TODO: CLEANUP - Remove the commented code, we're trying to not unmount the Legend panel anymore to check performance 2026-04-07
+  // Early return with empty fragment if not the active tab
+  // if (activeFooterBarTab.tabId !== 'legend' && activeAppBarTab.tabId !== 'legend') return null;
 
   return (
     <>

--- a/packages/geoview-core/src/core/components/legend/legend.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend.tsx
@@ -6,13 +6,12 @@ import { useTheme } from '@mui/material';
 
 import { ToggleAll } from '@/core/components/toggle-all/toggle-all';
 import { Box, List, Typography } from '@/ui';
-import { useGeoViewMapId, useUIActiveAppBarTab, useUIActiveFooterBarTab, useLayerLegendLayers } from '@/core/stores/';
+import { useStoreGeoViewMapId, useStoreLayerLayerPaths } from '@/core/stores/';
 import { logger } from '@/core/utils/logger';
 
 import { getSxClassesMain, getSxClasses } from './legend-styles';
 import { LegendLayer } from './legend-layer';
 import { LegendFullscreen, LegendFullscreenButton } from './legend-fullscreen';
-import type { TypeLegendLayer } from '@/core/components/layers/types';
 import { CONTAINER_TYPE } from '@/core/utils/constant';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { useEventListener } from '@/core/components/common/hooks/use-event-listener';
@@ -59,15 +58,13 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // State
-  const [formattedLegendLayerList, setFormattedLegendLayersList] = useState<TypeLegendLayer[][]>([]);
+  const [formattedLegendLayerList, setFormattedLegendLayersList] = useState<string[][]>([]);
   const [isFullScreen, setIsFullScreen] = useState(false);
   const fullScreenBtnRef = useRef<HTMLButtonElement>(null);
 
   // Store
-  const mapId = useGeoViewMapId();
-  const activeFooterBarTab = useUIActiveFooterBarTab();
-  const activeAppBarTab = useUIActiveAppBarTab();
-  const layersList = useLayerLegendLayers();
+  const mapId = useStoreGeoViewMapId();
+  const layerPaths = useStoreLayerLayerPaths();
 
   // Memoize breakpoint values
   const breakpoints = useMemo(() => {
@@ -98,20 +95,20 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
    * Transform the list of the legends into subsets of lists.
    * it will return subsets of lists with pattern:- [[0,4,8],[1,5,9],[2,6],[3,7] ]
    * This way we can layout the legends into column wraps.
-   * @param layers - Array of layers.
-   * @returns List of array of layers
+   * @param paths - Array of layer paths.
+   * @returns List of array of layer paths
    */
   const updateLegendLayerListByWindowSize = useCallback(
-    (layers: TypeLegendLayer[]): void => {
+    (paths: string[]): void => {
       const arrSize = getLegendLayerListSize();
-      const list = Array.from({ length: arrSize }, () => []) as Array<TypeLegendLayer[]>;
+      const list = Array.from({ length: arrSize }, () => []) as Array<string[]>;
 
-      layers.forEach((layer, index) => {
-        list[index % arrSize].push(layer);
+      paths.forEach((layerPath, index) => {
+        list[index % arrSize].push(layerPath);
       });
 
       // Format the list only if there is layers
-      setFormattedLegendLayersList(layers.length === 0 ? [] : list);
+      setFormattedLegendLayersList(paths.length === 0 ? [] : list);
     },
     [getLegendLayerListSize]
   );
@@ -119,8 +116,8 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
   // Memoize the window resize handler and use the hook to add listener to avoid many creation
   const handleWindowResize = useCallback(() => {
     // Update the layer list based on window size
-    updateLegendLayerListByWindowSize(layersList);
-  }, [layersList, updateLegendLayerListByWindowSize]);
+    updateLegendLayerListByWindowSize(layerPaths);
+  }, [layerPaths, updateLegendLayerListByWindowSize]);
 
   // Wire a handler using a custom hook on the window resize event
   useEventListener<Window>('resize', handleWindowResize, window);
@@ -128,11 +125,11 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
   // Handle initial layer setup
   useEffect(() => {
     // Log
-    logger.logTraceUseEffect('LEGEND - layer setup', layersList);
+    logger.logTraceUseEffect('LEGEND - layer setup', layerPaths);
 
     // Update the layer list based on window size
-    updateLegendLayerListByWindowSize(layersList);
-  }, [layersList, updateLegendLayerListByWindowSize]);
+    updateLegendLayerListByWindowSize(layerPaths);
+  }, [layerPaths, updateLegendLayerListByWindowSize]);
 
   // Memoize the no layers content
   const noLayersContent = useMemo(() => {
@@ -161,7 +158,7 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
       return noLayersContent;
     }
 
-    return formattedLegendLayerList.map((layers, idx) => (
+    return formattedLegendLayerList.map((paths, idx) => (
       <List
         className="legendList"
         // eslint-disable-next-line react/no-array-index-key
@@ -171,21 +168,18 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
           ...sxClasses.legendList,
         }}
       >
-        {layers.map((layer) => (
-          <LegendLayer layerPath={layer.layerPath} key={layer.layerPath} showControls={true} containerType={containerType} />
+        {paths.map((layerPath) => (
+          <LegendLayer layerPath={layerPath} key={layerPath} showControls={true} containerType={containerType} />
         ))}
       </List>
     ));
     // eslint-disable-next-line react-hooks/exhaustive-deps -- sxClasses is memoized from theme which is stable
   }, [formattedLegendLayerList, noLayersContent, containerType]);
 
-  // Early return with empty fragment if not the active tab
-  if (activeFooterBarTab.tabId !== 'legend' && activeAppBarTab.tabId !== 'legend') return null;
-
   return (
     <>
       <LegendFullscreen
-        layersList={layersList}
+        layerPaths={layerPaths}
         mapId={mapId}
         containerType={containerType}
         isOpen={isFullScreen}

--- a/packages/geoview-core/src/core/components/lightbox/lightbox.tsx
+++ b/packages/geoview-core/src/core/components/lightbox/lightbox.tsx
@@ -10,9 +10,9 @@ import 'yet-another-react-lightbox/styles.css';
 
 import { CloseIcon, ArrowRightIcon, ArrowLeftIcon, DownloadIcon, Tooltip } from '@/ui';
 import { logger } from '@/core/utils/logger';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { LIGHTBOX_SELECTORS } from '@/core/utils/constant';
-import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 
 /** Slide definition for the lightbox. */
 export interface LightBoxSlides {
@@ -63,8 +63,8 @@ export const LightboxImg = memo(function LightboxImg({ open, slides, index, exit
   const [closeOnBackdropClick] = useState(true);
 
   // Store
-  const mapId = useGeoViewMapId();
-  const activeTrapGeoView = useUIActiveTrapGeoView();
+  const mapId = useStoreGeoViewMapId();
+  const activeTrapGeoView = useStoreUIActiveTrapGeoView();
 
   /**
    * Syncs internal open state when the prop changes.

--- a/packages/geoview-core/src/core/components/map-info/map-info-rotation-button.tsx
+++ b/packages/geoview-core/src/core/components/map-info/map-info-rotation-button.tsx
@@ -4,10 +4,10 @@ import { useTheme } from '@mui/material/styles';
 import { Box, Tooltip } from '@/ui';
 import { NorthArrowIcon } from '@/core/components/north-arrow/north-arrow-icon';
 
-import { useMapRotation } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapRotation } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { useManageArrow } from '@/core/components/north-arrow/hooks/useManageArrow';
 import { logger } from '@/core/utils/logger';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 
 /**
  * Creates the map information rotation indicator component.
@@ -24,8 +24,8 @@ export const MapInfoRotationButton = memo(function MapInfoRotationButton(): JSX.
   const theme = useTheme();
 
   // Store
-  const mapId = useGeoViewMapId();
-  const mapRotation = useMapRotation();
+  const mapId = useStoreGeoViewMapId();
+  const mapRotation = useStoreMapRotation();
   const { rotationAngle } = useManageArrow();
 
   // Convert radians to degrees for tooltip

--- a/packages/geoview-core/src/core/components/map-info/map-info.tsx
+++ b/packages/geoview-core/src/core/components/map-info/map-info.tsx
@@ -7,9 +7,9 @@ import { MousePosition } from '@/core/components/mouse-position/mouse-position';
 import { Scale } from '@/core/components/scale/scale';
 import { MapInfoExpandButton } from './map-info-expand-button';
 import { MapInfoRotationButton } from './map-info-rotation-button';
-import { useMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 
 /** Base styles for the map info bar container. */
 const MAP_INFO_BASE_STYLES = {
@@ -45,8 +45,8 @@ export const MapInfo = memo(function MapInfo({ onScrollShellIntoView }: MapInfoP
   const theme = useTheme();
 
   // Store
-  const interaction = useMapInteraction(); // Static map, do not display mouse position or rotation controls
-  const mapId = useGeoViewMapId(); // Element id for panel height (expanded)
+  const mapId = useStoreGeoViewMapId();
+  const interaction = useStoreMapInteraction(); // Static map, do not display mouse position or rotation controls
 
   // State
   const [expanded, setExpanded] = useState(false);

--- a/packages/geoview-core/src/core/components/map/map.tsx
+++ b/packages/geoview-core/src/core/components/map/map.tsx
@@ -15,14 +15,14 @@ import type { MapViewer } from '@/geo/map/map-viewer';
 
 import { getSxClasses } from './map-style';
 import {
-  useMapInteraction,
-  useMapLoaded,
-  useMapNorthArrow,
-  useMapOverviewMap,
+  useStoreMapInteraction,
+  useStoreMapLoaded,
+  useStoreMapNorthArrow,
+  useStoreMapOverviewMap,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
-import { useLayerAreLayersLoading } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerAreLayersLoading } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 /** Props for the Map component. */
 type MapProps = {
@@ -50,12 +50,12 @@ export function Map(props: MapProps): JSX.Element {
   const deviceSizeMedUp = useMediaQuery(defaultTheme.breakpoints.up('md')); // if screen size is medium and up
 
   // get values from the store
-  const mapId = useGeoViewMapId();
-  const overviewMap = useMapOverviewMap();
-  const northArrow = useMapNorthArrow();
-  const mapLoaded = useMapLoaded();
-  const layersAreLoading = useLayerAreLayersLoading();
-  const mapInteraction = useMapInteraction();
+  const mapId = useStoreGeoViewMapId();
+  const overviewMap = useStoreMapOverviewMap();
+  const northArrow = useStoreMapNorthArrow();
+  const mapLoaded = useStoreMapLoaded();
+  const mapInteraction = useStoreMapInteraction();
+  const layersAreLoading = useStoreLayerAreLayersLoading();
 
   // flag to check if map is initialized. we added to prevent double rendering in StrictMode
   const hasRun = useRef<boolean>(false);

--- a/packages/geoview-core/src/core/components/mouse-position/mouse-position.tsx
+++ b/packages/geoview-core/src/core/components/mouse-position/mouse-position.tsx
@@ -4,7 +4,7 @@ import type { Coordinate } from 'ol/coordinate';
 import { useTheme } from '@mui/material/styles';
 import { Box, Button, CheckIcon } from '@/ui';
 
-import { useMapPointerPosition } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapPointerPosition } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { GeoUtilities } from '@/geo/utils/utilities';
 import { getSxClasses } from './mouse-position-style';
 
@@ -98,7 +98,7 @@ export const MousePosition = memo(function MousePosition({ expanded }: MousePosi
   const [positionMode, setPositionMode] = useState<number>(POSITION_MODES.DMS);
 
   // Store
-  const pointerPosition = useMapPointerPosition();
+  const pointerPosition = useStoreMapPointerPosition();
 
   /**
    * Formats position strings for all display modes.

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/basemap-select.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/basemap-select.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { createElement, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useMapHasGeoviewBasemapLayer, useMapBasemapOptions } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapHasGeoviewBasemapLayer, useStoreMapBasemapOptions } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
 import NavbarPanelButton from '@/core/components/nav-bar/nav-bar-panel-button';
 import type { TypeBasemapOptions } from '@/api/types/map-schema-types';
@@ -33,8 +33,8 @@ export default function BasemapSelect(): JSX.Element {
   const { t } = useTranslation<string>();
 
   // Get values from store
-  const configBasemapOptions = useMapBasemapOptions();
-  const hasGeoviewBasemapLayer = useMapHasGeoviewBasemapLayer();
+  const configBasemapOptions = useStoreMapBasemapOptions();
+  const hasGeoviewBasemapLayer = useStoreMapHasGeoviewBasemapLayer();
   const mapController = useMapController();
 
   // Check if the basemap from the config is one of our default basemaps.

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/fullscreen.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/fullscreen.tsx
@@ -4,8 +4,8 @@ import { useTheme } from '@mui/material/styles';
 import { IconButton, FullscreenIcon, FullscreenExitIcon } from '@/ui';
 import type { TypeHTMLElement } from '@/core/types/global-types';
 import { getSxClasses } from '@/core/components/nav-bar/nav-bar-style';
-import { useAppFullscreenActive } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreAppIsFullscreenActive } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
 import { useUIController } from '@/core/controllers/ui-controller';
 
@@ -18,14 +18,13 @@ export default function Fullscreen(): JSX.Element {
   // Log
   logger.logTraceRender('components/nav-bar/buttons/fullscreen');
 
-  const mapId = useGeoViewMapId();
-
   const { t } = useTranslation<string>();
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
 
   // get the values from store
-  const isFullScreen = useAppFullscreenActive();
+  const mapId = useStoreGeoViewMapId();
+  const isFullScreen = useStoreAppIsFullscreenActive();
   const uiController = useUIController();
 
   /**

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/home.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/home.tsx
@@ -20,7 +20,7 @@ export default function Home(): JSX.Element {
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
 
-  // Store actions
+  // Store
   const mapController = useMapController();
 
   /**

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/map-rotation.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/map-rotation.tsx
@@ -2,10 +2,10 @@ import type { ReactNode } from 'react';
 import { createElement, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  useMapRotation,
-  useMapFixNorth,
-  useMapNorthArrow,
-  useMapProjectionEPSG,
+  useStoreMapRotation,
+  useStoreMapFixNorth,
+  useStoreMapNorthArrow,
+  useStoreMapCurrentProjectionEPSG,
   setStoreMapFixNorth,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
@@ -17,7 +17,7 @@ import { useManageArrow } from '@/core/components/north-arrow/hooks/useManageArr
 import type { TypePanelProps } from '@/ui/panel/panel-types';
 import type { IconButtonPropsExtend } from '@/ui/icon-button/icon-button';
 import { IconButton } from '@/ui/icon-button/icon-button';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { useMapController } from '@/core/controllers/map-controller';
 
 /**
@@ -32,11 +32,11 @@ export default function MapRotation(): JSX.Element {
   const { t } = useTranslation<string>();
 
   // Get values from store
-  const mapId = useGeoViewMapId();
-  const mapRotation = useMapRotation();
-  const isFixNorth = useMapFixNorth();
-  const isNorthEnable = useMapNorthArrow();
-  const mapProjectionEPSG = useMapProjectionEPSG();
+  const mapId = useStoreGeoViewMapId();
+  const mapRotation = useStoreMapRotation();
+  const isFixNorth = useStoreMapFixNorth();
+  const isNorthEnable = useStoreMapNorthArrow();
+  const mapProjectionEPSG = useStoreMapCurrentProjectionEPSG();
   const { rotationAngle } = useManageArrow();
   const mapController = useMapController();
 

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/measurement.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/measurement.tsx
@@ -20,8 +20,8 @@ import { logger } from '@/core/utils/logger';
 import NavbarPanelButton from '@/core/components/nav-bar/nav-bar-panel-button';
 import { formatLength, formatArea } from '@/core/utils/utilities';
 import type { Draw } from '@/geo/interaction/draw';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
-import { useAppDisplayLanguage, useAppGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreAppDisplayLanguage, useStoreAppGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { GeoUtilities } from '@/geo/utils/utilities';
 import { useMapController } from '@/core/controllers/map-controller';
 
@@ -75,9 +75,9 @@ export default function Measurement(): JSX.Element {
   const { t } = useTranslation<string>();
 
   // Stores
-  const mapId = useGeoViewMapId();
-  const displayLanguage = useAppDisplayLanguage();
-  const mapElement = useAppGeoviewHTMLElement().querySelector(`[id^="mapTargetElement-${mapId}"]`) as HTMLElement;
+  const mapId = useStoreGeoViewMapId();
+  const displayLanguage = useStoreAppDisplayLanguage();
+  const mapElement = useStoreAppGeoviewHTMLElement().querySelector(`[id^="mapTargetElement-${mapId}"]`) as HTMLElement;
   const mapController = useMapController();
 
   // States

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/projection.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/projection.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { createElement, useCallback } from 'react';
-import { useMapProjection } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapCurrentProjection } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
 import NavbarPanelButton from '@/core/components/nav-bar/nav-bar-panel-button';
 import type { TypeValidMapProjectionCodes } from '@/api/types/map-schema-types';
@@ -35,7 +35,7 @@ export default function Projection(): JSX.Element {
   const { t } = useTranslation<string>();
 
   // Store
-  const projection = useMapProjection();
+  const projection = useStoreMapCurrentProjection();
   const mapController = useMapController();
 
   /**

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/zoom-in.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/zoom-in.tsx
@@ -2,7 +2,7 @@ import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { IconButton, ZoomInIcon } from '@/ui';
 import { getSxClasses } from '@/core/components/nav-bar/nav-bar-style';
-import { useMapZoom } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapZoom } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
 import { useMapController } from '@/core/controllers/map-controller';
 
@@ -20,7 +20,7 @@ export default function ZoomIn(): JSX.Element {
   const sxClasses = getSxClasses(theme);
 
   // get store values
-  const zoom = useMapZoom();
+  const zoom = useStoreMapZoom();
   const mapController = useMapController();
 
   return (

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/zoom-out.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/zoom-out.tsx
@@ -2,7 +2,7 @@ import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { IconButton, ZoomOutIcon } from '@/ui';
 import { getSxClasses } from '@/core/components/nav-bar/nav-bar-style';
-import { useMapZoom } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapZoom } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
 import { useMapController } from '@/core/controllers/map-controller';
 
@@ -20,7 +20,7 @@ export default function ZoomOut(): JSX.Element {
   const sxClasses = getSxClasses(theme);
 
   // get store values
-  const zoom = useMapZoom();
+  const zoom = useStoreMapZoom();
   const mapController = useMapController();
 
   return (

--- a/packages/geoview-core/src/core/components/nav-bar/nav-bar-panel-button.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/nav-bar-panel-button.tsx
@@ -5,12 +5,12 @@ import { useTranslation } from 'react-i18next';
 import { getSxClasses } from './nav-bar-style';
 import { Popper, IconButton, DialogTitle, DialogContent, Paper, Box } from '@/ui';
 import { CloseIcon } from '@/ui/icons';
-import { useAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
 import type { TypeButtonPanel } from '@/ui/panel/panel-types';
 import { logger } from '@/core/utils/logger';
 import { UseHtmlToReact } from '@/core/components/common/hooks/use-html-to-react';
 import { handleEscapeKey } from '@/core/utils/utilities';
-import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 
 /** The properties for the navbar panel button. */
 interface NavbarPanelButtonType {
@@ -36,8 +36,8 @@ export default function NavbarPanelButton({ buttonPanel, isActive = false }: Nav
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // Store
-  const activeTrapGeoView = useUIActiveTrapGeoView();
-  const shellContainer = useAppShellContainer();
+  const activeTrapGeoView = useStoreUIActiveTrapGeoView();
+  const shellContainer = useStoreAppShellContainer();
 
   // States
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);

--- a/packages/geoview-core/src/core/components/nav-bar/nav-bar.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/nav-bar.tsx
@@ -17,7 +17,7 @@ import type { TypeButtonPanel } from '@/ui/panel/panel-types';
 import { getSxClasses } from './nav-bar-style';
 import type { NavBarApi, NavBarCreatedEvent, NavBarRemovedEvent } from '@/core/components';
 import type { TypeValidNavBarProps } from '@/api/types/map-schema-types';
-import { useUINavbarComponents } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreUINavbarComponents } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { logger } from '@/core/utils/logger';
 import NavbarPanelButton from './nav-bar-panel-button';
 import { usePluginController } from '@/core/controllers/plugin-controller';
@@ -75,7 +75,7 @@ export function NavBar(props: NavBarProps): JSX.Element {
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // Store
-  const navBarComponents = useUINavbarComponents();
+  const navBarComponents = useStoreUINavbarComponents();
   const pluginController = usePluginController();
 
   // Ref

--- a/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
+++ b/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
@@ -2,13 +2,13 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Projection } from '@/geo/utils/projection';
 import { NORTH_POLE_POSITION } from '@/core/utils/constant';
 import {
-  useMapCenterCoordinates,
-  useMapFixNorth,
-  useMapNorthArrowElement,
-  useMapProjectionEPSG,
-  useMapRotation,
-  useMapSize,
-  useMapZoom,
+  useStoreMapCenterCoordinates,
+  useStoreMapFixNorth,
+  useStoreMapNorthArrowElement,
+  useStoreMapCurrentProjectionEPSG,
+  useStoreMapRotation,
+  useStoreMapSize,
+  useStoreMapZoom,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
 import { useMapController } from '@/core/controllers/map-controller';
@@ -36,13 +36,13 @@ export const useManageArrow = (): ArrowReturn => {
   const angle = useRef(0); // keep track of rotation angle for fix north
 
   // Store
-  const mapProjectionEPSG = useMapProjectionEPSG();
-  const northArrowElement = useMapNorthArrowElement();
-  const fixNorth = useMapFixNorth();
-  const mapZoom = useMapZoom();
-  const mapRotation = useMapRotation();
-  const mapCenterCoord = useMapCenterCoordinates();
-  const mapSize = useMapSize();
+  const mapProjectionEPSG = useStoreMapCurrentProjectionEPSG();
+  const northArrowElement = useStoreMapNorthArrowElement();
+  const fixNorth = useStoreMapFixNorth();
+  const mapZoom = useStoreMapZoom();
+  const mapRotation = useStoreMapRotation();
+  const mapCenterCoord = useStoreMapCenterCoordinates();
+  const mapSize = useStoreMapSize();
   const mapController = useMapController();
 
   /**

--- a/packages/geoview-core/src/core/components/north-arrow/north-arrow.tsx
+++ b/packages/geoview-core/src/core/components/north-arrow/north-arrow.tsx
@@ -8,12 +8,12 @@ import { NorthArrowIcon, NorthPoleIcon } from './north-arrow-icon';
 import { getSxClasses } from './north-arrow-style';
 import {
   setStoreMapOverlayNorthMarkerRef,
-  useMapNorthArrowElement,
-  useMapProjectionEPSG,
+  useStoreMapNorthArrowElement,
+  useStoreMapCurrentProjectionEPSG,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 
 import { useManageArrow } from './hooks/useManageArrow';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
 import { TIMEOUT } from '@/core/utils/constant';
 
@@ -35,8 +35,8 @@ export const NorthArrow = memo(function NorthArrow(): JSX.Element {
   const northArrowRef = useRef<HTMLDivElement>(null);
 
   // Store
-  const mapProjectionEPSG = useMapProjectionEPSG();
-  const northArrowElement = useMapNorthArrowElement();
+  const mapProjectionEPSG = useStoreMapCurrentProjectionEPSG();
+  const northArrowElement = useStoreMapNorthArrowElement();
   const { rotationAngle, northOffset } = useManageArrow();
 
   /**
@@ -77,12 +77,12 @@ export const NorthArrow = memo(function NorthArrow(): JSX.Element {
  */
 export const NorthPoleFlag = memo(function NorthPoleFlag(): JSX.Element {
   // State
-  const mapId = useGeoViewMapId();
-  const northPoleId = `${mapId}-northpole`;
   const northPoleRef = useRef<HTMLDivElement | null>(null);
 
   // Store
-  const mapProjectionEPSG = useMapProjectionEPSG();
+  const mapId = useStoreGeoViewMapId();
+  const northPoleId = `${mapId}-northpole`;
+  const mapProjectionEPSG = useStoreMapCurrentProjectionEPSG();
   setTimeout(() => setStoreMapOverlayNorthMarkerRef(mapId, northPoleRef.current as HTMLElement), TIMEOUT.deferExecution); // set marker reference
 
   const isVisible = mapProjectionEPSG === Projection.PROJECTION_NAMES.LCC;

--- a/packages/geoview-core/src/core/components/notifications/notifications.tsx
+++ b/packages/geoview-core/src/core/components/notifications/notifications.tsx
@@ -21,13 +21,13 @@ import {
   List,
 } from '@/ui';
 import { getSxClasses } from './notifications-style';
-import { useAppNotifications } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreAppNotifications } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
-import { useMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { useShake } from '@/core/utils/useSpringAnimations';
 import { handleEscapeKey } from '@/core/utils/utilities';
-import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import type { SxStyles } from '@/ui/style/types';
 import { CONTAINER_TYPE, TIMEOUT } from '@/core/utils/constant';
 import { useUIController } from '@/core/controllers/ui-controller';
@@ -199,13 +199,13 @@ export default memo(function Notifications(): JSX.Element {
   const [open, setOpen] = useState(false);
 
   // Store
-  const notifications = useAppNotifications();
-  const interaction = useMapInteraction();
-  const activeTrapGeoView = useUIActiveTrapGeoView();
+  const notifications = useStoreAppNotifications();
+  const interaction = useStoreMapInteraction();
+  const activeTrapGeoView = useStoreUIActiveTrapGeoView();
   const uiController = useUIController();
 
   // Get container
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
   const mapElem = document.getElementById(`shell-${mapId}`);
 
   // Animation

--- a/packages/geoview-core/src/core/components/overview-map/overview-map.tsx
+++ b/packages/geoview-core/src/core/components/overview-map/overview-map.tsx
@@ -8,8 +8,8 @@ import { ThemeProvider } from '@mui/material/styles';
 
 import { cgpvTheme } from '@/ui/style/theme';
 import { OverviewMapToggle } from './overview-map-toggle';
-import { useAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { useMapOverviewMapHideZoom, useMapZoom } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreMapOverviewMapHideZoom, useStoreMapZoom } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
 import { Box } from '@/ui/layout';
 import { TIMEOUT } from '@/core/utils/constant';
@@ -32,9 +32,9 @@ export function OverviewMap(props: OverviewMapProps): JSX.Element {
   logger.logTraceRender('components/overview-map/overview-map');
 
   // Store
-  const zoomLevel = useMapZoom();
-  const hideOnZoom = useMapOverviewMapHideZoom();
-  const displayLanguage = useAppDisplayLanguage();
+  const zoomLevel = useStoreMapZoom();
+  const hideOnZoom = useStoreMapOverviewMapHideZoom();
+  const displayLanguage = useStoreAppDisplayLanguage();
   const { i18n } = props;
   const mapController = useMapController();
 

--- a/packages/geoview-core/src/core/components/scale/scale.tsx
+++ b/packages/geoview-core/src/core/components/scale/scale.tsx
@@ -6,8 +6,8 @@ import { useTheme } from '@mui/material/styles';
 
 import { CheckIcon, Tooltip, Box, Button } from '@/ui';
 import { getSxClasses } from './scale-style';
-import { useMapInteraction, useMapScale } from '@/core/stores/store-interface-and-intial-values/map-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreMapInteraction, useStoreMapScale } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
 
 /** The properties for the scale component. */
@@ -56,9 +56,9 @@ export const Scale = memo(function Scale({ expanded }: ScaleProps): JSX.Element 
   const [scaleMode, setScaleMode] = useState<number>(SCALE_MODES.METRIC);
 
   // Store
-  const mapId = useGeoViewMapId();
-  const scale = useMapScale();
-  const interaction = useMapInteraction();
+  const mapId = useStoreGeoViewMapId();
+  const scale = useStoreMapScale();
+  const interaction = useStoreMapInteraction();
 
   /**
    * Builds the list of scale display options.

--- a/packages/geoview-core/src/core/components/toggle-all/toggle-all.tsx
+++ b/packages/geoview-core/src/core/components/toggle-all/toggle-all.tsx
@@ -4,12 +4,12 @@ import { useCallback } from 'react';
 import { Box, Switch, Tooltip } from '@/ui';
 import {
   setStoreMapAllMapLayerCollapsed,
-  useMapAllLayersCollapsedToggle,
-  useMapAllLayersVisibleToggle,
-  useMapHasCollapsibleLayersToggle,
+  useStoreMapAllLayersCollapsedToggle,
+  useStoreMapAllLayersVisibleToggle,
+  useStoreMapHasCollapsibleLayersToggle,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
-import { useLayerDisplayState, useLayerAreLayersLoading } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreLayerDisplayState, useStoreLayerAreLayersLoading } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
 
 import type { TypeContainerBox } from '@/core/types/global-types';
@@ -46,13 +46,13 @@ export function ToggleAll({ source, containerType }: ToggleAllProps): JSX.Elemen
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
   const { t } = useTranslation<string>();
-  const mapId = useGeoViewMapId();
+  const mapId = useStoreGeoViewMapId();
 
-  const displayState = useLayerDisplayState();
-  const allLayersVisible = useMapAllLayersVisibleToggle();
-  const allLayersCollapsed = useMapAllLayersCollapsedToggle();
-  const layersAreLoading = useLayerAreLayersLoading();
-  const hasCollapsibleLayers = useMapHasCollapsibleLayersToggle();
+  const displayState = useStoreLayerDisplayState();
+  const allLayersVisible = useStoreMapAllLayersVisibleToggle();
+  const allLayersCollapsed = useStoreMapAllLayersCollapsedToggle();
+  const layersAreLoading = useStoreLayerAreLayersLoading();
+  const hasCollapsibleLayers = useStoreMapHasCollapsibleLayersToggle();
   const mapController = useMapController();
 
   /**

--- a/packages/geoview-core/src/core/components/toggle-all/toggle-all.tsx
+++ b/packages/geoview-core/src/core/components/toggle-all/toggle-all.tsx
@@ -46,8 +46,9 @@ export function ToggleAll({ source, containerType }: ToggleAllProps): JSX.Elemen
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
   const { t } = useTranslation<string>();
-  const mapId = useStoreGeoViewMapId();
 
+  // Store
+  const mapId = useStoreGeoViewMapId();
   const displayState = useStoreLayerDisplayState();
   const allLayersVisible = useStoreMapAllLayersVisibleToggle();
   const allLayersCollapsed = useStoreMapAllLayersCollapsedToggle();

--- a/packages/geoview-core/src/core/containers/focus-trap.tsx
+++ b/packages/geoview-core/src/core/containers/focus-trap.tsx
@@ -9,8 +9,8 @@ import { UseHtmlToReact } from '@/core/components/common/hooks/use-html-to-react
 import { getFocusTrapSxClasses } from './containers-style';
 import { ARROW_KEY_CODES } from '@/core/utils/constant';
 import { logger } from '@/core/utils/logger';
-import { useAppGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreAppGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { useEventListener } from '@/core/components/common/hooks/use-event-listener';
 
 /** Interface for the focus trap properties. */
@@ -54,10 +54,10 @@ export function FocusTrapDialog(props: FocusTrapProps): JSX.Element {
   // Store
   // tracks if the last action was done through a keyboard (map navigation) or mouse (mouse movement)
   const uiController = useUIController();
-  const activeTrapGeoView = useUIActiveTrapGeoView();
+  const activeTrapGeoView = useStoreUIActiveTrapGeoView();
 
   // Get container and fullscreen state
-  const geoviewElement = useAppGeoviewHTMLElement();
+  const geoviewElement = useStoreAppGeoviewHTMLElement();
   const mapElementStore = geoviewElement.querySelector('[id^="mapTargetElement-"]') as HTMLElement;
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
 

--- a/packages/geoview-core/src/core/containers/shell.tsx
+++ b/packages/geoview-core/src/core/containers/shell.tsx
@@ -14,23 +14,23 @@ import type { TypeModalProps, ModalApi, ModalEvent } from '@/ui';
 import { Box, CircularProgress, Link, Modal, Snackbar, Button } from '@/ui';
 import { getShellSxClasses } from './containers-style';
 import { useUIController } from '@/core/controllers/ui-controller';
-import { useMapInteraction, useMapLoaded } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapInteraction, useStoreMapLoaded } from '@/core/stores/store-interface-and-intial-values/map-state';
 import {
-  useAppCircularProgressActive,
-  useAppFullscreenActive,
-  useAppGeoviewHTMLElement,
-  useAppHeight,
+  useStoreAppIsCircularProgressActive,
+  useStoreAppIsFullscreenActive,
+  useStoreAppGeoviewHTMLElement,
+  useStoreAppHeight,
 } from '@/core/stores/store-interface-and-intial-values/app-state';
 import {
-  useUIActiveFocusItem,
-  useUIActiveTrapGeoView,
-  useUIFooterPanelResizeValue,
-  useUIActiveFooterBarTab,
+  useStoreUIActiveFocusItem,
+  useStoreUIActiveTrapGeoView,
+  useStoreUIFooterPanelResizeValue,
+  useStoreUIActiveFooterBarTab,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import ExportModal from '@/core/components/export/export-modal';
 import DataTableModal from '@/core/components/data-table/data-table-modal';
 import FeatureDetailModal from '@/core/components/details/feature-detail-modal';
-import { useGeoViewConfig } from '@/core/stores/geoview-store';
+import { useStoreGeoViewConfig } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
 import type { MapViewer, MapComponentAddedEvent, MapComponentRemovedEvent } from '@/geo/map/map-viewer';
 
@@ -82,19 +82,19 @@ export function Shell(props: ShellProps): JSX.Element {
   const [snackbarButton, setSnackbarButton] = useState<JSX.Element>();
 
   // Store
-  const mapLoaded = useMapLoaded();
-  const circularProgressActive = useAppCircularProgressActive();
-  const activeTrapGeoView = useUIActiveTrapGeoView();
-  const interaction = useMapInteraction();
-  const geoviewConfig = useGeoViewConfig();
-  const focusItem = useUIActiveFocusItem();
-  const uiController = useUIController();
-  const isMapFullScreen = useAppFullscreenActive();
-  const footerPanelResizeValue = useUIFooterPanelResizeValue();
-  const { isOpen } = useUIActiveFooterBarTab();
-  const geoviewElement = useAppGeoviewHTMLElement();
-  const appHeight = useAppHeight();
+  const mapLoaded = useStoreMapLoaded();
+  const circularProgressActive = useStoreAppIsCircularProgressActive();
+  const activeTrapGeoView = useStoreUIActiveTrapGeoView();
+  const interaction = useStoreMapInteraction();
+  const geoviewConfig = useStoreGeoViewConfig();
+  const focusItem = useStoreUIActiveFocusItem();
+  const isMapFullScreen = useStoreAppIsFullscreenActive();
+  const footerPanelResizeValue = useStoreUIFooterPanelResizeValue();
+  const { isOpen } = useStoreUIActiveFooterBarTab();
+  const geoviewElement = useStoreAppGeoviewHTMLElement();
+  const appHeight = useStoreAppHeight();
   const footerTabContainer = geoviewElement.querySelector(`[id^="${mapId}-tabsContainer"]`) as HTMLElement;
+  const uiController = useUIController();
 
   // SxClasses
   const sxClasses = useMemo(() => getShellSxClasses(theme, appHeight), [theme, appHeight]);

--- a/packages/geoview-core/src/core/controllers/drawer-controller.ts
+++ b/packages/geoview-core/src/core/controllers/drawer-controller.ts
@@ -17,17 +17,17 @@ import { getGeoViewStore } from '@/core/stores/stores-managers';
 import {
   DEFAULT_TEXT_VALUES,
   isStoreDrawerInitialized,
-  getStoreActiveGeom,
-  getStoreDrawInstance,
-  getStoreHideMeasurements,
-  getStoreIconSrc,
-  getStoreIsDrawing,
-  getStoreIsEditing,
-  getStoreIsSnapping,
-  getStoreSelectedDrawing,
-  getStoreSnapInstance,
-  getStoreStyle,
-  getStoreTransformInstance,
+  getStoreDrawerActiveGeom,
+  getStoreDrawerDrawInstance,
+  getStoreDrawerHideMeasurements,
+  getStoreDrawerIconSrc,
+  getStoreDrawerIsDrawing,
+  getStoreDrawerIsEditing,
+  getStoreDrawerIsSnapping,
+  getStoreDrawerSelectedDrawing,
+  getStoreDrawerSnapInstance,
+  getStoreDrawerStyle,
+  getStoreDrawerTransformInstance,
   removeStoreDrawInstance,
   removeStoreSnapInstance,
   removeStoreTransformInstance,
@@ -67,7 +67,7 @@ import type { Draw } from '@/geo/interaction/draw';
 import { formatArea, formatLength, generateId } from '@/core/utils/utilities';
 import { GeoUtilities } from '@/geo/utils/utilities';
 import type { TypeDisplayLanguage, TypeValidMapProjectionCodes } from '@/api/types/map-schema-types';
-import { getStoreDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { getStoreAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
 import Collection from 'ol/Collection';
 import { Projection } from '@/geo/utils/projection';
 import { getArea, getLength } from 'ol/sphere';
@@ -211,26 +211,26 @@ export class DrawerController extends AbstractMapViewerController {
 
     // Get the map viewer instance and stop map pointer events if not already stopped
     const viewer = this.getMapViewer();
-    if (!getStoreIsEditing(mapId)) {
+    if (!getStoreDrawerIsEditing(mapId)) {
       viewer.unregisterMapPointerHandlers(viewer.map);
     }
 
     // If editing already, stop it
     // GV Moved the stop editing up so the rotation is set properly for any active text drawing
-    if (getStoreIsEditing(mapId)) {
+    if (getStoreDrawerIsEditing(mapId)) {
       this.stopEditing();
     }
 
     // Get current state values if not provided
-    const currentGeomType = geomType || getStoreActiveGeom(mapId);
-    const currentStyle = styleInput || getStoreStyle(mapId);
+    const currentGeomType = geomType || getStoreDrawerActiveGeom(mapId);
+    const currentStyle = styleInput || getStoreDrawerStyle(mapId);
 
     // Make new text horizontal, regardless of what the state rotation was
     // GV If a style input is added for the rotation, then this can be removed
     currentStyle.textRotation = 0;
 
     // If drawing already, stop and restart as it's likely a style change
-    if (getStoreDrawInstance(mapId)) {
+    if (getStoreDrawerDrawInstance(mapId)) {
       this.stopDrawing();
     }
 
@@ -263,7 +263,7 @@ export class DrawerController extends AbstractMapViewerController {
       this.setActiveGeom(geomType);
     }
 
-    if (getStoreIsSnapping(mapId)) {
+    if (getStoreDrawerIsSnapping(mapId)) {
       this.refreshSnappingInstance();
     }
   }
@@ -281,12 +281,12 @@ export class DrawerController extends AbstractMapViewerController {
     if (!isStoreDrawerInitialized(mapId)) return;
 
     // Restart Map Pointer handlers that place the details icon when clicking on the map
-    if (!getStoreIsEditing(mapId)) {
+    if (!getStoreDrawerIsEditing(mapId)) {
       const viewer = this.getMapViewer();
       viewer.registerMapPointerHandlers(viewer.map);
     }
 
-    getStoreDrawInstance(mapId)?.stopInteraction();
+    getStoreDrawerDrawInstance(mapId)?.stopInteraction();
 
     // Update state
     removeStoreDrawInstance(mapId);
@@ -301,7 +301,7 @@ export class DrawerController extends AbstractMapViewerController {
 
     if (!isStoreDrawerInitialized(mapId)) return;
 
-    if (getStoreIsDrawing(mapId)) {
+    if (getStoreDrawerIsDrawing(mapId)) {
       this.stopDrawing();
     } else {
       this.startDrawing();
@@ -328,11 +328,11 @@ export class DrawerController extends AbstractMapViewerController {
     // Get the geometry api
     const geometryApi = this.getGeometryApi();
 
-    if (!getStoreIsDrawing(mapId)) {
+    if (!getStoreDrawerIsDrawing(mapId)) {
       viewer.unregisterMapPointerHandlers(viewer.map);
     }
 
-    const oldTransformInstance = getStoreTransformInstance(mapId);
+    const oldTransformInstance = getStoreDrawerTransformInstance(mapId);
 
     // If editing already, stop and restart as it's likely a style change
     if (oldTransformInstance) {
@@ -360,12 +360,12 @@ export class DrawerController extends AbstractMapViewerController {
     }
 
     // If we have an active drawing instance, stop it
-    const drawInstance = getStoreDrawInstance(mapId);
+    const drawInstance = getStoreDrawerDrawInstance(mapId);
     if (drawInstance) {
       this.stopDrawing();
     }
 
-    if (getStoreIsSnapping(mapId)) {
+    if (getStoreDrawerIsSnapping(mapId)) {
       this.refreshSnappingInstance();
     }
   }
@@ -379,12 +379,12 @@ export class DrawerController extends AbstractMapViewerController {
 
     if (!isStoreDrawerInitialized(mapId)) return;
 
-    if (!getStoreIsDrawing(mapId)) {
+    if (!getStoreDrawerIsDrawing(mapId)) {
       const viewer = this.getMapViewer();
       viewer.registerMapPointerHandlers(viewer.map);
     }
 
-    const transformInstance = getStoreTransformInstance(mapId);
+    const transformInstance = getStoreDrawerTransformInstance(mapId);
 
     if (!transformInstance) return;
     transformInstance.stopInteraction();
@@ -400,7 +400,7 @@ export class DrawerController extends AbstractMapViewerController {
 
     if (!isStoreDrawerInitialized(mapId)) return;
 
-    const isEditing = getStoreIsEditing(mapId);
+    const isEditing = getStoreDrawerIsEditing(mapId);
     if (isEditing) {
       this.stopEditing();
     } else {
@@ -435,7 +435,7 @@ export class DrawerController extends AbstractMapViewerController {
 
     if (!isStoreDrawerInitialized(mapId)) return;
 
-    const snapInstance = getStoreSnapInstance(mapId);
+    const snapInstance = getStoreDrawerSnapInstance(mapId);
     snapInstance?.stopInteraction();
 
     removeStoreSnapInstance(mapId);
@@ -449,7 +449,7 @@ export class DrawerController extends AbstractMapViewerController {
     const mapId = this.getMapId();
     if (!isStoreDrawerInitialized(mapId)) return;
 
-    const isSnapping = getStoreIsSnapping(mapId);
+    const isSnapping = getStoreDrawerIsSnapping(mapId);
     if (isSnapping) {
       this.stopSnapping();
     } else {
@@ -503,7 +503,7 @@ export class DrawerController extends AbstractMapViewerController {
     // Delete all geometries from the group
     this.getGeometryApi().deleteGeometriesFromGroup(DrawerController.DRAW_GROUP_KEY);
 
-    if (getStoreIsEditing(mapId)) {
+    if (getStoreDrawerIsEditing(mapId)) {
       this.stopEditing();
     }
   }
@@ -519,13 +519,13 @@ export class DrawerController extends AbstractMapViewerController {
     if (!isStoreDrawerInitialized(mapId)) return;
 
     // If drawing, restart drawing to set the style
-    if (getStoreIsDrawing(mapId)) {
+    if (getStoreDrawerIsDrawing(mapId)) {
       this.startDrawing();
     }
 
     // If editing, restart editing
     // Do this after the start drawing so the group is created if missing
-    if (getStoreIsEditing(mapId)) {
+    if (getStoreDrawerIsEditing(mapId)) {
       this.stopEditing();
       this.startEditing();
     }
@@ -541,7 +541,7 @@ export class DrawerController extends AbstractMapViewerController {
 
     if (!isStoreDrawerInitialized(mapId)) return;
 
-    if (getStoreIsSnapping(mapId)) {
+    if (getStoreDrawerIsSnapping(mapId)) {
       this.stopSnapping();
       this.startSnapping();
     }
@@ -557,8 +557,8 @@ export class DrawerController extends AbstractMapViewerController {
 
     if (!isStoreDrawerInitialized(mapId)) return;
 
-    const hideMeasurements = getStoreHideMeasurements(mapId);
-    const selectedDrawingId = getStoreSelectedDrawing(mapId)?.getId();
+    const hideMeasurements = getStoreDrawerHideMeasurements(mapId);
+    const selectedDrawingId = getStoreDrawerSelectedDrawing(mapId)?.getId();
 
     // Get all overlays, ignoring currently selected features
     const features = this.#getDrawingFeatures();
@@ -809,11 +809,11 @@ export class DrawerController extends AbstractMapViewerController {
     const mapId = this.getMapId();
 
     // Refresh the draw instance with the new style
-    if (getStoreDrawInstance(mapId) !== undefined) {
+    if (getStoreDrawerDrawInstance(mapId) !== undefined) {
       this.startDrawing();
     }
 
-    this.updateTransformingFeatureStyle(getStoreStyle(mapId));
+    this.updateTransformingFeatureStyle(getStoreDrawerStyle(mapId));
   }
 
   /**
@@ -827,7 +827,7 @@ export class DrawerController extends AbstractMapViewerController {
 
     if (!isStoreDrawerInitialized(mapId)) return;
 
-    const transformInstance = getStoreTransformInstance(mapId);
+    const transformInstance = getStoreDrawerTransformInstance(mapId);
     if (!transformInstance) return;
 
     const selectedFeature = transformInstance.getSelectedFeature();
@@ -853,7 +853,7 @@ export class DrawerController extends AbstractMapViewerController {
         geomType = 'Point';
         featureStyle = new Style({
           image: new OLIcon({
-            src: getStoreIconSrc(mapId),
+            src: getStoreDrawerIconSrc(mapId),
             anchor: [0.5, 1],
             anchorXUnits: 'fraction',
             anchorYUnits: 'fraction',
@@ -885,7 +885,7 @@ export class DrawerController extends AbstractMapViewerController {
       }
 
       // Set the new feature properties and style
-      DrawerController.#setFeatureProperties(selectedFeature, geomType, newStyle, getStoreIconSrc(mapId));
+      DrawerController.#setFeatureProperties(selectedFeature, geomType, newStyle, getStoreDrawerIconSrc(mapId));
       selectedFeature.setStyle(featureStyle);
     }
   }
@@ -906,7 +906,7 @@ export class DrawerController extends AbstractMapViewerController {
     if (!isStoreDrawerInitialized(mapId)) return false;
 
     // If editing, undo the transform instance
-    const transformInstance = getStoreTransformInstance(mapId);
+    const transformInstance = getStoreDrawerTransformInstance(mapId);
     if (transformInstance && transformInstance.getSelectedFeature()) {
       if (transformInstance.canUndo()) {
         return transformInstance.undo(() => {
@@ -963,7 +963,7 @@ export class DrawerController extends AbstractMapViewerController {
     if (!isStoreDrawerInitialized(mapId)) return false;
 
     // If editing, redo the transform instance
-    const transformInstance = getStoreTransformInstance(mapId);
+    const transformInstance = getStoreDrawerTransformInstance(mapId);
     if (transformInstance && transformInstance.getSelectedFeature()) {
       if (transformInstance.canRedo()) {
         return transformInstance.redo(() => {
@@ -1209,8 +1209,8 @@ export class DrawerController extends AbstractMapViewerController {
           // Add overlays to non-point features
           if (!(olGeometry instanceof Point)) {
             // GV hideMeasurements has to be here, otherwise the value can be stale, unlike style and geomType which restart the interaction
-            const hideMeasurements = getStoreHideMeasurements(mapId);
-            const newOverlay = DrawerController.#createMeasureTooltip(feature, hideMeasurements, getStoreDisplayLanguage(mapId));
+            const hideMeasurements = getStoreDrawerHideMeasurements(mapId);
+            const newOverlay = DrawerController.#createMeasureTooltip(feature, hideMeasurements, getStoreAppDisplayLanguage(mapId));
             if (newOverlay) {
               viewer.map.addOverlay(newOverlay);
             }
@@ -1302,7 +1302,7 @@ export class DrawerController extends AbstractMapViewerController {
 
     // Check if state exist and if draw instance is enable, solve error when switch lang and no draw instance
     if (!isStoreDrawerInitialized(mapId)) return [];
-    if (!getStoreDrawInstance(mapId)) return [];
+    if (!getStoreDrawerDrawInstance(mapId)) return [];
 
     // Get features from drawing group
     const geometryGroup = this.#geometryApi.getGeometryGroup(DrawerController.DRAW_GROUP_KEY);
@@ -1379,7 +1379,7 @@ export class DrawerController extends AbstractMapViewerController {
       this.getGeometryApi().addToGeometryGroup(feature, DrawerController.DRAW_GROUP_KEY);
 
       // Add to transform instance if editing is active
-      const transformInstance = getStoreTransformInstance(mapId);
+      const transformInstance = getStoreDrawerTransformInstance(mapId);
       if (transformInstance) {
         transformInstance.addFeature(feature);
       }
@@ -1387,7 +1387,7 @@ export class DrawerController extends AbstractMapViewerController {
       // Recreate measurement overlay
       const geom = feature.getGeometry();
       if (geom && !(geom instanceof Point)) {
-        const overlay = DrawerController.#createMeasureTooltip(feature, false, getStoreDisplayLanguage(mapId));
+        const overlay = DrawerController.#createMeasureTooltip(feature, false, getStoreAppDisplayLanguage(mapId));
         if (overlay) viewer.map.addOverlay(overlay);
       }
     });
@@ -1454,7 +1454,7 @@ export class DrawerController extends AbstractMapViewerController {
           // Recreate measurement overlay only if geometry changed
           const geom = currentFeature.getGeometry();
           if (geom && !(geom instanceof Point)) {
-            const overlay = DrawerController.#createMeasureTooltip(currentFeature, false, getStoreDisplayLanguage(mapId));
+            const overlay = DrawerController.#createMeasureTooltip(currentFeature, false, getStoreAppDisplayLanguage(mapId));
             if (overlay) viewer.map.addOverlay(overlay);
           }
         }
@@ -1489,7 +1489,7 @@ export class DrawerController extends AbstractMapViewerController {
           // Recreate overlay
           const geom = currentFeature.getGeometry();
           if (geom && !(geom instanceof Point)) {
-            const overlay = DrawerController.#createMeasureTooltip(currentFeature, false, getStoreDisplayLanguage(mapId));
+            const overlay = DrawerController.#createMeasureTooltip(currentFeature, false, getStoreAppDisplayLanguage(mapId));
             if (overlay) viewer.map.addOverlay(overlay);
           }
         }
@@ -1515,7 +1515,7 @@ export class DrawerController extends AbstractMapViewerController {
 
     if (!isStoreDrawerInitialized(mapId)) return;
 
-    const transformInstance = getStoreTransformInstance(mapId);
+    const transformInstance = getStoreDrawerTransformInstance(mapId);
     if (transformInstance) {
       transformInstance.selectFeature(action.features[0], false);
     }
@@ -1531,8 +1531,8 @@ export class DrawerController extends AbstractMapViewerController {
 
     if (!isStoreDrawerInitialized(mapId)) return;
 
-    const transformInstance = getStoreTransformInstance(mapId);
-    if (transformInstance && getStoreSelectedDrawing(mapId)) {
+    const transformInstance = getStoreDrawerTransformInstance(mapId);
+    if (transformInstance && getStoreDrawerSelectedDrawing(mapId)) {
       const undoDisabled = !transformInstance.canUndo();
       const redoDisabled = !transformInstance.canRedo();
 
@@ -1610,8 +1610,8 @@ export class DrawerController extends AbstractMapViewerController {
     return (_sender: unknown, event: DrawEvent): void => {
       if (!isStoreDrawerInitialized(mapId)) return;
 
-      const currentGeomType = getStoreActiveGeom(mapId);
-      const currentStyle = getStoreStyle(mapId);
+      const currentGeomType = getStoreDrawerActiveGeom(mapId);
+      const currentStyle = getStoreDrawerStyle(mapId);
 
       const viewer = this.getMapViewer();
       const { feature } = event;
@@ -1626,7 +1626,7 @@ export class DrawerController extends AbstractMapViewerController {
         // For points, use a circle style
         featureStyle = new Style({
           image: new OLIcon({
-            src: getStoreIconSrc(mapId),
+            src: getStoreDrawerIconSrc(mapId),
             anchor: [0.5, 1], // 50% of X = Middle, 100% Y = Bottom
             anchorXUnits: 'fraction',
             anchorYUnits: 'fraction',
@@ -1666,13 +1666,13 @@ export class DrawerController extends AbstractMapViewerController {
       feature.setStyle(featureStyle);
 
       // Set the feature properties for proper download / upload
-      DrawerController.#setFeatureProperties(feature, currentGeomType, currentStyle, getStoreIconSrc(mapId));
+      DrawerController.#setFeatureProperties(feature, currentGeomType, currentStyle, getStoreDrawerIconSrc(mapId));
 
       // Add overlays to non-point features
       if (!(geom instanceof Point)) {
         // GV hideMeasurements has to be here, otherwise the value can be stale, unlike style and geomType which restart the interaction
-        const hideMeasurements = getStoreHideMeasurements(mapId);
-        const newOverlay = DrawerController.#createMeasureTooltip(feature, hideMeasurements, getStoreDisplayLanguage(mapId));
+        const hideMeasurements = getStoreDrawerHideMeasurements(mapId);
+        const newOverlay = DrawerController.#createMeasureTooltip(feature, hideMeasurements, getStoreAppDisplayLanguage(mapId));
         if (newOverlay) {
           viewer.map.addOverlay(newOverlay);
         }
@@ -1688,7 +1688,7 @@ export class DrawerController extends AbstractMapViewerController {
 
       // For text features, create a temporary transform for immediate editing
       if (currentGeomType === 'Text') {
-        const drawInstance = getStoreDrawInstance(mapId);
+        const drawInstance = getStoreDrawerDrawInstance(mapId);
         drawInstance?.stopInteraction();
 
         const featureCollection = new Collection([feature]); // Only select this specific feature
@@ -1776,7 +1776,7 @@ export class DrawerController extends AbstractMapViewerController {
       if (geom instanceof Point) return;
 
       // Update the overlay with new values
-      DrawerController.#createMeasureTooltip(feature, true, getStoreDisplayLanguage(mapId));
+      DrawerController.#createMeasureTooltip(feature, true, getStoreAppDisplayLanguage(mapId));
 
       // Update the undo redo state
       this.#updateUndoRedoState();
@@ -1821,7 +1821,7 @@ export class DrawerController extends AbstractMapViewerController {
       // GV Get hideMeasurements here so the value is not stale
       let hideMeasurements = false;
       if (isStoreDrawerInitialized(mapId)) {
-        hideMeasurements = getStoreHideMeasurements(mapId);
+        hideMeasurements = getStoreDrawerHideMeasurements(mapId);
       }
 
       const { previousFeature, newFeature, createSelectAction } = event;
@@ -1897,7 +1897,7 @@ export class DrawerController extends AbstractMapViewerController {
 
         if (!isStoreDrawerInitialized(mapId)) return;
 
-        const featureProperties = DrawerController.#getFeatureProperties(newFeature, getStoreStyle(mapId));
+        const featureProperties = DrawerController.#getFeatureProperties(newFeature, getStoreDrawerStyle(mapId));
         updateStoreStateStyle(mapId, featureProperties);
       }
 

--- a/packages/geoview-core/src/core/controllers/layer-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-controller.ts
@@ -19,9 +19,9 @@ import { LayerNotEsriDynamicError, LayerNotGeoJsonError, LayerWrongTypeError } f
 import { useControllers } from '@/core/controllers/base/controller-manager';
 import {
   getStoreLayerMosaicRule,
-  getStoreLayerStateHighlightedLayer,
-  getStoreLayerStateLegendLayerByPath,
-  getStoreLayerStateLegendLayers,
+  getStoreLayerHighlightedLayer,
+  getStoreLayerLegendLayerByPath,
+  getStoreLayerLegendLayers,
   setStoreHighlightedLayer,
   setStoreLayerBoundsForLayerAndParentsAndForget,
   setStoreLayerDateTemporal,
@@ -1033,10 +1033,10 @@ export class LayerController extends AbstractMapViewerController {
 
     // Get legend layers and legend layer to update
     // GV This object is about to get mutated multiple times, that's why we can use it to set legend layers later... (pattern should be changed..)
-    const curLayers = getStoreLayerStateLegendLayers(this.getMapId());
+    const curLayers = getStoreLayerLegendLayers(this.getMapId());
 
     // Get the particular object holding the items array itself from the store
-    const layerStore = getStoreLayerStateLegendLayerByPath(this.getMapId(), layerPath)!;
+    const layerStore = getStoreLayerLegendLayerByPath(this.getMapId(), layerPath)!;
 
     const itemsToggled: TypeLegendItem[] = [];
     try {
@@ -1114,7 +1114,7 @@ export class LayerController extends AbstractMapViewerController {
    */
   setHighlightLayer(layerPath: string): void {
     // Get highlighted layer to set active button state because there can only be one highlighted layer at a time.
-    const currentHighlight = getStoreLayerStateHighlightedLayer(this.getMapId());
+    const currentHighlight = getStoreLayerHighlightedLayer(this.getMapId());
 
     // Highlight layer and get new highlighted layer path from map controller.
     const highlightedLayerpath = this.getControllersRegistry().mapController.changeOrRemoveLayerHighlight(layerPath, currentHighlight);

--- a/packages/geoview-core/src/core/controllers/layer-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-controller.ts
@@ -551,7 +551,7 @@ export class LayerController extends AbstractMapViewerController {
    *
    * @param layerPath - The layer path to the layer's configuration.
    * @param timeout - Optionally indicate the timeout after which time to abandon the promise
-   * @param checkFrequency - Optionally indicate the frequency at which to check for the condition on the layerabstract
+   * @param checkFrequency - Optionally indicate the frequency at which to check for the condition on the layer
    * @returns A promise that resolves to an OpenLayer layer associated to the layer path.
    */
   getOLLayerAsync(layerPath: string, timeout?: number, checkFrequency?: number): Promise<BaseLayer> {

--- a/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
@@ -41,6 +41,10 @@ import { LayerEntryConfigError } from '@/core/exceptions/layer-entry-config-exce
 import { LayerCreatedTwiceError } from '@/core/exceptions/layer-exceptions';
 import { getStoreAppDisplayDateMode } from '@/core/stores/store-interface-and-intial-values/app-state';
 import {
+  getStoreLayerSelectedLayerPath,
+  setStoreLayerSelectedLayersTabLayer,
+} from '@/core/stores/store-interface-and-intial-values/layer-state';
+import {
   addStoreGeochartChart,
   isStoreGeochartInitialized,
   removeStoreGeochartChart,
@@ -583,6 +587,13 @@ export class LayerCreatorController extends AbstractMapViewerController {
 
       // Log
       logger.logInfo(`Layer removed for ${layerPath}`);
+
+      // Clear the selected path if it was set to it
+      const currentlySelectedLayerPath = getStoreLayerSelectedLayerPath(this.getMapId());
+      if (layerPath === currentlySelectedLayerPath) {
+        // Clear it
+        setStoreLayerSelectedLayersTabLayer(this.getMapId(), '');
+      }
 
       // Redirect to feature info delete
       deleteStoreDetailsFeatureInfo(this.getMapId(), layerPath);

--- a/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
@@ -39,7 +39,7 @@ import { formatError, NotSupportedError } from '@/core/exceptions/core-exception
 import { GeoViewError } from '@/core/exceptions/geoview-exceptions';
 import { LayerEntryConfigError } from '@/core/exceptions/layer-entry-config-exceptions';
 import { LayerCreatedTwiceError } from '@/core/exceptions/layer-exceptions';
-import { getStoreDisplayDateMode } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { getStoreAppDisplayDateMode } from '@/core/stores/store-interface-and-intial-values/app-state';
 import {
   addStoreGeochartChart,
   isStoreGeochartInitialized,
@@ -675,7 +675,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
     const promiseLayer = new Promise<void>((resolve, reject) => {
       // Continue the addition process
       layerBeingAdded
-        .createGeoViewLayers(getStoreDisplayDateMode(this.getMapId()), this.getMapViewer().getProjection(), abortSignal)
+        .createGeoViewLayers(getStoreAppDisplayDateMode(this.getMapId()), this.getMapViewer().getProjection(), abortSignal)
         .then(() => {
           // Add the layer on the map
           this.#addToMap(layerBeingAdded, geoviewLayerConfig);

--- a/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
@@ -348,7 +348,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
   }
 
   /**
-   * Refreshes GeoCore Layers
+   * Refreshes GeoCore layers.
    */
   reloadGeocoreLayers(): void {
     const configs = this.getControllersRegistry().layerController.getLayerEntryConfigs();
@@ -465,7 +465,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
   }
 
   /**
-   * Removes all geoview layers from the map
+   * Removes all geoview layers from the map.
    */
   removeAllGeoviewLayers(): void {
     this.getControllersRegistry()
@@ -1083,7 +1083,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
    * @param language - The language setting used for layer labels and metadata.
    * @param mapConfigLayerEntries - The array of layer entries to convert.
    * @param errorCallback - Callback invoked when an error occurs during layer processing.
-   * @returns An array of promises, each resolving to a `TypeGeoviewLayerConfig` object
+   * @returns An array of promises, each resolving to a TypeGeoviewLayerConfig object
    */
   static convertMapConfigsToGeoviewLayerConfig(
     mapId: string,
@@ -1110,7 +1110,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
    * @param language - The language setting used for layer labels and metadata.
    * @param entry - The array of layer entry to convert.
    * @param errorCallback - Callback invoked when an error occurs during layer processing.
-   * @returns A promise that resolves to a `TypeGeoviewLayerConfig` object
+   * @returns A promise that resolves to a TypeGeoviewLayerConfig object
    */
   static convertMapConfigToGeoviewLayerConfig(
     mapId: string,
@@ -1357,8 +1357,11 @@ export class LayerCreatorController extends AbstractMapViewerController {
   // #endregion EVENTS
 }
 
+/** Represents the result of adding a GeoView layer. */
 export type GeoViewLayerAddedResult = {
+  /** The created GeoView layer instance. */
   layer: AbstractGeoViewLayer;
+  /** A promise that resolves when the layer is fully loaded. */
   promiseLayer: Promise<void>;
 };
 
@@ -1366,7 +1369,7 @@ export type GeoViewLayerAddedResult = {
  * Define an event for the delegate
  */
 export type LayerEvent = {
-  // The loaded layer
+  /** The loaded layer. */
   layer: AbstractGVLayer;
 };
 
@@ -1379,10 +1382,10 @@ export type LayerDelegate = EventDelegateBase<LayerCreatorController, LayerEvent
  * Define an event for the delegate
  */
 export type LayerPathEvent = {
-  // The layer path
+  /** The layer path. */
   layerPath: string;
 
-  // The layer name
+  /** The layer name. */
   layerName: string;
 };
 
@@ -1407,10 +1410,10 @@ export type LayerBuilderDelegate = EventDelegateBase<LayerCreatorController, Lay
  * Define an event for the delegate
  */
 export type LayerConfigErrorEvent = {
-  // The layer path (or the geoview layer id) depending when the error occurs in the process
+  /** The layer path (or the geoview layer id) depending when the error occurs in the process. */
   layerPath: string;
 
-  // The error
+  /** The error message. */
   error: string;
 };
 

--- a/packages/geoview-core/src/core/controllers/layer-set-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-set-controller.ts
@@ -12,9 +12,9 @@ import {
   type TypeFeatureInfoResultSet,
 } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import {
-  getStoreActiveFooterBarTab,
-  getStoreAppBarComponents,
-  getStoreFooterBarComponents,
+  getStoreUIActiveFooterBarTab,
+  getStoreUIAppBarComponents,
+  getStoreUIFooterBarComponents,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import {
   getStoreMapConfigGlobalSettings,
@@ -39,7 +39,7 @@ import { FeatureInfoLayerSet } from '@/geo/layer/layer-sets/feature-info-layer-s
 import { AbstractGVVector } from '@/geo/layer/gv-layers/vector/abstract-gv-vector';
 import type { TypeLegendItem, TypeLegendLayer, TypeLegendLayerItem } from '@/core/components/layers/types';
 import {
-  getStoreLayerStateLegendLayers,
+  getStoreLayerLegendLayers,
   setStoreLegendLayersDirectly,
   type TypeLegendResultSetEntry,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
@@ -271,14 +271,14 @@ export class LayerSetController extends AbstractMapViewerController {
     // Show details panel as soon as there is a click on the map
     // If the current tab is not 'details' nor 'geochart', switch to details
     if (
-      getStoreActiveFooterBarTab(this.getMapId()) === undefined ||
-      (!['details', 'geochart'].includes(getStoreActiveFooterBarTab(this.getMapId()).tabId) &&
-        getStoreFooterBarComponents(this.getMapId()).includes('details'))
+      getStoreUIActiveFooterBarTab(this.getMapId()) === undefined ||
+      (!['details', 'geochart'].includes(getStoreUIActiveFooterBarTab(this.getMapId()).tabId) &&
+        getStoreUIFooterBarComponents(this.getMapId()).includes('details'))
     ) {
       this.getControllersRegistry().uiController.setActiveFooterBarTab('details');
     }
     // Open details appbar tab when user clicked on map layer.
-    if (getStoreAppBarComponents(this.getMapId()).includes('details')) {
+    if (getStoreUIAppBarComponents(this.getMapId()).includes('details')) {
       this.getControllersRegistry().uiController.setActiveAppBarTab('details', true, true);
     }
   }
@@ -300,8 +300,9 @@ export class LayerSetController extends AbstractMapViewerController {
     // TODO: REFACTOR - propagateLegendToStore - IMPORTANT, this function uses 'createNewLegendEntries' recursively which sends the children array (existingEntries[entryIndex].children)
     // TO.DOCONT: in a loop and pushes objects into the array... However, when pushing objects into an array coming from a Zustand store (or react in general)
     // TO.DOCONT: the array remains the same object and a hook on the array
-    // TO.DOCONT: (for example here the "useLayerSelectorChildren = createLayerSelectorHook('children')") will never trigger, because
+    // TO.DOCONT: (for example here the "useStoreLayerChildren = createLayerSelectorHook('children')") will never trigger, because
     // TO.DOCONT: as far as react is concerned, it's the same array object.
+    // TO.DOCONT: UPDATE: Recently the stores have been fixed so that children are now a new array when updated. Refactoring this should be a bit more straightforward.
 
     const { layerPath } = legendResultSetEntry;
     const layerPathNodes = layerPath.split('/');
@@ -475,7 +476,7 @@ export class LayerSetController extends AbstractMapViewerController {
     };
 
     // Obtain the list of layers currently in the store
-    const layers = getStoreLayerStateLegendLayers(this.getMapId());
+    const layers = getStoreLayerLegendLayers(this.getMapId());
 
     // Process creation of legend entries
     createNewLegendEntries(2, layers);

--- a/packages/geoview-core/src/core/controllers/map-controller.ts
+++ b/packages/geoview-core/src/core/controllers/map-controller.ts
@@ -78,22 +78,22 @@ import {
   type TypeOrderedLayerInfo,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { getStoreDataTableSelectedLayerPath, getStoreTableFilter } from '@/core/stores/store-interface-and-intial-values/data-table-state';
-import { getStoreActiveAppBarTab, getStoreActiveFooterBarTab } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { getStoreUIActiveAppBarTab, getStoreUIActiveFooterBarTab } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import {
-  getStoreDisplayTheme,
-  getStoreIsCrosshairsActive,
+  getStoreAppDisplayTheme,
+  getStoreAppIsCrosshairsActive,
   getStoreShowLayerHighlightLayerBbox,
 } from '@/core/stores/store-interface-and-intial-values/app-state';
 import {
-  getStoreLayerStateHighlightedLayer,
-  getStoreLayerStateLayerBounds,
-  getStoreLayerStateLegendLayerByPath,
-  getStoreLayerStateSelectedLayerPath,
+  getStoreLayerHighlightedLayer,
+  getStoreLayerBounds,
+  getStoreLayerLegendLayerByPath,
+  getStoreLayerSelectedLayerPath,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import {
   getStoreTimeSliderFilter,
   getStoreTimeSliderLayers,
-  getStoreTimeSliderSelectedLayer,
+  getStoreTimeSliderSelectedLayerPath,
   isStoreTimeSliderInitialized,
   type TypeTimeSliderProps,
 } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
@@ -299,7 +299,7 @@ export class MapController extends AbstractMapViewerController {
     const options: FitOptions = fitOptions ?? { padding: OL_ZOOM_PADDING, duration: OL_ZOOM_DURATION };
 
     // Get the layer bounds
-    const bounds = getStoreLayerStateLayerBounds(this.getMapId(), layerPath);
+    const bounds = getStoreLayerBounds(this.getMapId(), layerPath);
 
     // If found
     if (bounds) {
@@ -509,7 +509,7 @@ export class MapController extends AbstractMapViewerController {
     this.getControllersRegistry().layerController.highlightLayer(layerPath);
 
     // Get bounds and highlight a bounding box for the layer (if true in global settings)
-    const bounds = getStoreLayerStateLayerBounds(this.getMapId(), layerPath);
+    const bounds = getStoreLayerBounds(this.getMapId(), layerPath);
     if (bounds && getStoreShowLayerHighlightLayerBbox(this.getMapId())) this.highlightBBox(bounds, true);
 
     return layerPath;
@@ -661,7 +661,7 @@ export class MapController extends AbstractMapViewerController {
       this.getControllersRegistry().layerController.refreshLayers();
 
       // Remove layer highlight if present to avoid bad reprojection
-      const highlightName = getStoreLayerStateHighlightedLayer(this.getMapId());
+      const highlightName = getStoreLayerHighlightedLayer(this.getMapId());
       if (highlightName !== '') {
         this.changeOrRemoveLayerHighlight(highlightName, highlightName);
       }
@@ -721,7 +721,7 @@ export class MapController extends AbstractMapViewerController {
     setStoreMapClickCoordinates(this.getMapId(), clickCoordinates);
 
     // If in WCAG mode, we need to emit the event
-    if (getStoreIsCrosshairsActive(this.getMapId())) this.getMapViewer().emitMapSingleClick(clickCoordinates);
+    if (getStoreAppIsCrosshairsActive(this.getMapId())) this.getMapViewer().emitMapSingleClick(clickCoordinates);
   }
 
   /**
@@ -1230,7 +1230,7 @@ export class MapController extends AbstractMapViewerController {
       // Construct map config
       const newMapConfig: TypeMapFeaturesInstance = {
         map,
-        theme: getStoreDisplayTheme(mapId),
+        theme: getStoreAppDisplayTheme(mapId),
         navBar: getStoreMapConfigNavBar(mapId),
         footerBar: getStoreMapConfigFooterBar(mapId),
         appBar: getStoreMapConfigAppBar(mapId),
@@ -1246,27 +1246,27 @@ export class MapController extends AbstractMapViewerController {
 
       // Set app bar tab settings
       if (newMapConfig.appBar) {
-        newMapConfig.appBar.selectedTab = getStoreActiveAppBarTab(mapId).tabId as TypeValidAppBarCoreProps;
+        newMapConfig.appBar.selectedTab = getStoreUIActiveAppBarTab(mapId).tabId as TypeValidAppBarCoreProps;
 
         const selectedDataTableLayerPath = getStoreDataTableSelectedLayerPath(mapId);
         if (selectedDataTableLayerPath) newMapConfig.appBar.selectedDataTableLayerPath = selectedDataTableLayerPath;
-        const selectedLayerPath = getStoreLayerStateSelectedLayerPath(mapId);
+        const selectedLayerPath = getStoreLayerSelectedLayerPath(mapId);
         if (selectedLayerPath) newMapConfig.appBar.selectedLayersLayerPath = selectedLayerPath;
       }
 
       // Set footer bar tab settings
       if (newMapConfig.footerBar) {
-        newMapConfig.footerBar.selectedTab = getStoreActiveFooterBarTab(mapId).tabId as TypeValidFooterBarTabsCoreProps;
+        newMapConfig.footerBar.selectedTab = getStoreUIActiveFooterBarTab(mapId).tabId as TypeValidFooterBarTabsCoreProps;
 
         const selectedDataTableLayerPath = getStoreDataTableSelectedLayerPath(mapId);
         if (selectedDataTableLayerPath) newMapConfig.footerBar.selectedDataTableLayerPath = selectedDataTableLayerPath;
-        const selectedLayerLayerPath = getStoreLayerStateSelectedLayerPath(mapId);
+        const selectedLayerLayerPath = getStoreLayerSelectedLayerPath(mapId);
         if (selectedLayerLayerPath) newMapConfig.footerBar.selectedLayersLayerPath = selectedLayerLayerPath;
 
         // If the TimeSlider plugin is initialized
         if (isStoreTimeSliderInitialized(mapId)) {
           // Store it
-          newMapConfig.footerBar.selectedTimeSliderLayerPath = getStoreTimeSliderSelectedLayer(mapId);
+          newMapConfig.footerBar.selectedTimeSliderLayerPath = getStoreTimeSliderSelectedLayerPath(mapId);
         }
       }
 
@@ -1403,7 +1403,7 @@ export class MapController extends AbstractMapViewerController {
 
     // Get info
     const orderedLayerInfo = getStoreMapOrderedLayerInfoByPath(mapId, layerPath)!; // Should always find one, so use a '!', otherwise let it break (was like this before)
-    const legendLayerInfo = getStoreLayerStateLegendLayerByPath(mapId, layerPath);
+    const legendLayerInfo = getStoreLayerLegendLayerByPath(mapId, layerPath);
 
     // Check if the layer is a geocore layers
     const isGeocore = isValidUUID(layerPath.split('/')[0]);
@@ -1477,7 +1477,7 @@ export class MapController extends AbstractMapViewerController {
 
     const layerEntryConfig = this.getControllersRegistry().layerController.getLayerEntryConfig(layerPath);
     const orderedLayerInfo = getStoreMapOrderedLayerInfoByPath(mapId, layerPath)!; // Should always find one, so use a '!', otherwise let it break (was like this before)
-    const legendLayerInfo = getStoreLayerStateLegendLayerByPath(mapId, layerPath);
+    const legendLayerInfo = getStoreLayerLegendLayerByPath(mapId, layerPath);
 
     // Get original layerEntryConfig from map config
     const pathArray = layerPath.split('/');

--- a/packages/geoview-core/src/core/controllers/map-controller.ts
+++ b/packages/geoview-core/src/core/controllers/map-controller.ts
@@ -8,12 +8,16 @@ import {
   MAP_EXTENTS,
   MAX_EXTENTS_RESTRICTION,
   type Extent,
+  type TypeAltitudeResponse,
   type TypeBasemapOptions,
   type TypeFeatureInfoEntry,
   type TypeMapConfig,
   type TypeMapFeaturesInstance,
   type TypeMapMouseInfo,
+  type TypeNtsResponse,
   type TypePointMarker,
+  type TypeServiceUrls,
+  type TypeUtmZoneResponse,
   type TypeValidAppBarCoreProps,
   type TypeValidFooterBarTabsCoreProps,
   type TypeValidMapProjectionCodes,
@@ -33,6 +37,7 @@ import { AbstractMapViewerController } from '@/core/controllers/base/abstract-ma
 import { LayerCreatorController } from '@/core/controllers/layer-creator-controller';
 import { useControllers } from '@/core/controllers/base/controller-manager';
 import {
+  getStoreMapClickCoordinates,
   getStoreMapConfigAppBar,
   getStoreMapConfigComponents,
   getStoreMapConfigCorePackages,
@@ -97,9 +102,17 @@ import {
   isStoreTimeSliderInitialized,
   type TypeTimeSliderProps,
 } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
-import { DEFAULT_OL_FITOPTIONS, OL_ZOOM_DURATION, OL_ZOOM_PADDING } from '@/core/utils/constant';
+import {
+  updateStoreCoordinateInfoLayer,
+  getStoreDetailsCoordinateInfoEnabled,
+  setStoreDetailsCoordinateInfoEnabled,
+  deleteStoreDetailsFeatureInfo,
+  LAYER_PATH_COORDINATE_INFO,
+} from '@/core/stores/store-interface-and-intial-values/feature-info-state';
+import { DEFAULT_OL_FITOPTIONS, OL_ZOOM_DURATION, OL_ZOOM_PADDING, TIMEOUT } from '@/core/utils/constant';
 import { DateMgt, type TimeDimension } from '@/core/utils/date-mgt';
-import { delay, isValidUUID } from '@/core/utils/utilities';
+import { delay, doTimeout, isValidUUID } from '@/core/utils/utilities';
+import { Fetch } from '@/core/utils/fetch-helper';
 import { logger } from '@/core/utils/logger';
 import { MapViewer } from '@/geo/map/map-viewer';
 import { LayerFilters } from '@/geo/layer/gv-layers/layer-filters';
@@ -715,10 +728,21 @@ export class MapController extends AbstractMapViewerController {
    *
    * @param clickCoordinates - The click coordinate information
    */
-  setClickCoordinates(clickCoordinates: TypeMapMouseInfo): void {
+  setClickCoordinates(clickCoordinates: TypeMapMouseInfo, abortSignal?: AbortSignal): void {
     // GV: We do not need to perform query, there is a handler on the map click in layer set.
     // Save in store
     setStoreMapClickCoordinates(this.getMapId(), clickCoordinates);
+
+    // If the coordinate info is enabled
+    if (getStoreDetailsCoordinateInfoEnabled(this.getMapId())) {
+      // Update the coordinate info with the new click coordinates
+      this.updateStoreCoordinateInfo(clickCoordinates, getStoreMapConfigServiceUrls(this.getMapId()), abortSignal).catch(
+        (error: unknown) => {
+          // Log
+          logger.logPromiseFailed('in updateStoreCoordinateInfo in mapController.setClickCoordinates', error);
+        }
+      );
+    }
 
     // If in WCAG mode, we need to emit the event
     if (getStoreAppIsCrosshairsActive(this.getMapId())) this.getMapViewer().emitMapSingleClick(clickCoordinates);
@@ -856,6 +880,162 @@ export class MapController extends AbstractMapViewerController {
     // Do the actual view map rotation
     this.getMapViewer().map.getView().animate({ rotation });
     // GV No need to Save to the store, because this will trigger an event on MapViewer which will take care of updating the store
+  }
+
+  /**
+   * Toggles the coordinate info display on or off.
+   *
+   * When toggled on, clicking the map will display coordinate information such as UTM zone, NTS sheet, and altitude.
+   * When toggled off, any existing coordinate info will be removed from the store and map.
+   *
+   * @param abortSignal - Optional AbortSignal to cancel the fetch requests if needed.
+   */
+  toggleCoordinateInfoEnabled(abortSignal: AbortSignal): void {
+    // Get the state value
+    const oldCoordinateInfoEnabledState = getStoreDetailsCoordinateInfoEnabled(this.getMapId());
+    const newCoordinateInfoEnabledState = !oldCoordinateInfoEnabledState;
+    setStoreDetailsCoordinateInfoEnabled(this.getMapId(), newCoordinateInfoEnabledState);
+
+    // If activating and there's coordinates stored already in the map store
+    const clickCoordinates = getStoreMapClickCoordinates(this.getMapId());
+    if (newCoordinateInfoEnabledState && clickCoordinates) {
+      // Refresh the coordinate info
+      this.updateStoreCoordinateInfo(clickCoordinates, getStoreMapConfigServiceUrls(this.getMapId()), abortSignal).catch(
+        (error: unknown) => {
+          // Log
+          logger.logPromiseFailed('in updateStoreCoordinateInfo in mapController.toggleCoordinateInfoEnabled', error);
+        }
+      );
+      return;
+    }
+
+    // If toggling it off
+    if (!newCoordinateInfoEnabledState) {
+      // Remove coordinate info layer when disabled
+      deleteStoreDetailsFeatureInfo(this.getMapId(), LAYER_PATH_COORDINATE_INFO);
+    }
+  }
+
+  /**
+   * Creates or deletes coordinate info based on the current enabled state.
+   *
+   * When coordinate info is enabled, fetches UTM zone, NTS sheet, and altitude
+   * data from the configured service URLs and creates a coordinate info layer
+   * entry in the store. When disabled, removes any existing coordinate info.
+   *
+   * @param mapId - The map identifier.
+   * @param coordinates - The map mouse info containing click coordinates.
+   * @param serviceUrls - Optional service URLs for UTM, NTS, and altitude lookups.
+   * @param abortSignal - Optional AbortSignal to cancel the fetch requests if needed.
+   */
+  async updateStoreCoordinateInfo(coordinates: TypeMapMouseInfo, serviceUrls: TypeServiceUrls, abortSignal?: AbortSignal): Promise<void> {
+    const [lng, lat] = coordinates.lonlat;
+    const { utmZoneUrl, ntsSheetUrl, altitudeUrl } = serviceUrls;
+
+    try {
+      // Reset it in the store
+      updateStoreCoordinateInfoLayer(this.getMapId(), [], 'processing');
+
+      // Query utm zone information
+      const promiseUtmZoneResponse = Fetch.fetchJson<TypeUtmZoneResponse>(`${utmZoneUrl}?bbox=${lng}%2C${lat}%2C${lng}%2C${lat}`, {
+        signal: abortSignal,
+      });
+
+      // Query Nts information
+      const promiseNtsResponse = Fetch.fetchJson<TypeNtsResponse>(`${ntsSheetUrl}?bbox=${lng}%2C${lat}%2C${lng}%2C${lat}`, {
+        signal: abortSignal,
+      });
+
+      // Query altitude information
+      const promiseAltitudeResponse = Fetch.fetchJson<TypeAltitudeResponse>(`${altitudeUrl}?lat=${lat}&lon=${lng}`, {
+        signal: abortSignal,
+      });
+
+      // Start a timer to warn the user if fetches take too long
+      const slowWarningTimer = doTimeout(TIMEOUT.delayBeforeShwoingSlowCoordinateInfoWarning);
+      slowWarningTimer.promise
+        .then((timeoutResult) => {
+          // If the signal has been aborted, it means we don't care about the fetch result anymore, so ignore
+          if (abortSignal?.aborted) return;
+
+          // If the slow warning timer was cancelled, it means the fetches completed in time, so ignore
+          if (timeoutResult === 'cancelled') return;
+
+          // It took too long
+          this.getMapViewer().notifications.showWarning('warning.layer.slowCoordinateInfo');
+        })
+        .catch((error: unknown) => {
+          // Log
+          logger.logPromiseFailed('in slowWarningTimer in mapController.updateStoreCoordinateInfo', error);
+        });
+
+      // Await all promises are settled
+      const [utmResult, ntsResult, elevationResult] = await Promise.allSettled([
+        promiseUtmZoneResponse,
+        promiseNtsResponse,
+        promiseAltitudeResponse,
+      ]);
+
+      // Cancel the warning timer, because we got a response
+      slowWarningTimer.cancel();
+
+      const utmData = utmResult.status === 'fulfilled' ? utmResult.value : undefined;
+      const ntsData = ntsResult.status === 'fulfilled' ? ntsResult.value : undefined;
+      const elevationData = elevationResult.status === 'fulfilled' ? elevationResult.value : undefined;
+
+      const utmIdentifier = utmData?.features[0].properties.identifier;
+      const [easting, northing] = utmIdentifier
+        ? Projection.transformToUTMNorthingEasting(coordinates.lonlat, utmIdentifier)
+        : [undefined, undefined];
+
+      // Create coordinate info layer entry
+      const coordinateFeature: TypeFeatureInfoEntry[] = [
+        {
+          uid: 'coordinate-info-feature',
+          fieldInfo: {
+            latitude: { value: lat.toFixed(6), fieldKey: 0, dataType: 'number', alias: 'Latitude' },
+            longitude: { value: lng.toFixed(6), fieldKey: 1, dataType: 'number', alias: 'Longitude' },
+            utmZone: { value: utmIdentifier, fieldKey: 2, dataType: 'string', alias: 'UTM Identifier' },
+            easting: { value: easting?.toFixed(2), fieldKey: 3, dataType: 'number', alias: 'Easting' },
+            northing: { value: northing?.toFixed(2), fieldKey: 4, dataType: 'number', alias: 'Northing' },
+            ntsMapsheet: {
+              value: ntsData?.features
+                .filter((f) => f.properties.name !== '')
+                .sort((f) => f.properties.scale)
+                .map((f) => {
+                  const scale = `${f.properties.scale / 1000}K`;
+                  return `${f.properties.identifier} - ${f.properties.name} - ${scale}`;
+                })
+                .join('\n'),
+              fieldKey: 5,
+              dataType: 'string',
+              alias: 'NTS Mapsheets',
+            },
+            elevation: {
+              value: elevationData?.altitude ? `${elevationData.altitude} m` : undefined,
+              fieldKey: 6,
+              dataType: 'string',
+              alias: 'Elevation',
+            },
+          },
+          extent: undefined,
+          geometry: undefined,
+          featureKey: 0,
+          geoviewLayerType: 'CSV',
+          supportZoomTo: true,
+          layerPath: LAYER_PATH_COORDINATE_INFO,
+        },
+      ];
+
+      // Update it in the store
+      updateStoreCoordinateInfoLayer(this.getMapId(), coordinateFeature, 'processed');
+    } catch (error: unknown) {
+      // Update it in the store
+      updateStoreCoordinateInfoLayer(this.getMapId(), [], 'error');
+
+      // Keep throwing
+      throw error;
+    }
   }
 
   // #endregion PUBLIC METHODS - OTHERS

--- a/packages/geoview-core/src/core/controllers/map-controller.ts
+++ b/packages/geoview-core/src/core/controllers/map-controller.ts
@@ -886,7 +886,8 @@ export class MapController extends AbstractMapViewerController {
    * Toggles the coordinate info display on or off.
    *
    * When toggled on, clicking the map will display coordinate information such as UTM zone, NTS sheet, and altitude.
-   * When toggled off, any existing coordinate info will be removed from the store and map.
+   * When toggled off, any existing details coordinate info is removed from the details store.
+   * The clicked coordinates themselves remain in the map store.
    *
    * @param abortSignal - Optional AbortSignal to cancel the fetch requests if needed.
    */

--- a/packages/geoview-core/src/core/controllers/map-controller.ts
+++ b/packages/geoview-core/src/core/controllers/map-controller.ts
@@ -923,9 +923,8 @@ export class MapController extends AbstractMapViewerController {
    * data from the configured service URLs and creates a coordinate info layer
    * entry in the store. When disabled, removes any existing coordinate info.
    *
-   * @param mapId - The map identifier.
    * @param coordinates - The map mouse info containing click coordinates.
-   * @param serviceUrls - Optional service URLs for UTM, NTS, and altitude lookups.
+   * @param serviceUrls - Service URLs for UTM, NTS, and altitude lookups.
    * @param abortSignal - Optional AbortSignal to cancel the fetch requests if needed.
    */
   async updateStoreCoordinateInfo(coordinates: TypeMapMouseInfo, serviceUrls: TypeServiceUrls, abortSignal?: AbortSignal): Promise<void> {

--- a/packages/geoview-core/src/core/controllers/map-controller.ts
+++ b/packages/geoview-core/src/core/controllers/map-controller.ts
@@ -952,7 +952,7 @@ export class MapController extends AbstractMapViewerController {
       });
 
       // Start a timer to warn the user if fetches take too long
-      const slowWarningTimer = doTimeout(TIMEOUT.delayBeforeShwoingSlowCoordinateInfoWarning);
+      const slowWarningTimer = doTimeout(TIMEOUT.delayBeforeShowingSlowCoordinateInfoWarning);
       slowWarningTimer.promise
         .then((timeoutResult) => {
           // If the signal has been aborted, it means we don't care about the fetch result anymore, so ignore

--- a/packages/geoview-core/src/core/controllers/ui-controller.ts
+++ b/packages/geoview-core/src/core/controllers/ui-controller.ts
@@ -44,10 +44,10 @@ import KeyboardZoom from 'ol/interaction/KeyboardZoom';
  * Extends AbstractMapViewerController and delegates state mutations to the UIStateAdaptor.
  */
 export class UIController extends AbstractMapViewerController {
-  /** The UI Domain instance associated with this controller */
+  /** The UI Domain instance associated with this controller. */
   #uiDomain: UIDomain;
 
-  /** The bounded reference to the handle display language changed */
+  /** The bounded reference to the display language changed handler. */
   #boundedHandleDisplayLanguageChanged: DomainLanguageChangedDelegate;
 
   /**
@@ -443,7 +443,10 @@ export class UIController extends AbstractMapViewerController {
   // GV.CONT but for now this allows us to keep domain-store interactions in one place and call application-level processes as needed during migration.
 
   /**
-   * TODO: JSDOC THIS
+   * Handles the display language changed event from the UI domain.
+   *
+   * @param sender - The UI domain that emitted the event
+   * @param event - The language changed event containing the new language
    */
   #handleDisplayLanguageChanged(sender: UIDomain, event: DomainLanguageChangedEvent): void {
     setStoreDisplayLanguage(this.getMapId(), event.language);

--- a/packages/geoview-core/src/core/controllers/ui-controller.ts
+++ b/packages/geoview-core/src/core/controllers/ui-controller.ts
@@ -1,4 +1,4 @@
-import { type TypeDisplayLanguage, type TypeDisplayTheme } from '@/api/types/map-schema-types';
+import type { TypeDisplayLanguage, TypeDisplayTheme } from '@/api/types/map-schema-types';
 import { useControllers } from '@/core/controllers/base/controller-manager';
 import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
 import {

--- a/packages/geoview-core/src/core/controllers/ui-controller.ts
+++ b/packages/geoview-core/src/core/controllers/ui-controller.ts
@@ -4,7 +4,6 @@ import { AbstractMapViewerController } from '@/core/controllers/base/abstract-ma
 import {
   disableStoreFocusTrap,
   enableStoreFocusTrap,
-  getStoreActiveAppBarTab,
   hideStoreTabButton,
   setStoreActiveAppBarTab,
   setStoreActiveFooterBarTab,
@@ -12,12 +11,11 @@ import {
   setStoreFooterBarIsOpen,
   setStoreFooterPanelResizeValue,
   showStoreTabButton,
-  type ActiveAppBarTabType,
   type FocusItemProps,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import {
   addStoreNotification,
-  getStoreGeoviewAssetsURL,
+  getStoreAppGeoviewAssetsURL,
   removeStoreAllNotifications,
   removeStoreNotification,
   setStoreCircularProgress,
@@ -127,15 +125,6 @@ export class UIController extends AbstractMapViewerController {
   setActiveFooterBarTab(tab: string | undefined): void {
     // Save in store
     setStoreActiveFooterBarTab(this.getMapId(), tab);
-  }
-
-  /**
-   * Gets the active app bar tab from the store.
-   *
-   * @returns The active app bar tab info.
-   */
-  getActiveAppBarTab(): ActiveAppBarTabType {
-    return getStoreActiveAppBarTab(this.getMapId());
   }
 
   /**
@@ -434,7 +423,7 @@ export class UIController extends AbstractMapViewerController {
 
     try {
       // Create the guide
-      const guide = await createGuideObject(language, getStoreGeoviewAssetsURL(mapId));
+      const guide = await createGuideObject(language, getStoreAppGeoviewAssetsURL(mapId));
 
       // Save in store
       setStoreGuide(mapId, guide);

--- a/packages/geoview-core/src/core/stores/geoview-store.ts
+++ b/packages/geoview-core/src/core/stores/geoview-store.ts
@@ -125,9 +125,9 @@ export type GeoviewStoreType = UseBoundStore<Mutate<StoreApi<IGeoviewState>, Sub
 // **********************************************************
 // GeoView state selectors
 // **********************************************************
-export const useGeoViewMapId = (): string => useStore(useGeoViewStore(), (state) => state.mapId);
-export const useGeoViewConfig = (): TypeMapFeaturesConfig | undefined => useStore(useGeoViewStore(), (state) => state.mapConfig);
-export const useGeoViewSharedMode = (): boolean | undefined => useStore(useGeoViewStore(), (state) => state.mapConfig?.sharedMode);
+export const useStoreGeoViewMapId = (): string => useStore(useGeoViewStore(), (state) => state.mapId);
+export const useStoreGeoViewConfig = (): TypeMapFeaturesConfig | undefined => useStore(useGeoViewStore(), (state) => state.mapConfig);
+export const useStoreGeoViewSharedMode = (): boolean | undefined => useStore(useGeoViewStore(), (state) => state.mapConfig?.sharedMode);
 
 /** To be able to compare objects for hooks */
 type EqualityFn<T> = (prev: T, next: T) => boolean;

--- a/packages/geoview-core/src/core/stores/state-api.ts
+++ b/packages/geoview-core/src/core/stores/state-api.ts
@@ -13,7 +13,8 @@ import {
   setStoreMapLegendCollapsed,
   utilFindMapLayerAndChildrenFromOrderedInfo,
 } from './store-interface-and-intial-values/map-state';
-import { getStoreTimeSliderLayers, type TimeSliderLayerSet } from './store-interface-and-intial-values/time-slider-state';
+import type { TimeSliderLayerSet } from './store-interface-and-intial-values/time-slider-state';
+import { getStoreTimeSliderLayers } from './store-interface-and-intial-values/time-slider-state';
 import { getStoreSwiperLayerPaths } from './store-interface-and-intial-values/swiper-state';
 import { logger } from '@/core/utils/logger';
 import type { EventDelegateBase } from '@/api/events/event-helper';

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/app-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/app-state.ts
@@ -8,7 +8,8 @@ import type { TypeSetStore, TypeGetStore } from '@/core/stores/geoview-store';
 import type { NotificationDetailsType } from '@/core/components/notifications/notifications';
 import type { TypeMapFeaturesConfig } from '@/core/types/global-types';
 import { getScriptAndAssetURL } from '@/core/utils/utilities';
-import { DateMgt, type TimeIANA, type TypeDisplayDateDefaults } from '@/core/utils/date-mgt';
+import type { TimeIANA, TypeDisplayDateDefaults } from '@/core/utils/date-mgt';
+import { DateMgt } from '@/core/utils/date-mgt';
 
 // #region INTERFACE DEFINITION
 

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/app-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/app-state.ts
@@ -283,105 +283,10 @@ export function initializeAppState(set: TypeSetStore, get: TypeGetStore): IAppSt
 
 // #endregion STATE INITIALIZATION
 
-// #region STATE HOOKS
-// GV To be used by React components
-
-/** Hook that returns whether the circular progress indicator is active. */
-export const useAppCircularProgressActive = (): boolean => useStore(useGeoViewStore(), (state) => state.appState.isCircularProgressActive);
-
-/** Hook that returns whether the crosshairs overlay is active. */
-export const useAppCrosshairsActive = (): boolean => useStore(useGeoViewStore(), (state) => state.appState.isCrosshairsActive);
-
-/** Hook that returns the list of disabled layer types. */
-export const useAppDisabledLayerTypes = (): TypeInitialGeoviewLayerType[] =>
-  useStore(useGeoViewStore(), (state) => state.appState.disabledLayerTypes);
-
-/** Hook that returns the current display language. */
-export const useAppDisplayLanguage = (): TypeDisplayLanguage => useStore(useGeoViewStore(), (state) => state.appState.displayLanguage);
-
-/** Hook that returns the current display date mode. */
-export const useAppDisplayDateMode = (): DisplayDateMode => useStore(useGeoViewStore(), (state) => state.appState.displayDateMode);
-
-/** Hook that returns the current display date timezone. */
-export const useDisplayDateTimezone = (): TimeIANA => useStore(useGeoViewStore(), (state) => state.appState.displayDateTimezone);
-
-/** Hook that returns the current display theme. */
-export const useAppDisplayTheme = (): TypeDisplayTheme => useStore(useGeoViewStore(), (state) => state.appState.displayTheme);
-
-/** Hook that returns whether fullscreen mode is active. */
-export const useAppFullscreenActive = (): boolean => useStore(useGeoViewStore(), (state) => state.appState.isFullscreenActive);
-
-/** Hook that returns the geolocator service URL. */
-export const useAppGeolocatorServiceURL = (): string | undefined =>
-  useStore(useGeoViewStore(), (state) => state.appState.geolocatorServiceURL);
-
-/** Hook that returns the metadata service URL. */
-export const useAppMetadataServiceURL = (): string | undefined => useStore(useGeoViewStore(), (state) => state.appState.metadataServiceURL);
-
-/** Hook that returns the root GeoView HTML element for the current map. */
-export const useAppGeoviewHTMLElement = (): HTMLElement => useStore(useGeoViewStore(), (state) => state.appState.geoviewHTMLElement);
-
-/** Hook that returns the current map container height in pixels. */
-export const useAppHeight = (): number => useStore(useGeoViewStore(), (state) => state.appState.height);
-
-/** Hook that returns the base URL for GeoView static assets. */
-export const useAppGeoviewAssetsURL = (): string => useStore(useGeoViewStore(), (state) => state.appState.geoviewAssetsURL);
-
-/** Hook that returns the guide content object. */
-export const useAppGuide = (): TypeGuideObject | undefined => useStore(useGeoViewStore(), (state) => state.appState.guide);
-
-/** Hook that returns the list of active notifications. */
-export const useAppNotifications = (): NotificationDetailsType[] => useStore(useGeoViewStore(), (state) => state.appState.notifications);
-
-/** Hook that returns whether unsymbolized features should be displayed. */
-export const useAppShowUnsymbolizedFeatures = (): boolean =>
-  useStore(useGeoViewStore(), (state) => state.appState.showUnsymbolizedFeatures);
-
-/**
- * Hook that returns the shell container HTML element for the current map.
- *
- * Queries the DOM for the element whose id starts with `shell-{mapId}`.
- *
- * @returns The shell container element.
- */
-export const useAppShellContainer = (): HTMLElement => {
-  const geoviewElement = useAppGeoviewHTMLElement();
-  const mapId = useStore(useGeoViewStore(), (state) => state.mapId);
-  return geoviewElement.querySelector(`[id^="shell-${mapId}"]`) as HTMLElement;
-};
-
-/**
- * Hook that returns the display language for a specific map by its id.
- *
- * Used in app-start.tsx before the GeoView context is assigned to the map.
- * Do not use this technique elsewhere; it is only intended for reloading language and theme.
- *
- * @param mapId - The map identifier.
- * @returns The display language for the given map.
- */
-// GV This hook uses getGeoViewStore, because of the context not being ready at the time this hook is used in app-start.
-export const useAppDisplayLanguageById = (mapId: string): TypeDisplayLanguage =>
-  useStore(getGeoViewStore(mapId), (state) => state.appState.displayLanguage);
-
-/**
- * Hook that returns the display theme for a specific map by its id.
- *
- * Used in app-start.tsx before the GeoView context is assigned to the map.
- * Do not use this technique elsewhere; it is only intended for reloading language and theme.
- *
- * @param mapId - The map identifier.
- * @returns The display theme for the given map.
- */
-// GV This hook uses getGeoViewStore, because of the context not being ready at the time this hook is used in app-start.
-export const useAppDisplayThemeById = (mapId: string): TypeDisplayTheme =>
-  useStore(getGeoViewStore(mapId), (state) => state.appState.displayTheme);
-
-// #endregion STATE HOOKS
-
-// #region STATE SELECTORS
-// GV Should only be used specifically to access the Store.
-// GV Use sparingly and only if you are sure of what you are doing.
-// GV DO NOT USE this technique in React components, use the hooks above instead.
+// #region STATE GETTERS & HOOKS
+// GV Getters should be used to get the values at a moment in time.
+// GV Hooks should be used to attach to values and trigger UI components when they change.
+// GV Typically they are listed in couples (getter + hook) for the same value.
 
 /**
  * Returns the full app state slice for the given map.
@@ -395,12 +300,87 @@ export const useAppDisplayThemeById = (mapId: string): TypeDisplayTheme =>
 const getStoreAppState = (mapId: string): IAppState => getGeoViewStore(mapId).getState().appState;
 
 /**
+ * Gets whether the circular progress indicator is active for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns True if the progress indicator is active.
+ */
+export const getStoreAppIsCircularProgressActive = (mapId: string): boolean => getStoreAppState(mapId).isCircularProgressActive;
+
+/** Hook that returns whether the circular progress indicator is active. */
+export const useStoreAppIsCircularProgressActive = (): boolean =>
+  useStore(useGeoViewStore(), (state) => state.appState.isCircularProgressActive);
+
+/**
+ * Gets whether the crosshairs overlay is active for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns True if crosshairs are active.
+ */
+export const getStoreAppIsCrosshairsActive = (mapId: string): boolean => getStoreAppState(mapId).isCrosshairsActive;
+
+/** Hook that returns whether the crosshairs overlay is active. */
+export const useStoreAppIsCrosshairsActive = (): boolean => useStore(useGeoViewStore(), (state) => state.appState.isCrosshairsActive);
+
+/**
  * Gets the disabled layer types for the given map.
  *
  * @param mapId - The map identifier.
  * @returns The list of disabled layer types.
  */
-export const getStoreDisabledLayerTypes = (mapId: string): TypeInitialGeoviewLayerType[] => getStoreAppState(mapId).disabledLayerTypes;
+export const getStoreAppDisabledLayerTypes = (mapId: string): TypeInitialGeoviewLayerType[] => getStoreAppState(mapId).disabledLayerTypes;
+
+/** Hook that returns the list of disabled layer types. */
+export const useStoreAppDisabledLayerTypes = (): TypeInitialGeoviewLayerType[] =>
+  useStore(useGeoViewStore(), (state) => state.appState.disabledLayerTypes);
+
+/**
+ * Gets the display language for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns The display language.
+ */
+export const getStoreAppDisplayLanguage = (mapId: string): TypeDisplayLanguage => getStoreAppState(mapId).displayLanguage;
+
+/** Hook that returns the current display language. */
+export const useStoreAppDisplayLanguage = (): TypeDisplayLanguage => useStore(useGeoViewStore(), (state) => state.appState.displayLanguage);
+
+/**
+ * Hook that returns the display language for a specific map by its id.
+ *
+ * Used in app-start.tsx before the GeoView context is assigned to the map.
+ * Do not use this technique elsewhere; it is only intended for reloading language and theme.
+ *
+ * @param mapId - The map identifier.
+ * @returns The display language for the given map.
+ */
+// GV This hook uses getGeoViewStore, because of the context not being ready at the time this hook is used in app-start.
+export const useStoreAppDisplayLanguageById = (mapId: string): TypeDisplayLanguage =>
+  useStore(getGeoViewStore(mapId), (state) => state.appState.displayLanguage);
+
+/**
+ * Gets the display theme for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns The display theme.
+ */
+export const getStoreAppDisplayTheme = (mapId: string): TypeDisplayTheme => getStoreAppState(mapId).displayTheme;
+
+/** Hook that returns the current display theme. */
+export const useStoreAppDisplayTheme = (): TypeDisplayTheme => useStore(useGeoViewStore(), (state) => state.appState.displayTheme);
+
+/**
+ * Hook that returns the display theme for a specific map by its id.
+ *
+ * Used in app-start.tsx before the GeoView context is assigned to the map.
+ * Do not use this technique elsewhere; it is only intended for reloading language and theme.
+ *
+ * @param mapId - The map identifier.
+ * @returns The display theme for the given map.
+ */
+// GV This hook uses getGeoViewStore, because of the context not being ready at the time this hook is used in app-start.
+export const useStoreAppDisplayThemeById = (mapId: string): TypeDisplayTheme =>
+  useStore(getGeoViewStore(mapId), (state) => state.appState.displayTheme);
 
 /**
  * Gets the display date mode for the given map.
@@ -408,7 +388,10 @@ export const getStoreDisabledLayerTypes = (mapId: string): TypeInitialGeoviewLay
  * @param mapId - The map identifier.
  * @returns The display date mode.
  */
-export const getStoreDisplayDateMode = (mapId: string): DisplayDateMode => getStoreAppState(mapId).displayDateMode;
+export const getStoreAppDisplayDateMode = (mapId: string): DisplayDateMode => getStoreAppState(mapId).displayDateMode;
+
+/** Hook that returns the current display date mode. */
+export const useStoreAppDisplayDateMode = (): DisplayDateMode => useStore(useGeoViewStore(), (state) => state.appState.displayDateMode);
 
 /**
  * Gets the display date timezone for the given map.
@@ -418,86 +401,8 @@ export const getStoreDisplayDateMode = (mapId: string): DisplayDateMode => getSt
  */
 export const getStoreDisplayDateTimezone = (mapId: string): TimeIANA => getStoreAppState(mapId).displayDateTimezone;
 
-/**
- * Gets the display language for the given map.
- *
- * @param mapId - The map identifier.
- * @returns The display language.
- */
-export const getStoreDisplayLanguage = (mapId: string): TypeDisplayLanguage => getStoreAppState(mapId).displayLanguage;
-
-/**
- * Gets the display theme for the given map.
- *
- * @param mapId - The map identifier.
- * @returns The display theme.
- */
-export const getStoreDisplayTheme = (mapId: string): TypeDisplayTheme => getStoreAppState(mapId).displayTheme;
-
-/**
- * Gets the default date format settings derived from the current display date mode.
- *
- * @param mapId - The map identifier.
- * @returns The default date display settings.
- */
-export const getStoreDisplayDateFormatDefault = (mapId: string): TypeDisplayDateDefaults =>
-  DateMgt.getDisplayDateDefaults(getStoreDisplayDateMode(mapId));
-
-/**
- * Gets the geolocator service URL for the given map.
- *
- * @param mapId - The map identifier.
- * @returns The geolocator service URL, or undefined if not configured.
- */
-export const getStoreGeolocatorServiceURL = (mapId: string): string | undefined => getStoreAppState(mapId).geolocatorServiceURL;
-
-/**
- * Gets the GeoView assets base URL for the given map.
- *
- * @param mapId - The map identifier.
- * @returns The assets base URL.
- */
-export const getStoreGeoviewAssetsURL = (mapId: string): string => getStoreAppState(mapId).geoviewAssetsURL;
-
-/**
- * Gets the root GeoView HTML element for the given map.
- *
- * @param mapId - The map identifier.
- * @returns The HTML element hosting the map.
- */
-export const getStoreGeoviewHTMLElement = (mapId: string): HTMLElement => getStoreAppState(mapId).geoviewHTMLElement;
-
-/**
- * Gets the guide content object for the given map.
- *
- * @param mapId - The map identifier.
- * @returns The guide object, or undefined if not set.
- */
-export const getStoreGuide = (mapId: string): TypeGuideObject | undefined => getStoreAppState(mapId).guide;
-
-/**
- * Gets the map container height for the given map.
- *
- * @param mapId - The map identifier.
- * @returns The height in pixels.
- */
-export const getStoreHeight = (mapId: string): number => getStoreAppState(mapId).height;
-
-/**
- * Gets whether the circular progress indicator is active for the given map.
- *
- * @param mapId - The map identifier.
- * @returns True if the progress indicator is active.
- */
-export const getStoreIsCircularProgressActive = (mapId: string): boolean => getStoreAppState(mapId).isCircularProgressActive;
-
-/**
- * Gets whether the crosshairs overlay is active for the given map.
- *
- * @param mapId - The map identifier.
- * @returns True if crosshairs are active.
- */
-export const getStoreIsCrosshairsActive = (mapId: string): boolean => getStoreAppState(mapId).isCrosshairsActive;
+/** Hook that returns the current display date timezone. */
+export const useStoreDisplayDateTimezone = (): TimeIANA => useStore(useGeoViewStore(), (state) => state.appState.displayDateTimezone);
 
 /**
  * Gets whether fullscreen mode is active for the given map.
@@ -505,7 +410,22 @@ export const getStoreIsCrosshairsActive = (mapId: string): boolean => getStoreAp
  * @param mapId - The map identifier.
  * @returns True if fullscreen is active.
  */
-export const getStoreIsFullscreenActive = (mapId: string): boolean => getStoreAppState(mapId).isFullscreenActive;
+export const getStoreAppIsFullscreenActive = (mapId: string): boolean => getStoreAppState(mapId).isFullscreenActive;
+
+/** Hook that returns whether fullscreen mode is active. */
+export const useStoreAppIsFullscreenActive = (): boolean => useStore(useGeoViewStore(), (state) => state.appState.isFullscreenActive);
+
+/**
+ * Gets the geolocator service URL for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns The geolocator service URL, or undefined if not configured.
+ */
+export const getStoreAppGeolocatorServiceURL = (mapId: string): string | undefined => getStoreAppState(mapId).geolocatorServiceURL;
+
+/** Hook that returns the geolocator service URL. */
+export const useStoreAppGeolocatorServiceURL = (): string | undefined =>
+  useStore(useGeoViewStore(), (state) => state.appState.geolocatorServiceURL);
 
 /**
  * Gets the metadata service URL for the given map.
@@ -513,7 +433,55 @@ export const getStoreIsFullscreenActive = (mapId: string): boolean => getStoreAp
  * @param mapId - The map identifier.
  * @returns The metadata service URL, or undefined if not configured.
  */
-export const getStoreMetadataServiceURL = (mapId: string): string | undefined => getStoreAppState(mapId).metadataServiceURL;
+export const getStoreAppMetadataServiceURL = (mapId: string): string | undefined => getStoreAppState(mapId).metadataServiceURL;
+
+/** Hook that returns the metadata service URL. */
+export const useStoreAppMetadataServiceURL = (): string | undefined =>
+  useStore(useGeoViewStore(), (state) => state.appState.metadataServiceURL);
+
+/**
+ * Gets the root GeoView HTML element for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns The HTML element hosting the map.
+ */
+export const getStoreAppGeoviewHTMLElement = (mapId: string): HTMLElement => getStoreAppState(mapId).geoviewHTMLElement;
+
+/** Hook that returns the root GeoView HTML element for the current map. */
+export const useStoreAppGeoviewHTMLElement = (): HTMLElement => useStore(useGeoViewStore(), (state) => state.appState.geoviewHTMLElement);
+
+/**
+ * Gets the map container height for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns The height in pixels.
+ */
+export const getStoreAppHeight = (mapId: string): number => getStoreAppState(mapId).height;
+
+/** Hook that returns the current map container height in pixels. */
+export const useStoreAppHeight = (): number => useStore(useGeoViewStore(), (state) => state.appState.height);
+
+/**
+ * Gets the GeoView assets base URL for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns The assets base URL.
+ */
+export const getStoreAppGeoviewAssetsURL = (mapId: string): string => getStoreAppState(mapId).geoviewAssetsURL;
+
+/** Hook that returns the base URL for GeoView static assets. */
+export const useStoreAppGeoviewAssetsURL = (): string => useStore(useGeoViewStore(), (state) => state.appState.geoviewAssetsURL);
+
+/**
+ * Gets the guide content object for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns The guide object, or undefined if not set.
+ */
+export const getStoreAppGuide = (mapId: string): TypeGuideObject | undefined => getStoreAppState(mapId).guide;
+
+/** Hook that returns the guide content object. */
+export const useStoreAppGuide = (): TypeGuideObject | undefined => useStore(useGeoViewStore(), (state) => state.appState.guide);
 
 /**
  * Gets the list of active notifications for the given map.
@@ -521,7 +489,40 @@ export const getStoreMetadataServiceURL = (mapId: string): string | undefined =>
  * @param mapId - The map identifier.
  * @returns The array of notifications.
  */
-export const getStoreNotifications = (mapId: string): NotificationDetailsType[] => getStoreAppState(mapId).notifications;
+export const getStoreAppNotifications = (mapId: string): NotificationDetailsType[] => getStoreAppState(mapId).notifications;
+
+/** Hook that returns the list of active notifications. */
+export const useStoreAppNotifications = (): NotificationDetailsType[] =>
+  useStore(useGeoViewStore(), (state) => state.appState.notifications);
+
+/**
+ * Gets whether unsymbolized features should be displayed for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns True if unsymbolized features should be shown.
+ */
+export const getStoreAppShowUnsymbolizedFeatures = (mapId: string): boolean => getStoreAppState(mapId).showUnsymbolizedFeatures;
+
+/** Hook that returns whether unsymbolized features should be displayed. */
+export const useStoreAppShowUnsymbolizedFeatures = (): boolean =>
+  useStore(useGeoViewStore(), (state) => state.appState.showUnsymbolizedFeatures);
+
+// #endregion STATE GETTERS & HOOKS
+
+// #region STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
+
+/**
+ * Hook that returns the shell container HTML element for the current map.
+ *
+ * Queries the DOM for the element whose id starts with `shell-{mapId}`.
+ *
+ * @returns The shell container element.
+ */
+export const useStoreAppShellContainer = (): HTMLElement => {
+  const geoviewElement = useStoreAppGeoviewHTMLElement();
+  const mapId = useStore(useGeoViewStore(), (state) => state.mapId);
+  return geoviewElement.querySelector(`[id^="shell-${mapId}"]`) as HTMLElement;
+};
 
 /**
  * Gets whether to show highlight bounding boxes around layer features for the given map.
@@ -532,17 +533,18 @@ export const getStoreNotifications = (mapId: string): NotificationDetailsType[] 
 export const getStoreShowLayerHighlightLayerBbox = (mapId: string): boolean => getStoreAppState(mapId).showLayerHighlightLayerBbox;
 
 /**
- * Gets whether unsymbolized features should be displayed for the given map.
+ * Gets the default date format settings derived from the current display date mode.
  *
  * @param mapId - The map identifier.
- * @returns True if unsymbolized features should be shown.
+ * @returns The default date display settings.
  */
-export const getStoreShowUnsymbolizedFeatures = (mapId: string): boolean => getStoreAppState(mapId).showUnsymbolizedFeatures;
+export const getStoreDisplayDateFormatDefault = (mapId: string): TypeDisplayDateDefaults =>
+  DateMgt.getDisplayDateDefaults(getStoreAppDisplayDateMode(mapId));
 
-// #endregion STATE SELECTORS
-// GV These methods should be called from a State Adaptor class listening on domain events triggered by controllers.
+// #endregion STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
 
 // #region STATE ADAPTORS
+// GV These methods should be called from a State Adaptor class listening on domain events triggered by controllers.
 
 /**
  * Sets the circular progress indicator active state.

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
@@ -318,43 +318,10 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
 
 // #endregion STATE INITIALIZATION
 
-// #region STATE HOOKS
-// GV To be used by React components
-
-/** Hook that returns the aggregated feature info result set entries for all layers. */
-export const useDataTableAllFeaturesDataArray = (): TypeAllFeatureInfoResultSetEntry[] =>
-  useStore(useGeoViewStore(), (state) => state.dataTableState.allFeaturesDataArray);
-
-/** Hook that returns the table filters record keyed by layer path. */
-export const useDataTableFilters = (): Record<string, string> => useStore(useGeoViewStore(), (state) => state.dataTableState.tableFilters);
-
-/**
- * Hook that returns the table filter for a specific layer.
- *
- * @param layerPath - The layer path to get the filter for.
- * @returns The filter string for the layer, or undefined if not set.
- */
-export const useDataTableFilterSelector = (layerPath: string): string | undefined => {
-  return useStore(useGeoViewStore(), (state) => state.dataTableState.tableFilters[layerPath]);
-};
-
-/** Hook that returns the currently selected data table layer path. */
-export const useDataTableSelectedLayerPath = (): string => useStore(useGeoViewStore(), (state) => state.dataTableState.selectedLayerPath);
-
-/** Hook that returns the per-layer data table settings record. */
-export const useDataTableLayerSettings = (): Record<string, IDataTableSettings> =>
-  useStore(useGeoViewStore(), (state) => state.dataTableState.layersDataTableSetting);
-
-/** Hook that returns the currently selected feature in the data table. */
-export const useDataTableSelectedFeature = (): TypeFeatureInfoEntry | null =>
-  useStore(useGeoViewStore(), (state) => state.dataTableState.selectedFeature);
-
-// #endregion STATE HOOKS
-
-// #region STATE SELECTORS
-// GV Should only be used specifically to access the Store.
-// GV Use sparingly and only if you are sure of what you are doing.
-// GV DO NOT USE this technique in React components, use the hooks above instead.
+// #region STATE GETTERS & HOOKS
+// GV Getters should be used to get the values at a moment in time.
+// GV Hooks should be used to attach to values and trigger UI components when they change.
+// GV Typically they are listed in couples (getter + hook) for the same value.
 
 /**
  * Returns the full data table state slice for the given map.
@@ -373,8 +340,32 @@ const getStoreDataTableState = (mapId: string): IDataTableState => getGeoViewSto
  * @param layerPath - The path of the layer
  * @returns The data table filter(s) for the layer
  */
+export const getStoreDataTableFilters = (mapId: string): Record<string, string> | undefined => {
+  return getStoreDataTableState(mapId)?.tableFilters;
+};
+
+/** Hook that returns the table filters record keyed by layer path. */
+export const useStoreDataTableFilters = (): Record<string, string> =>
+  useStore(useGeoViewStore(), (state) => state.dataTableState.tableFilters);
+
+/**
+ * Gets filter(s) for a layer.
+ * @param mapId - The map id of the state to act on
+ * @param layerPath - The path of the layer
+ * @returns The data table filter(s) for the layer
+ */
 export const getStoreTableFilter = (mapId: string, layerPath: string): string | undefined => {
   return getStoreDataTableState(mapId)?.tableFilters?.[layerPath];
+};
+
+/**
+ * Hook that returns the table filter for a specific layer.
+ *
+ * @param layerPath - The layer path to get the filter for.
+ * @returns The filter string for the layer, or undefined if not set.
+ */
+export const useStoreTableFilter = (layerPath: string): string | undefined => {
+  return useStore(useGeoViewStore(), (state) => state.dataTableState.tableFilters[layerPath]);
 };
 
 /**
@@ -387,6 +378,28 @@ export const getStoreDataTableSelectedLayerPath = (mapId: string): string => {
   return getStoreDataTableState(mapId)?.selectedLayerPath ?? '';
 };
 
+/** Hook that returns the currently selected data table layer path. */
+export const useStoreDataTableSelectedLayerPath = (): string =>
+  useStore(useGeoViewStore(), (state) => state.dataTableState.selectedLayerPath);
+
+/**
+ * Gets the aggregated feature info array for all layers in the data table.
+ *
+ * @param mapId - The map identifier.
+ * @returns The array of feature info result set entries.
+ */
+export const getStoreDataTableAllFeaturesDataArray = (mapId: string): TypeAllFeatureInfoResultSetEntry[] => {
+  return getStoreDataTableState(mapId)?.allFeaturesDataArray ?? [];
+};
+
+/** Hook that returns the aggregated feature info result set entries for all layers. */
+export const useStoreDataTableAllFeaturesDataArray = (): TypeAllFeatureInfoResultSetEntry[] =>
+  useStore(useGeoViewStore(), (state) => state.dataTableState.allFeaturesDataArray);
+
+// #endregion STATE GETTERS & HOOKS
+
+// #region STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
+
 /**
  * Gets whether the data table is filtered to the current map extent for a specific layer.
  *
@@ -398,17 +411,15 @@ export const getStoreMapFilteredRecord = (mapId: string, layerPath: string): boo
   return getStoreDataTableState(mapId)?.layersDataTableSetting?.[layerPath]?.mapFilteredRecord;
 };
 
-/**
- * Gets the aggregated feature info array for all layers in the data table.
- *
- * @param mapId - The map identifier.
- * @returns The array of feature info result set entries.
- */
-export const getStoreDataTableAllFeaturesArray = (mapId: string): TypeAllFeatureInfoResultSetEntry[] => {
-  return getStoreDataTableState(mapId)?.allFeaturesDataArray ?? [];
-};
+/** Hook that returns the per-layer data table settings record. */
+export const useStoreDataTableLayerSettings = (): Record<string, IDataTableSettings> =>
+  useStore(useGeoViewStore(), (state) => state.dataTableState.layersDataTableSetting);
 
-// #endregion STATE SELECTORS
+/** Hook that returns the currently selected feature in the data table. */
+export const useStoreDataTableSelectedFeature = (): TypeFeatureInfoEntry | null =>
+  useStore(useGeoViewStore(), (state) => state.dataTableState.selectedFeature);
+
+// #endregion STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
 
 // #region STATE ADAPTORS
 // GV These methods should be called from a State Adaptor class listening on domain events triggered by controllers.

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/drawer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/drawer-state.ts
@@ -24,19 +24,30 @@ export interface IDrawerState {
   /** The current drawing style properties. */
   style: StyleProps;
 
-  /** The active Draw interaction instance, or undefined when not drawing. */
+  /**
+   * The active Draw interaction instance, or undefined when not drawing.
+   *
+   * @deprecated This class instance shouldn't be in the store, remove this property
+   */
   drawInstance: Draw | undefined;
 
   /** Whether the drawer is in editing mode. */
   isEditing: boolean;
 
-  /** The active Transform interaction instance, or undefined when not editing. */
+  /**
+   * The active Transform interaction instance, or undefined when not editing.
+   *
+   * @deprecated This class instance shouldn't be in the store, remove this property
+   */
   transformInstance: Transform | undefined;
 
   /** The currently selected drawing feature, or undefined. */
   selectedDrawing: Feature | undefined;
 
-  /** The active Snap interaction instance, or undefined when snapping is disabled. */
+  /** The active Snap interaction instance, or undefined when snapping is disabled.
+   *
+   * @deprecated This class instance shouldn't be in the store, remove this property
+   */
   snapInstance: Snap | undefined;
 
   /** Whether measurement overlays are hidden. */
@@ -89,7 +100,7 @@ export interface IDrawerState {
 
 // #endregion INTERFACE DEFINITIONS
 
-// #region UTIL FUNCTIONS
+// #region UTIL FUNCTIONS (PRIVATE)
 
 /**
  * Reads the geometry type of a drawing feature.
@@ -109,7 +120,7 @@ const utilReadDrawingType = (feature: Feature<Geometry> | undefined): string | u
   return geometry?.getType();
 };
 
-// #endregion UTIL FUNCTIONS
+// #endregion UTIL FUNCTIONS (PRIVATE)
 
 // #region STATE INITIALIZATION
 
@@ -473,10 +484,10 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
 
 // #endregion STATE INITIALIZATION
 
-// #region STATE SELECTORS
-// GV Should only be used specifically to access the Store.
-// GV Use sparingly and only if you are sure of what you are doing.
-// GV DO NOT USE this technique in React components, use the hooks above instead.
+// #region STATE GETTERS & HOOKS
+// GV Getters should be used to get the values at a moment in time.
+// GV Hooks should be used to attach to values and trigger UI components when they change.
+// GV Typically they are listed in couples (getter + hook) for the same value.
 
 /**
  * Returns the full drawer state slice for the given map.
@@ -516,19 +527,12 @@ export const isStoreDrawerInitialized = (mapId: string): boolean => {
  * @param mapId - The map identifier
  * @returns The active geometry type
  */
-export const getStoreActiveGeom = (mapId: string): string => {
+export const getStoreDrawerActiveGeom = (mapId: string): string => {
   return getStoreDrawerState(mapId).activeGeom;
 };
 
-/**
- * Gets the available geometry types from the drawer store.
- *
- * @param mapId - The map identifier
- * @returns The array of geometry type strings
- */
-export const getStoreGeomTypes = (mapId: string): string[] => {
-  return getStoreDrawerState(mapId).geomTypes;
-};
+/** Hooks the active geometry type from the drawer state. */
+export const useStoreDrawerActiveGeom = (): string => useStore(useGeoViewStore(), (state) => state.drawerState.activeGeom);
 
 /**
  * Gets the current drawing style from the drawer store.
@@ -536,9 +540,12 @@ export const getStoreGeomTypes = (mapId: string): string[] => {
  * @param mapId - The map identifier
  * @returns The style properties
  */
-export const getStoreStyle = (mapId: string): StyleProps => {
+export const getStoreDrawerStyle = (mapId: string): StyleProps => {
   return getStoreDrawerState(mapId).style;
 };
+
+/** Hooks the current drawing style. */
+export const useStoreDrawerStyle = (): StyleProps => useStore(useGeoViewStore(), (state) => state.drawerState.style);
 
 /**
  * Checks whether drawing mode is active.
@@ -546,9 +553,74 @@ export const getStoreStyle = (mapId: string): StyleProps => {
  * @param mapId - The map identifier
  * @returns True if a Draw instance is present
  */
-export const getStoreIsDrawing = (mapId: string): boolean => {
+export const getStoreDrawerIsDrawing = (mapId: string): boolean => {
   return getStoreDrawerState(mapId).drawInstance !== undefined;
 };
+
+/** Hooks whether drawing mode is active. */
+export const useStoreDrawerIsDrawing = (): boolean => useStore(useGeoViewStore(), (state) => state.drawerState.drawInstance !== undefined);
+
+/** Hooks the Draw interaction instance. */
+export const useStoreDrawerDrawInstance = (): Draw | undefined => useStore(useGeoViewStore(), (state) => state.drawerState.drawInstance);
+
+/**
+ * Checks whether editing mode is active.
+ *
+ * @param mapId - The map identifier
+ * @returns True if a Transform instance is present
+ */
+export const getStoreDrawerIsEditing = (mapId: string): boolean => {
+  return getStoreDrawerState(mapId).transformInstance !== undefined;
+};
+
+/** Hooks whether editing mode is active. */
+export const useStoreDrawerIsEditing = (): boolean =>
+  useStore(useGeoViewStore(), (state) => state.drawerState.transformInstance !== undefined);
+
+/**
+ * Checks whether snapping mode is active.
+ *
+ * @param mapId - The map identifier
+ * @returns True if a Snap instance is present
+ */
+export const getStoreDrawerIsSnapping = (mapId: string): boolean => {
+  return getStoreDrawerState(mapId).snapInstance !== undefined;
+};
+
+/** Hooks whether snapping mode is active. */
+export const useStoreDrawerIsSnapping = (): boolean => useStore(useGeoViewStore(), (state) => state.drawerState.snapInstance !== undefined);
+
+/**
+ * Gets the currently selected drawing feature from the store.
+ *
+ * @param mapId - The map identifier
+ * @returns The selected feature, or undefined
+ * @deprecated This class instance shouldn't be in the store, remove this selector
+ */
+export const getStoreDrawerSelectedDrawing = (mapId: string): Feature | undefined => {
+  return getStoreDrawerState(mapId).selectedDrawing;
+};
+
+/** Hooks the geometry type of the currently selected drawing. */
+export const useStoreDrawerSelectedDrawing = (): string | undefined =>
+  useStore(useGeoViewStore(), (state) => utilReadDrawingType(state.drawerState.selectedDrawing));
+
+/**
+ * Gets the hide measurements flag from the drawer store.
+ *
+ * @param mapId - The map identifier
+ * @returns Whether measurements are hidden
+ */
+export const getStoreDrawerHideMeasurements = (mapId: string): boolean => {
+  return getStoreDrawerState(mapId).hideMeasurements;
+};
+
+/** Hooks whether measurements are hidden. */
+export const useStoreDrawerHideMeasurements = (): boolean => useStore(useGeoViewStore(), (state) => state.drawerState.hideMeasurements);
+
+// #endregion STATE GETTERS & HOOKS
+
+// #region STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
 
 /**
  * Gets the Draw interaction instance from the store.
@@ -557,18 +629,8 @@ export const getStoreIsDrawing = (mapId: string): boolean => {
  * @returns The Draw instance, or undefined
  * @deprecated This class instance shouldn't be in the store, remove this selector
  */
-export const getStoreDrawInstance = (mapId: string): Draw | undefined => {
+export const getStoreDrawerDrawInstance = (mapId: string): Draw | undefined => {
   return getStoreDrawerState(mapId).drawInstance;
-};
-
-/**
- * Checks whether editing mode is active.
- *
- * @param mapId - The map identifier
- * @returns True if a Transform instance is present
- */
-export const getStoreIsEditing = (mapId: string): boolean => {
-  return getStoreDrawerState(mapId).transformInstance !== undefined;
 };
 
 /**
@@ -578,18 +640,8 @@ export const getStoreIsEditing = (mapId: string): boolean => {
  * @returns The Transform instance, or undefined
  * @deprecated This class instance shouldn't be in the store, remove this selector
  */
-export const getStoreTransformInstance = (mapId: string): Transform | undefined => {
+export const getStoreDrawerTransformInstance = (mapId: string): Transform | undefined => {
   return getStoreDrawerState(mapId).transformInstance;
-};
-
-/**
- * Checks whether snapping mode is active.
- *
- * @param mapId - The map identifier
- * @returns True if a Snap instance is present
- */
-export const getStoreIsSnapping = (mapId: string): boolean => {
-  return getStoreDrawerState(mapId).snapInstance !== undefined;
 };
 
 /**
@@ -599,19 +651,18 @@ export const getStoreIsSnapping = (mapId: string): boolean => {
  * @returns The Snap instance, or undefined
  * @deprecated This class instance shouldn't be in the store, remove this selector
  */
-export const getStoreSnapInstance = (mapId: string): Snap | undefined => {
+export const getStoreDrawerSnapInstance = (mapId: string): Snap | undefined => {
   return getStoreDrawerState(mapId).snapInstance;
 };
 
 /**
- * Gets the currently selected drawing feature from the store.
+ * Gets the available geometry types from the drawer store.
  *
  * @param mapId - The map identifier
- * @returns The selected feature, or undefined
- * @deprecated This class instance shouldn't be in the store, remove this selector
+ * @returns The array of geometry type strings
  */
-export const getStoreSelectedDrawing = (mapId: string): Feature | undefined => {
-  return getStoreDrawerState(mapId).selectedDrawing;
+export const getStoreDrawerGeomTypes = (mapId: string): string[] => {
+  return getStoreDrawerState(mapId).geomTypes;
 };
 
 /**
@@ -620,18 +671,8 @@ export const getStoreSelectedDrawing = (mapId: string): Feature | undefined => {
  * @param mapId - The map identifier
  * @returns The drawing type string, or undefined if no selection
  */
-export const getStoreSelectedDrawingType = (mapId: string): string | undefined => {
-  return utilReadDrawingType(getStoreSelectedDrawing(mapId));
-};
-
-/**
- * Gets the hide measurements flag from the drawer store.
- *
- * @param mapId - The map identifier
- * @returns Whether measurements are hidden
- */
-export const getStoreHideMeasurements = (mapId: string): boolean => {
-  return getStoreDrawerState(mapId).hideMeasurements;
+export const getStoreDrawerSelectedDrawingType = (mapId: string): string | undefined => {
+  return utilReadDrawingType(getStoreDrawerSelectedDrawing(mapId));
 };
 
 /**
@@ -640,47 +681,17 @@ export const getStoreHideMeasurements = (mapId: string): boolean => {
  * @param mapId - The map identifier
  * @returns The icon source URL
  */
-export const getStoreIconSrc = (mapId: string): string => {
+export const getStoreDrawerIconSrc = (mapId: string): string => {
   return getStoreDrawerState(mapId).iconSrc;
 };
 
-// #endregion STATE SELECTORS
-
-// #region STATE HOOKS
-// GV To be used by React components
-
-/** Hooks whether drawing mode is active. */
-export const useDrawerIsDrawing = (): boolean => useStore(useGeoViewStore(), (state) => state.drawerState.drawInstance !== undefined);
-
-/** Hooks whether editing mode is active. */
-export const useDrawerIsEditing = (): boolean => useStore(useGeoViewStore(), (state) => state.drawerState.transformInstance !== undefined);
-
-/** Hooks whether snapping mode is active. */
-export const useDrawerIsSnapping = (): boolean => useStore(useGeoViewStore(), (state) => state.drawerState.snapInstance !== undefined);
-
-/** Hooks the geometry type of the currently selected drawing. */
-export const useDrawerSelectedDrawingType = (): string | undefined =>
-  useStore(useGeoViewStore(), (state) => utilReadDrawingType(state.drawerState.selectedDrawing));
-
-/** Hooks the active geometry type from the drawer state. */
-export const useDrawerActiveGeom = (): string => useStore(useGeoViewStore(), (state) => state.drawerState.activeGeom);
-
-/** Hooks the current drawing style. */
-export const useDrawerStyle = (): StyleProps => useStore(useGeoViewStore(), (state) => state.drawerState.style);
-
-/** Hooks the Draw interaction instance. */
-export const useDrawerDrawInstance = (): Draw | undefined => useStore(useGeoViewStore(), (state) => state.drawerState.drawInstance);
-
-/** Hooks whether measurements are hidden. */
-export const useDrawerHideMeasurements = (): boolean => useStore(useGeoViewStore(), (state) => state.drawerState.hideMeasurements);
-
 /** Hooks whether the undo action is disabled. */
-export const useDrawerUndoDisabled = (): boolean => useStore(useGeoViewStore(), (state) => state.drawerState.undoDisabled);
+export const useStoreDrawerUndoDisabled = (): boolean => useStore(useGeoViewStore(), (state) => state.drawerState.undoDisabled);
 
 /** Hooks whether the redo action is disabled. */
-export const useDrawerRedoDisabled = (): boolean => useStore(useGeoViewStore(), (state) => state.drawerState.redoDisabled);
+export const useStoreDrawerRedoDisabled = (): boolean => useStore(useGeoViewStore(), (state) => state.drawerState.redoDisabled);
 
-// #endregion STATE HOOKS
+// #endregion STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
 
 // #region STATE ADAPTORS
 // GV These methods should be called from a State Adaptor class listening on domain events triggered by controllers.

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/drawer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/drawer-state.ts
@@ -195,6 +195,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
     },
 
     actions: {
+      /**
+       * Sets the active geometry type.
+       *
+       * @param geomType - The geometry type to set as active
+       */
       setActiveGeom: (geomType: string) => {
         set({
           drawerState: {
@@ -204,6 +209,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the drawing style.
+       *
+       * @param style - The style properties to apply
+       */
       setStyle: (style: StyleProps) => {
         set({
           drawerState: {
@@ -213,6 +223,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the fill color.
+       *
+       * @param fillColor - The fill color value
+       */
       setFillColor: (fillColor: string) => {
         set({
           drawerState: {
@@ -225,6 +240,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the stroke color.
+       *
+       * @param strokeColor - The stroke color value
+       */
       setStrokeColor: (strokeColor: string) => {
         set({
           drawerState: {
@@ -237,6 +257,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the stroke width.
+       *
+       * @param strokeWidth - The stroke width value
+       */
       setStrokeWidth: (strokeWidth: number) => {
         set({
           drawerState: {
@@ -249,6 +274,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the icon size.
+       *
+       * @param iconSize - The icon size value
+       */
       setIconSize: (iconSize: number) => {
         set({
           drawerState: {
@@ -261,6 +291,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the text value.
+       *
+       * @param text - The text content
+       */
       setTextValue: (text: string) => {
         set({
           drawerState: {
@@ -273,6 +308,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the text size.
+       *
+       * @param textSize - The text size value
+       */
       setTextSize: (textSize: number) => {
         set({
           drawerState: {
@@ -285,6 +325,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the text font.
+       *
+       * @param textFont - The font family name
+       */
       setTextFont: (textFont: string) => {
         set({
           drawerState: {
@@ -297,6 +342,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the text color.
+       *
+       * @param textColor - The text color value
+       */
       setTextColor: (textColor: string) => {
         set({
           drawerState: {
@@ -309,6 +359,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the text halo color.
+       *
+       * @param textHaloColor - The text halo color value
+       */
       setTextHaloColor: (textHaloColor: string) => {
         set({
           drawerState: {
@@ -321,6 +376,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the text halo width.
+       *
+       * @param textHaloWidth - The text halo width value
+       */
       setTextHaloWidth: (textHaloWidth: number) => {
         set({
           drawerState: {
@@ -333,6 +393,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the text bold state.
+       *
+       * @param textBold - Whether text should be bold
+       */
       setTextBold: (textBold: boolean) => {
         set({
           drawerState: {
@@ -345,6 +410,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the text italic state.
+       *
+       * @param textItalic - Whether text should be italic
+       */
       setTextItalic: (textItalic: boolean) => {
         set({
           drawerState: {
@@ -357,6 +427,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the text rotation angle.
+       *
+       * @param textRotation - The rotation angle in degrees
+       */
       setTextRotation: (textRotation: number) => {
         set({
           drawerState: {
@@ -369,6 +444,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the draw interaction instance.
+       *
+       * @param drawInstance - The OpenLayers Draw interaction
+       */
       setDrawInstance: (drawInstance: Draw) => {
         set({
           drawerState: {
@@ -378,6 +458,9 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Removes the draw interaction instance.
+       */
       removeDrawInstance: () => {
         set({
           drawerState: {
@@ -387,6 +470,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the transform interaction instance.
+       *
+       * @param transformInstance - The OpenLayers Transform interaction
+       */
       setTransformInstance: (transformInstance: Transform) => {
         set({
           drawerState: {
@@ -396,6 +484,9 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Removes the transform interaction instance.
+       */
       removeTransformInstance: () => {
         set({
           drawerState: {
@@ -405,6 +496,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the selected drawing feature.
+       *
+       * @param selectedDrawing - The selected feature
+       */
       setSelectedDrawing(selectedDrawing: Feature) {
         set({
           drawerState: {
@@ -414,6 +510,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the snap interaction instance.
+       *
+       * @param snapInstance - The OpenLayers Snap interaction
+       */
       setSnapInstance(snapInstance: Snap) {
         set({
           drawerState: {
@@ -423,6 +524,9 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Removes the snap interaction instance.
+       */
       removeSnapInstance() {
         set({
           drawerState: {
@@ -432,6 +536,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets whether measurements are hidden.
+       *
+       * @param hideMeasurements - Whether to hide measurements
+       */
       setHideMeasurements: (hideMeasurements: boolean) => {
         set({
           drawerState: {
@@ -441,6 +550,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the icon source URL.
+       *
+       * @param iconSrc - The icon source path
+       */
       setIconSrc: (iconSrc: string) => {
         set({
           drawerState: {
@@ -450,6 +564,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the undo button disabled state.
+       *
+       * @param undoDisabled - Whether undo is disabled
+       */
       setUndoDisabled: (undoDisabled: boolean) => {
         set({
           drawerState: {
@@ -459,6 +578,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Sets the redo button disabled state.
+       *
+       * @param redoDisabled - Whether redo is disabled
+       */
       setRedoDisabled: (redoDisabled: boolean) => {
         set({
           drawerState: {
@@ -468,6 +592,11 @@ export function initializeDrawerState(set: TypeSetStore, get: TypeGetStore): IDr
         });
       },
 
+      /**
+       * Updates the drawing style state.
+       *
+       * @param style - The new style properties
+       */
       updateStateStyle: (style: StyleProps) => {
         set({
           drawerState: {

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
@@ -79,38 +79,27 @@ export interface IFeatureInfoState {
 
 // #endregion INTERFACE DEFINITION
 
-// #region STATE HOOKS
-// GV To be used by React components
+// #region UTIL FUNCTIONS (PRIVATE)
 
-/** Hook that returns the list of checked/selected features. */
-export const useDetailsCheckedFeatures = (): TypeFeatureInfoEntry[] =>
-  useStore(useGeoViewStore(), (state) => state.detailsState.checkedFeatures);
+/**
+ * Gets the layer data array for one layer.
+ * @param mapId - The map id.
+ * @param layerPath - The path of the layer to get.
+ * @returns The ordered layer info.
+ */
+const findLayerDataFromLayerDataArray = (
+  layerPath: string,
+  layerDataArray: TypeFeatureInfoResultSetEntry[]
+): TypeFeatureInfoResultSetEntry | undefined => {
+  return layerDataArray.find((layer) => layer.layerPath === layerPath);
+};
 
-/** Hook that returns the feature info layer data array. */
-export const useDetailsLayerDataArray = (): TypeFeatureInfoResultSetEntry[] =>
-  useStore(useGeoViewStore(), (state) => state.detailsState.layerDataArray);
+// #endregion UTIL FUNCTIONS (PRIVATE)
 
-/** Hook that returns the batched feature info layer data array. */
-export const useDetailsLayerDataArrayBatch = (): TypeFeatureInfoResultSetEntry[] =>
-  useStore(useGeoViewStore(), (state) => state.detailsState.layerDataArrayBatch);
-
-/** Hook that returns the selected layer path in the details panel. */
-export const useDetailsSelectedLayerPath = (): string => useStore(useGeoViewStore(), (state) => state.detailsState.selectedLayerPath);
-
-/** Hook that returns whether coordinate info is enabled. */
-export const useDetailsCoordinateInfoEnabled = (): boolean =>
-  useStore(useGeoViewStore(), (state) => state.detailsState.coordinateInfoEnabled);
-
-/** Hook that returns whether the coordinate info switch is hidden. */
-export const useMapHideCoordinateInfoSwitch = (): boolean =>
-  useStore(useGeoViewStore(), (state) => state.detailsState.hideCoordinateInfoSwitch);
-
-// #endregion STATE HOOKS
-
-// #region STATE SELECTORS
-// GV Should only be used specifically to access the Store.
-// GV Use sparingly and only if you are sure of what you are doing.
-// GV DO NOT USE this technique in React components, use the hooks above instead.
+// #region STATE GETTERS & HOOKS
+// GV Getters should be used to get the values at a moment in time.
+// GV Hooks should be used to attach to values and trigger UI components when they change.
+// GV Typically they are listed in couples (getter + hook) for the same value.
 
 /**
  * Returns the full feature info state slice for the given map.
@@ -124,20 +113,6 @@ export const useMapHideCoordinateInfoSwitch = (): boolean =>
 const getStoreDetailsState = (mapId: string): IFeatureInfoState => getGeoViewStore(mapId).getState().detailsState;
 
 /**
- * Gets the layer data array for one layer.
- * @param mapId - The map id.
- * @param layerPath - The path of the layer to get.
- * @returns The ordered layer info.
- */
-const findLayerDataFromLayerDataArray = (
-  mapId: string,
-  layerPath: string,
-  layerDataArray: TypeFeatureInfoResultSetEntry[] = getStoreDetailsState(mapId).layerDataArray
-): TypeFeatureInfoResultSetEntry | undefined => {
-  return layerDataArray.find((layer) => layer.layerPath === layerPath);
-};
-
-/**
  * Gets the selected layer path in the details panel for the given map.
  *
  * @param mapId - The map identifier.
@@ -147,6 +122,13 @@ export const getStoreDetailsSelectedLayerPath = (mapId: string): string => {
   return getStoreDetailsState(mapId).selectedLayerPath;
 };
 
+/** Hook that returns the selected layer path in the details panel. */
+export const useStoreDetailsSelectedLayerPath = (): string => useStore(useGeoViewStore(), (state) => state.detailsState.selectedLayerPath);
+
+// #endregion STATE GETTERS & HOOKS
+
+// #region STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
+
 /**
  * Gets the feature info entries for a specific layer.
  *
@@ -155,10 +137,31 @@ export const getStoreDetailsSelectedLayerPath = (mapId: string): string => {
  * @returns The feature info entries, or undefined if the layer is not found.
  */
 export const getStoreDetailsFeatures = (mapId: string, layerPath: string): TypeFeatureInfoEntry[] | undefined => {
-  return findLayerDataFromLayerDataArray(mapId, layerPath)?.features;
+  const { layerDataArray } = getStoreDetailsState(mapId);
+  return findLayerDataFromLayerDataArray(layerPath, layerDataArray)?.features;
 };
 
-// #endregion STATE SELECTORS
+/** Hook that returns the list of checked/selected features. */
+export const useStoreDetailsCheckedFeatures = (): TypeFeatureInfoEntry[] =>
+  useStore(useGeoViewStore(), (state) => state.detailsState.checkedFeatures);
+
+/** Hook that returns the feature info layer data array. */
+export const useStoreDetailsLayerDataArray = (): TypeFeatureInfoResultSetEntry[] =>
+  useStore(useGeoViewStore(), (state) => state.detailsState.layerDataArray);
+
+/** Hook that returns the batched feature info layer data array. */
+export const useStoreDetailsLayerDataArrayBatch = (): TypeFeatureInfoResultSetEntry[] =>
+  useStore(useGeoViewStore(), (state) => state.detailsState.layerDataArrayBatch);
+
+/** Hook that returns whether coordinate info is enabled. */
+export const useStoreDetailsCoordinateInfoEnabled = (): boolean =>
+  useStore(useGeoViewStore(), (state) => state.detailsState.coordinateInfoEnabled);
+
+/** Hook that returns whether the coordinate info switch is hidden. */
+export const useStoreDetailsHideCoordinateInfoSwitch = (): boolean =>
+  useStore(useGeoViewStore(), (state) => state.detailsState.hideCoordinateInfoSwitch);
+
+// #endregion STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
 
 // #region STATE ADAPTORS
 

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/feature-info-state.ts
@@ -15,16 +15,10 @@ import type {
   TypeResultSetEntry,
   TypeQueryStatus,
   TypeFieldEntry,
-  TypeUtmZoneResponse,
-  TypeAltitudeResponse,
-  TypeNtsResponse,
-  TypeServiceUrls,
-  TypeMapMouseInfo,
 } from '@/api/types/map-schema-types';
 import type { TypeGeoviewLayerType } from '@/api/types/layer-schema-types';
 import type { TypeMapFeaturesConfig } from '@/core/types/global-types';
 import { logger } from '@/core/utils/logger';
-import { Projection } from '@/geo/utils/projection';
 import { doUntil } from '@/core/utils/utilities';
 
 // #region INTERFACE DEFINITION
@@ -73,11 +67,19 @@ export interface IFeatureInfoState {
     setLayerDataArrayBatch: (layerDataArray: TypeFeatureInfoResultSetEntry[]) => void;
     setLayerDataArrayBatchLayerPathBypass: (layerPath: string) => void;
     setSelectedLayerPath: (selectedLayerPath: string) => void;
-    toggleCoordinateInfoEnabled: () => void;
+    setCoordinateInfoEnabled: (coordinateInfoEnabled: boolean) => void;
+    updateCoordinateInfoLayer: (features: TypeFeatureInfoEntry[], queryStatus: TypeQueryStatus) => void;
   };
 }
 
 // #endregion INTERFACE DEFINITION
+
+// #region PUBLIC CONSTANTS
+
+/** The layer path for the coordinate info feature. */
+export const LAYER_PATH_COORDINATE_INFO = 'coordinate-info';
+
+// #endregion PUBLIC CONSTANTS
 
 // #region UTIL FUNCTIONS (PRIVATE)
 
@@ -125,6 +127,53 @@ export const getStoreDetailsSelectedLayerPath = (mapId: string): string => {
 /** Hook that returns the selected layer path in the details panel. */
 export const useStoreDetailsSelectedLayerPath = (): string => useStore(useGeoViewStore(), (state) => state.detailsState.selectedLayerPath);
 
+/**
+ * Gets the layer query status for a given layer path.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to get the query status for.
+ * @returns The query status for the layer, or undefined if the layer is not found.
+ */
+export const getStoreDetailsQueryStatus = (mapId: string, layerPath: string): TypeQueryStatus | undefined => {
+  return findLayerDataFromLayerDataArray(layerPath, getStoreDetailsState(mapId).layerDataArray)?.queryStatus;
+};
+
+/** Hook that returns the selected layer path in the details panel. */
+export const useStoreDetailsQueryStatus = (layerPath: string): TypeQueryStatus | undefined => {
+  return useStore(useGeoViewStore(), (state) => findLayerDataFromLayerDataArray(layerPath, state.detailsState.layerDataArray)?.queryStatus);
+};
+
+/**
+ * Gets the coordinate info enabled state for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns Whether coordinate info is enabled.
+ */
+export const getStoreDetailsCoordinateInfoEnabled = (mapId: string): boolean => {
+  return getStoreDetailsState(mapId).coordinateInfoEnabled;
+};
+
+/** Hook that returns whether coordinate info is enabled. */
+export const useStoreDetailsCoordinateInfoEnabled = (): boolean =>
+  useStore(useGeoViewStore(), (state) => state.detailsState.coordinateInfoEnabled);
+
+/**
+ * Gets the feature info entry for the coordinate info layer from the details store.
+ *
+ * @param mapId - The map identifier.
+ * @returns The feature info entry for the coordinate info layer, or undefined if not found.
+ */
+export const getStoreDetailsLayerDataArrayFeature = (mapId: string): TypeFeatureInfoEntry | undefined => {
+  return findLayerDataFromLayerDataArray(LAYER_PATH_COORDINATE_INFO, getStoreDetailsState(mapId).layerDataArray)?.features?.[0];
+};
+
+/** Hook that returns the feature info for the coordinate info layer data array. */
+export const useStoreDetailsLayerDataArrayFeature = (): TypeFeatureInfoEntry | undefined =>
+  useStore(
+    useGeoViewStore(),
+    (state) => findLayerDataFromLayerDataArray(LAYER_PATH_COORDINATE_INFO, state.detailsState.layerDataArray)?.features?.[0]
+  );
+
 // #endregion STATE GETTERS & HOOKS
 
 // #region STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
@@ -145,17 +194,9 @@ export const getStoreDetailsFeatures = (mapId: string, layerPath: string): TypeF
 export const useStoreDetailsCheckedFeatures = (): TypeFeatureInfoEntry[] =>
   useStore(useGeoViewStore(), (state) => state.detailsState.checkedFeatures);
 
-/** Hook that returns the feature info layer data array. */
-export const useStoreDetailsLayerDataArray = (): TypeFeatureInfoResultSetEntry[] =>
-  useStore(useGeoViewStore(), (state) => state.detailsState.layerDataArray);
-
 /** Hook that returns the batched feature info layer data array. */
 export const useStoreDetailsLayerDataArrayBatch = (): TypeFeatureInfoResultSetEntry[] =>
   useStore(useGeoViewStore(), (state) => state.detailsState.layerDataArrayBatch);
-
-/** Hook that returns whether coordinate info is enabled. */
-export const useStoreDetailsCoordinateInfoEnabled = (): boolean =>
-  useStore(useGeoViewStore(), (state) => state.detailsState.coordinateInfoEnabled);
 
 /** Hook that returns whether the coordinate info switch is hidden. */
 export const useStoreDetailsHideCoordinateInfoSwitch = (): boolean =>
@@ -226,12 +267,12 @@ export const removeStoreDetailsCheckedFeature = (mapId: string, feature: TypeFea
 };
 
 /**
- * Toggles the coordinate info enabled state in the store.
+ * Sets whether the coordinate info feature is enabled in the store.
  *
  * @param mapId - The map identifier.
  */
-export const toggleStoreDetailsCoordinateInfoEnabled = (mapId: string): void => {
-  getStoreDetailsState(mapId).actions.toggleCoordinateInfoEnabled();
+export const setStoreDetailsCoordinateInfoEnabled = (mapId: string, coordinateInfoEnabled: boolean): void => {
+  getStoreDetailsState(mapId).actions.setCoordinateInfoEnabled(coordinateInfoEnabled);
 };
 
 /**
@@ -288,125 +329,17 @@ export const deleteStoreDetailsFeatureInfo = (mapId: string, layerPath: string):
 };
 
 /**
- * Creates (or replaces) the coordinate-info layer entry in the details store.
+ * Updates (creates/replaces) the specific coordinate information layer entry in the details store.
  *
- * Builds a synthetic layer data entry with a 'coordinate-info' layer path
+ * Builds a synthetic layer data entry with a specific layer path
  * and appends it to the current layer data array.
  *
  * @param mapId - The map identifier.
  * @param features - Optional feature entries to include in the coordinate info layer.
+ * @param queryStatus - The status of the query.
  */
-export const createStoreCoordinateInfoLayer = (mapId: string, features: TypeFeatureInfoEntry[] = []): void => {
-  const coordinateInfoLayer = {
-    layerPath: 'coordinate-info',
-    layerName: 'Coordinate Information',
-    eventListenerEnabled: false,
-    queryStatus: 'processed',
-    layerStatus: 'processed',
-    numOffeature: 1,
-    features,
-  } as unknown as TypeFeatureInfoResultSetEntry & { numOffeatures: number };
-
-  // Get layer array, minus the coordinate-info layer
-  const featureInfoState = getStoreDetailsState(mapId);
-  const currentLayerDataArray = [...featureInfoState.layerDataArray].filter((layer) => layer.layerPath !== 'coordinate-info');
-
-  // Add the new coordinate info layer
-  currentLayerDataArray.push(coordinateInfoLayer);
-
-  // Update the store directly
-  featureInfoState.actions.setLayerDataArray(currentLayerDataArray);
-};
-
-/**
- * Creates or deletes coordinate info based on the current enabled state.
- *
- * When coordinate info is enabled, fetches UTM zone, NTS sheet, and altitude
- * data from the configured service URLs and creates a coordinate info layer
- * entry in the store. When disabled, removes any existing coordinate info.
- *
- * @param mapId - The map identifier.
- * @param coordinates - The map mouse info containing click coordinates.
- * @param serviceUrls - Optional service URLs for UTM, NTS, and altitude lookups.
- */
-export const createOrDeleteStoreCoordinateInfo = (
-  mapId: string,
-  coordinates: TypeMapMouseInfo,
-  serviceUrls: TypeServiceUrls | undefined
-): void => {
-  // If the coordinate info is not enabled, clear any existing info
-  const state = getStoreDetailsState(mapId);
-  if (!state.coordinateInfoEnabled) {
-    deleteStoreDetailsFeatureInfo(mapId, 'coordinate-info');
-    return;
-  }
-
-  const [lng, lat] = coordinates.lonlat;
-
-  if (!serviceUrls) return;
-
-  const { utmZoneUrl, ntsSheetUrl, altitudeUrl } = serviceUrls;
-  Promise.allSettled([
-    fetch(`${utmZoneUrl}?bbox=${lng}%2C${lat}%2C${lng}%2C${lat}`).then((r) => r.json()) as Promise<TypeUtmZoneResponse>,
-    fetch(`${ntsSheetUrl}?bbox=${lng}%2C${lat}%2C${lng}%2C${lat}`).then((r) => r.json()) as Promise<TypeNtsResponse>,
-    fetch(`${altitudeUrl}?lat=${lat}&lon=${lng}`).then((r) => r.json()) as Promise<TypeAltitudeResponse>,
-  ])
-    .then(([utmResult, ntsResult, elevationResult]) => {
-      const utmData = utmResult.status === 'fulfilled' ? utmResult.value : undefined;
-      const ntsData = ntsResult.status === 'fulfilled' ? ntsResult.value : undefined;
-      const elevationData = elevationResult.status === 'fulfilled' ? elevationResult.value : undefined;
-
-      const utmIdentifier = utmData?.features[0].properties.identifier;
-      const [easting, northing] = utmIdentifier
-        ? Projection.transformToUTMNorthingEasting(coordinates.lonlat, utmIdentifier)
-        : [undefined, undefined];
-
-      // Create coordinate info layer entry
-      const coordinateFeature: TypeFeatureInfoEntry[] = [
-        {
-          uid: 'coordinate-info-feature',
-          fieldInfo: {
-            latitude: { value: lat.toFixed(6), fieldKey: 0, dataType: 'number', alias: 'Latitude' },
-            longitude: { value: lng.toFixed(6), fieldKey: 1, dataType: 'number', alias: 'Longitude' },
-            utmZone: { value: utmIdentifier, fieldKey: 2, dataType: 'string', alias: 'UTM Identifier' },
-            easting: { value: easting?.toFixed(2), fieldKey: 3, dataType: 'number', alias: 'Easting' },
-            northing: { value: northing?.toFixed(2), fieldKey: 4, dataType: 'number', alias: 'Northing' },
-            ntsMapsheet: {
-              value: ntsData?.features
-                .filter((f) => f.properties.name !== '')
-                .sort((f) => f.properties.scale)
-                .map((f) => {
-                  const scale = `${f.properties.scale / 1000}K`;
-                  return `${f.properties.identifier} - ${f.properties.name} - ${scale}`;
-                })
-                .join('\n'),
-              fieldKey: 5,
-              dataType: 'string',
-              alias: 'NTS Mapsheets',
-            },
-            elevation: {
-              value: elevationData?.altitude ? `${elevationData.altitude} m` : undefined,
-              fieldKey: 6,
-              dataType: 'string',
-              alias: 'Elevation',
-            },
-          },
-          extent: undefined,
-          geometry: undefined,
-          featureKey: 0,
-          geoviewLayerType: 'CSV',
-          supportZoomTo: true,
-          layerPath: 'coordinate-info',
-        },
-      ];
-
-      // Create it in the store
-      createStoreCoordinateInfoLayer(mapId, coordinateFeature);
-    })
-    .catch((error: unknown) => {
-      // Log
-      logger.logPromiseFailed('Failed to get coordinate info', error);
-    });
+export const updateStoreCoordinateInfoLayer = (mapId: string, features: TypeFeatureInfoEntry[], queryStatus: TypeQueryStatus): void => {
+  getStoreDetailsState(mapId).actions.updateCoordinateInfoLayer(features, queryStatus);
 };
 
 // #region STATE ADAPTORS - BATCH PROPAGATION
@@ -465,6 +398,22 @@ export const propagateStoreFeatureInfoBatch = (mapId: string, layerDataArray: Ty
  * @returns The initialized FeatureInfo State
  */
 export function initFeatureInfoState(set: TypeSetStore, get: TypeGetStore): IFeatureInfoState {
+  // Wait for the state to be ready and initialize the coordinate info layer
+  // GV There may be a better way to do this, but it's what we were doing at the time of this refactor
+  doUntil(() => {
+    // Once the details state is ready in the store
+    if (get().detailsState) {
+      // Updates the store coodinate info layer if it needs to be there
+      if (get().detailsState.coordinateInfoEnabled) updateStoreCoordinateInfoLayer(get().mapId, [], 'init');
+
+      // We did it
+      return true;
+    }
+
+    // Keep waiting
+    return false;
+  }, 1000);
+
   return {
     checkedFeatures: [],
     layerDataArray: [],
@@ -575,22 +524,47 @@ export function initFeatureInfoState(set: TypeSetStore, get: TypeGetStore): IFea
       },
 
       /**
-       * Toggles the coordinate info enabled state.
+       * Sets whether the coordinate info feature is enabled in the store.
        *
-       * When enabling, also triggers coordinate info creation if click coordinates exist.
+       * @param coordinateInfoEnabled - Whether coordinate info is enabled.
        */
-      toggleCoordinateInfoEnabled: () => {
-        const { coordinateInfoEnabled } = get().detailsState;
+      setCoordinateInfoEnabled: (coordinateInfoEnabled: boolean) => {
         set({
           detailsState: {
             ...get().detailsState,
-            coordinateInfoEnabled: !coordinateInfoEnabled,
+            coordinateInfoEnabled,
           },
         });
-        const { clickCoordinates } = get().mapState;
-        if (!coordinateInfoEnabled && clickCoordinates) {
-          createOrDeleteStoreCoordinateInfo(get().mapId, clickCoordinates, get().mapConfig?.serviceUrls);
-        }
+      },
+
+      /**
+       * Updates (creates/replaces) the coordinate-info synthetic layer entry.
+       *
+       * @param features - Optional feature entries to include in the coordinate info layer.
+       */
+      updateCoordinateInfoLayer: (features: TypeFeatureInfoEntry[], queryStatus: TypeQueryStatus) => {
+        const coordinateInfoLayer = {
+          layerPath: LAYER_PATH_COORDINATE_INFO,
+          queryStatus,
+          features,
+          featuresHaveGeometry: true,
+        } as TypeFeatureInfoResultSetEntry;
+
+        // Get layer array, minus the coordinate-info layer
+        const currentLayerDataArray = [...get().detailsState.layerDataArray].filter(
+          (layer) => layer.layerPath !== LAYER_PATH_COORDINATE_INFO
+        );
+
+        // Add the new coordinate info layer
+        currentLayerDataArray.push(coordinateInfoLayer);
+
+        // Update the store
+        set({
+          detailsState: {
+            ...get().detailsState,
+            layerDataArray: currentLayerDataArray,
+          },
+        });
       },
     },
   } as IFeatureInfoState;
@@ -630,44 +604,8 @@ export function initDetailsStateSubscriptions(store: GeoviewStoreType): void {
     }
   );
 
-  const clickCoordinates = store.subscribe(
-    (state) => state.mapState.clickCoordinates,
-    (coords) => {
-      if (!coords) return;
-      // Log
-      logger.logTraceCoreStoreSubscription('FEATURE-INFO STATE - clickCoordinates', coords);
-
-      createOrDeleteStoreCoordinateInfo(mapId, coords, store.getState().mapConfig?.serviceUrls);
-    }
-  );
-
-  const coordinateInfoEnabledSubscription = store.subscribe(
-    (state) => state.detailsState.coordinateInfoEnabled,
-    (enabled) => {
-      if (enabled) {
-        // Create empty coordinate info layer when enabled
-        createStoreCoordinateInfoLayer(mapId);
-      } else {
-        // Remove coordinate info layer when disabled
-        deleteStoreDetailsFeatureInfo(mapId, 'coordinate-info');
-      }
-    }
-  );
-
-  // Check initial state and create coordinate info layer if neeeded
-  if (store.getState().detailsState.coordinateInfoEnabled) {
-    doUntil(() => {
-      if (mapId) {
-        createStoreCoordinateInfoLayer(mapId);
-        return true;
-      }
-      return false;
-    }, 1000);
-  }
-
   // Add subscriptions to the list of subscriptions to be used by the state
-  subscriptions[mapId] = [];
-  subscriptions[mapId].push(...[layerDataArrayUpdateBatch, clickCoordinates, coordinateInfoEnabledSubscription]);
+  subscriptions[mapId] = [layerDataArrayUpdateBatch];
 }
 
 /**

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/geochart-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/geochart-state.ts
@@ -466,6 +466,8 @@ const subscriptions: Record<string, SubscriptionDelegate[]> = {};
  * @param store - The GeoView Zustand store instance.
  */
 export function initGeochartStateSubscriptions(store: GeoviewStoreType): void {
+  const { mapId } = store.getState();
+
   // Checks for updated layers in layer data array from the details state
   const layerDataArrayUpdate = store.subscribe(
     (state) => state.detailsState.layerDataArray as TypeGeochartResultSetEntry[],
@@ -474,7 +476,7 @@ export function initGeochartStateSubscriptions(store: GeoviewStoreType): void {
       logger.logTraceCoreStoreSubscription('GEOCHART STATE - detailsState.layerDataArray', cur);
 
       // Also propagate in the geochart arrays
-      setStoreGeochartLayerDataArray(store.getState().mapId, cur);
+      setStoreGeochartLayerDataArray(mapId, cur);
     }
   );
 
@@ -486,7 +488,7 @@ export function initGeochartStateSubscriptions(store: GeoviewStoreType): void {
       logger.logTraceCoreStoreSubscription('GEOCHART STATE - geochartState.layerDataArray', cur);
 
       // Also propagate in the batched array
-      propagateStoreGeochartFeatureInfoBatch(store.getState().mapId, cur).catch((error: unknown) => {
+      propagateStoreGeochartFeatureInfoBatch(mapId, cur).catch((error: unknown) => {
         // Log
         logger.logPromiseFailed('propagateStoreGeochartFeatureInfoBatch in layerDataArrayUpdateBatch subscribe in geochart-state', error);
       });
@@ -494,7 +496,7 @@ export function initGeochartStateSubscriptions(store: GeoviewStoreType): void {
   );
 
   // Add subscriptions to the list of subscriptions to be used by the state
-  subscriptions[store.getState().mapId] = [layerDataArrayUpdate, layerDataArrayUpdateBatch];
+  subscriptions[mapId] = [layerDataArrayUpdate, layerDataArrayUpdateBatch];
 }
 
 /**

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/geochart-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/geochart-state.ts
@@ -144,45 +144,10 @@ export function initializeGeochartState(set: TypeSetStore, get: TypeGetStore): I
 
 // #endregion STATE INITIALIZATION
 
-// #region STATE HOOKS
-// GV To be used by React components
-
-/**
- * Hook that returns the geochart chart configurations.
- *
- * Uses optional chaining because this hook may be called from components
- * outside the GeoChart plugin where the geochartState may be undefined.
- *
- * @returns The geochart configurations keyed by layer path, or undefined.
- */
-export const useGeochartConfigs = (): GeoChartStoreByLayerPath | undefined => {
-  // GV This hook is called from other components than the GeoChart so the '?' on the geochartState is mandatory
-  return useStore(useGeoViewStore(), (state) => state.geochartState?.geochartChartsConfig);
-};
-
-/** Hook that returns the geochart layer data array. */
-export const useGeochartLayerDataArray = (): TypeGeochartResultSetEntry[] =>
-  useStore(useGeoViewStore(), (state) => state.geochartState.layerDataArray);
-
-/**
- * Hook that returns the batched geochart layer data array.
- *
- * Uses optional chaining because this hook may be called from components
- * outside the GeoChart plugin where the geochartState may be undefined.
- *
- * @returns The batched geochart result set entries, or undefined.
- */
-export const useGeochartLayerDataArrayBatch = (): TypeGeochartResultSetEntry[] | undefined => {
-  // GV This hook is called from other components than the GeoChart so the '?' on the geochartState is mandatory
-  return useStore(useGeoViewStore(), (state) => state.geochartState?.layerDataArrayBatch);
-};
-
-/** Hook that returns the currently selected geochart layer path. */
-export const useGeochartSelectedLayerPath = (): string => useStore(useGeoViewStore(), (state) => state.geochartState.selectedLayerPath);
-
-// #endregion STATE HOOKS
-
-// #region STATE SELECTORS
+// #region STATE GETTERS & HOOKS
+// GV Getters should be used to get the values at a moment in time.
+// GV Hooks should be used to attach to values and trigger UI components when they change.
+// GV Typically they are listed in couples (getter + hook) for the same value.
 
 /**
  * Returns the full geochart state slice for the given map.
@@ -226,6 +191,10 @@ export const isStoreGeochartInitialized = (mapId: string): boolean => {
  */
 export const getStoreGeochartSelectedLayerPath = (mapId: string): string => getStoreGeochartState(mapId).selectedLayerPath;
 
+/** Hook that returns the currently selected geochart layer path. */
+export const useStoreGeochartSelectedLayerPath = (): string =>
+  useStore(useGeoViewStore(), (state) => state.geochartState.selectedLayerPath);
+
 /**
  * Gets the geochart chart configurations for the given map.
  *
@@ -234,6 +203,23 @@ export const getStoreGeochartSelectedLayerPath = (mapId: string): string => getS
  * @throws {PluginStateUninitializedError} When the Geochart plugin is uninitialized.
  */
 export const getStoreGeochartChartsConfig = (mapId: string): GeoChartStoreByLayerPath => getStoreGeochartState(mapId).geochartChartsConfig;
+
+/**
+ * Hook that returns the geochart chart configurations.
+ *
+ * Uses optional chaining because this hook may be called from components
+ * outside the GeoChart plugin where the geochartState may be undefined.
+ *
+ * @returns The geochart configurations keyed by layer path, or undefined.
+ */
+export const useStoreGeochartChartsConfig = (): GeoChartStoreByLayerPath | undefined => {
+  // GV This hook is called from other components than the GeoChart so the '?' on the geochartState is mandatory
+  return useStore(useGeoViewStore(), (state) => state.geochartState?.geochartChartsConfig);
+};
+
+// #endregion STATE GETTERS & HOOKS
+
+// #region STATE GETTERS & HOOKS (no match between getter-hook)
 
 /**
  * Gets the geochart layer data array for the given map.
@@ -254,7 +240,20 @@ export const getStoreGeochartLayerDataArray = (mapId: string): TypeGeochartResul
 export const getStoreGeochartLayerDataArrayBatchLayerPathBypass = (mapId: string): string =>
   getStoreGeochartState(mapId).layerDataArrayBatchLayerPathBypass;
 
-// #endregion STATE SELECTORS
+/**
+ * Hook that returns the batched geochart layer data array.
+ *
+ * Uses optional chaining because this hook may be called from components
+ * outside the GeoChart plugin where the geochartState may be undefined.
+ *
+ * @returns The batched geochart result set entries, or undefined.
+ */
+export const useStoreGeochartLayerDataArrayBatch = (): TypeGeochartResultSetEntry[] | undefined => {
+  // GV This hook is called from other components than the GeoChart so the '?' on the geochartState is mandatory
+  return useStore(useGeoViewStore(), (state) => state.geochartState?.layerDataArrayBatch);
+};
+
+// #endregion STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
 
 // #region STATE ADAPTORS
 // GV These methods should be called from a State Adaptor class listening on domain events triggered by controllers.

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -917,6 +917,7 @@ export const getStoreLayerDisplayDateFormat = (mapId: string, layerPath: string)
 
 /**
  * React hook that returns the display date format for a specific layer.
+ *
  * The hook first attempts to resolve a layer-specific display date format
  * using the provided layer path. If the layer does not define its own
  * display date format (or cannot be found), the application-wide display
@@ -963,6 +964,7 @@ export const useStoreLayerDisplayDateFormatSet = (): Record<string, TypeDisplayD
 
 /**
  * React hook that returns the display date format for a specific layer.
+ *
  * The hook first attempts to resolve a layer-specific display date format
  * using the provided layer path. If the layer does not define its own
  * display date format (or cannot be found), the application-wide display
@@ -985,6 +987,7 @@ export const useStoreLayerDisplayDateFormatShort = (layerPath: string | undefine
 
 /**
  * React hook that returns the display date timezone for a specific layer.
+ *
  * The hook first attempts to resolve a layer-specific display date timezone
  * using the provided layer path. If the layer does not define its own
  * display date timezone (or cannot be found), the application-wide display

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -195,6 +195,19 @@ const utilDeleteLayerFromLegendLayers = (legendLayers: TypeLegendLayer[], layerP
 };
 
 /**
+ * Recursively checks whether all children of a layer are visible.
+ *
+ * @param layer - The legend layer to check
+ * @param visibleLayers - The set of currently visible layer paths
+ * @returns True if every descendant layer path is in visibleLayers
+ */
+const utilAllChildrenVisible = (layer: TypeLegendLayer, visibleLayers: string[]): boolean => {
+  return layer.children.every(
+    (child) => visibleLayers.includes(child.layerPath) && (!child.children?.length || utilAllChildrenVisible(child, visibleLayers))
+  );
+};
+
+/**
  * Checks whether any layer in the subtree has visibility disabled in its controls.
  *
  * @param layer - The root layer to start the check from
@@ -727,6 +740,22 @@ export const useStoreLayerBounds4326 = createLayerSelectorHook('bounds4326');
 export const useStoreLayerCanToggle = createLayerSelectorHook('canToggle');
 
 /**
+ * Selects whether all sublayers of a layer are visible.
+ *
+ * Reads from both layerState (children tree) and mapState (visibleLayers).
+ *
+ * @param layerPath - The layer path to check
+ * @returns True if all children and descendants are visible
+ */
+export const useStoreLayerAllChildrenVisible = (layerPath: string): boolean => {
+  return useStore(useGeoViewStore(), (state): boolean => {
+    const layer = utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath);
+    if (!layer || !layer.children.length) return true;
+    return utilAllChildrenVisible(layer, state.mapState.visibleLayers);
+  });
+};
+
+/**
  * Selects the child layer paths for a specific layer.
  *
  * Uses useStableSelector with shallowObjectEqual so the component only re-renders
@@ -745,8 +774,6 @@ export const useStoreLayerChildPaths = (layerPath: string): string[] | undefined
 
 /**
  * Selects whether any layer in the subtree (including the layer itself) has visibility disabled.
- *
- * Returns a boolean so Object.is comparison prevents unnecessary re-renders.
  *
  * @param layerPath - The layer path to check
  * @returns True if any node in the subtree has controls.visibility === false
@@ -795,6 +822,24 @@ export const useStoreLayerStyleConfig = createLayerSelectorHook('styleConfig');
 /** Hook that returns the text visibility for a specific layer. */
 export const useStoreLayerTextVisibility = createLayerSelectorHook('textVisible');
 
+/** Hook that returns the layer attribution for a specific layer. */
+export const useStoreLayerAttribution = createLayerSelectorHook('layerAttribution');
+
+/** Hook that returns the layer opacity for a specific layer. */
+export const useStoreLayerOpacity = createLayerSelectorHook('opacity');
+
+/** Hook that returns the max opacity inherited from parent for a specific layer. */
+export const useStoreLayerOpacityMaxFromParent = createLayerSelectorHook('opacityMaxFromParent');
+
+/** Hook that returns the hoverable flag for a specific layer. */
+export const useStoreLayerHoverable = createLayerSelectorHook('hoverable');
+
+/** Hook that returns the queryable flag for a specific layer. */
+export const useStoreLayerQueryable = createLayerSelectorHook('queryable');
+
+/** Hook that returns the URL for a specific layer. */
+export const useStoreLayerUrl = createLayerSelectorHook('url');
+
 // #endregion STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
 
 // #region STATE GETTERS & HOOKS - SPECIALIZED
@@ -823,19 +868,6 @@ export const useStoreLayerNameSet = (): Record<string, string> => {
     }, {});
   });
 };
-
-/**
- * Hook that returns the full legend layer for a given path.
- *
- * Returns a new reference whenever any property of the layer changes.
- * Use only in components that display all layer details (e.g. LayerDetails).
- * Prefer targeted createLayerSelectorHook hooks elsewhere.
- *
- * @param layerPath - The layer path to look up
- * @returns The matching legend layer, or undefined if not found
- */
-export const useStoreLayerByPath = (layerPath: string): TypeLegendLayer | undefined =>
-  useStore(useGeoViewStore(), (state) => utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath));
 
 /**
  * Hook that returns the icon set (image URLs) for a specific layer.

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -41,9 +41,6 @@ export interface ILayerState {
   /** The layer path of the currently highlighted layer. */
   highlightedLayer: string;
 
-  /** The full legend layer object for the currently selected layer. */
-  selectedLayer: TypeLegendLayer;
-
   /** The layer path of the currently selected layer, or undefined if none is selected. */
   selectedLayerPath?: string;
 
@@ -319,13 +316,10 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
       setSelectedLayerPath: (layerPath: string | undefined): void => {
         let theLayerPath: string | undefined = layerPath;
         if (layerPath && layerPath.length === 0) theLayerPath = undefined;
-        const curLayers = get().layerState.legendLayers;
-        const layer = utilLegendLayerByPathRec(curLayers, layerPath);
         set({
           layerState: {
             ...get().layerState,
             selectedLayerPath: theLayerPath,
-            selectedLayer: layer as TypeLegendLayer,
           },
         });
       },
@@ -465,6 +459,13 @@ export const getStoreLayerSelectedLayerPath = (mapId: string): string | undefine
 /** Hook that returns the selected layer path. */
 export const useStoreLayerSelectedLayerPath = (): string | null | undefined =>
   useStore(useGeoViewStore(), (state) => state.layerState.selectedLayerPath);
+
+/** Hook that returns the layer name of the currently selected layer. Primitive string so Object.is prevents spurious re-renders. */
+export const useStoreLayerSelectedLayerName = (): string | undefined =>
+  useStore(
+    useGeoViewStore(),
+    (state) => utilLegendLayerByPathRec(state.layerState.legendLayers, state.layerState.selectedLayerPath)?.layerName
+  );
 
 /**
  * Gets the highlighted layer path for the given map.
@@ -728,9 +729,6 @@ export const getStoreLayerItemVisibility = (mapId: string, layerPath: string, na
   return getStoreLayerLegendLayerByPath(mapId, layerPath)?.items.find((item) => item.name === name);
 };
 
-/** Hook that returns the selected legend layer object. */
-export const useStoreLayerSelectedLayer = (): TypeLegendLayer => useStore(useGeoViewStore(), (state) => state.layerState.selectedLayer);
-
 /** Hook that returns the EPSG:4326 bounds for a specific layer. */
 export const useStoreLayerBounds4326 = createLayerSelectorHook('bounds4326');
 
@@ -836,18 +834,17 @@ export const useStoreLayerNameSet = (): Record<string, string> => {
 };
 
 /**
- * Hook that returns the selected legend layer by looking it up from the legend layers array.
+ * Hook that returns the full legend layer for a given path.
  *
- * @returns The selected legend layer, or undefined if none is selected.
+ * Returns a new reference whenever any property of the layer changes.
+ * Use only in components that display all layer details (e.g. LayerDetails).
+ * Prefer targeted createLayerSelectorHook hooks elsewhere.
+ *
+ * @param layerPath - The layer path to look up
+ * @returns The matching legend layer, or undefined if not found
  */
-export const useStoreSelectedLayer = (): TypeLegendLayer | undefined => {
-  const layers = useStore(useGeoViewStore(), (state) => state.layerState.legendLayers);
-  const selectedLayerPath = useStore(useGeoViewStore(), (state) => state.layerState.selectedLayerPath);
-  if (selectedLayerPath) {
-    return utilLegendLayerByPathRec(layers, selectedLayerPath);
-  }
-  return undefined;
-};
+export const useStoreLayerByPath = (layerPath: string): TypeLegendLayer | undefined =>
+  useStore(useGeoViewStore(), (state) => utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath));
 
 /**
  * Hook that returns the icon set (image URLs) for a specific layer.

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -339,19 +339,10 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
       },
 
       /**
-       * Updates the deletion progress of a specific layer in the store.
-       * This function immutably updates the `legendLayers` array in the
-       * `layerState` by setting or removing the `deletionProgressPercentage`
-       * property for the layer identified by `layerPath`.
+       * Sets the deletion start time for the layer identified by the given layer path.
        *
-       * @param layerPath - The unique path or identifier of the layer to update.
-       * @param progression - The deletion progress percentage (0–100).
-       *   - If a number is provided, sets `deletionProgressPercentage` to that value.
-       *   - If `undefined`, removes the `deletionProgressPercentage` property from the layer.
-       * @remarks
-       * This function uses `utilUpdateLayerByPath` to find the
-       * target layer and update it immutably, ensuring that the rest of the
-       * `legendLayers` array remains unchanged.
+       * @param layerPath - The unique path or identifier of the layer to update
+       * @param startTime - The deletion start time timestamp, or undefined to remove it
        */
       setLayerDeletionStartTime: (layerPath: string, startTime: number | undefined): void => {
         set((state) => {

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -6,9 +6,11 @@ import type { Projection as OLProjection } from 'ol/proj';
 import { getGeoViewStore, useGeoViewStore } from '@/core/stores/stores-managers';
 import type { TypeLayersViewDisplayState, TypeLegendItem, TypeLegendLayer } from '@/core/components/layers/types';
 import type { TypeMapFeaturesConfig } from '@/core/types/global-types';
-import { type TypeGetStore, type TypeSetStore, useStableSelector } from '@/core/stores/geoview-store';
+import type { TypeGetStore, TypeSetStore } from '@/core/stores/geoview-store';
+import { useStableSelector } from '@/core/stores/geoview-store';
 import type { TypeLayerStyleConfig, TypeResultSet, TypeResultSetEntry } from '@/api/types/map-schema-types';
-import { DateMgt, type TemporalMode, type TimeDimension, type TimeIANA, type TypeDisplayDateFormat } from '@/core/utils/date-mgt';
+import type { TemporalMode, TimeDimension, TimeIANA, TypeDisplayDateFormat } from '@/core/utils/date-mgt';
+import { DateMgt } from '@/core/utils/date-mgt';
 import type {
   TypeGeoviewLayerType,
   TypeLayerStatus,

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -745,10 +745,11 @@ export const useStoreLayerCanToggle = createLayerSelectorHook('canToggle');
  * @returns The child layer paths, or undefined if no children exist
  */
 export const useStoreLayerChildPaths = (layerPath: string): string[] | undefined => {
-  return useStableSelector(useGeoViewStore(), (state): string[] | undefined => {
+  const result = useStableSelector(useGeoViewStore(), (state): string[] => {
     const layer = utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath);
-    return layer?.children?.map((child) => child.layerPath);
+    return layer?.children?.map((child) => child.layerPath) ?? [];
   });
+  return result.length > 0 ? result : undefined;
 };
 
 /**

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -69,12 +69,13 @@ export interface ILayerState {
     setSelectedLayerPath: (layerPath: string | undefined) => void;
     setLayersAreLoading: (areLoading: boolean) => void;
     setLayerDeletionStartTime: (layerPath: string, startTime: number | undefined) => void;
+    updateLayerByPath: (layerPath: string, updater: (layer: TypeLegendLayer) => TypeLegendLayer) => void;
   };
 }
 
 // #endregion INTERFACE DEFINITION
 
-// #region UTIL FUNCTIONS
+// #region UTIL FUNCTIONS (PRIVATE)
 
 /**
  * Recursively searches the legend layers tree for a layer matching the given path.
@@ -143,7 +144,96 @@ const utilFindAllLayers = (layers: TypeLegendLayer[]): Record<string, TypeLegend
   return total;
 };
 
-// #endregion UTIL FUNCTIONS
+/**
+ * Immutably updates a layer in the legend layer tree by its path.
+ *
+ * Creates new object references along the path to the target layer,
+ * leaving all other branches untouched. This ensures Zustand detects
+ * the change and hooks re-render correctly.
+ *
+ * @param layers - The legend layers array to search.
+ * @param layerPath - The layer path of the layer to update.
+ * @param updater - A function that receives the current layer and returns the updated layer.
+ * @returns A new legend layers array with the target layer updated.
+ */
+const utilUpdateLayerByPath = (
+  layers: TypeLegendLayer[],
+  layerPath: string,
+  updater: (layer: TypeLegendLayer) => TypeLegendLayer
+): TypeLegendLayer[] => {
+  return layers.map((layer) => {
+    if (layer.layerPath === layerPath) {
+      return updater(layer);
+    }
+
+    if (layer.children?.length) {
+      return {
+        ...layer,
+        children: utilUpdateLayerByPath(layer.children, layerPath, updater),
+      };
+    }
+
+    return layer;
+  });
+};
+
+/**
+ * Recursively removes a layer from the legend layers array by producing new arrays.
+ *
+ * @param legendLayers - The legend layers array to search.
+ * @param layerPath - The layer path to remove.
+ * @returns A new legend layers array with the target layer removed.
+ */
+const utilDeleteLayerFromLegendLayers = (legendLayers: TypeLegendLayer[], layerPath: string): TypeLegendLayer[] => {
+  return legendLayers
+    .filter((layer) => layer.layerPath !== layerPath)
+    .map((layer) => {
+      if (layer.children?.length) {
+        return { ...layer, children: utilDeleteLayerFromLegendLayers(layer.children, layerPath) };
+      }
+      return layer;
+    });
+};
+
+/**
+ * Checks whether any layer in the subtree has visibility disabled in its controls.
+ *
+ * @param layer - The root layer to start the check from
+ * @returns True if any node in the subtree has controls.visibility === false
+ */
+const utilHasDisabledVisibilityRec = (layer: TypeLegendLayer): boolean => {
+  if (layer.controls?.visibility === false) return true;
+  if (layer.children?.length > 0) {
+    return layer.children.some((child) => utilHasDisabledVisibilityRec(child));
+  }
+  return false;
+};
+
+/**
+ * Generic hook that selects a single property from a legend layer by path.
+ *
+ * @param layerPath - The layer path to look up.
+ * @param key - The property key to select from the layer.
+ * @returns The value of the property, or undefined if the layer is not found.
+ */
+function useLayerSelectorLayerValueGeneric<K extends keyof TypeLegendLayer>(layerPath: string, key: K): TypeLegendLayer[K] | undefined {
+  return useStore(useGeoViewStore(), (state) => {
+    const layer = utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath);
+    return layer?.[key];
+  });
+}
+
+/**
+ * Factory that creates a strongly typed hook for selecting a specific legend layer property.
+ *
+ * @param key - The property key to create a selector hook for.
+ * @returns A hook that accepts a layerPath and returns the property value.
+ */
+function createLayerSelectorHook<K extends keyof TypeLegendLayer>(key: K) {
+  return (layerPath: string): TypeLegendLayer[K] | undefined => useLayerSelectorLayerValueGeneric(layerPath, key);
+}
+
+// #endregion UTIL FUNCTIONS (PRIVATE)
 
 // #region STATE INITIALIZATION
 
@@ -155,30 +245,6 @@ const utilFindAllLayers = (layers: TypeLegendLayer[]): Record<string, TypeLegend
  * @returns The initialized Layer State
  */
 export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILayerState {
-  /**
-   * Helper function to update a layer property given its layer path.
-   */
-  const helperUpdateLayerByPath = (
-    layers: TypeLegendLayer[],
-    layerPath: string,
-    updater: (layer: TypeLegendLayer) => TypeLegendLayer
-  ): TypeLegendLayer[] => {
-    return layers.map((layer) => {
-      if (layer.layerPath === layerPath) {
-        return updater(layer);
-      }
-
-      if (layer.children?.length) {
-        return {
-          ...layer,
-          children: helperUpdateLayerByPath(layer.children, layerPath, updater),
-        };
-      }
-
-      return layer;
-    });
-  };
-
   return {
     highlightedLayer: '',
     legendLayers: [] as TypeLegendLayer[],
@@ -229,16 +295,16 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
       /**
        * Sets the legend layers state.
        *
+       * Callers must pass a new array reference (e.g. from map/filter/sort).
+       * Single-layer updates should use updateLayerByPath instead.
+       *
        * @param legendLayers - The legend layers to set.
        */
-      // TODO: REFACTOR - Calls to setLegendLayers are probably overkill when updating only parts of the whole objects array
       setLegendLayers: (legendLayers: TypeLegendLayer[]): void => {
         set({
           layerState: {
             ...get().layerState,
-            legendLayers: [...legendLayers],
-            // GV Here, we use the spread operator for the custom selector hooks such as useLayerSelectorLayerStatus to
-            // GV notice and eventually trigger the changes that need to be get triggered
+            legendLayers,
           },
         });
       },
@@ -287,14 +353,14 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
        *   - If a number is provided, sets `deletionProgressPercentage` to that value.
        *   - If `undefined`, removes the `deletionProgressPercentage` property from the layer.
        * @remarks
-       * This function uses the helper `helperUpdateLayerByPath` to find the
+       * This function uses `utilUpdateLayerByPath` to find the
        * target layer and update it immutably, ensuring that the rest of the
        * `legendLayers` array remains unchanged.
        */
       setLayerDeletionStartTime: (layerPath: string, startTime: number | undefined): void => {
         set((state) => {
           // Create updated legendLayers immutably
-          const updatedLegendLayers = helperUpdateLayerByPath(state.layerState.legendLayers, layerPath, (layer) => {
+          const updatedLegendLayers = utilUpdateLayerByPath(state.layerState.legendLayers, layerPath, (layer) => {
             if (startTime === undefined) {
               // Remove deletionStartTime immutably
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -316,40 +382,462 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
           };
         });
       },
+
+      /**
+       * Immutably updates a single layer identified by its path.
+       *
+       * @param layerPath - The layer path to find and update
+       * @param updater - A function that receives the current layer and returns the updated layer
+       */
+      updateLayerByPath: (layerPath: string, updater: (layer: TypeLegendLayer) => TypeLegendLayer): void => {
+        set((state) => ({
+          layerState: {
+            ...state.layerState,
+            legendLayers: utilUpdateLayerByPath(state.layerState.legendLayers, layerPath, updater),
+          },
+        }));
+      },
     },
   } as ILayerState;
 }
 
 // #endregion STATE INITIALIZATION
 
-// #region STATE HOOKS
-// GV To be used by React components
+// #region STATE GETTERS & HOOKS
+// GV Getters should be used to get the values at a moment in time.
+// GV Hooks should be used to attach to values and trigger UI components when they change.
+// GV Typically they are listed in couples (getter + hook) for the same value.
 
-/** Hook that returns the highlighted layer path. */
-export const useLayerHighlightedLayer = (): string => useStore(useGeoViewStore(), (state) => state.layerState.highlightedLayer);
+/**
+ * Returns the full layer state slice for the given map.
+ *
+ * Internal-only selector - not exported to avoid direct store access from outside this module.
+ *
+ * @param mapId - The map identifier.
+ * @returns The ILayerState for the given map.
+ */
+// GV No export for the main state!
+const getStoreLayerState = (mapId: string): ILayerState => getGeoViewStore(mapId).getState().layerState;
 
-/** Hook that returns the full legend layers array. */
-export const useLayerLegendLayers = (): TypeLegendLayer[] => useStore(useGeoViewStore(), (state) => state.layerState.legendLayers);
+/**
+ * Gets the full legend layers array for the given map.
+ *
+ * GV This getter shouldn't have a hook equivalent, favor precise hooks for specific properties instead to
+ * GV avoid unnecessary re-renders of the full layers tree when any single layer property changes.
+ * GV See examples below for how to create these precise hooks using the createLayerSelectorHook factory.
+ *
+ * @param mapId - The map identifier.
+ * @returns The legend layers array.
+ */
+export const getStoreLayerLegendLayers = (mapId: string): TypeLegendLayer[] => {
+  return getStoreLayerState(mapId).legendLayers;
+};
 
-/** Hook that returns the selected legend layer object. */
-export const useLayerSelectedLayer = (): TypeLegendLayer => useStore(useGeoViewStore(), (state) => state.layerState.selectedLayer);
+// Don't do this, see note in the getter above.
+// export const useStoreLayerStateLegendLayers = ...
+
+/**
+ * Gets the layer paths for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns The layer paths array.
+ */
+export const getStoreLayerLayerPaths = (mapId: string): string[] => {
+  return getStoreLayerState(mapId).legendLayers.map((layer) => layer.layerPath);
+};
+
+/** Hook that returns only the top-level layer paths. Re-renders only when layers are added, removed, or reordered. */
+export const useStoreLayerLayerPaths = (): string[] =>
+  useStableSelector(useGeoViewStore(), (state) => state.layerState.legendLayers.map((layer) => layer.layerPath));
+
+/**
+ * Gets the selected layer path for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns The selected layer path, or undefined if none is selected.
+ */
+export const getStoreLayerSelectedLayerPath = (mapId: string): string | undefined => {
+  return getStoreLayerState(mapId).selectedLayerPath;
+};
 
 /** Hook that returns the selected layer path. */
-export const useLayerSelectedLayerPath = (): string | null | undefined =>
+export const useStoreLayerSelectedLayerPath = (): string | null | undefined =>
   useStore(useGeoViewStore(), (state) => state.layerState.selectedLayerPath);
 
+/**
+ * Gets the highlighted layer path for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns The highlighted layer path.
+ */
+export const getStoreLayerHighlightedLayer = (mapId: string): string => {
+  return getStoreLayerState(mapId).highlightedLayer;
+};
+
+/** Hook that returns the highlighted layer path. */
+export const useStoreLayerHighlightedLayer = (): string => useStore(useGeoViewStore(), (state) => state.layerState.highlightedLayer);
+
+/**
+ * Gets the layers panel display state for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns The display state.
+ */
+export const getStoreLayerDisplayState = (mapId: string): TypeLayersViewDisplayState => {
+  return getStoreLayerState(mapId).displayState;
+};
+
 /** Hook that returns the current layers panel display state. */
-export const useLayerDisplayState = (): TypeLayersViewDisplayState => useStore(useGeoViewStore(), (state) => state.layerState.displayState);
+export const useStoreLayerDisplayState = (): TypeLayersViewDisplayState =>
+  useStore(useGeoViewStore(), (state) => state.layerState.displayState);
+
+/**
+ * Gets whether layers are currently loading for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns True if layers are loading.
+ */
+export const getStoreLayerAreLayersLoading = (mapId: string): boolean => {
+  return getStoreLayerState(mapId).layersAreLoading;
+};
 
 /** Hook that returns whether layers are currently loading. */
-export const useLayerAreLayersLoading = (): boolean => useStore(useGeoViewStore(), (state) => state.layerState.layersAreLoading);
+export const useStoreLayerAreLayersLoading = (): boolean => useStore(useGeoViewStore(), (state) => state.layerState.layersAreLoading);
+
+/**
+ * Gets a specific legend layer by its path for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to look up.
+ * @returns The matching legend layer, or undefined if not found.
+ */
+export const getStoreLayerLegendLayerByPath = (mapId: string, layerPath: string): TypeLegendLayer | undefined => {
+  return utilLegendLayerByPathRec(getStoreLayerLegendLayers(mapId), layerPath);
+};
+
+/**
+ * Gets the selected layer path for the given map.
+ *
+ * @param mapId - The map identifier.
+ * @returns The selected layer path, or undefined if none is selected.
+ */
+export const getStoreLayerId = (mapId: string, layerPath: string): string | undefined => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.layerId;
+};
+
+/** Hook that returns the layer id for a specific layer. */
+export const useStoreLayerId = createLayerSelectorHook('layerId');
+
+/**
+ * Gets the bounds extent for a specific layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to look up.
+ * @returns The layer bounds extent, or undefined.
+ */
+export const getStoreLayerBounds = (mapId: string, layerPath: string): Extent | undefined => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.bounds;
+};
+
+/** Hook that returns the bounds extent for a specific layer. */
+export const useStoreLayerBounds = createLayerSelectorHook('bounds');
+
+/**
+ * Gets the layer status for a specific layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to look up.
+ * @returns The layer status, or undefined.
+ */
+export const getStoreLayerStatus = (mapId: string, layerPath: string): TypeLayerStatus | undefined => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.layerStatus;
+};
+
+/** Hook that returns the layer status for a specific layer. */
+export const useStoreLayerStatus = createLayerSelectorHook('layerStatus');
+
+/**
+ * Hook that returns a record of layer statuses for all layers.
+ *
+ * @returns A record of layer statuses keyed by layer path, defaulting to 'newInstance'.
+ */
+export const useStoreLayerStatusSet = (): Record<string, TypeLayerStatus> => {
+  // Hook
+  return useStableSelector(useGeoViewStore(), (state) => {
+    // Get all layers
+    const allLayers = utilFindAllLayers(state.layerState.legendLayers);
+
+    // Return the object with the layer statuses for all layers, using the default 'newInstance' when not defined at the layer level
+    return Object.values(allLayers).reduce<Record<string, TypeLayerStatus>>((acc, layer) => {
+      if (layer.layerPath) {
+        // eslint-disable-next-line no-param-reassign
+        acc[layer.layerPath] = layer.layerStatus ?? 'newInstance'; // Defaults to most basic
+      }
+      return acc;
+    }, {});
+  });
+};
+
+/**
+ * Gets the WMS style for a specific layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to look up.
+ * @returns The WMS style name, or undefined.
+ */
+export const getStoreLayerWmsStyle = (mapId: string, layerPath: string): string | undefined => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.wmsStyle;
+};
+
+/** Hook that returns the WMS style for a specific layer. */
+export const useStoreLayerWmsStyle = createLayerSelectorHook('wmsStyle');
+
+/**
+ * Gets the available WMS styles metadata for a specific layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to look up.
+ * @returns The WMS styles metadata, or undefined.
+ */
+export const getStoreLayerWmsStyles = (mapId: string, layerPath: string): TypeMetadataWMSCapabilityLayerStyle[] | undefined => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.wmsStyles;
+};
+
+/** Hook that returns the available WMS styles metadata for a specific layer. */
+export const useStoreLayerWmsStyles = createLayerSelectorHook('wmsStyles');
+
+/**
+ * Gets the mosaic rule for a specific layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to look up.
+ * @returns The mosaic rule, or undefined.
+ */
+export const getStoreLayerMosaicRule = (mapId: string, layerPath: string): TypeMosaicRule | undefined => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.mosaicRule;
+};
+
+/** Hook that returns the mosaic rule for a specific layer. */
+export const useStoreLayerMosaicRule = createLayerSelectorHook('mosaicRule');
+
+/**
+ * Gets the raster function for a specific layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to look up.
+ * @returns The raster function name, or undefined.
+ */
+export const getStoreLayerRasterFunction = (mapId: string, layerPath: string): string | undefined => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.rasterFunction;
+};
+
+/** Hook that returns the raster function for a specific layer. */
+export const useStoreLayerRasterFunction = createLayerSelectorHook('rasterFunction');
+
+/**
+ * Gets the raster function infos for a specific layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to look up.
+ * @returns The raster function infos, or undefined.
+ */
+export const getStoreLayerRasterFunctionInfos = (mapId: string, layerPath: string): TypeMetadataEsriRasterFunctionInfos[] | undefined => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.rasterFunctionInfos;
+};
+
+/** Hook that returns the raster function infos for a specific layer. */
+export const useStoreLayerRasterFunctionInfos = createLayerSelectorHook('rasterFunctionInfos');
+
+/**
+ * Gets the allowed mosaic methods for a specific layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to look up.
+ * @returns The allowed mosaic methods, or undefined.
+ */
+export const getStoreLayerAllowedMosaicMethods = (mapId: string, layerPath: string): TypeMosaicMethod[] | undefined => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.allowedMosaicMethods;
+};
+
+/** Hook that returns the allowed mosaic methods for a specific layer. */
+export const useStoreLayerAllowedMosaicMethods = createLayerSelectorHook('allowedMosaicMethods');
+
+/**
+ * Gets the time dimension for a specific layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to look up.
+ * @returns The time dimension, or undefined.
+ */
+export const getStoreLayerTimeDimension = (mapId: string, layerPath: string): TimeDimension | undefined => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.timeDimension;
+};
+
+/** Hook that returns the time dimension for a specific layer. */
+export const useStoreLayerTimeDimension = createLayerSelectorHook('timeDimension');
+
+/**
+ * Gets the available style settings for a layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path.
+ * @returns Array of available style setting types.
+ */
+export const getStoreLayerStyleSettings = (mapId: string, layerPath: string): string[] => {
+  const layer = getStoreLayerLegendLayerByPath(mapId, layerPath);
+  if (!layer) return []; // Not in the store, no settings
+
+  // Check if raster function infos are present
+  const settings: string[] = [];
+
+  if (layer.rasterFunctionInfos && layer.rasterFunctionInfos.length > 0) {
+    settings.push('rasterFunction');
+  }
+
+  // Check if mosaicMode is present
+  const { mosaicRule } = layer;
+  if (mosaicRule) {
+    settings.push('mosaicRule');
+  }
+
+  // Check if multiple WMS styles are available
+  const { wmsStyles } = layer;
+  if (wmsStyles && wmsStyles.length > 1) {
+    settings.push('wmsStyles');
+  }
+
+  // Add other layer types with settings here
+  return settings;
+};
+
+// #endregion STATE GETTERS & HOOKS
+
+// #region STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
+
+/**
+ * Gets a specific legend item by name for a layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to look up.
+ * @param name - The legend item name to find.
+ * @returns The matching legend item, or undefined.
+ */
+export const getStoreLayerItemVisibility = (mapId: string, layerPath: string, name: string): TypeLegendItem | undefined => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.items.find((item) => item.name === name);
+};
+
+/** Hook that returns the selected legend layer object. */
+export const useStoreLayerSelectedLayer = (): TypeLegendLayer => useStore(useGeoViewStore(), (state) => state.layerState.selectedLayer);
+
+/** Hook that returns the EPSG:4326 bounds for a specific layer. */
+export const useStoreLayerBounds4326 = createLayerSelectorHook('bounds4326');
+
+/** Hook that returns whether toggling is allowed for a specific layer. */
+export const useStoreLayerCanToggle = createLayerSelectorHook('canToggle');
+
+/**
+ * Selects the child layer paths for a specific layer.
+ *
+ * Uses useStableSelector with shallowObjectEqual so the component only re-renders
+ * when children are added, removed, or reordered — not when a descendant's property changes.
+ *
+ * @param layerPath - The layer path to look up
+ * @returns The child layer paths, or undefined if no children exist
+ */
+export const useStoreLayerChildPaths = (layerPath: string): string[] | undefined => {
+  return useStableSelector(useGeoViewStore(), (state): string[] | undefined => {
+    const layer = utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath);
+    return layer?.children?.map((child) => child.layerPath);
+  });
+};
+
+/**
+ * Selects whether any layer in the subtree (including the layer itself) has visibility disabled.
+ *
+ * Returns a boolean so Object.is comparison prevents unnecessary re-renders.
+ *
+ * @param layerPath - The layer path to check
+ * @returns True if any node in the subtree has controls.visibility === false
+ */
+export const useStoreLayerHasDisabledVisibility = (layerPath: string): boolean => {
+  return useStore(useGeoViewStore(), (state): boolean => {
+    const layer = utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath);
+    if (!layer) return false;
+    return utilHasDisabledVisibilityRec(layer);
+  });
+};
+
+/** Hook that returns the controls configuration for a specific layer. */
+export const useStoreLayerControls = createLayerSelectorHook('controls');
+
+/** Hook that returns the deletion start time for a specific layer. */
+export const useStoreLayerDeletionStartTime = createLayerSelectorHook('deletionStartTime');
+
+/** Hook that returns the entry type for a specific layer. */
+export const useStoreLayerEntryType = createLayerSelectorHook('entryType');
+
+/** Hook that returns if the layer has text. */
+export const useStoreLayerHasText = createLayerSelectorHook('hasText');
+
+/** Hook that returns the layer filter for a specific layer. */
+export const useStoreLayerFilter = createLayerSelectorHook('layerFilter');
+
+/** Hook that returns the layer filter class for a specific layer. */
+export const useStoreLayerFilterClass = createLayerSelectorHook('layerFilterClass');
+
+/** Hook that returns the legend query status for a specific layer. */
+export const useStoreLayerLegendQueryStatus = createLayerSelectorHook('legendQueryStatus');
+
+/** Hook that returns the legend icons for a specific layer. */
+export const useStoreLayerIcons = createLayerSelectorHook('icons');
+
+/** Hook that returns the legend items for a specific layer. */
+export const useStoreLayerItems = createLayerSelectorHook('items');
+
+/** Hook that returns the schema tag for a specific layer. */
+export const useStoreLayerSchemaTag = createLayerSelectorHook('schemaTag');
+
+/** Hook that returns the style configuration for a specific layer. */
+export const useStoreLayerStyleConfig = createLayerSelectorHook('styleConfig');
+
+/** Hook that returns the text visibility for a specific layer. */
+export const useStoreLayerTextVisibility = createLayerSelectorHook('textVisible');
+
+// #endregion STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
+
+// #region STATE GETTERS & HOOKS - SPECIALIZED
+
+/** Hook that returns the layer name for a specific layer. */
+export const useStoreLayerName = createLayerSelectorHook('layerName');
+
+/**
+ * Hook that returns a record of layer names for all layers.
+ *
+ * @returns A record of layer names keyed by layer path.
+ */
+export const useStoreLayerNameSet = (): Record<string, string> => {
+  // Hook
+  return useStableSelector(useGeoViewStore(), (state) => {
+    // Get all layers
+    const allLayers = utilFindAllLayers(state.layerState.legendLayers);
+
+    // Return the object with the layer names for all layers
+    return Object.values(allLayers).reduce<Record<string, string>>((acc, layer) => {
+      if (layer.layerPath) {
+        // eslint-disable-next-line no-param-reassign
+        acc[layer.layerPath] = layer.layerName;
+      }
+      return acc;
+    }, {});
+  });
+};
 
 /**
  * Hook that returns the selected legend layer by looking it up from the legend layers array.
  *
  * @returns The selected legend layer, or undefined if none is selected.
  */
-export const useSelectedLayer = (): TypeLegendLayer | undefined => {
+export const useStoreSelectedLayer = (): TypeLegendLayer | undefined => {
   const layers = useStore(useGeoViewStore(), (state) => state.layerState.legendLayers);
   const selectedLayerPath = useStore(useGeoViewStore(), (state) => state.layerState.selectedLayerPath);
   if (selectedLayerPath) {
@@ -366,7 +854,7 @@ export const useSelectedLayer = (): TypeLegendLayer | undefined => {
  * @param layerPath - The layer path to get icons for.
  * @returns An array of icon image strings.
  */
-export const useLayerIconLayerSet = (layerPath: string): string[] => {
+export const useStoreLayerIconLayerSet = (layerPath: string): string[] => {
   const layers = useStore(useGeoViewStore(), (state) => state.layerState.legendLayers);
   const layer = utilLegendLayerByPathRec(layers, layerPath);
   if (layer && layer.schemaTag !== CONST_LAYER_TYPES.WMS) {
@@ -379,11 +867,24 @@ export const useLayerIconLayerSet = (layerPath: string): string[] => {
 };
 
 /**
+ * React hook that returns if the temporal mode of the dates for the layer.
+ *
+ * @param layerPath - Unique path identifying the layer in the legend state.
+ * @returns The temporal mode of the dates for the layer. Default: DateMgt.DEFAULT_TEMPORAL_MODE.
+ */
+export const useStoreLayerDateTemporalMode = (layerPath: string | undefined): TemporalMode => {
+  // Hook
+  return useStore(useGeoViewStore(), (state) => {
+    return utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.dateTemporalMode ?? DateMgt.DEFAULT_TEMPORAL_MODE;
+  });
+};
+
+/**
  * React hook that returns if the temporal modes for the layers.
  *
  * @returns The temporal mode of the dates for the layer.
  */
-export const useLayerDateTemporalModes = (): Record<string, TemporalMode> => {
+export const useStoreLayerDateTemporalModeSet = (): Record<string, TemporalMode> => {
   // Hook
   return useStableSelector(useGeoViewStore(), (state) => {
     // Get all layers
@@ -401,15 +902,34 @@ export const useLayerDateTemporalModes = (): Record<string, TemporalMode> => {
 };
 
 /**
- * React hook that returns if the temporal mode of the dates for the layer.
+ * Gets the display date format for a specific layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to look up.
+ * @returns The display date format, or undefined.
+ */
+export const getStoreLayerDisplayDateFormat = (mapId: string, layerPath: string): TypeDisplayDateFormat | undefined => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.displayDateFormat;
+};
+
+/**
+ * React hook that returns the display date format for a specific layer.
+ * The hook first attempts to resolve a layer-specific display date format
+ * using the provided layer path. If the layer does not define its own
+ * display date format (or cannot be found), the application-wide display
+ * date format for the current map is returned as a fallback.
  *
  * @param layerPath - Unique path identifying the layer in the legend state.
- * @returns The temporal mode of the dates for the layer. Default: DateMgt.DEFAULT_TEMPORAL_MODE.
+ * @returns The display date format to use for the layer, falling back to the
+ * application's default display date format when none is defined.
  */
-export const useLayerDateTemporalMode = (layerPath: string | undefined): TemporalMode => {
+export const useStoreLayerDisplayDateFormat = (layerPath: string | undefined): TypeDisplayDateFormat => {
   // Hook
   return useStore(useGeoViewStore(), (state) => {
-    return utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.dateTemporalMode ?? DateMgt.DEFAULT_TEMPORAL_MODE;
+    return (
+      utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.displayDateFormat ??
+      getStoreDisplayDateFormatDefault(state.mapId).datetimeFormat
+    );
   });
 };
 
@@ -418,7 +938,7 @@ export const useLayerDateTemporalMode = (layerPath: string | undefined): Tempora
  *
  * @returns The display date format of the dates for the layer.
  */
-export const useLayerDisplayDateFormats = (): Record<string, TypeDisplayDateFormat> => {
+export const useStoreLayerDisplayDateFormatSet = (): Record<string, TypeDisplayDateFormat> => {
   // Hook
   return useStableSelector(useGeoViewStore(), (state) => {
     // Get the default format
@@ -449,28 +969,7 @@ export const useLayerDisplayDateFormats = (): Record<string, TypeDisplayDateForm
  * @returns The display date format to use for the layer, falling back to the
  * application's default display date format when none is defined.
  */
-export const useLayerDisplayDateFormat = (layerPath: string | undefined): TypeDisplayDateFormat => {
-  // Hook
-  return useStore(useGeoViewStore(), (state) => {
-    return (
-      utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.displayDateFormat ??
-      getStoreDisplayDateFormatDefault(state.mapId).datetimeFormat
-    );
-  });
-};
-
-/**
- * React hook that returns the display date format for a specific layer.
- * The hook first attempts to resolve a layer-specific display date format
- * using the provided layer path. If the layer does not define its own
- * display date format (or cannot be found), the application-wide display
- * date format for the current map is returned as a fallback.
- *
- * @param layerPath - Unique path identifying the layer in the legend state.
- * @returns The display date format to use for the layer, falling back to the
- * application's default display date format when none is defined.
- */
-export const useLayerDisplayDateFormatShort = (layerPath: string | undefined): TypeDisplayDateFormat => {
+export const useStoreLayerDisplayDateFormatShort = (layerPath: string | undefined): TypeDisplayDateFormat => {
   // Hook
   return useStore(useGeoViewStore(), (state) => {
     return (
@@ -482,11 +981,31 @@ export const useLayerDisplayDateFormatShort = (layerPath: string | undefined): T
 };
 
 /**
+ * React hook that returns the display date timezone for a specific layer.
+ * The hook first attempts to resolve a layer-specific display date timezone
+ * using the provided layer path. If the layer does not define its own
+ * display date timezone (or cannot be found), the application-wide display
+ * date timezone for the current map is returned as a fallback.
+ *
+ * @param layerPath - Unique path identifying the layer in the legend state.
+ * @returns The display date timezone to use for the layer, falling back to the
+ * application's default display date timezone when none is defined.
+ */
+export const useStoreLayerDisplayDateTimezone = (layerPath: string | undefined): TimeIANA => {
+  // Hook
+  return useStore(useGeoViewStore(), (state) => {
+    return (
+      utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.displayDateTimezone ?? getStoreDisplayDateTimezone(state.mapId)
+    );
+  });
+};
+
+/**
  * React hook that returns if the display date timezones for the layers.
  *
  * @returns The display date timezone of the dates for the layer.
  */
-export const useLayerDisplayDateTimezones = (): Record<string, TimeIANA> => {
+export const useStoreLayerDisplayDateTimezoneSet = (): Record<string, TimeIANA> => {
   // Hook
   return useStableSelector(useGeoViewStore(), (state) => {
     // Get all layers
@@ -504,404 +1023,37 @@ export const useLayerDisplayDateTimezones = (): Record<string, TimeIANA> => {
 };
 
 /**
- * React hook that returns the display date timezone for a specific layer.
- * The hook first attempts to resolve a layer-specific display date timezone
- * using the provided layer path. If the layer does not define its own
- * display date timezone (or cannot be found), the application-wide display
- * date timezone for the current map is returned as a fallback.
+ * Hook that returns the available style settings for a layer.
  *
- * @param layerPath - Unique path identifying the layer in the legend state.
- * @returns The display date timezone to use for the layer, falling back to the
- * application's default display date timezone when none is defined.
- */
-export const useLayerDisplayDateTimezone = (layerPath: string | undefined): TimeIANA => {
-  // Hook
-  return useStore(useGeoViewStore(), (state) => {
-    return (
-      utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.displayDateTimezone ?? getStoreDisplayDateTimezone(state.mapId)
-    );
-  });
-};
-
-/**
- * Generic hook that selects a single property from a legend layer by path.
- *
- * @param layerPath - The layer path to look up.
- * @param key - The property key to select from the layer.
- * @returns The value of the property, or undefined if the layer is not found.
- */
-function useLayerSelectorLayerValueGeneric<K extends keyof TypeLegendLayer>(layerPath: string, key: K): TypeLegendLayer[K] | undefined {
-  return useStore(useGeoViewStore(), (state) => {
-    const layer = utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath);
-    return layer?.[key];
-  });
-}
-
-/**
- * Factory that creates a strongly typed hook for selecting a specific legend layer property.
- *
- * @param key - The property key to create a selector hook for.
- * @returns A hook that accepts a layerPath and returns the property value.
- */
-function createLayerSelectorHook<K extends keyof TypeLegendLayer>(key: K) {
-  return (layerPath: string): TypeLegendLayer[K] | undefined => useLayerSelectorLayerValueGeneric(layerPath, key);
-}
-
-/** Hook that returns the layer id for a specific layer. */
-export const useLayerSelectorId = createLayerSelectorHook('layerId');
-
-/** Hook that returns the layer name for a specific layer. */
-export const useLayerSelectorName = createLayerSelectorHook('layerName');
-
-/**
- * Hook that returns a record of layer names for all layers.
- *
- * @returns A record of layer names keyed by layer path.
- */
-export const useLayerNames = (): Record<string, string> => {
-  // Hook
-  return useStableSelector(useGeoViewStore(), (state) => {
-    // Get all layers
-    const allLayers = utilFindAllLayers(state.layerState.legendLayers);
-
-    // Return the object with the layer names for all layers
-    return Object.values(allLayers).reduce<Record<string, string>>((acc, layer) => {
-      if (layer.layerPath) {
-        // eslint-disable-next-line no-param-reassign
-        acc[layer.layerPath] = layer.layerName;
-      }
-      return acc;
-    }, {});
-  });
-};
-
-/** Hook that returns the layer status for a specific layer. */
-export const useLayerSelectorStatus = createLayerSelectorHook('layerStatus');
-
-/**
- * Hook that returns a record of layer statuses for all layers.
- *
- * @returns A record of layer statuses keyed by layer path, defaulting to 'newInstance'.
- */
-export const useLayerStatuses = (): Record<string, TypeLayerStatus> => {
-  // Hook
-  return useStableSelector(useGeoViewStore(), (state) => {
-    // Get all layers
-    const allLayers = utilFindAllLayers(state.layerState.legendLayers);
-
-    // Return the object with the layer statuses for all layers, using the default 'newInstance' when not defined at the layer level
-    return Object.values(allLayers).reduce<Record<string, TypeLayerStatus>>((acc, layer) => {
-      if (layer.layerPath) {
-        // eslint-disable-next-line no-param-reassign
-        acc[layer.layerPath] = layer.layerStatus ?? 'newInstance'; // Defaults to most basic
-      }
-      return acc;
-    }, {});
-  });
-};
-
-/** Hook that returns the deletion start time for a specific layer. */
-export const useLayerSelectorDeletionStartTime = createLayerSelectorHook('deletionStartTime');
-
-/** Hook that returns the layer filter for a specific layer. */
-export const useLayerSelectorFilter = createLayerSelectorHook('layerFilter');
-
-/** Hook that returns the layer filter class for a specific layer. */
-export const useLayerSelectorFilterClass = createLayerSelectorHook('layerFilterClass');
-
-/** Hook that returns the schema tag for a specific layer. */
-export const useLayerSelectorSchemaTag = createLayerSelectorHook('schemaTag');
-
-/** Hook that returns the entry type for a specific layer. */
-export const useLayerSelectorEntryType = createLayerSelectorHook('entryType');
-
-/** Hook that returns the bounds extent for a specific layer. */
-export const useLayerSelectorBounds = createLayerSelectorHook('bounds');
-
-/** Hook that returns the EPSG:4326 bounds for a specific layer. */
-export const useLayerSelectorBounds4326 = createLayerSelectorHook('bounds4326');
-
-/** Hook that returns the controls configuration for a specific layer. */
-export const useLayerSelectorControls = createLayerSelectorHook('controls');
-
-/** Hook that returns the children layers for a specific layer. */
-export const useLayerSelectorChildren = createLayerSelectorHook('children');
-
-/** Hook that returns the legend items for a specific layer. */
-export const useLayerSelectorItems = createLayerSelectorHook('items');
-
-/** Hook that returns the legend icons for a specific layer. */
-export const useLayerSelectorIcons = createLayerSelectorHook('icons');
-
-/** Hook that returns the legend query status for a specific layer. */
-export const useLayerSelectorLegendQueryStatus = createLayerSelectorHook('legendQueryStatus');
-
-/** Hook that returns whether toggling is allowed for a specific layer. */
-export const useLayerSelectorCanToggle = createLayerSelectorHook('canToggle');
-
-/** Hook that returns the style configuration for a specific layer. */
-export const useLayerSelectorStyleConfig = createLayerSelectorHook('styleConfig');
-
-/** Hook that returns the raster function for a specific layer. */
-export const useLayerSelectorRasterFunction = createLayerSelectorHook('rasterFunction');
-
-/** Hook that returns the mosaic rule for a specific layer. */
-export const useLayerSelectorMosaicRule = createLayerSelectorHook('mosaicRule');
-
-/** Hook that returns the WMS style for a specific layer. */
-export const useLayerSelectorWmsStyle = createLayerSelectorHook('wmsStyle');
-
-/** Hook that returns the available WMS styles metadata for a specific layer. */
-export const useLayerSelectorWmsStyles = createLayerSelectorHook('wmsStyles');
-
-/** Hook that returns if the layer has text. */
-export const useLayerSelectorHasText = createLayerSelectorHook('hasText');
-
-/** Hook that returns the text visibility for a specific layer. */
-export const useLayerSelectorTextVisibility = createLayerSelectorHook('textVisible');
-
-/** Hook that returns the raster function infos for a specific layer. */
-export const useLayerSelectorRasterFunctionInfos = createLayerSelectorHook('rasterFunctionInfos');
-
-/** Hook that returns the allowed mosaic methods for a specific layer. */
-export const useLayerSelectorAllowedMosaicMethods = createLayerSelectorHook('allowedMosaicMethods');
-
-/** Hook that returns the time dimension for a specific layer. */
-export const useLayerTimeDimension = createLayerSelectorHook('timeDimension');
-
-// #endregion STATE HOOKS
-
-// #region STATE SELECTORS
-
-/**
- * Returns the full layer state slice for the given map.
- *
- * Internal-only selector - not exported to avoid direct store access from outside this module.
- *
- * @param mapId - The map identifier.
- * @returns The ILayerState for the given map.
- */
-// GV No export for the main state!
-const getStoreLayerState = (mapId: string): ILayerState => getGeoViewStore(mapId).getState().layerState;
-
-/**
- * Gets the selected layer path for the given map.
- *
- * @param mapId - The map identifier.
- * @returns The selected layer path, or undefined if none is selected.
- */
-export const getStoreLayerStateSelectedLayerPath = (mapId: string): string | undefined => {
-  return getStoreLayerState(mapId).selectedLayerPath;
-};
-
-/**
- * Gets the highlighted layer path for the given map.
- *
- * @param mapId - The map identifier.
- * @returns The highlighted layer path.
- */
-export const getStoreLayerStateHighlightedLayer = (mapId: string): string => {
-  return getStoreLayerState(mapId).highlightedLayer;
-};
-
-/**
- * Gets the layers panel display state for the given map.
- *
- * @param mapId - The map identifier.
- * @returns The display state.
- */
-export const getStoreLayerStateDisplayState = (mapId: string): TypeLayersViewDisplayState => {
-  return getStoreLayerState(mapId).displayState;
-};
-
-/**
- * Gets whether layers are currently loading for the given map.
- *
- * @param mapId - The map identifier.
- * @returns True if layers are loading.
- */
-export const getStoreLayerStateAreLayersLoading = (mapId: string): boolean => {
-  return getStoreLayerState(mapId).layersAreLoading;
-};
-
-/**
- * Gets the full legend layers array for the given map.
- *
- * @param mapId - The map identifier.
- * @returns The legend layers array.
- */
-export const getStoreLayerStateLegendLayers = (mapId: string): TypeLegendLayer[] => {
-  return getStoreLayerState(mapId).legendLayers;
-};
-
-/**
- * Gets a specific legend layer by its path for the given map.
- *
- * @param mapId - The map identifier.
- * @param layerPath - The layer path to look up.
- * @returns The matching legend layer, or undefined if not found.
- */
-export const getStoreLayerStateLegendLayerByPath = (mapId: string, layerPath: string): TypeLegendLayer | undefined => {
-  return utilLegendLayerByPathRec(getStoreLayerStateLegendLayers(mapId), layerPath);
-};
-
-/**
- * Gets the bounds extent for a specific layer.
- *
- * @param mapId - The map identifier.
- * @param layerPath - The layer path to look up.
- * @returns The layer bounds extent, or undefined.
- */
-export const getStoreLayerStateLayerBounds = (mapId: string, layerPath: string): Extent | undefined => {
-  return getStoreLayerStateLegendLayerByPath(mapId, layerPath)?.bounds;
-};
-
-/**
- * Gets the layer status for a specific layer.
- *
- * @param mapId - The map identifier.
- * @param layerPath - The layer path to look up.
- * @returns The layer status, or undefined.
- */
-export const getStoreLayerStateLayerStatus = (mapId: string, layerPath: string): TypeLayerStatus | undefined => {
-  return getStoreLayerStateLegendLayerByPath(mapId, layerPath)?.layerStatus;
-};
-
-/**
- * Gets a specific legend item by name for a layer.
- *
- * @param mapId - The map identifier.
- * @param layerPath - The layer path to look up.
- * @param name - The legend item name to find.
- * @returns The matching legend item, or undefined.
- */
-export const getStoreLayerItemVisibility = (mapId: string, layerPath: string, name: string): TypeLegendItem | undefined => {
-  return getStoreLayerStateLegendLayerByPath(mapId, layerPath)?.items.find((item) => item.name === name);
-};
-
-/**
- * Gets the display date format for a specific layer.
- *
- * @param mapId - The map identifier.
- * @param layerPath - The layer path to look up.
- * @returns The display date format, or undefined.
- */
-export const getStoreLayerDisplayDateFormat = (mapId: string, layerPath: string): TypeDisplayDateFormat | undefined => {
-  return getStoreLayerStateLegendLayerByPath(mapId, layerPath)?.displayDateFormat;
-};
-
-/**
- * Gets the WMS style for a specific layer.
- *
- * @param mapId - The map identifier.
- * @param layerPath - The layer path to look up.
- * @returns The WMS style name, or undefined.
- */
-export const getStoreLayerWmsStyle = (mapId: string, layerPath: string): string | undefined => {
-  return getStoreLayerStateLegendLayerByPath(mapId, layerPath)?.wmsStyle;
-};
-
-/**
- * Gets the available WMS styles metadata for a specific layer.
- *
- * @param mapId - The map identifier.
- * @param layerPath - The layer path to look up.
- * @returns The WMS styles metadata, or undefined.
- */
-export const getStoreLayerWmsStyles = (mapId: string, layerPath: string): TypeMetadataWMSCapabilityLayerStyle[] | undefined => {
-  return getStoreLayerStateLegendLayerByPath(mapId, layerPath)?.wmsStyles;
-};
-
-/**
- * Gets the mosaic rule for a specific layer.
- *
- * @param mapId - The map identifier.
- * @param layerPath - The layer path to look up.
- * @returns The mosaic rule, or undefined.
- */
-export const getStoreLayerMosaicRule = (mapId: string, layerPath: string): TypeMosaicRule | undefined => {
-  return getStoreLayerStateLegendLayerByPath(mapId, layerPath)?.mosaicRule;
-};
-
-/**
- * Gets the raster function for a specific layer.
- *
- * @param mapId - The map identifier.
- * @param layerPath - The layer path to look up.
- * @returns The raster function name, or undefined.
- */
-export const getStoreLayerRasterFunction = (mapId: string, layerPath: string): string | undefined => {
-  return getStoreLayerStateLegendLayerByPath(mapId, layerPath)?.rasterFunction;
-};
-
-/**
- * Gets the raster function infos for a specific layer.
- *
- * @param mapId - The map identifier.
- * @param layerPath - The layer path to look up.
- * @returns The raster function infos, or undefined.
- */
-export const getStoreLayerRasterFunctionInfos = (mapId: string, layerPath: string): TypeMetadataEsriRasterFunctionInfos[] | undefined => {
-  return getStoreLayerStateLegendLayerByPath(mapId, layerPath)?.rasterFunctionInfos;
-};
-
-/**
- * Gets the allowed mosaic methods for a specific layer.
- *
- * @param mapId - The map identifier.
- * @param layerPath - The layer path to look up.
- * @returns The allowed mosaic methods, or undefined.
- */
-export const getStoreLayerAllowedMosaicMethods = (mapId: string, layerPath: string): TypeMosaicMethod[] | undefined => {
-  return getStoreLayerStateLegendLayerByPath(mapId, layerPath)?.allowedMosaicMethods;
-};
-
-/**
- * Gets the time dimension for a specific layer.
- *
- * @param mapId - The map identifier.
- * @param layerPath - The layer path to look up.
- * @returns The time dimension, or undefined.
- */
-export const getStoreLayerTimeDimension = (mapId: string, layerPath: string): TimeDimension | undefined => {
-  return getStoreLayerStateLegendLayerByPath(mapId, layerPath)?.timeDimension;
-};
-
-/**
- * Gets the available style settings for a layer.
- *
- * @param mapId - The map identifier.
- * @param layerPath - The layer path.
+ * @param layerPath - The layer path to get settings for.
  * @returns Array of available style setting types.
  */
-export const getStoreLayerStyleSettings = (mapId: string, layerPath: string): string[] => {
-  const layer = getStoreLayerStateLegendLayerByPath(mapId, layerPath);
-  if (!layer) return []; // Not in the store, no settings
+export const useStoreLayerStyleSettings = (layerPath: string): string[] => {
+  return useStableSelector(useGeoViewStore(), (state) => {
+    const layer = utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath);
+    if (!layer) return [];
 
-  // Check if raster function infos are present
-  const settings: string[] = [];
+    const settings: string[] = [];
 
-  if (layer.rasterFunctionInfos && layer.rasterFunctionInfos.length > 0) {
-    settings.push('rasterFunction');
-  }
+    if (layer.rasterFunctionInfos && layer.rasterFunctionInfos.length > 0) {
+      settings.push('rasterFunction');
+    }
 
-  // Check if mosaicMode is present
-  const { mosaicRule } = layer;
-  if (mosaicRule) {
-    settings.push('mosaicRule');
-  }
+    const { mosaicRule } = layer;
+    if (mosaicRule) {
+      settings.push('mosaicRule');
+    }
 
-  // Check if multiple WMS styles are available
-  const { wmsStyles } = layer;
-  if (wmsStyles && wmsStyles.length > 1) {
-    settings.push('wmsStyles');
-  }
+    const { wmsStyles } = layer;
+    if (wmsStyles && wmsStyles.length > 1) {
+      settings.push('wmsStyles');
+    }
 
-  // Add other layer types with settings here
-  return settings;
+    return settings;
+  });
 };
 
-// #endregion STATE SELECTORS
+// #endregion STATE GETTERS & HOOKS - SPECIALIZED
 
 // #region STATE ADAPTORS
 // GV These methods should be called from a State Adaptor class listening on domain events triggered by controllers.
@@ -924,17 +1076,7 @@ export const setStoreLayerDisplayState = (mapId: string, displayState: TypeLayer
  * @param layerStatus - The new layer status.
  */
 export const setStoreLayerStatus = (mapId: string, layerPath: string, layerStatus: TypeLayerStatus): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  if (layer) {
-    // Update the value
-    layer.layerStatus = layerStatus;
-
-    // Set updated legend layers
-    getStoreLayerState(mapId).actions.setLegendLayers(layers);
-  }
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, layerStatus }));
 };
 
 /**
@@ -945,17 +1087,7 @@ export const setStoreLayerStatus = (mapId: string, layerPath: string, layerStatu
  * @static
  */
 export const setStoreLayerName = (mapId: string, layerPath: string, layerName: string | undefined): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  if (layer) {
-    // Update the value
-    layer.layerName = layerName ?? ''; // Default to empty string if undefined
-
-    // Set updated legend layers
-    getStoreLayerState(mapId).actions.setLegendLayers(layers);
-  }
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, layerName: layerName ?? '' }));
 };
 
 /**
@@ -966,17 +1098,7 @@ export const setStoreLayerName = (mapId: string, layerPath: string, layerName: s
  * @param queryable - Whether the layer should be queryable.
  */
 export const setStoreLayerQueryable = (mapId: string, layerPath: string, queryable: boolean): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  if (layer) {
-    // Update the value
-    layer.queryable = queryable;
-
-    // Set updated legend layers
-    getStoreLayerState(mapId).actions.setLegendLayers(layers);
-  }
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, queryable }));
 };
 
 /**
@@ -987,17 +1109,7 @@ export const setStoreLayerQueryable = (mapId: string, layerPath: string, queryab
  * @param hoverable - Whether the layer should be hoverable.
  */
 export const setStoreLayerHoverable = (mapId: string, layerPath: string, hoverable: boolean): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  if (layer) {
-    // Update the value
-    layer.hoverable = hoverable;
-
-    // Set updated legend layers
-    getStoreLayerState(mapId).actions.setLegendLayers(layers);
-  }
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, hoverable }));
 };
 
 /**
@@ -1018,22 +1130,11 @@ export const setStoreLayerBounds = (
   mapProjection: OLProjection,
   stops: number
 ): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  if (layer) {
-    // Update the value
-    layer.bounds = bounds;
-    layer.bounds4326 = undefined;
-
-    if (bounds) {
-      layer.bounds4326 = Projection.transformExtentFromProj(bounds, mapProjection, Projection.getProjectionLonLat(), stops);
-    }
-
-    // Set updated legend layers
-    getStoreLayerState(mapId).actions.setLegendLayers(layers);
-  }
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({
+    ...layer,
+    bounds,
+    bounds4326: bounds ? Projection.transformExtentFromProj(bounds, mapProjection, Projection.getProjectionLonLat(), stops) : undefined,
+  }));
 };
 
 /**
@@ -1115,44 +1216,27 @@ export const setStoreLayerItemVisibility = (
   visibility: boolean,
   classFilter: string | undefined
 ): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  // If found
-  if (layer) {
-    // ! Change the visibility of the given item.
-    // ! which happens to be the same object reference as the one in the items array here
-    // TODO: REFACTOR - Rethink this pattern to find a better cohesive solution for ALL 'set' that go in the store and change them all
-    // Update the value
-    // eslint-disable-next-line no-param-reassign
-    item.isVisible = visibility;
-
-    // Shadow-copy this specific array so that the hooks are triggered for this items array and this one only
-    layer.items = [...layer.items];
-    layer.layerFilterClass = classFilter;
-  }
-
-  // Set updated legend layers
-  getStoreLayerState(mapId).actions.setLegendLayers(layers);
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({
+    ...layer,
+    items: layer.items.map((i) => (i.name === item.name ? { ...i, isVisible: visibility } : i)),
+    layerFilterClass: classFilter,
+  }));
 };
 
 /**
- * Recursively sets the opacity and opacityMaxFromParent of all children of the given layer.
+ * Recursively creates new children with updated opacity and opacityMaxFromParent values.
  *
- * @param layer - The layer on which to update the children opacity values.
+ * @param children - The children array to update.
  * @param opacity - The opacity to set.
+ * @returns A new children array with updated opacity values.
  */
-const setStoreOpacityRec = (layer: TypeLegendLayer, opacity: number): void => {
-  // Set the opacity along with all the children
-  layer.children?.forEach((child) => {
-    // eslint-disable-next-line no-param-reassign
-    child.opacity = opacity;
-    // eslint-disable-next-line no-param-reassign
-    child.opacityMaxFromParent = opacity;
-    // Go recursive
-    setStoreOpacityRec(child, opacity);
-  });
+const utilSetOpacityRec = (children: TypeLegendLayer[], opacity: number): TypeLegendLayer[] => {
+  return children.map((child) => ({
+    ...child,
+    opacity,
+    opacityMaxFromParent: opacity,
+    ...(child.children?.length ? { children: utilSetOpacityRec(child.children, opacity) } : {}),
+  }));
 };
 
 /**
@@ -1163,20 +1247,11 @@ const setStoreOpacityRec = (layer: TypeLegendLayer, opacity: number): void => {
  * @param opacity - The opacity value (0–1).
  */
 export const setStoreOpacity = (mapId: string, layerPath: string, opacity: number): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  if (layer) {
-    // Update the value
-    layer.opacity = opacity;
-
-    // Go recursive
-    setStoreOpacityRec(layer, opacity);
-  }
-
-  // Set updated legend layers
-  getStoreLayerState(mapId).actions.setLegendLayers(layers);
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({
+    ...layer,
+    opacity,
+    ...(layer.children?.length ? { children: utilSetOpacityRec(layer.children, opacity) } : {}),
+  }));
 };
 
 /**
@@ -1198,17 +1273,7 @@ export const setStoreHighlightedLayer = (mapId: string, layerPath: string): void
  * @param displayDateFormat - The display date format to set.
  */
 export const setStoreLayerDisplayDateFormat = (mapId: string, layerPath: string, displayDateFormat: TypeDisplayDateFormat): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  if (layer) {
-    // Update the value
-    layer.displayDateFormat = displayDateFormat;
-
-    // Set updated legend layers
-    getStoreLayerState(mapId).actions.setLegendLayers(layers);
-  }
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, displayDateFormat }));
 };
 
 /**
@@ -1219,17 +1284,7 @@ export const setStoreLayerDisplayDateFormat = (mapId: string, layerPath: string,
  * @param displayDateFormat - The short display date format to set.
  */
 export const setStoreLayerDisplayDateFormatShort = (mapId: string, layerPath: string, displayDateFormat: TypeDisplayDateFormat): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  if (layer) {
-    // Update the value
-    layer.displayDateFormatShort = displayDateFormat;
-
-    // Set updated legend layers
-    getStoreLayerState(mapId).actions.setLegendLayers(layers);
-  }
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, displayDateFormatShort: displayDateFormat }));
 };
 
 /**
@@ -1240,17 +1295,7 @@ export const setStoreLayerDisplayDateFormatShort = (mapId: string, layerPath: st
  * @param temporalMode - The temporal mode to set.
  */
 export const setStoreLayerDateTemporal = (mapId: string, layerPath: string, temporalMode: TemporalMode): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  if (layer) {
-    // Update the value
-    layer.dateTemporalMode = temporalMode;
-
-    // Set updated legend layers
-    getStoreLayerState(mapId).actions.setLegendLayers(layers);
-  }
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, dateTemporalMode: temporalMode }));
 };
 
 /**
@@ -1261,17 +1306,7 @@ export const setStoreLayerDateTemporal = (mapId: string, layerPath: string, temp
  * @param mosaicRule - The mosaic rule to set, or undefined to clear.
  */
 export const setStoreLayerMosaicRule = (mapId: string, layerPath: string, mosaicRule: TypeMosaicRule | undefined): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  if (layer) {
-    // Update the value
-    layer.mosaicRule = mosaicRule;
-
-    // Set updated legend layers
-    getStoreLayerState(mapId).actions.setLegendLayers(layers);
-  }
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, mosaicRule }));
 };
 
 /**
@@ -1282,17 +1317,7 @@ export const setStoreLayerMosaicRule = (mapId: string, layerPath: string, mosaic
  * @param rasterFunctionId - The raster function id to set, or undefined to clear.
  */
 export const setStoreLayerRasterFunction = (mapId: string, layerPath: string, rasterFunctionId: string | undefined): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  if (layer) {
-    // Update the value
-    layer.rasterFunction = rasterFunctionId;
-
-    // Set updated legend layers
-    getStoreLayerState(mapId).actions.setLegendLayers(layers);
-  }
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, rasterFunction: rasterFunctionId }));
 };
 
 /**
@@ -1303,17 +1328,7 @@ export const setStoreLayerRasterFunction = (mapId: string, layerPath: string, ra
  * @param wmsStyleName - The WMS style name to set, or undefined to clear.
  */
 export const setStoreLayerWmsStyle = (mapId: string, layerPath: string, wmsStyleName: string | undefined): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  if (layer) {
-    // Update the value
-    layer.wmsStyle = wmsStyleName;
-
-    // Set updated legend layers
-    getStoreLayerState(mapId).actions.setLegendLayers(layers);
-  }
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, wmsStyle: wmsStyleName }));
 };
 
 /**
@@ -1324,17 +1339,7 @@ export const setStoreLayerWmsStyle = (mapId: string, layerPath: string, wmsStyle
  * @param textVisible - Whether the text is visible.
  */
 export const setStoreLayerTextVisibility = (mapId: string, layerPath: string, textVisible: boolean): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
-
-  if (layer) {
-    // Update the value
-    layer.textVisible = textVisible;
-
-    // Set updated legend layers
-    getStoreLayerState(mapId).actions.setLegendLayers(layers);
-  }
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, textVisible }));
 };
 
 /**
@@ -1354,8 +1359,8 @@ export const setStoreLayerSelectedLayersTabLayer = (mapId: string, layerPath: st
  * @param mapId - The map identifier.
  */
 export const setStoreReorderLegendLayers = (mapId: string): void => {
-  // Sort the layers
-  const sortedLayers = getStoreLayerStateLegendLayers(mapId).sort(
+  // Create a sorted copy of the layers (toSorted produces a new array)
+  const sortedLayers = [...getStoreLayerLegendLayers(mapId)].sort(
     (a, b) => getStoreMapOrderedLayerIndexByPath(mapId, a.layerPath) - getStoreMapOrderedLayerIndexByPath(mapId, b.layerPath)
   );
 
@@ -1390,46 +1395,16 @@ export const setStoreLegendQueryStatus = (
   legendQueryStatus: LegendQueryStatus,
   data: TypeLegend | undefined
 ): void => {
-  // Find the layer for the given layer path
-  const layers = getStoreLayerStateLegendLayers(mapId);
-  const layer = utilLegendLayerByPathRec(layers, layerPath);
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => {
+    const updated: TypeLegendLayer = { ...layer, legendQueryStatus, styleConfig: data?.styleConfig };
 
-  if (layer) {
-    // Set layer queryable
-    layer.legendQueryStatus = legendQueryStatus;
-    layer.styleConfig = data?.styleConfig;
-
-    // If data.type
     if (data?.type) {
-      layer.icons = GeoUtilities.getLayerIconImage(data.type, data) ?? [];
-      layer.items = GeoUtilities.getLayerItemsFromIcons(data.type, layer.icons);
+      updated.icons = GeoUtilities.getLayerIconImage(data.type, data) ?? [];
+      updated.items = GeoUtilities.getLayerItemsFromIcons(data.type, updated.icons);
     }
 
-    // Set updated legend layers
-    getStoreLayerState(mapId).actions.setLegendLayers(layers);
-  }
-};
-
-/**
- * Recursively removes a layer from the legend layers array and its children.
- *
- * @param mapId - The map identifier.
- * @param legendLayers - The legend layers array to search and modify.
- * @param layerPath - The layer path to remove.
- */
-const deleteStoreLayersFromLegendLayersAndChildren = (mapId: string, legendLayers: TypeLegendLayer[], layerPath: string): void => {
-  // Find index of layer and remove it
-  const layersIndexToDelete = legendLayers.findIndex((l) => l.layerPath === layerPath);
-  if (layersIndexToDelete >= 0) {
-    legendLayers.splice(layersIndexToDelete, 1);
-  } else {
-    // Check for layer to remove in children
-    legendLayers.forEach((layer) => {
-      if (layer.children && layer.children.length > 0) {
-        deleteStoreLayersFromLegendLayersAndChildren(mapId, layer.children, layerPath);
-      }
-    });
-  }
+    return updated;
+  });
 };
 
 /**
@@ -1439,14 +1414,8 @@ const deleteStoreLayersFromLegendLayersAndChildren = (mapId: string, legendLayer
  * @param layerPath - The layer path to remove.
  */
 export const deleteStoreLayerFromLegendLayers = (mapId: string, layerPath: string): void => {
-  // Get legend layers to pass to recursive function
-  const curLayers = getStoreLayerStateLegendLayers(mapId);
-
-  // Remove layer and children
-  deleteStoreLayersFromLegendLayersAndChildren(mapId, curLayers, layerPath);
-
-  // Set updated legend layers after delete
-  getStoreLayerState(mapId).actions.setLegendLayers(curLayers);
+  const layers = getStoreLayerLegendLayers(mapId);
+  getStoreLayerState(mapId).actions.setLegendLayers(utilDeleteLayerFromLegendLayers(layers, layerPath));
 };
 
 /**

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
@@ -351,6 +351,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
     actions: {
       /**
        * Sets the map size.
+       *
        * @param size - The size of the map.
        */
       setMapSize: (size: Size): void => {
@@ -364,6 +365,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the map scale.
+       *
        * @param scale - The scale information.
        */
       setMapScale: (scale: TypeScaleInfo): void => {
@@ -377,6 +379,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets whether the map is loaded.
+       *
        * @param mapLoaded - Flag indicating if the map is loaded.
        */
       setMapLoaded: (mapLoaded: boolean): void => {
@@ -402,6 +405,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the attribution of the map.
+       *
        * @param attribution - The attribution information.
        */
       setAttribution: (attribution: string[]): void => {
@@ -415,6 +419,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the current basemap options.
+       *
        * @param basemapOptions - The new basemap options.
        */
       setCurrentBasemapOptions: (basemapOptions: TypeBasemapOptions): void => {
@@ -428,6 +433,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the initial filters of the map layers.
+       *
        * @param filters - The filters.
        */
       setInitialFilters: (filters: Record<string, string>): void => {
@@ -441,6 +447,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the initial view of the map.
+       *
        * @param view - The view extent or zoom&center.
        */
       setInitialView: (view: TypeZoomAndCenter | Extent): void => {
@@ -459,6 +466,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the geolocator search area with coordinates and optional bounding box.
+       *
        * @param area - The search area object containing coordinates and optional bounding box, or undefined to clear.
        * @param area.searchItem - The search item description.
        * @param area.coords - The coordinates of the search location.
@@ -475,6 +483,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the view of the home button.
+       *
        * @param view - The view to use.
        */
       setHomeView: (view: TypeMapViewSettings): void => {
@@ -488,6 +497,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the interaction of the map.
+       *
        * @param interaction - The interaction type.
        */
       setInteraction: (interaction: TypeInteraction): void => {
@@ -501,6 +511,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets to true if mouse is inside map.
+       *
        * @param isMouseInsideMap - True if mouse is inside map.
        */
       setIsMouseInsideMap: (isMouseInsideMap: boolean): void => {
@@ -514,6 +525,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the zoom level of the map.
+       *
        * @param zoom - The zoom level.
        */
       setZoom: (zoom: number): void => {
@@ -527,6 +539,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the rotation of the map.
+       *
        * @param rotation - The rotation angle.
        */
       setRotation: (rotation: number): void => {
@@ -540,6 +553,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the overlay click marker of the map.
+       *
        * @param overlayClickMarker - The overlay click marker.
        */
       setOverlayClickMarker: (overlayClickMarker: Overlay): void => {
@@ -553,6 +567,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the overlay north marker of the map.
+       *
        * @param overlayNorthMarker - The overlay north marker.
        */
       setOverlayNorthMarker: (overlayNorthMarker: Overlay): void => {
@@ -566,6 +581,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the projection of the map.
+       *
        * @param projectionCode - The projection code.
        */
       setProjection: (projectionCode: TypeValidMapProjectionCodes): void => {
@@ -579,6 +595,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the point markers.
+       *
        * @param pointMarkers - The new point markers.
        */
       setPointMarkers: (pointMarkers: Record<string, TypePointMarker[]>): void => {
@@ -592,6 +609,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets map move end properties.
+       *
        * @param centerCoordinates - The center coordinates of the map.
        * @param pointerPosition - The pointer position information.
        * @param degreeRotation - The degree rotation.
@@ -631,6 +649,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the pointer position of the map.
+       *
        * @param pointerPosition - The pointer position.
        */
       setPointerPosition: (pointerPosition: TypeMapMouseInfo): void => {
@@ -644,6 +663,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the click coordinates of the map.
+       *
        * @param clickCoordinates - The click coordinates.
        */
       setClickCoordinates: (clickCoordinates: TypeMapMouseInfo): void => {
@@ -657,6 +677,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets whether the map is fixed to north.
+       *
        * @param fixNorth - Flag indicating if the map should be fixed to north.
        */
       setFixNorth: (fixNorth: boolean): void => {
@@ -670,6 +691,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the highlighted features of the map.
+       *
        * @param highlightedFeatures - The highlighted features.
        */
       setHighlightedFeatures: (highlightedFeatures: TypeFeatureInfoEntry[]): void => {
@@ -683,6 +705,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the visible layers of the map.
+       *
        * @param visibleLayers - The visible layers.
        */
       setVisibleLayers: (visibleLayers: string[]): void => {
@@ -696,6 +719,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the layers of the map that are in visible range.
+       *
        * @param visibleRangeLayers - The layers in their visible range
        */
       setVisibleRangeLayers: (visibleRangeLayers: string[]): void => {
@@ -709,6 +733,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the ordered layer information of the map.
+       *
        * @param orderedLayerInfo - The ordered layer information.
        */
       setOrderedLayerInfo: (orderedLayerInfo: TypeOrderedLayerInfo[]): void => {
@@ -749,6 +774,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the visible layers of the map.
+       *
        * @param orderedLayers - The ordered layers.
        */
       setOrderedLayers: (orderedLayers: string[]): void => {
@@ -762,6 +788,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets whether a layer is hoverable.
+       *
        * @param layerPath - The path of the layer.
        * @param hoverable - Flag indicating if the layer should be hoverable.
        */
@@ -771,6 +798,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets whether a layer legend is collapsed.
+       *
        * @param layerPath - The path of the layer.
        * @param collapsed - Flag indicating if the layer should be collapsed.
        */
@@ -780,6 +808,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets whether a layer is queryable.
+       *
        * @param layerPath - The path of the layer.
        * @param queryable - Flag indicating if the layer should be queryable.
        */
@@ -791,6 +820,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Immutably updates a single entry in orderedLayerInfo and recalculates derived state.
+       *
        * @param layerPath - The layer path to update.
        * @param updates - Partial properties to merge into the matching entry.
        */
@@ -803,6 +833,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the click marker of the map.
+       *
        * @param coord - The click marker coordinates.
        */
       setClickMarker: (coord: number[] | undefined): void => {
@@ -813,6 +844,7 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
       /**
        * Sets the hover feature information to be displayed in the hover tooltip.
+       *
        * @param hoverFeatureInfo - The hover feature information.
        */
       setHoverFeatureInfo(hoverFeatureInfo: TypeHoverFeatureInfo) {

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
@@ -31,14 +31,16 @@ import type {
   TypeValidVersions,
 } from '@/api/types/map-schema-types';
 import { DEFAULT_HIGHLIGHT_COLOR, MAP_CENTER, MAP_ZOOM_LEVEL } from '@/api/types/map-schema-types';
+import type { MapConfigLayerEntry } from '@/api/types/layer-schema-types';
+import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import { getGeoViewStore, useGeoViewStore } from '@/core/stores/stores-managers';
-import { type TypeSetStore, type TypeGetStore, useStableSelector } from '@/core/stores/geoview-store';
+import type { TypeSetStore, TypeGetStore } from '@/core/stores/geoview-store';
+import { useStableSelector } from '@/core/stores/geoview-store';
 import type { TypeMapFeaturesConfig } from '@/core/types/global-types';
 import type { TypeClickMarker } from '@/core/components/click-marker/click-marker';
 import type { TypeHoverFeatureInfo } from './feature-info-state';
 import { getStoreLayerStatus, getStoreLayerLegendLayerByPath } from './layer-state';
 import type { TypeMapStateForExportLayout } from '@/core/components/export/utilities';
-import { CONST_LAYER_TYPES, type MapConfigLayerEntry } from '@/api/types/layer-schema-types';
 
 // #region INTERFACE DEFINITION
 

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
@@ -1145,6 +1145,13 @@ export const getStoreMapPointerPosition = (mapId: string): TypeMapMouseInfo | un
 export const useStoreMapPointerPosition = (): TypeMapMouseInfo | undefined =>
   useStore(useGeoViewStore(), (state) => state.mapState.pointerPosition);
 
+/** Returns the current pointer position, or undefined if unavailable. */
+export const getStoreMapClickCoordinates = (mapId: string): TypeMapMouseInfo | undefined => getStoreMapState(mapId).clickCoordinates;
+
+/** Selects the click coordinates from the store. */
+export const useStoreMapClickCoordinates = (): TypeMapMouseInfo | undefined =>
+  useStore(useGeoViewStore(), (state) => state.mapState.clickCoordinates);
+
 /** Returns the current basemap options. */
 export const getStoreMapCurrentBasemapOptions = (mapId: string): TypeBasemapOptions => {
   return getStoreMapState(mapId).currentBasemapOptions;
@@ -1251,10 +1258,6 @@ export const useStoreMapCenterCoordinates = (): Coordinate => useStore(useGeoVie
 
 /** Selects the click marker state from the store. */
 export const useStoreMapClickMarker = (): TypeClickMarker | undefined => useStore(useGeoViewStore(), (state) => state.mapState.clickMarker);
-
-/** Selects the click coordinates from the store. */
-export const useStoreMapClickCoordinates = (): TypeMapMouseInfo | undefined =>
-  useStore(useGeoViewStore(), (state) => state.mapState.clickCoordinates);
 
 /** Selects the current map extent from the store. */
 export const useStoreMapExtent = (): Extent | undefined => useStore(useGeoViewStore(), (state) => state.mapState.mapExtent);

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
@@ -36,7 +36,7 @@ import { type TypeSetStore, type TypeGetStore, useStableSelector } from '@/core/
 import type { TypeMapFeaturesConfig } from '@/core/types/global-types';
 import type { TypeClickMarker } from '@/core/components/click-marker/click-marker';
 import type { TypeHoverFeatureInfo } from './feature-info-state';
-import { getStoreLayerStateLayerStatus, getStoreLayerStateLegendLayerByPath } from './layer-state';
+import { getStoreLayerStatus, getStoreLayerLegendLayerByPath } from './layer-state';
 import type { TypeMapStateForExportLayout } from '@/core/components/export/utilities';
 import { CONST_LAYER_TYPES, type MapConfigLayerEntry } from '@/api/types/layer-schema-types';
 
@@ -127,6 +127,7 @@ export interface IMapState {
     setHoverable: (layerPath: string, hoverable: boolean) => void;
     setLegendCollapsed: (layerPath: string, newValue?: boolean) => void;
     setQueryable: (layerPath: string, queryable: boolean) => void;
+    updateOrderedLayerInfoByPath: (layerPath: string, updates: Partial<TypeOrderedLayerInfo>) => void;
     setClickMarker: (coord: number[] | undefined) => void;
     setHoverFeatureInfo: (hoverFeatureInfo: TypeHoverFeatureInfo) => void;
   };
@@ -171,7 +172,7 @@ export const utilFindMapLayerAndChildrenFromOrderedInfo = (
  * @param orderedLayerInfo - The ordered layer info array to search in
  * @returns True if any parent layer is hidden, false otherwise
  */
-const utilGetParentHidden = (layerPath: string, orderedLayerInfo: TypeOrderedLayerInfo[]): boolean => {
+const utilGetParentLayerHiddenOnMap = (layerPath: string, orderedLayerInfo: TypeOrderedLayerInfo[]): boolean => {
   // For each parent
   const parentLayerPathArray = layerPath.split('/');
   parentLayerPathArray.pop();
@@ -193,6 +194,24 @@ const utilGetParentHidden = (layerPath: string, orderedLayerInfo: TypeOrderedLay
 };
 
 /**
+ * Checks whether a layer is hidden on the map.
+ *
+ * A layer is considered hidden if any of its parent layers are hidden,
+ * it is not in the visible range, or it is not visible.
+ *
+ * @param layerPath - The layer path to check
+ * @param orderedLayerInfo - The ordered layer info array to search in
+ * @returns True if the layer is hidden on the map, false otherwise
+ */
+const utilGetLayerHiddenOnMap = (layerPath: string, orderedLayerInfo: TypeOrderedLayerInfo[]): boolean => {
+  return (
+    utilGetParentLayerHiddenOnMap(layerPath, orderedLayerInfo) ||
+    !utilFindMapLayerFromOrderedInfo(layerPath, orderedLayerInfo)?.inVisibleRange ||
+    !utilFindMapLayerFromOrderedInfo(layerPath, orderedLayerInfo)?.visible
+  );
+};
+
+/**
  * Returns the ordered layer info entries that have collapsible legends.
  *
  * A layer is considered collapsible if it has children, multiple legend items,
@@ -203,9 +222,9 @@ const utilGetParentHidden = (layerPath: string, orderedLayerInfo: TypeOrderedLay
  * @returns The ordered layer info entries with collapsible legends
  */
 const utilGetLegendCollapsibleLayers = (mapId: string, orderedLayerInfo: TypeOrderedLayerInfo[]): TypeOrderedLayerInfo[] => {
-  // TODO: CHECK - This store references another store by using getStoreLayerStateLegendLayerByPath below :/
+  // TODO: CHECK - This store references another store by using getStoreLayerLegendLayerByPath below :/
   return orderedLayerInfo.filter((layer) => {
-    const legendLayer = getStoreLayerStateLegendLayerByPath(mapId, layer.layerPath);
+    const legendLayer = getStoreLayerLegendLayerByPath(mapId, layer.layerPath);
     return (
       (legendLayer?.children && legendLayer.children.length > 0) ||
       (legendLayer?.items && legendLayer.items.length > 1) ||
@@ -213,6 +232,33 @@ const utilGetLegendCollapsibleLayers = (mapId: string, orderedLayerInfo: TypeOrd
         legendLayer?.icons?.some((icon) => icon.iconImage && icon.iconImage !== 'no data'))
     );
   });
+};
+
+/**
+ * Immutably updates a single entry in the ordered layer info array by layer path.
+ *
+ * Returns a new array where only the matching entry is replaced with a shallow-merged copy.
+ * Non-matching entries keep their original object references.
+ *
+ * @param orderedLayerInfo - The current ordered layer info array
+ * @param layerPath - The layer path to update
+ * @param updates - Partial properties to merge into the matching entry
+ * @returns A new array with the updated entry, or the same array if the path was not found
+ */
+const utilUpdateOrderedLayerInfoByPath = (
+  orderedLayerInfo: TypeOrderedLayerInfo[],
+  layerPath: string,
+  updates: Partial<TypeOrderedLayerInfo>
+): TypeOrderedLayerInfo[] => {
+  let found = false;
+  const result = orderedLayerInfo.map((entry) => {
+    if (entry.layerPath === layerPath) {
+      found = true;
+      return { ...entry, ...updates };
+    }
+    return entry;
+  });
+  return found ? result : orderedLayerInfo;
 };
 
 // #region STATE INITIALIZATION
@@ -663,14 +709,11 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
        * Sets the ordered layer information of the map.
        * @param orderedLayerInfo - The ordered layer information.
        */
-      // TODO: REFACTOR - Calls to setOrderedLayerInfo are probably overkill when updating only parts of the whole objects array
       setOrderedLayerInfo: (orderedLayerInfo: TypeOrderedLayerInfo[]): void => {
         set({
           mapState: {
             ...get().mapState,
-            orderedLayerInfo: [...orderedLayerInfo],
-            // GV Here, we use the spread operator for the custom selector hooks such as useMapSelectorLayerLegendCollapsed to
-            // GV notice and eventually trigger the changes that need to be get triggered
+            orderedLayerInfo,
           },
         });
 
@@ -721,30 +764,16 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
        * @param hoverable - Flag indicating if the layer should be hoverable.
        */
       setHoverable: (layerPath: string, hoverable: boolean): void => {
-        const curLayerInfo = get().mapState.orderedLayerInfo;
-        const layerInfo = curLayerInfo.find((info) => info.layerPath === layerPath);
-        if (layerInfo) {
-          layerInfo.hoverable = hoverable;
-
-          // Redirect
-          get().mapState.actions.setOrderedLayerInfo(curLayerInfo);
-        }
+        get().mapState.actions.updateOrderedLayerInfoByPath(layerPath, { hoverable });
       },
 
       /**
-       * Sets whether a layer is hoverable.
+       * Sets whether a layer legend is collapsed.
        * @param layerPath - The path of the layer.
        * @param collapsed - Flag indicating if the layer should be collapsed.
        */
       setLegendCollapsed: (layerPath: string, collapsed: boolean): void => {
-        const curLayerInfo = get().mapState.orderedLayerInfo;
-        const layerInfo = curLayerInfo.find((info) => info.layerPath === layerPath);
-        if (layerInfo) {
-          layerInfo.legendCollapsed = collapsed;
-
-          // Redirect
-          get().mapState.actions.setOrderedLayerInfo(curLayerInfo);
-        }
+        get().mapState.actions.updateOrderedLayerInfoByPath(layerPath, { legendCollapsed: collapsed });
       },
 
       /**
@@ -753,14 +782,20 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
        * @param queryable - Flag indicating if the layer should be queryable.
        */
       setQueryable: (layerPath: string, queryable: boolean): void => {
-        const curLayerInfo = get().mapState.orderedLayerInfo;
-        const layerInfo = curLayerInfo.find((info) => info.layerPath === layerPath);
-        if (layerInfo) {
-          layerInfo.queryableState = queryable;
-          if (queryable) layerInfo.hoverable = queryable;
+        const updates: Partial<TypeOrderedLayerInfo> = { queryableState: queryable };
+        if (queryable) updates.hoverable = true;
+        get().mapState.actions.updateOrderedLayerInfoByPath(layerPath, updates);
+      },
 
-          // Redirect
-          get().mapState.actions.setOrderedLayerInfo(curLayerInfo);
+      /**
+       * Immutably updates a single entry in orderedLayerInfo and recalculates derived state.
+       * @param layerPath - The layer path to update.
+       * @param updates - Partial properties to merge into the matching entry.
+       */
+      updateOrderedLayerInfoByPath: (layerPath: string, updates: Partial<TypeOrderedLayerInfo>): void => {
+        const newOrderedLayerInfo = utilUpdateOrderedLayerInfoByPath(get().mapState.orderedLayerInfo, layerPath, updates);
+        if (newOrderedLayerInfo !== get().mapState.orderedLayerInfo) {
+          get().mapState.actions.setOrderedLayerInfo(newOrderedLayerInfo);
         }
       },
 
@@ -774,6 +809,10 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
         });
       },
 
+      /**
+       * Sets the hover feature information to be displayed in the hover tooltip.
+       * @param hoverFeatureInfo - The hover feature information.
+       */
       setHoverFeatureInfo(hoverFeatureInfo: TypeHoverFeatureInfo) {
         set({
           mapState: {
@@ -790,235 +829,10 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
 
 // #endregion STATE INITIALIZATION
 
-// #region STATE HOOKS
-// GV To be used by React components
-
-/** Selects the map attribution strings from the store. */
-export const useMapAttribution = (): string[] => useStore(useGeoViewStore(), (state) => state.mapState.attribution);
-/** Selects the initial basemap options from the store. */
-export const useMapBasemapOptions = (): TypeBasemapOptions => useStore(useGeoViewStore(), (state) => state.mapState.basemapOptions);
-/** Selects the current basemap options from the store. */
-export const useMapCurrentBasemapOptions = (): TypeBasemapOptions =>
-  useStore(useGeoViewStore(), (state) => state.mapState.currentBasemapOptions);
-/** Selects the map center coordinates from the store. */
-export const useMapCenterCoordinates = (): Coordinate => useStore(useGeoViewStore(), (state) => state.mapState.centerCoordinates);
-/** Selects the click marker state from the store. */
-export const useMapClickMarker = (): TypeClickMarker | undefined => useStore(useGeoViewStore(), (state) => state.mapState.clickMarker);
-/** Selects the click coordinates from the store. */
-export const useMapClickCoordinates = (): TypeMapMouseInfo | undefined =>
-  useStore(useGeoViewStore(), (state) => state.mapState.clickCoordinates);
-/** Selects the current map extent from the store. */
-export const useMapExtent = (): Extent | undefined => useStore(useGeoViewStore(), (state) => state.mapState.mapExtent);
-/** Selects whether the map has a geoview basemap layer from the store. */
-export const useMapHasGeoviewBasemapLayer = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.hasGeoviewBasemapLayer);
-/** Selects the feature highlight color settings from the store. */
-export const useMapFeatureHighlightColor = (): TypeHighlightColors =>
-  useStore(useGeoViewStore(), (state) => state.mapState.featureHighlightColor);
-/** Selects whether the map is fixed to north from the store. */
-export const useMapFixNorth = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.fixNorth);
-/** Selects the initial layer filters from the store. */
-export const useMapInitialFilters = (): Record<string, string> => useStore(useGeoViewStore(), (state) => state.mapState.initialFilters);
-/** Selects the initial view settings from the store. */
-export const useMapInitialView = (): TypeMapViewSettings => useStore(useGeoViewStore(), (state) => state.mapState.initialView);
-/** Selects the map interaction mode from the store. */
-export const useMapInteraction = (): TypeInteraction => useStore(useGeoViewStore(), (state) => state.mapState.interaction);
-/** Selects whether the mouse is inside the map from the store. */
-export const useMapIsMouseInsideMap = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.isMouseInsideMap);
-/** Selects the hover feature info from the store. */
-export const useMapHoverFeatureInfo = (): TypeHoverFeatureInfo => useStore(useGeoViewStore(), (state) => state.mapState.hoverFeatureInfo);
-/** Selects whether the map is loaded from the store. */
-export const useMapLoaded = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.mapLoaded);
-/** Selects whether the map is displayed from the store. */
-export const useMapDisplayed = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.mapDisplayed);
-/** Selects whether the north arrow is enabled from the store. */
-export const useMapNorthArrow = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.northArrow);
-/** Selects the north arrow element state from the store. */
-export const useMapNorthArrowElement = (): TypeNorthArrow => useStore(useGeoViewStore(), (state) => state.mapState.northArrowElement);
-/** Selects whether the overview map is enabled from the store. */
-export const useMapOverviewMap = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.overviewMap);
-/** Selects the zoom level at which the overview map hides from the store. */
-export const useMapOverviewMapHideZoom = (): number => useStore(useGeoViewStore(), (state) => state.mapState.overviewMapHideZoom);
-/** Selects the current pointer position from the store. */
-export const useMapPointerPosition = (): TypeMapMouseInfo | undefined =>
-  useStore(useGeoViewStore(), (state) => state.mapState.pointerPosition);
-/** Selects the point markers grouped by name from the store. */
-export const useMapPointMarkers = (): Record<string, TypePointMarker[]> =>
-  useStore(useGeoViewStore(), (state) => state.mapState.pointMarkers);
-/** Selects the current map projection code from the store. */
-export const useMapProjection = (): TypeValidMapProjectionCodes => useStore(useGeoViewStore(), (state) => state.mapState.currentProjection);
-/** Selects the current map projection as an EPSG string from the store. */
-export const useMapProjectionEPSG = (): string => useStore(useGeoViewStore(), (state) => `EPSG:${state.mapState.currentProjection}`);
-/** Selects the map rotation angle from the store. */
-export const useMapRotation = (): number => useStore(useGeoViewStore(), (state) => state.mapState.rotation);
-/** Selects the map scale information from the store. */
-export const useMapScale = (): TypeScaleInfo => useStore(useGeoViewStore(), (state) => state.mapState.scale);
-/** Selects the map size from the store. */
-export const useMapSize = (): Size => useStore(useGeoViewStore(), (state) => state.mapState.size);
-/** Selects the ordered layer paths from the store. */
-export const useMapOrderedLayers = (): string[] => useStore(useGeoViewStore(), (state) => state.mapState.orderedLayers);
-/** Selects the visible layer paths from the store. */
-export const useMapVisibleLayers = (): string[] => useStore(useGeoViewStore(), (state) => state.mapState.visibleLayers);
-/** Selects the current zoom level from the store. */
-export const useMapZoom = (): number => useStore(useGeoViewStore(), (state) => state.mapState.zoom);
-
-/**
- * Selects the union of visible and in-range layer paths.
- *
- * Used by data-table, details, geochart, and time-slider left panel components.
- *
- * @returns The deduplicated array of layer paths that are visible or in visible range
- */
-export const useMapAllVisibleandInRangeLayers = (): string[] => {
-  const visibleLayers = useStore(useGeoViewStore(), (state) => state.mapState.visibleLayers);
-  const visibleRangeLayers = useStore(useGeoViewStore(), (state) => state.mapState.visibleRangeLayers);
-  return useMemo(() => {
-    return [...new Set([...visibleLayers, ...visibleRangeLayers])];
-  }, [visibleLayers, visibleRangeLayers]);
-};
-
-/**
- * Selects the visibility state of a single layer.
- *
- * @param layerPath - The layer path to check visibility for
- * @returns True if the layer is visible, false otherwise
- */
-export const useMapSelectorLayerVisibility = (layerPath: string): boolean => {
-  // Hook
-  return useStore(
-    useGeoViewStore(),
-    (state) => utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.visible || false
-  );
-};
-
-/**
- * Selects whether any of the given layer paths are visible.
- *
- * @param layerPaths - The layer paths to check visibility for
- * @returns True if at least one layer is visible, false otherwise
- */
-export const useMapSelectorLayerArrayVisibility = (layerPaths: string[]): boolean => {
-  return useStore(useGeoViewStore(), (state) => {
-    // Return true if all layers are visible (or don't exist yet)
-    return layerPaths.some((layerPath) => {
-      return utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.visible || false;
-    });
-  });
-};
-
-/**
- * Selects whether any parent of the given layer is hidden.
- *
- * @param layerPath - The layer path to check parent visibility for
- * @returns True if any parent layer is hidden
- */
-export const useMapSelectorLayerParentHidden = (layerPath: string): boolean => {
-  return useStore(useGeoViewStore(), (state) => utilGetParentHidden(layerPath, state.mapState.orderedLayerInfo));
-};
-
-/**
- * Selects whether a layer is within its visible zoom range.
- *
- * @param layerPath - The layer path to check
- * @returns True if the layer is in visible range
- */
-export const useMapSelectorLayerInVisibleRange = (layerPath: string): boolean => {
-  // Hook
-  return useStore(
-    useGeoViewStore(),
-    (state) => utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.inVisibleRange || false
-  );
-};
-
-/**
- * Selects whether a layer is effectively hidden on the map.
- *
- * A layer is hidden if any parent is hidden, or if it is out of visible range, or if it is not visible.
- *
- * @param layerPath - The layer path to check
- * @returns True if the layer is hidden on the map
- */
-export const useMapSelectorIsLayerHiddenOnMap = (layerPath: string): boolean => {
-  return useStore(
-    useGeoViewStore(),
-    (state) =>
-      utilGetParentHidden(layerPath, state.mapState.orderedLayerInfo) ||
-      !utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.inVisibleRange ||
-      !utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.visible
-  );
-};
-
-/**
- * Selects the legend collapsed state for a given layer.
- *
- * @param layerPath - The layer path to check
- * @returns True if the layer legend is collapsed
- */
-export const useMapSelectorLayerLegendCollapsed = (layerPath: string): boolean => {
-  // Hook
-  return useStore(
-    useGeoViewStore(),
-    (state) => utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.legendCollapsed || false
-  );
-};
-
-/**
- * Selects the queryable state for multiple layer paths.
- *
- * @param layerPaths - The layer paths to check queryable state for
- * @returns A record mapping each layer path to its queryable state
- */
-export const useMapSelectorLayerQueryable = (layerPaths: string[]): Record<string, boolean> => {
-  // Hook
-  return useStableSelector(useGeoViewStore(), (state) => {
-    const result: Record<string, boolean> = {};
-
-    for (const layerPath of layerPaths) {
-      result[layerPath] = utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.queryableState || false;
-    }
-
-    return result;
-  });
-};
-
-/**
- * Selects whether all layers are visible (excluding errored layers).
- *
- * @returns True if all non-errored layers are visible
- */
-export const useMapAllLayersVisibleToggle = (): boolean =>
-  // TODO: CHECK - Cross-stores, here we jump into the layer store :/
-  useStore(useGeoViewStore(), (state) =>
-    state.mapState.orderedLayerInfo.every(
-      (layer) => layer.visible || getStoreLayerStateLayerStatus(state.mapId, layer.layerPath) === 'error'
-    )
-  );
-
-/**
- * Selects whether there are any layers with collapsible legends.
- *
- * @returns True if at least one layer has a collapsible legend
- */
-export const useMapHasCollapsibleLayersToggle = (): boolean =>
-  useStore(useGeoViewStore(), (state) => utilGetLegendCollapsibleLayers(state.mapId, state.mapState.orderedLayerInfo).length > 0);
-
-/**
- * Selects whether all collapsible layer legends are collapsed.
- *
- * @returns True if all collapsible legends are collapsed, or if there are no collapsible layers
- */
-export const useMapAllLayersCollapsedToggle = (): boolean =>
-  useStore(useGeoViewStore(), (state) => {
-    // Get the legend collapsible layers
-    const collapsibleLayers = utilGetLegendCollapsibleLayers(state.mapId, state.mapState.orderedLayerInfo);
-
-    // If there are no collapsible layers, return true
-    if (collapsibleLayers.length === 0) return true;
-    return collapsibleLayers.every((layer) => layer.legendCollapsed);
-  });
-
-// #region STATE HOOKS
-
-// #region STATE SELECTORS
+// #region STATE GETTERS & HOOKS
+// GV Getters should be used to get the values at a moment in time.
+// GV Hooks should be used to attach to values and trigger UI components when they change.
+// GV Typically they are listed in couples (getter + hook) for the same value.
 
 /**
  * Returns the full layer state slice for the given map.
@@ -1088,10 +902,56 @@ export const getStoreMapOrderedLayerInfoByPath = (mapId: string, layerPath: stri
   return utilFindMapLayerFromOrderedInfo(layerPath, getStoreMapOrderedLayerInfo(mapId));
 };
 
+/** Returns the legend collapsed state for all layers, defaulting to true if not found. */
+export const getStoreMapLegendCollapsedSet = (mapId: string): Record<string, boolean> => {
+  const collapsedSet: Record<string, boolean> = {};
+  getStoreMapOrderedLayerInfo(mapId).forEach((layer) => {
+    collapsedSet[layer.layerPath] = layer.legendCollapsed ?? true;
+  });
+  return collapsedSet;
+};
+
 /** Returns the legend collapsed state for a layer, defaulting to true if not found. */
 export const getStoreMapLegendCollapsedByPath = (mapId: string, layerPath: string): boolean => {
-  return getStoreMapOrderedLayerInfoByPath(mapId, layerPath)?.legendCollapsed !== false;
+  return getStoreMapOrderedLayerInfoByPath(mapId, layerPath)?.legendCollapsed ?? true;
 };
+
+/**
+ * Selects the legend collapsed state for a given layer.
+ *
+ * @param layerPath - The layer path to check
+ * @returns True if the layer legend is collapsed
+ */
+export const useStoreMapLegendCollapsedByPath = (layerPath: string): boolean => {
+  // Hook
+  return useStore(
+    useGeoViewStore(),
+    (state) => utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.legendCollapsed || false
+  );
+};
+
+/**
+ * Selects whether all collapsible layer legends are collapsed.
+ *
+ * @returns True if all collapsible legends are collapsed, or if there are no collapsible layers
+ */
+export const useStoreMapAllLayersCollapsedToggle = (): boolean =>
+  useStore(useGeoViewStore(), (state) => {
+    // Get the legend collapsible layers
+    const collapsibleLayers = utilGetLegendCollapsibleLayers(state.mapId, state.mapState.orderedLayerInfo);
+
+    // If there are no collapsible layers, return true
+    if (collapsibleLayers.length === 0) return true;
+    return collapsibleLayers.every((layer) => layer.legendCollapsed);
+  });
+
+/**
+ * Selects whether there are any layers with collapsible legends.
+ *
+ * @returns True if at least one layer has a collapsible legend
+ */
+export const useStoreMapHasCollapsibleLayersToggle = (): boolean =>
+  useStore(useGeoViewStore(), (state) => utilGetLegendCollapsibleLayers(state.mapId, state.mapState.orderedLayerInfo).length > 0);
 
 /** Returns the visibility state of a layer, or undefined if the layer is not found. */
 export const getStoreMapVisibilityByPath = (mapId: string, layerPath: string): boolean | undefined => {
@@ -1101,12 +961,12 @@ export const getStoreMapVisibilityByPath = (mapId: string, layerPath: string): b
 /** Returns whether any parent of the given layer is hidden. */
 export const getStoreMapLayerParentHidden = (mapId: string, layerPath: string): boolean => {
   const orderedLayerInfo = getStoreMapOrderedLayerInfo(mapId);
-  return utilGetParentHidden(layerPath, orderedLayerInfo);
+  return utilGetParentLayerHiddenOnMap(layerPath, orderedLayerInfo);
 };
 
 /** Returns whether the layer is within its visible zoom range, defaulting to true. */
 export const getStoreMapInVisibleRangeByPath = (mapId: string, layerPath: string): boolean => {
-  return getStoreMapOrderedLayerInfoByPath(mapId, layerPath)?.inVisibleRange !== false;
+  return getStoreMapOrderedLayerInfoByPath(mapId, layerPath)?.inVisibleRange ?? true;
 };
 
 /** Returns all layer paths from the ordered layer info. */
@@ -1135,6 +995,10 @@ export const getStoreMapInitialFilter = (mapId: string, layerPath: string): stri
   return getStoreMapState(mapId).initialFilters[layerPath];
 };
 
+/** Selects the initial layer filters from the store. */
+export const useStoreMapInitialFilters = (): Record<string, string> =>
+  useStore(useGeoViewStore(), (state) => state.mapState.initialFilters);
+
 /** Returns the layer paths of all layers currently in their visible zoom range. */
 export const getStoreMapLayersInVisibleRange = (mapId: string): string[] => {
   const { orderedLayerInfo } = getStoreMapState(mapId);
@@ -1142,34 +1006,160 @@ export const getStoreMapLayersInVisibleRange = (mapId: string): string[] => {
   return layersInVisibleRange;
 };
 
+/**
+ * Selects the visibility state of a single layer.
+ *
+ * @param layerPath - The layer path to check visibility for
+ * @returns True if the layer is visible, false otherwise
+ */
+export const useStoreMapLayerVisibility = (layerPath: string): boolean => {
+  // Hook
+  return useStore(
+    useGeoViewStore(),
+    (state) => utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.visible || false
+  );
+};
+
+/**
+ * Selects whether any of the given layer paths are visible.
+ *
+ * @param layerPaths - The layer paths to check visibility for
+ * @returns True if at least one layer is visible, false otherwise
+ */
+export const useStoreMapLayerArrayVisibility = (layerPaths: string[]): boolean => {
+  return useStore(useGeoViewStore(), (state) => {
+    // Return true if all layers are visible (or don't exist yet)
+    return layerPaths.some((layerPath) => {
+      return utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.visible || false;
+    });
+  });
+};
+
+/**
+ * Selects whether a layer is within its visible zoom range.
+ *
+ * @param layerPath - The layer path to check
+ * @returns True if the layer is in visible range
+ */
+export const useStoreMapLayerInVisibleRange = (layerPath: string): boolean => {
+  // Hook
+  return useStore(
+    useGeoViewStore(),
+    (state) => utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.inVisibleRange || false
+  );
+};
+
+/**
+ * Selects whether all layers are visible (excluding errored layers).
+ *
+ * @returns True if all non-errored layers are visible
+ */
+export const useStoreMapAllLayersVisibleToggle = (): boolean =>
+  // TODO: CHECK - Cross-stores, here we jump into the layer store :/
+  useStore(useGeoViewStore(), (state) =>
+    state.mapState.orderedLayerInfo.every((layer) => layer.visible || getStoreLayerStatus(state.mapId, layer.layerPath) === 'error')
+  );
+
 /** Returns whether a layer is effectively hidden on the map (parent hidden, out of range, or not visible). */
 export const getStoreMapIsLayerHiddenOnMap = (mapId: string, layerPath: string): boolean => {
   const { orderedLayerInfo } = getStoreMapState(mapId);
-  return (
-    utilGetParentHidden(layerPath, orderedLayerInfo) ||
-    !utilFindMapLayerFromOrderedInfo(layerPath, orderedLayerInfo)?.inVisibleRange ||
-    !utilFindMapLayerFromOrderedInfo(layerPath, orderedLayerInfo)?.visible
-  );
+  return utilGetLayerHiddenOnMap(layerPath, orderedLayerInfo);
+};
+
+/**
+ * Selects whether a layer is effectively hidden on the map.
+ *
+ * A layer is hidden if any parent is hidden, or if it is out of visible range, or if it is not visible.
+ *
+ * @param layerPath - The layer path to check
+ * @returns True if the layer is hidden on the map
+ */
+export const useStoreMapIsLayerHiddenOnMap = (layerPath: string): boolean => {
+  return useStore(useGeoViewStore(), (state) => utilGetLayerHiddenOnMap(layerPath, state.mapState.orderedLayerInfo));
+};
+
+/**
+ * Selects the hidden-on-map state for all layers.
+ *
+ * @returns A record mapping each layer path to whether it is hidden on the map
+ */
+export const useStoreMapIsLayerHiddenOnMapSet = (): Record<string, boolean> => {
+  return useStableSelector(useGeoViewStore(), (state) => {
+    return state.mapState.orderedLayerInfo.reduce<Record<string, boolean>>((acc, layer) => {
+      if (layer.layerPath) {
+        // eslint-disable-next-line no-param-reassign
+        acc[layer.layerPath] = utilGetLayerHiddenOnMap(layer.layerPath, state.mapState.orderedLayerInfo);
+      }
+      return acc;
+    }, {});
+  });
+};
+
+/**
+ * Selects whether any parent of the given layer is hidden.
+ *
+ * @param layerPath - The layer path to check parent visibility for
+ * @returns True if any parent layer is hidden
+ */
+export const useStoreMapIsParentLayerHiddenOnMap = (layerPath: string): boolean => {
+  return useStore(useGeoViewStore(), (state) => utilGetParentLayerHiddenOnMap(layerPath, state.mapState.orderedLayerInfo));
+};
+
+/**
+ * Selects the parent-hidden state for all layers.
+ *
+ * @returns A record mapping each layer path to whether any of its parents are hidden
+ */
+export const useStoreMapIsParentLayerHiddenOnMapSet = (): Record<string, boolean> => {
+  return useStableSelector(useGeoViewStore(), (state) => {
+    return state.mapState.orderedLayerInfo.reduce<Record<string, boolean>>((acc, layer) => {
+      if (layer.layerPath) {
+        // eslint-disable-next-line no-param-reassign
+        acc[layer.layerPath] = utilGetParentLayerHiddenOnMap(layer.layerPath, state.mapState.orderedLayerInfo);
+      }
+      return acc;
+    }, {});
+  });
 };
 
 /** Returns the current map projection code. */
 export const getStoreMapCurrentProjection = (mapId: string): TypeValidMapProjectionCodes => getStoreMapState(mapId).currentProjection;
 
+/** Selects the current map projection code from the store. */
+export const useStoreMapCurrentProjection = (): TypeValidMapProjectionCodes =>
+  useStore(useGeoViewStore(), (state) => state.mapState.currentProjection);
+
 /** Returns the current map projection as an EPSG string. */
 export const getStoreMapCurrentProjectionEPSG = (mapId: string): string => `EPSG:${getStoreMapState(mapId).currentProjection}`;
 
+/** Selects the current map projection as an EPSG string from the store. */
+export const useStoreMapCurrentProjectionEPSG = (): string =>
+  useStore(useGeoViewStore(), (state) => `EPSG:${state.mapState.currentProjection}`);
+
 /** Returns the current pointer position, or undefined if unavailable. */
 export const getStoreMapPointerPosition = (mapId: string): TypeMapMouseInfo | undefined => getStoreMapState(mapId).pointerPosition;
+
+/** Selects the current pointer position from the store. */
+export const useStoreMapPointerPosition = (): TypeMapMouseInfo | undefined =>
+  useStore(useGeoViewStore(), (state) => state.mapState.pointerPosition);
 
 /** Returns the current basemap options. */
 export const getStoreMapCurrentBasemapOptions = (mapId: string): TypeBasemapOptions => {
   return getStoreMapState(mapId).currentBasemapOptions;
 };
 
+/** Selects the current basemap options from the store. */
+export const useStoreMapCurrentBasemapOptions = (): TypeBasemapOptions =>
+  useStore(useGeoViewStore(), (state) => state.mapState.currentBasemapOptions);
+
 /** Returns the basemap options, falling back to initial options if current are not set. */
 export const getStoreMapBasemapOptions = (mapId: string): TypeBasemapOptions => {
+  // TODO: CHECK - This getter actually uses both state values, revise its name?
   return getStoreMapCurrentBasemapOptions(mapId) || getStoreMapState(mapId).basemapOptions;
 };
+
+/** Selects the initial basemap options from the store. */
+export const useStoreMapBasemapOptions = (): TypeBasemapOptions => useStore(useGeoViewStore(), (state) => state.mapState.basemapOptions);
 
 /** Returns the home view settings for the map. */
 export const getStoreMapHomeView = (mapId: string): TypeMapViewSettings => {
@@ -1181,10 +1171,16 @@ export const getStoreMapInitialView = (mapId: string): TypeMapViewSettings | und
   return getStoreMapState(mapId).initialView;
 };
 
+/** Selects the initial view settings from the store. */
+export const useStoreMapInitialView = (): TypeMapViewSettings => useStore(useGeoViewStore(), (state) => state.mapState.initialView);
+
 /** Returns the current map rotation angle in radians. */
 export const getStoreMapRotation = (mapId: string): number => {
   return getStoreMapState(mapId).rotation;
 };
+
+/** Selects the map rotation angle from the store. */
+export const useStoreMapRotation = (): number => useStore(useGeoViewStore(), (state) => state.mapState.rotation);
 
 /** Returns the geolocator search area with coordinates and optional bounding box. */
 export const getStoreMapGeolocatorSearchArea = (mapId: string): { coords: Coordinate; bbox?: Extent } | undefined => {
@@ -1196,20 +1192,35 @@ export const getStoreMapFeatureHighlightColor = (mapId: string): TypeHighlightCo
   return getStoreMapState(mapId).featureHighlightColor;
 };
 
+/** Selects the feature highlight color settings from the store. */
+export const useStoreMapFeatureHighlightColor = (): TypeHighlightColors =>
+  useStore(useGeoViewStore(), (state) => state.mapState.featureHighlightColor);
+
 /** Returns the hover feature info state. */
 export const getStoreMapHoverFeatureInfo = (mapId: string): TypeHoverFeatureInfo => {
   return getStoreMapState(mapId).hoverFeatureInfo;
 };
+
+/** Selects the hover feature info from the store. */
+export const useStoreMapHoverFeatureInfo = (): TypeHoverFeatureInfo =>
+  useStore(useGeoViewStore(), (state) => state.mapState.hoverFeatureInfo);
 
 /** Returns the point markers grouped by name. */
 export const getStoreMapPointMarkers = (mapId: string): Record<string, TypePointMarker[]> => {
   return getStoreMapState(mapId).pointMarkers;
 };
 
+/** Selects the point markers grouped by name from the store. */
+export const useStoreMapPointMarkers = (): Record<string, TypePointMarker[]> =>
+  useStore(useGeoViewStore(), (state) => state.mapState.pointMarkers);
+
 /** Returns the current map interaction mode. */
 export const getStoreMapInteraction = (mapId: string): TypeInteraction => {
   return getStoreMapState(mapId).interaction;
 };
+
+/** Selects the map interaction mode from the store. */
+export const useStoreMapInteraction = (): TypeInteraction => useStore(useGeoViewStore(), (state) => state.mapState.interaction);
 
 /** Returns the array of currently highlighted features. */
 export const getStoreMapHighlightedFeatures = (mapId: string): TypeFeatureInfoEntry[] => {
@@ -1226,7 +1237,101 @@ export const getStoreMapLegendCollapsibleLayers = (mapId: string): TypeOrderedLa
   return utilGetLegendCollapsibleLayers(mapId, getStoreMapOrderedLayerInfo(mapId));
 };
 
-// #endregion STATE SELECTORS
+// #endregion STATE GETTERS & HOOKS
+
+// #region STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
+
+/** Selects the map attribution strings from the store. */
+export const useStoreMapAttribution = (): string[] => useStore(useGeoViewStore(), (state) => state.mapState.attribution);
+
+/** Selects the map center coordinates from the store. */
+export const useStoreMapCenterCoordinates = (): Coordinate => useStore(useGeoViewStore(), (state) => state.mapState.centerCoordinates);
+
+/** Selects the click marker state from the store. */
+export const useStoreMapClickMarker = (): TypeClickMarker | undefined => useStore(useGeoViewStore(), (state) => state.mapState.clickMarker);
+
+/** Selects the click coordinates from the store. */
+export const useStoreMapClickCoordinates = (): TypeMapMouseInfo | undefined =>
+  useStore(useGeoViewStore(), (state) => state.mapState.clickCoordinates);
+
+/** Selects the current map extent from the store. */
+export const useStoreMapExtent = (): Extent | undefined => useStore(useGeoViewStore(), (state) => state.mapState.mapExtent);
+
+/** Selects whether the map has a geoview basemap layer from the store. */
+export const useStoreMapHasGeoviewBasemapLayer = (): boolean =>
+  useStore(useGeoViewStore(), (state) => state.mapState.hasGeoviewBasemapLayer);
+
+/** Selects whether the map is fixed to north from the store. */
+export const useStoreMapFixNorth = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.fixNorth);
+
+/** Selects whether the mouse is inside the map from the store. */
+export const useStoreMapIsMouseInsideMap = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.isMouseInsideMap);
+
+/** Selects whether the map is loaded from the store. */
+export const useStoreMapLoaded = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.mapLoaded);
+
+/** Selects whether the map is displayed from the store. */
+export const useStoreMapDisplayed = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.mapDisplayed);
+
+/** Selects whether the north arrow is enabled from the store. */
+export const useStoreMapNorthArrow = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.northArrow);
+
+/** Selects the north arrow element state from the store. */
+export const useStoreMapNorthArrowElement = (): TypeNorthArrow => useStore(useGeoViewStore(), (state) => state.mapState.northArrowElement);
+
+/** Selects the zoom level at which the overview map hides from the store. */
+export const useStoreMapOverviewMapHideZoom = (): number => useStore(useGeoViewStore(), (state) => state.mapState.overviewMapHideZoom);
+
+/** Selects the map scale information from the store. */
+export const useStoreMapScale = (): TypeScaleInfo => useStore(useGeoViewStore(), (state) => state.mapState.scale);
+
+/** Selects the map size from the store. */
+export const useStoreMapSize = (): Size => useStore(useGeoViewStore(), (state) => state.mapState.size);
+
+/** Selects the ordered layer paths from the store. */
+export const useStoreMapOrderedLayers = (): string[] => useStore(useGeoViewStore(), (state) => state.mapState.orderedLayers);
+
+/** Selects the visible layer paths from the store. */
+export const useStoreMapVisibleLayers = (): string[] => useStore(useGeoViewStore(), (state) => state.mapState.visibleLayers);
+
+/**
+ * Selects the union of visible and in-range layer paths.
+ *
+ * Used by data-table, details, geochart, and time-slider left panel components.
+ *
+ * @returns The deduplicated array of layer paths that are visible or in visible range
+ */
+export const useStoreMapAllVisibleandInRangeLayers = (): string[] => {
+  const visibleLayers = useStore(useGeoViewStore(), (state) => state.mapState.visibleLayers);
+  const visibleRangeLayers = useStore(useGeoViewStore(), (state) => state.mapState.visibleRangeLayers);
+  return useMemo(() => {
+    return [...new Set([...visibleLayers, ...visibleRangeLayers])];
+  }, [visibleLayers, visibleRangeLayers]);
+};
+
+/** Selects the current zoom level from the store. */
+export const useStoreMapZoom = (): number => useStore(useGeoViewStore(), (state) => state.mapState.zoom);
+
+/**
+ * Selects the queryable state for multiple layer paths.
+ *
+ * @param layerPaths - The layer paths to check queryable state for
+ * @returns A record mapping each layer path to its queryable state
+ */
+export const useStoreMapLayerQueryable = (layerPaths: string[]): Record<string, boolean> => {
+  // Hook
+  return useStableSelector(useGeoViewStore(), (state) => {
+    const result: Record<string, boolean> = {};
+
+    for (const layerPath of layerPaths) {
+      result[layerPath] = utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.queryableState || false;
+    }
+
+    return result;
+  });
+};
+
+// #endregion STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
 
 // #region STATE SELECTORS MAPCONFIG
 
@@ -1274,6 +1379,9 @@ export const getStoreMapConfigAppBar = (mapId: string): TypeAppBarProps | undefi
 
 /** Returns the overview map configuration from the map config. */
 export const getStoreMapConfigOverviewMap = (mapId: string): TypeOverviewMapProps | undefined => getStoreMapConfigState(mapId).overviewMap;
+
+/** Selects whether the overview map is enabled from the store. */
+export const useStoreMapOverviewMap = (): boolean => useStore(useGeoViewStore(), (state) => state.mapState.overviewMap);
 
 /** Returns the enabled map components from the map config. */
 export const getStoreMapConfigComponents = (mapId: string): TypeValidMapComponentProps[] | undefined =>
@@ -1421,16 +1529,7 @@ export const setStoreMapHoverFeatureInfo = (mapId: string, hoverFeatureInfo: Typ
  * @param visibility - The visibility to set
  */
 export const setStoreMapLayerVisibility = (mapId: string, layerPath: string, visibility: boolean): void => {
-  const orderedLayerInfo = getStoreMapOrderedLayerInfo(mapId);
-
-  // Get and update ordered layer info
-  const layerInfo = orderedLayerInfo.find((orderedInfo) => orderedInfo.layerPath === layerPath);
-  if (layerInfo && layerInfo.visible !== visibility) {
-    layerInfo.visible = visibility;
-
-    // Save
-    getStoreMapState(mapId).actions.setOrderedLayerInfo(orderedLayerInfo);
-  }
+  getStoreMapState(mapId).actions.updateOrderedLayerInfoByPath(layerPath, { visible: visibility });
 };
 
 /**
@@ -1441,15 +1540,7 @@ export const setStoreMapLayerVisibility = (mapId: string, layerPath: string, vis
  * @param inVisibleRange - Whether the layer is within its visible zoom range
  */
 export const setStoreLayerInVisibleRange = (mapId: string, layerPath: string, inVisibleRange: boolean): void => {
-  const orderedLayerInfo = getStoreMapOrderedLayerInfo(mapId);
-  const orderedInfo = getStoreMapOrderedLayerInfoByPath(mapId, layerPath);
-
-  if (orderedInfo && orderedInfo.inVisibleRange !== inVisibleRange) {
-    orderedInfo.inVisibleRange = inVisibleRange;
-
-    // Save
-    getStoreMapState(mapId).actions.setOrderedLayerInfo(orderedLayerInfo);
-  }
+  getStoreMapState(mapId).actions.updateOrderedLayerInfoByPath(layerPath, { inVisibleRange });
 };
 
 /** Sets the map interaction mode in the store. */

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/swiper-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/swiper-state.ts
@@ -35,6 +35,7 @@ export interface ISwiperState {
 
 /**
  * Initializes a Swiper state object.
+ *
  * @param set - The store set callback function
  * @param get - The store get callback function
  * @returns The Swiper state object
@@ -45,6 +46,11 @@ export function initializeSwiperState(set: TypeSetStore, get: TypeGetStore): ISw
     orientation: 'vertical',
 
     actions: {
+      /**
+       * Sets the layer paths for the swiper.
+       *
+       * @param layerPaths - The array of layer paths
+       */
       setLayerPaths(layerPaths: string[]) {
         set({
           swiperState: {
@@ -53,6 +59,11 @@ export function initializeSwiperState(set: TypeSetStore, get: TypeGetStore): ISw
           },
         });
       },
+      /**
+       * Sets the swiper orientation.
+       *
+       * @param orientation - The swipe orientation
+       */
       setOrientation(orientation: SwipeOrientation) {
         set({
           swiperState: {

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/swiper-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/swiper-state.ts
@@ -69,18 +69,10 @@ export function initializeSwiperState(set: TypeSetStore, get: TypeGetStore): ISw
 
 // #endregion STATE INITIALIZATION
 
-// #region STATE HOOKS
-// GV To be used by React components
-
-/** Hooks the swiper layer paths from the store. */
-export const useSwiperLayerPaths = (): string[] => useStore(useGeoViewStore(), (state) => state.swiperState.layerPaths);
-
-/** Hooks the swiper orientation from the store. */
-export const useSwiperOrientation = (): string => useStore(useGeoViewStore(), (state) => state.swiperState.orientation);
-
-// #endregion STATE HOOKS
-
-// #region STATE SELECTORS
+// #region STATE GETTERS & HOOKS
+// GV Getters should be used to get the values at a moment in time.
+// GV Hooks should be used to attach to values and trigger UI components when they change.
+// GV Typically they are listed in couples (getter + hook) for the same value.
 
 /**
  * Returns the full swiper state slice for the given map.
@@ -127,7 +119,25 @@ export const getStoreSwiperLayerPaths = (mapId: string): string[] => {
   return getStoreSwiperState(mapId).layerPaths;
 };
 
-// #endregion STATE SELECTORS
+/** Hooks the swiper layer paths from the store. */
+export const useStoreSwiperLayerPaths = (): string[] => useStore(useGeoViewStore(), (state) => state.swiperState.layerPaths);
+
+/**
+ * Gets the swiper orientation from the store.
+ *
+ * @param mapId - The map id to read swiper layer paths from.
+ * @returns The array of layer paths participating in the swiper.
+ * @throws {PluginStateUninitializedError} When the Swiper plugin is uninitialized.
+ */
+export const getStoreSwiperOrientation = (mapId: string): SwipeOrientation => {
+  // Return the layer paths from the state
+  return getStoreSwiperState(mapId).orientation;
+};
+
+/** Hooks the swiper orientation from the store. */
+export const useStoreSwiperOrientation = (): SwipeOrientation => useStore(useGeoViewStore(), (state) => state.swiperState.orientation);
+
+// #endregion STATE GETTERS & HOOKS
 
 // #region STATE ADAPTORS
 // GV These methods should be called from a State Adaptor class listening on domain events triggered by controllers.

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/time-slider-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/time-slider-state.ts
@@ -103,7 +103,7 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
 
     // TODO: REFACTOR - These setters reassign the whole 'timeSliderLayers' object (for all layerPaths) instead of just
     // TO.DOCONT: changing the one for the layerPath in question. This should be changed and a hook selector should be put in
-    // TO.DOCONT: place - instead of the too-high-level: useTimeSliderLayers
+    // TO.DOCONT: place - instead of the too-high-level: useStoreTimeSliderLayers
     actions: {
       addTimeSliderLayer(newLayer: TimeSliderLayerSet): void {
         set({
@@ -261,30 +261,10 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
 
 // #endregion STATE INITIALIZATION
 
-// #region STATE HOOKS
-// GV To be used by React components
-
-/** Hooks the full set of time-slider layers. Safe to call outside the TimeSlider plugin (optional chaining). */
-// GV This hook is called from other components than the TimeSlider so the '?' on the timeSliderState is mandatory
-export const useTimeSliderLayers = (): TimeSliderLayerSet | undefined =>
-  useStore(useGeoViewStore(), (state) => state.timeSliderState?.timeSliderLayers);
-
-/** Hooks the time-slider values for a specific layer path. Safe to call outside the TimeSlider plugin. */
-// GV This hook is called from other components than the TimeSlider so the '?' on the timeSliderState is mandatory
-export const useTimeSliderLayersSelector = (layerPath: string): TypeTimeSliderValues | undefined =>
-  useStore(useGeoViewStore(), (state) => state.timeSliderState?.timeSliderLayers[layerPath]);
-
-/** Hooks the currently selected layer path in the time slider. */
-export const useTimeSliderSelectedLayerPath = (): string => useStore(useGeoViewStore(), (state) => state.timeSliderState.selectedLayerPath);
-
-/** Hooks the slider filter string for a specific layer path. Safe to call outside the TimeSlider plugin. */
-// GV This hook is called from other components than the TimeSlider so the '?' on the timeSliderState is mandatory
-export const useTimeSliderFiltersSelector = (layerPath: string): string | undefined =>
-  useStore(useGeoViewStore(), (state) => state.timeSliderState?.sliderFilters[layerPath]);
-
-// #endregion STATE HOOKS
-
-// #region STATE SELECTORS
+// #region STATE GETTERS & HOOKS
+// GV Getters should be used to get the values at a moment in time.
+// GV Hooks should be used to attach to values and trigger UI components when they change.
+// GV Typically they are listed in couples (getter + hook) for the same value.
 
 /**
  * Returns the full time slider state slice for the given map.
@@ -330,6 +310,11 @@ export const getStoreTimeSliderLayers = (mapId: string): TimeSliderLayerSet => {
   return getStoreTimeSliderState(mapId).timeSliderLayers;
 };
 
+/** Hooks the full set of time-slider layers. Safe to call outside the TimeSlider plugin (optional chaining). */
+// GV This hook is called from other components than the TimeSlider so the '?' on the timeSliderState is mandatory
+export const useStoreTimeSliderLayers = (): TimeSliderLayerSet | undefined =>
+  useStore(useGeoViewStore(), (state) => state.timeSliderState?.timeSliderLayers);
+
 /**
  * Gets the time-slider values for a specific layer path.
  *
@@ -342,6 +327,11 @@ export const getStoreTimeSliderLayer = (mapId: string, layerPath: string): TypeT
   return getStoreTimeSliderState(mapId).timeSliderLayers[layerPath];
 };
 
+/** Hooks the time-slider values for a specific layer path. Safe to call outside the TimeSlider plugin. */
+// GV This hook is called from other components than the TimeSlider so the '?' on the timeSliderState is mandatory
+export const useStoreTimeSliderLayer = (layerPath: string): TypeTimeSliderValues | undefined =>
+  useStore(useGeoViewStore(), (state) => state.timeSliderState?.timeSliderLayers[layerPath]);
+
 /**
  * Gets the currently selected layer path from the time slider.
  *
@@ -349,9 +339,13 @@ export const getStoreTimeSliderLayer = (mapId: string, layerPath: string): TypeT
  * @returns The selected layer path.
  * @throws {PluginStateUninitializedError} When the TimeSlider plugin is uninitialized.
  */
-export const getStoreTimeSliderSelectedLayer = (mapId: string): string => {
+export const getStoreTimeSliderSelectedLayerPath = (mapId: string): string => {
   return getStoreTimeSliderState(mapId).selectedLayerPath;
 };
+
+/** Hooks the currently selected layer path in the time slider. */
+export const useStoreTimeSliderSelectedLayerPath = (): string =>
+  useStore(useGeoViewStore(), (state) => state.timeSliderState.selectedLayerPath);
 
 /**
  * Gets all slider filter expressions keyed by layer path.
@@ -376,7 +370,12 @@ export const getStoreTimeSliderFilter = (mapId: string, layerPath: string): stri
   return getStoreTimeSliderFilters(mapId)[layerPath];
 };
 
-// #endregion STATE SELECTORS
+/** Hooks the slider filter string for a specific layer path. Safe to call outside the TimeSlider plugin. */
+// GV This hook is called from other components than the TimeSlider so the '?' on the timeSliderState is mandatory
+export const useStoreTimeSliderFilter = (layerPath: string): string | undefined =>
+  useStore(useGeoViewStore(), (state) => state.timeSliderState?.sliderFilters[layerPath]);
+
+// #endregion STATE GETTERS & HOOKS
 
 // #region STATE ADAPTORS
 // GV These methods should be called from a State Adaptor class listening on domain events triggered by controllers.

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/time-slider-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/time-slider-state.ts
@@ -105,6 +105,11 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
     // TO.DOCONT: changing the one for the layerPath in question. This should be changed and a hook selector should be put in
     // TO.DOCONT: place - instead of the too-high-level: useStoreTimeSliderLayers
     actions: {
+      /**
+       * Adds a time slider layer.
+       *
+       * @param newLayer - The time slider layer set to add
+       */
       addTimeSliderLayer(newLayer: TimeSliderLayerSet): void {
         set({
           timeSliderState: {
@@ -113,6 +118,12 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
           },
         });
       },
+
+      /**
+       * Removes a time slider layer.
+       *
+       * @param layerPath - The layer path to remove
+       */
       removeTimeSliderLayer(layerPath: string): void {
         const sliderLayers = get().timeSliderState.timeSliderLayers;
         delete sliderLayers[layerPath];
@@ -123,6 +134,13 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
           },
         });
       },
+
+      /**
+       * Sets the title for a time slider layer.
+       *
+       * @param layerPath - The layer path
+       * @param title - The title to set
+       */
       setTitle(layerPath: string, title: string): void {
         const sliderLayers = get().timeSliderState.timeSliderLayers;
         sliderLayers[layerPath].title = title;
@@ -133,6 +151,13 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
           },
         });
       },
+
+      /**
+       * Sets the description for a time slider layer.
+       *
+       * @param layerPath - The layer path
+       * @param description - The description to set
+       */
       setDescription(layerPath: string, description: string): void {
         const sliderLayers = get().timeSliderState.timeSliderLayers;
         sliderLayers[layerPath].description = description;
@@ -143,6 +168,13 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
           },
         });
       },
+
+      /**
+       * Sets the delay for a time slider layer.
+       *
+       * @param layerPath - The layer path
+       * @param delay - The delay value in milliseconds
+       */
       setDelay(layerPath: string, delay: number): void {
         const sliderLayers = get().timeSliderState.timeSliderLayers;
         sliderLayers[layerPath].delay = delay;
@@ -154,6 +186,12 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
         });
       },
 
+      /**
+       * Sets the display date format for a time slider layer.
+       *
+       * @param layerPath - The layer path
+       * @param displayDateFormat - The date format to use
+       */
       setDisplayDateFormat: (layerPath: string, displayDateFormat: TypeDisplayDateFormat): void => {
         const sliderLayers = get().timeSliderState.timeSliderLayers;
         sliderLayers[layerPath].displayDateFormat = displayDateFormat;
@@ -165,6 +203,12 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
         });
       },
 
+      /**
+       * Sets the short display date format for a time slider layer.
+       *
+       * @param layerPath - The layer path
+       * @param displayDateFormatShort - The short date format to use
+       */
       setDisplayDateFormatShort: (layerPath: string, displayDateFormatShort: TypeDisplayDateFormat): void => {
         const sliderLayers = get().timeSliderState.timeSliderLayers;
         sliderLayers[layerPath].displayDateFormatShort = displayDateFormatShort;
@@ -176,6 +220,12 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
         });
       },
 
+      /**
+       * Sets the display date timezone for a time slider layer.
+       *
+       * @param layerPath - The layer path
+       * @param displayDateTimezone - The IANA timezone identifier
+       */
       setDisplayDateTimezone: (layerPath: string, displayDateTimezone: TimeIANA): void => {
         const sliderLayers = get().timeSliderState.timeSliderLayers;
         sliderLayers[layerPath].displayDateTimezone = displayDateTimezone;
@@ -187,6 +237,12 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
         });
       },
 
+      /**
+       * Sets the filtering state for a time slider layer.
+       *
+       * @param layerPath - The layer path
+       * @param filtering - Whether filtering is enabled
+       */
       setFiltering(layerPath: string, filtering: boolean): void {
         const sliderLayers = get().timeSliderState.timeSliderLayers;
         sliderLayers[layerPath].filtering = filtering;
@@ -197,6 +253,13 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
           },
         });
       },
+
+      /**
+       * Sets the locked state for a time slider layer.
+       *
+       * @param layerPath - The layer path
+       * @param locked - Whether the slider is locked
+       */
       setLocked(layerPath: string, locked: boolean): void {
         const sliderLayers = get().timeSliderState.timeSliderLayers;
         sliderLayers[layerPath].locked = locked;
@@ -207,6 +270,13 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
           },
         });
       },
+
+      /**
+       * Sets the reversed state for a time slider layer.
+       *
+       * @param layerPath - The layer path
+       * @param reversed - Whether the slider is reversed
+       */
       setReversed(layerPath: string, reversed: boolean): void {
         const sliderLayers = get().timeSliderState.timeSliderLayers;
         sliderLayers[layerPath].reversed = reversed;
@@ -217,6 +287,12 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
           },
         });
       },
+
+      /**
+       * Sets the selected layer path for the time slider.
+       *
+       * @param layerPath - The layer path to select
+       */
       setSelectedLayerPath(layerPath: string): void {
         set({
           timeSliderState: {
@@ -225,6 +301,12 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
           },
         });
       },
+
+      /**
+       * Sets the slider filters.
+       *
+       * @param newSliderFilters - The new slider filter values
+       */
       setSliderFilters(newSliderFilters: Record<string, string>): void {
         set({
           timeSliderState: {
@@ -233,6 +315,13 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
           },
         });
       },
+
+      /**
+       * Sets the step value for a time slider layer.
+       *
+       * @param layerPath - The layer path
+       * @param step - The step value
+       */
       setStep(layerPath: string, step: number): void {
         const sliderLayers = get().timeSliderState.timeSliderLayers;
         sliderLayers[layerPath].step = step;
@@ -243,6 +332,13 @@ export function initializeTimeSliderState(set: TypeSetStore, get: TypeGetStore):
           },
         });
       },
+
+      /**
+       * Sets the values for a time slider layer.
+       *
+       * @param layerPath - The layer path
+       * @param values - The slider values
+       */
       setValues(layerPath: string, values: number[]): void {
         const sliderLayers = get().timeSliderState.timeSliderLayers;
         sliderLayers[layerPath].values = values;

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
@@ -133,6 +133,11 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
     },
 
     actions: {
+      /**
+       * Enables the focus trap for the given UI element.
+       *
+       * @param uiFocus - The focus item properties
+       */
       enableFocusTrap: (uiFocus: FocusItemProps) => {
         set({
           uiState: {
@@ -141,10 +146,16 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
           },
         });
       },
+
       // TODO: WCAG Issue #3222 RAF seems to be working well for timing purposes
       // (RAF ensures that modal transitions, focus trap releases, and DOM updates, are completed before focus restoration takes place)
       // Try removing setTimeout from all instances of disableFocusTrap as that might now be redundant
       // See issue #3222 for more detail.
+      /**
+       * Disables the focus trap and restores focus to the callback element.
+       *
+       * @param callBackElementId - The element ID to restore focus to
+       */
       disableFocusTrap: (callBackElementId: string) => {
         const id = callBackElementId ?? (get().uiState.focusItem.callbackElementId as string);
         requestAnimationFrame(() => {
@@ -163,6 +174,12 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
           },
         });
       },
+
+      /**
+       * Sets the active footer bar tab.
+       *
+       * @param tabId - The tab ID to activate, or undefined to clear
+       */
       setActiveFooterBarTab: (tabId: string | undefined) => {
         set({
           uiState: {
@@ -174,6 +191,12 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
           },
         });
       },
+
+      /**
+       * Sets whether the GeoView trap is active.
+       *
+       * @param active - Whether the trap is active
+       */
       setActiveTrapGeoView: (active: boolean) => {
         set({
           uiState: {
@@ -182,6 +205,12 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
           },
         });
       },
+
+      /**
+       * Sets the hidden tabs list.
+       *
+       * @param hiddenTabs - The array of tab IDs to hide
+       */
       setHiddenTabs: (hiddenTabs: string[]) => {
         set({
           uiState: {
@@ -190,6 +219,12 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
           },
         });
       },
+
+      /**
+       * Sets the footer panel resize value.
+       *
+       * @param value - The resize value
+       */
       setFooterPanelResizeValue: (value) => {
         set({
           uiState: {
@@ -198,7 +233,13 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
           },
         });
       },
+
       // TODO: the setter for footer bar is still split in 2 instead of following app bar. Ken, can you set it up correclty with your PR for footer....
+      /**
+       * Sets whether the footer bar is open.
+       *
+       * @param open - Whether the footer bar should be open
+       */
       setFooterBarIsOpen: (open: boolean) => {
         set({
           uiState: {
@@ -210,6 +251,14 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
           },
         });
       },
+
+      /**
+       * Sets the active app bar tab.
+       *
+       * @param tabId - The tab ID to activate, or undefined to clear
+       * @param isOpen - Whether the app bar panel should be open
+       * @param isFocusTrapped - Optional whether focus should be trapped in the panel
+       */
       setActiveAppBarTab: (tabId: string | undefined, isOpen: boolean, isFocusTrapped: boolean = false) => {
         // Gv Side effect with focus trap and side panel app bar open
         // We need to check if the viewer is in keyboard navigation mode. If not, we don't apply the focus trap.

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
@@ -236,49 +236,10 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
 
 // #endregion STATE INITIALIZATION
 
-// #region STATE HOOKS
-// GV To be used by React components
-
-/** Hooks the current focus-trap item from the UI state. */
-export const useUIActiveFocusItem = (): FocusItemProps => useStore(useGeoViewStore(), (state) => state.uiState.focusItem);
-
-/** Hooks the active app-bar tab state. */
-export const useUIActiveAppBarTab = (): ActiveAppBarTabType => useStore(useGeoViewStore(), (state) => state.uiState.activeAppBarTab);
-
-/** Hooks the active footer-bar tab state. */
-export const useUIActiveFooterBarTab = (): ActiveFooterBarTabType =>
-  useStore(useGeoViewStore(), (state) => state.uiState.activeFooterBarTab);
-
-/** Hooks whether the GeoView-level keyboard focus trap is active. */
-export const useUIActiveTrapGeoView = (): boolean => useStore(useGeoViewStore(), (state) => state.uiState.activeTrapGeoView);
-
-/** Hooks the app-bar component identifiers. */
-export const useUIAppbarComponents = (): TypeValidAppBarCoreProps[] =>
-  useStore(useGeoViewStore(), (state) => state.uiState.appBarComponents);
-
-/** Hooks the footer-bar component identifiers. */
-export const useUIFooterBarComponents = (): TypeValidFooterBarTabsCoreProps[] =>
-  useStore(useGeoViewStore(), (state) => state.uiState.footerBarComponents);
-
-/** Hooks the core package component identifiers. */
-export const useUICorePackagesComponents = (): TypeValidMapCorePackageProps[] =>
-  useStore(useGeoViewStore(), (state) => state.uiState.corePackagesComponents);
-
-/** Hooks the footer panel resize value. */
-export const useUIFooterPanelResizeValue = (): number => useStore(useGeoViewStore(), (state) => state.uiState.footerPanelResizeValue);
-
-/** Hooks the list of hidden tab identifiers. */
-export const useUIHiddenTabs = (): string[] => useStore(useGeoViewStore(), (state) => state.uiState.hiddenTabs);
-
-/** Hooks the nav-bar component identifiers. */
-export const useUINavbarComponents = (): TypeValidNavBarProps[] => useStore(useGeoViewStore(), (state) => state.uiState.navBarComponents);
-
-// #endregion STATE HOOKS
-
-// #region STATE SELECTORS
-// GV Should only be used specifically to access the Store.
-// GV Use sparingly and only if you are sure of what you are doing.
-// GV DO NOT USE this technique in React components, use the hooks above instead.
+// #region STATE GETTERS & HOOKS
+// GV Getters should be used to get the values at a moment in time.
+// GV Hooks should be used to attach to values and trigger UI components when they change.
+// GV Typically they are listed in couples (getter + hook) for the same value.
 
 /**
  * Returns the full UI state slice for the given map.
@@ -297,7 +258,11 @@ const getStoreUIState = (mapId: string): IUIState => getGeoViewStore(mapId).getS
  * @param mapId - The map id.
  * @returns The active footer-bar tab state.
  */
-export const getStoreActiveFooterBarTab = (mapId: string): ActiveFooterBarTabType => getStoreUIState(mapId).activeFooterBarTab;
+export const getStoreUIActiveFooterBarTab = (mapId: string): ActiveFooterBarTabType => getStoreUIState(mapId).activeFooterBarTab;
+
+/** Hooks the active footer-bar tab state. */
+export const useStoreUIActiveFooterBarTab = (): ActiveFooterBarTabType =>
+  useStore(useGeoViewStore(), (state) => state.uiState.activeFooterBarTab);
 
 /**
  * Gets the active app-bar tab from the store.
@@ -305,7 +270,10 @@ export const getStoreActiveFooterBarTab = (mapId: string): ActiveFooterBarTabTyp
  * @param mapId - The map id.
  * @returns The active app-bar tab state.
  */
-export const getStoreActiveAppBarTab = (mapId: string): ActiveAppBarTabType => getStoreUIState(mapId).activeAppBarTab;
+export const getStoreUIActiveAppBarTab = (mapId: string): ActiveAppBarTabType => getStoreUIState(mapId).activeAppBarTab;
+
+/** Hooks the active app-bar tab state. */
+export const useStoreUIActiveAppBarTab = (): ActiveAppBarTabType => useStore(useGeoViewStore(), (state) => state.uiState.activeAppBarTab);
 
 /**
  * Gets the footer-bar component identifiers from the store.
@@ -313,7 +281,12 @@ export const getStoreActiveAppBarTab = (mapId: string): ActiveAppBarTabType => g
  * @param mapId - The map id.
  * @returns The array of footer-bar component props.
  */
-export const getStoreFooterBarComponents = (mapId: string): TypeValidFooterBarTabsCoreProps[] => getStoreUIState(mapId).footerBarComponents;
+export const getStoreUIFooterBarComponents = (mapId: string): TypeValidFooterBarTabsCoreProps[] =>
+  getStoreUIState(mapId).footerBarComponents;
+
+/** Hooks the footer-bar component identifiers. */
+export const useStoreUIFooterBarComponents = (): TypeValidFooterBarTabsCoreProps[] =>
+  useStore(useGeoViewStore(), (state) => state.uiState.footerBarComponents);
 
 /**
  * Gets the app-bar component identifiers from the store.
@@ -321,7 +294,11 @@ export const getStoreFooterBarComponents = (mapId: string): TypeValidFooterBarTa
  * @param mapId - The map id.
  * @returns The array of app-bar component props.
  */
-export const getStoreAppBarComponents = (mapId: string): TypeValidAppBarCoreProps[] => getStoreUIState(mapId).appBarComponents;
+export const getStoreUIAppBarComponents = (mapId: string): TypeValidAppBarCoreProps[] => getStoreUIState(mapId).appBarComponents;
+
+/** Hooks the app-bar component identifiers. */
+export const useStoreUIAppbarComponents = (): TypeValidAppBarCoreProps[] =>
+  useStore(useGeoViewStore(), (state) => state.uiState.appBarComponents);
 
 /**
  * Gets the nav-bar component identifiers from the store.
@@ -329,7 +306,11 @@ export const getStoreAppBarComponents = (mapId: string): TypeValidAppBarCoreProp
  * @param mapId - The map id.
  * @returns The array of nav-bar component props.
  */
-export const getStoreNavBarComponents = (mapId: string): TypeValidNavBarProps[] => getStoreUIState(mapId).navBarComponents;
+export const getStoreUINavBarComponents = (mapId: string): TypeValidNavBarProps[] => getStoreUIState(mapId).navBarComponents;
+
+/** Hooks the nav-bar component identifiers. */
+export const useStoreUINavbarComponents = (): TypeValidNavBarProps[] =>
+  useStore(useGeoViewStore(), (state) => state.uiState.navBarComponents);
 
 /**
  * Gets the core package component identifiers from the store.
@@ -337,13 +318,29 @@ export const getStoreNavBarComponents = (mapId: string): TypeValidNavBarProps[] 
  * @param mapId - The map id.
  * @returns The array of core package component props.
  */
-export const getStoreCorePackageComponents = (mapId: string): TypeValidMapCorePackageProps[] =>
+export const getStoreUICorePackageComponents = (mapId: string): TypeValidMapCorePackageProps[] =>
   getStoreUIState(mapId).corePackagesComponents;
 
-// #endregion STATE SELECTORS
-// GV These methods should be called from a State Adaptor class listening on domain events triggered by controllers.
+/** Hooks the core package component identifiers. */
+export const useStoreUICorePackagesComponents = (): TypeValidMapCorePackageProps[] =>
+  useStore(useGeoViewStore(), (state) => state.uiState.corePackagesComponents);
+
+/** Hooks the current focus-trap item from the UI state. */
+export const useStoreUIActiveFocusItem = (): FocusItemProps => useStore(useGeoViewStore(), (state) => state.uiState.focusItem);
+
+/** Hooks whether the GeoView-level keyboard focus trap is active. */
+export const useStoreUIActiveTrapGeoView = (): boolean => useStore(useGeoViewStore(), (state) => state.uiState.activeTrapGeoView);
+
+/** Hooks the footer panel resize value. */
+export const useStoreUIFooterPanelResizeValue = (): number => useStore(useGeoViewStore(), (state) => state.uiState.footerPanelResizeValue);
+
+/** Hooks the list of hidden tab identifiers. */
+export const useStoreUIHiddenTabs = (): string[] => useStore(useGeoViewStore(), (state) => state.uiState.hiddenTabs);
+
+// #endregion STATE GETTERS & HOOKS
 
 // #region STATE ADAPTORS
+// GV These methods should be called from a State Adaptor class listening on domain events triggered by controllers.
 
 /**
  * Sets the active footer bar tab.

--- a/packages/geoview-core/src/core/utils/constant.ts
+++ b/packages/geoview-core/src/core/utils/constant.ts
@@ -134,7 +134,11 @@ export const TIMEOUT: Record<string, number> = {
   northPoleVisibility: 1000,
 
   deleteLayerUndoWindow: 2500,
+
+  delayBeforeShwoingSlowCoordinateInfoWarning: 3000,
+
   featureHighlight: 5000,
+
   geolocationReturn: 10000,
   deleteLayerLoading: 10000,
 };

--- a/packages/geoview-core/src/core/utils/constant.ts
+++ b/packages/geoview-core/src/core/utils/constant.ts
@@ -135,7 +135,7 @@ export const TIMEOUT: Record<string, number> = {
 
   deleteLayerUndoWindow: 2500,
 
-  delayBeforeShwoingSlowCoordinateInfoWarning: 3000,
+  delayBeforeShowingSlowCoordinateInfoWarning: 3000,
 
   featureHighlight: 5000,
 

--- a/packages/geoview-core/src/core/utils/logger.ts
+++ b/packages/geoview-core/src/core/utils/logger.ts
@@ -63,6 +63,9 @@ export class ConsoleLogger {
     useEffect: 0,
   };
 
+  /** The number of render logs - per component. */
+  logCountRenderPerComponent: { [component: string]: number } = {};
+
   /**
    * Constructor.
    *
@@ -129,8 +132,18 @@ export class ConsoleLogger {
   logTraceRender(component: string, ...messages: unknown[]): void {
     // Validate log active
     if (!LOG_ACTIVE) return;
+
+    // Keep track of the number of times the render happened, per component
+    if (!this.logCountRenderPerComponent[component]) this.logCountRenderPerComponent[component] = 0;
+
     // Redirect
-    this.#logLevel(LOG_TRACE_RENDER, `RENDR - ${this.logCount.renderer++}`, 'plum', component, ...messages); // Not a typo, 5 characters for alignment
+    this.#logLevel(
+      LOG_TRACE_RENDER,
+      `RENDR - ${this.logCount.renderer++} - ${this.logCountRenderPerComponent[component]++}`,
+      'plum',
+      component,
+      ...messages
+    ); // Not a typo, 5 characters for alignment
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -6,12 +6,12 @@ import { bbox } from 'ol/loadingstrategy';
 
 import { AbstractGeoViewVector } from '@/geo/layer/geoview-layers/vector/abstract-geoview-vector';
 import { WMS } from '@/geo/layer/geoview-layers/raster/wms';
-import {
-  type DisplayDateMode,
-  type TypeLayerStyleSettings,
-  type TypeOutfields,
-  type TypeOutfieldsType,
-  type TypeStyleGeometry,
+import type {
+  DisplayDateMode,
+  TypeLayerStyleSettings,
+  TypeOutfields,
+  TypeOutfieldsType,
+  TypeStyleGeometry,
 } from '@/api/types/map-schema-types';
 import type {
   TypeGeoviewLayerConfig,

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -32,7 +32,7 @@ import type {
   codedValueType,
   rangeDomainType,
 } from '@/api/types/map-schema-types';
-import { type TypeLayerMetadataFields, type TypeGeoviewLayerType, type TypeMetadataEsriDynamicLayer } from '@/api/types/layer-schema-types';
+import type { TypeLayerMetadataFields, TypeGeoviewLayerType, TypeMetadataEsriDynamicLayer } from '@/api/types/layer-schema-types';
 import type { GeoViewError } from '@/core/exceptions/geoview-exceptions';
 import { LayerFailedToLoadError, LayerImageFailedToLoadError } from '@/core/exceptions/geoview-exceptions';
 import type { TypeLegendItem } from '@/core/components/layers/types';

--- a/packages/geoview-core/src/geo/layer/gv-layers/layer-filters.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/layer-filters.ts
@@ -1,5 +1,5 @@
 import { GeoviewRenderer } from '@/geo/utils/renderer/geoview-renderer';
-import { type FilterNodeType } from '@/geo/utils/renderer/geoview-renderer-types';
+import type { FilterNodeType } from '@/geo/utils/renderer/geoview-renderer-types';
 
 /**
  * Aggregates and composes the different filter fragments applied at various

--- a/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
@@ -12,7 +12,7 @@ import {
   type TypeFeatureInfoResultSet,
   type TypeFeatureInfoResultSetEntry,
 } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
-import { getStoreShowUnsymbolizedFeatures } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { getStoreAppShowUnsymbolizedFeatures } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { RequestAbortedError } from '@/core/exceptions/core-exceptions';
 import { LayerNoLastQueryToPerformError } from '@/core/exceptions/geoview-exceptions';
 import { logger } from '@/core/utils/logger';
@@ -196,7 +196,7 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
 
           // Filter out unsymbolized features if the showUnsymbolizedFeatures config is false
           // GV: KML and ESRI Image is excluded as they currently have no symbology.
-          if (!getStoreShowUnsymbolizedFeatures(this.getMapId()) && !(layer instanceof GVKML) && !(layer instanceof GVEsriImage)) {
+          if (!getStoreAppShowUnsymbolizedFeatures(this.getMapId()) && !(layer instanceof GVKML) && !(layer instanceof GVEsriImage)) {
             // eslint-disable-next-line no-param-reassign
             promiseResult.results = arrayOfRecords.filter((record) => record.featureIcon);
           }

--- a/packages/geoview-core/src/geo/layer/layer-sets/legends-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/legends-layer-set.ts
@@ -10,6 +10,7 @@ import type { PropagationType } from '@/geo/layer/layer-sets/abstract-layer-set'
 import { AbstractLayerSet } from '@/geo/layer/layer-sets/abstract-layer-set';
 import {
   deleteStoreLayerFromLegendLayers,
+  setStoreLayerStatus,
   setStoreLegendQueryStatus,
   type TypeLegend,
   type TypeLegendResultSet,
@@ -145,6 +146,9 @@ export class LegendsLayerSet extends AbstractLayerSet {
     // Change the layer status!
     this.resultSet[layerPath].layerStatus = layerStatus;
 
+    // Save to the store
+    this.#propagateToStoreLayerStatus(layerPath, layerStatus);
+
     // Check if ready to query legend
     this.#checkQueryLegend(layer, false);
   }
@@ -257,7 +261,21 @@ export class LegendsLayerSet extends AbstractLayerSet {
   }
 
   /**
-   * Propagates the legend query status to the store
+   * Propagates the layer status to the store.
+   *
+   * @param layerPath - The layer path to propagate the status for
+   * @param layerStatus - The layer status to propagate
+   */
+  #propagateToStoreLayerStatus(layerPath: string, layerStatus: TypeLayerStatus): void {
+    // Propagate
+    setStoreLayerStatus(this.getMapId(), layerPath, layerStatus);
+  }
+
+  /**
+   * Propagates the legend query status to the store.
+   *
+   * @param layerPath - The layer path to propagate the legend query status for
+   * @param resultSetEntry - The legend result set entry containing the legend query status and data to propagate
    */
   #propagateToStoreLegendQueryStatus(layerPath: string, resultSetEntry: TypeLegendResultSetEntry): void {
     // Propagate
@@ -315,12 +333,6 @@ export class LegendsLayerSet extends AbstractLayerSet {
 
       // Process a layer status changed
       this.processLayerStatusChanged(layerConfig.layerPath, layerStatusEvent.layerStatus, layer);
-
-      // If still existing (it's possible a layer set might want to unregister a layer config depending on its status, so we check)
-      if (this.resultSet[layerConfig.layerPath]) {
-        // Propagate the status to the store so that the UI gets updated
-        this.#propagateToStore(this.resultSet[layerConfig.layerPath]);
-      }
 
       // Emit the layer set updated changed event
       this.onLayerSetUpdatedProcess(layerConfig.layerPath);

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -1,10 +1,8 @@
-// TODO: REFACTOR IMPORTANT - Rename this file to layer-api and move it in /api folder instead of /core
-
 import type BaseLayer from 'ol/layer/Base';
 import type { GeoJSONObject } from 'ol/format/GeoJSON';
 import type { FitOptions } from 'ol/View';
 
-import { type TypeOutfieldsType } from '@/api/types/map-schema-types';
+import type { TypeOutfieldsType } from '@/api/types/map-schema-types';
 import type { TypeGeoviewLayerConfig, TypeMosaicRule } from '@/api/types/layer-schema-types';
 import type { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
 import type { GroupLayerEntryConfig } from '@/api/config/validation-classes/group-layer-entry-config';
@@ -39,7 +37,7 @@ import type {
   LayerPathDelegate,
   LayerPathEvent,
 } from '@/core/controllers/layer-creator-controller';
-import { type TypeOrderedLayerInfo } from '@/core/stores/store-interface-and-intial-values/map-state';
+import type { TypeOrderedLayerInfo } from '@/core/stores/store-interface-and-intial-values/map-state';
 import type { HoverFeatureInfoLayerSet } from '@/geo/layer/layer-sets/hover-feature-info-layer-set';
 import type { AllFeatureInfoLayerSet } from '@/geo/layer/layer-sets/all-feature-info-layer-set';
 import type { LegendsLayerSet } from '@/geo/layer/layer-sets/legends-layer-set';

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -94,7 +94,7 @@ import {
   getStoreMapInteraction,
   setStoreMapInteraction,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
-import { getStoreDisplayTheme } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { getStoreAppDisplayTheme } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { setStoreLayerSelectedLayersTabLayer, type TypeLegend } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { TIME_DELAY_BETWEEN_PROPAGATION_FOR_BATCH } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import { GeoUtilities } from '@/geo/utils/utilities';
@@ -599,7 +599,7 @@ export class MapViewer {
    * @returns The display theme
    */
   getDisplayTheme(): TypeDisplayTheme {
-    return getStoreDisplayTheme(this.mapId);
+    return getStoreAppDisplayTheme(this.mapId);
   }
 
   /**

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -1242,6 +1242,23 @@ export class MapViewer {
   }
 
   /**
+   * Waits for the map to be ready before resolving the promise.
+   *
+   * This function checks if the map is already ready, and if not, it waits for the onMapReady event to be triggered.
+   *
+   * @returns A promise that resolves when the map is ready.
+   */
+  waitForMapReady(): Promise<void> {
+    // If already ready
+    if (this.#mapReady) return Promise.resolve();
+
+    // Wait for onMapReady to be triggered
+    return new Promise((resolve) => {
+      this.onMapReady(() => resolve());
+    });
+  }
+
+  /**
    * Waits until all GeoView layers reach the specified status before resolving the promise.
    *
    * This function repeatedly checks whether all layers have reached the given layerStatus.
@@ -1286,7 +1303,10 @@ export class MapViewer {
    *
    * @returns A promise that resolves with the number of layers that have reached the specified status
    */
-  waitForLayersLoaded(): Promise<number> {
+  async waitForLayersLoaded(): Promise<number> {
+    // First, wait for the map to be ready in case it's not ready yet. We need the layer configs to be registered at least!
+    await this.waitForMapReady();
+
     // Redirect
     return this.waitAllLayersStatus('loaded');
   }

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -65,7 +65,7 @@ import EventHelper from '@/api/events/event-helper';
 import { ModalApi } from '@/ui';
 import { delay, generateId, getLocalizedMessage, whenThisThen } from '@/core/utils/utilities';
 import { debounce } from '@/core/utils/debounce';
-import { type TimeIANA } from '@/core/utils/date-mgt';
+import type { TimeIANA } from '@/core/utils/date-mgt';
 import { logger } from '@/core/utils/logger';
 import { NORTH_POLE_POSITION, TIMEOUT } from '@/core/utils/constant';
 import type { TypeMapFeaturesConfig, TypeHTMLElement } from '@/core/types/global-types';

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -748,7 +748,7 @@ export abstract class GeoUtilities {
             const legendLayerListItem: TypeLegendItem = {
               geometryType,
               icon: iconDetailsEntry.iconImage,
-              name: iconDetailsEntry.name,
+              name: iconDetailsEntry.name ?? '',
               isVisible: true,
             };
             iconDetailsEntry.iconList = [legendLayerListItem];
@@ -761,7 +761,7 @@ export abstract class GeoUtilities {
                 const legendLayerListItem: TypeLegendItem = {
                   geometryType,
                   icon: canvas ? canvas.toDataURL() : null,
-                  name: styleSettings.info[i].label,
+                  name: styleSettings.info[i].label ?? '',
                   isVisible: styleSettings.info[i].visible !== false,
                 };
                 iconDetailsEntry.iconList?.push(legendLayerListItem);
@@ -771,7 +771,7 @@ export abstract class GeoUtilities {
               const legendLayerListItem: TypeLegendItem = {
                 geometryType,
                 icon: styleRepresentation.defaultCanvas.toDataURL(),
-                name: styleSettings.info[styleSettings.info.length - 1].label,
+                name: styleSettings.info[styleSettings.info.length - 1].label ?? '',
                 isVisible: styleSettings.info[styleSettings.info.length - 1].visible !== false,
               };
               iconDetailsEntry.iconList.push(legendLayerListItem);

--- a/packages/geoview-core/src/ui/panel/panel.tsx
+++ b/packages/geoview-core/src/ui/panel/panel.tsx
@@ -16,11 +16,11 @@ import type { IconButtonPropsExtend } from '@/ui/icon-button/icon-button';
 import { IconButton } from '@/ui/icon-button/icon-button';
 import { getSxClasses } from '@/ui/panel/panel-style';
 import { UseHtmlToReact } from '@/core/components/common/hooks/use-html-to-react';
-import { useUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { FocusTrapContainer } from '@/core/components/common';
 import { delay } from '@/core/utils/utilities';
 import { logger } from '@/core/utils/logger';
-import { useGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { CONTAINER_TYPE } from '@/core/utils/constant';
 
 /**
@@ -77,10 +77,10 @@ function PanelUI(props: TypePanelAppProps): JSX.Element {
   const closeBtnRef = useRef<HTMLButtonElement>(null);
   const panelWidth = panel?.width ?? 100; //percentage
   const sxClasses = useMemo(() => getSxClasses(theme, open, panelWidth), [theme, open, panelWidth]);
-  const mapId = useGeoViewMapId();
 
   // Store
-  const activeTrapGeoView = useUIActiveTrapGeoView();
+  const mapId = useStoreGeoViewMapId();
+  const activeTrapGeoView = useStoreUIActiveTrapGeoView();
 
   useEffect(() => {
     logger.logTraceUseEffect('UI.PANEL - open');

--- a/packages/geoview-custom-legend/src/components/description-text.tsx
+++ b/packages/geoview-custom-legend/src/components/description-text.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import type { TypeWindow } from 'geoview-core/core/types/global-types';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 import { logger } from 'geoview-core/core/utils/logger';
 
@@ -27,7 +27,7 @@ export function DescriptionText({ description, sxClasses }: DescriptionTextProps
   const { ui } = cgpv;
   const { Box, Typography, KeyboardArrowDownIcon, KeyboardArrowUpIcon, IconButton, Collapse } = ui.elements;
 
-  const displayLanguage = useAppDisplayLanguage();
+  const displayLanguage = useStoreAppDisplayLanguage();
   const [expanded, setExpanded] = useState<boolean>(!description.collapsed);
 
   /**

--- a/packages/geoview-custom-legend/src/components/group-item.tsx
+++ b/packages/geoview-custom-legend/src/components/group-item.tsx
@@ -1,7 +1,7 @@
 import type { TypeWindow } from 'geoview-core/core/types/global-types';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import { logger } from 'geoview-core/core/utils/logger';
-import { useMapSelectorLayerArrayVisibility } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapLayerArrayVisibility } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 
 import type { TypeGroupLayer, TypeLegendItem } from '../custom-legend-types';
@@ -66,7 +66,7 @@ export function GroupItem({ item, sxClasses, itemPath }: GroupItemProps): JSX.El
     KeyboardArrowUpIcon,
   } = ui.elements;
 
-  const displayLanguage = useAppDisplayLanguage();
+  const displayLanguage = useStoreAppDisplayLanguage();
   const mapController = useMapController();
 
   const [collapsed, setCollapsed] = useState<boolean>(isGroupLayer(item) ? (item.collapsed ?? false) : false);
@@ -75,7 +75,7 @@ export function GroupItem({ item, sxClasses, itemPath }: GroupItemProps): JSX.El
   const layerPaths = useMemo(() => collectLayerPaths(item.children), [item.children]);
 
   // Check if all child layers are visible
-  const allVisible = useMapSelectorLayerArrayVisibility(layerPaths);
+  const allVisible = useStoreMapLayerArrayVisibility(layerPaths);
 
   if (!isGroupLayer(item)) return;
 

--- a/packages/geoview-custom-legend/src/custom-legend-panel.tsx
+++ b/packages/geoview-custom-legend/src/custom-legend-panel.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import type { TypeWindow } from 'geoview-core/core/types/global-types';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import { logger } from 'geoview-core/core/utils/logger';
 
 import { getSxClasses } from './custom-legend-style';
@@ -33,7 +33,7 @@ export function CustomLegendPanel(props: CustomLegendPanelProps): JSX.Element {
   const theme = ui.useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
-  const appDisplayLanguage = useAppDisplayLanguage();
+  const appDisplayLanguage = useStoreAppDisplayLanguage();
 
   return (
     <Box sx={sxClasses.container}>

--- a/packages/geoview-drawer/src/buttons/clear.tsx
+++ b/packages/geoview-drawer/src/buttons/clear.tsx
@@ -1,7 +1,7 @@
 import { type TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 
 import { IconButton, DeleteIcon } from 'geoview-core/ui';
 import { logger } from 'geoview-core/core/utils/logger';
@@ -23,7 +23,7 @@ export default function Clear(): JSX.Element {
   // Get store values
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const displayLanguage = useAppDisplayLanguage();
+  const displayLanguage = useStoreAppDisplayLanguage();
   const drawerController = useDrawerController();
 
   /**

--- a/packages/geoview-drawer/src/buttons/clear.tsx
+++ b/packages/geoview-drawer/src/buttons/clear.tsx
@@ -1,4 +1,4 @@
-import { type TypeWindow } from 'geoview-core';
+import type { TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';

--- a/packages/geoview-drawer/src/buttons/download.tsx
+++ b/packages/geoview-drawer/src/buttons/download.tsx
@@ -1,7 +1,7 @@
 import { type TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 
 import { IconButton, DownloadIcon } from 'geoview-core/ui';
 import { logger } from 'geoview-core/core/utils/logger';
@@ -23,7 +23,7 @@ export default function Download(): JSX.Element {
   // Get store values
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const displayLanguage = useAppDisplayLanguage();
+  const displayLanguage = useStoreAppDisplayLanguage();
   const drawerController = useDrawerController();
 
   /**

--- a/packages/geoview-drawer/src/buttons/download.tsx
+++ b/packages/geoview-drawer/src/buttons/download.tsx
@@ -1,4 +1,4 @@
-import { type TypeWindow } from 'geoview-core';
+import type { TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';

--- a/packages/geoview-drawer/src/buttons/draw.tsx
+++ b/packages/geoview-drawer/src/buttons/draw.tsx
@@ -1,4 +1,4 @@
-import { type TypeWindow } from 'geoview-core';
+import type { TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';

--- a/packages/geoview-drawer/src/buttons/draw.tsx
+++ b/packages/geoview-drawer/src/buttons/draw.tsx
@@ -1,8 +1,8 @@
 import { type TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
-import { useDrawerIsDrawing } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreDrawerIsDrawing } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
 
 import { IconButton, DrawIcon } from 'geoview-core/ui';
 import { logger } from 'geoview-core/core/utils/logger';
@@ -24,8 +24,8 @@ export default function Draw(): JSX.Element {
   // Get store values
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const displayLanguage = useAppDisplayLanguage();
-  const isDrawing = useDrawerIsDrawing();
+  const displayLanguage = useStoreAppDisplayLanguage();
+  const isDrawing = useStoreDrawerIsDrawing();
   const drawerController = useDrawerController();
 
   /**

--- a/packages/geoview-drawer/src/buttons/edit.tsx
+++ b/packages/geoview-drawer/src/buttons/edit.tsx
@@ -1,4 +1,4 @@
-import { type TypeWindow } from 'geoview-core';
+import type { TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';

--- a/packages/geoview-drawer/src/buttons/edit.tsx
+++ b/packages/geoview-drawer/src/buttons/edit.tsx
@@ -1,8 +1,8 @@
 import { type TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
-import { useDrawerIsEditing } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreDrawerIsEditing } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
 
 import { IconButton, EditIcon, EditOffIcon } from 'geoview-core/ui';
 import { logger } from 'geoview-core/core/utils/logger';
@@ -24,8 +24,8 @@ export default function Edit(): JSX.Element {
   // Get store values
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const displayLanguage = useAppDisplayLanguage();
-  const isEditing = useDrawerIsEditing();
+  const displayLanguage = useStoreAppDisplayLanguage();
+  const isEditing = useStoreDrawerIsEditing();
   const drawerController = useDrawerController();
 
   /**

--- a/packages/geoview-drawer/src/buttons/geometry-picker.tsx
+++ b/packages/geoview-drawer/src/buttons/geometry-picker.tsx
@@ -1,11 +1,11 @@
 import ReactDOMServer from 'react-dom/server';
-import { useGeoViewMapId, type TypeWindow } from 'geoview-core';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreGeoViewMapId, type TypeWindow } from 'geoview-core';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import {
   setStoreDrawerIconSrc,
-  useDrawerActiveGeom,
-  useDrawerIsDrawing,
-  useDrawerStyle,
+  useStoreDrawerActiveGeom,
+  useStoreDrawerIsDrawing,
+  useStoreDrawerStyle,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 
@@ -36,9 +36,9 @@ export function PointIcon(props: PointIconProps): JSX.Element {
   const { useEffect } = cgpv.reactUtilities.react;
   const { IconComponent } = props;
 
-  const mapId = useGeoViewMapId();
-
-  const { fillColor, strokeColor, strokeWidth } = useDrawerStyle();
+  // Store
+  const mapId = useStoreGeoViewMapId();
+  const { fillColor, strokeColor, strokeWidth } = useStoreDrawerStyle();
 
   useEffect(() => {
     logger.logTraceUseEffect('POINT ICON - Icon style sync', IconComponent, fillColor, strokeColor, strokeWidth);
@@ -97,8 +97,8 @@ export function GeometryPickerButton(): JSX.Element {
   const { useMemo } = cgpv.reactUtilities.react;
   const { PlaceIcon, TextFieldsIcon, ShapeLineIcon, ShowChartIcon, HexagonIcon, RectangleIcon, CircleIcon, StarIcon } = cgpv.ui.elements;
 
-  const geomType = useDrawerActiveGeom();
-  const style = useDrawerStyle();
+  const geomType = useStoreDrawerActiveGeom();
+  const style = useStoreDrawerStyle();
   const iconStyle = useMemo(
     () => ({
       fillColor: style.fillColor,
@@ -137,13 +137,13 @@ export function GeometryPickerPanel(props: GeometryPickerPanelProps): JSX.Elemen
   const { geomTypes, closePanel } = props;
 
   // Get store values
-  const displayLanguage = useAppDisplayLanguage();
+  const displayLanguage = useStoreAppDisplayLanguage();
   const drawerController = useDrawerController();
 
   // Store actions
-  const style = useDrawerStyle();
-  const activeGeom = useDrawerActiveGeom();
-  const isDrawing = useDrawerIsDrawing();
+  const style = useStoreDrawerStyle();
+  const activeGeom = useStoreDrawerActiveGeom();
+  const isDrawing = useStoreDrawerIsDrawing();
 
   const memoIconStyle = useMemo(
     () => ({

--- a/packages/geoview-drawer/src/buttons/geometry-picker.tsx
+++ b/packages/geoview-drawer/src/buttons/geometry-picker.tsx
@@ -136,14 +136,12 @@ export function GeometryPickerPanel(props: GeometryPickerPanelProps): JSX.Elemen
 
   const { geomTypes, closePanel } = props;
 
-  // Get store values
+  // Store
   const displayLanguage = useStoreAppDisplayLanguage();
-  const drawerController = useDrawerController();
-
-  // Store actions
   const style = useStoreDrawerStyle();
   const activeGeom = useStoreDrawerActiveGeom();
   const isDrawing = useStoreDrawerIsDrawing();
+  const drawerController = useDrawerController();
 
   const memoIconStyle = useMemo(
     () => ({

--- a/packages/geoview-drawer/src/buttons/measurements.tsx
+++ b/packages/geoview-drawer/src/buttons/measurements.tsx
@@ -2,8 +2,8 @@ import { createSvgIcon } from '@mui/material/utils';
 import { type TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
-import { useDrawerHideMeasurements } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreDrawerHideMeasurements } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
 
 import { IconButton, StraightenIcon } from 'geoview-core/ui';
 import { logger } from 'geoview-core/core/utils/logger';
@@ -35,8 +35,8 @@ export default function Measurements(): JSX.Element {
   // Get store values
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const displayLanguage = useAppDisplayLanguage();
-  const hideMeasurements = useDrawerHideMeasurements();
+  const displayLanguage = useStoreAppDisplayLanguage();
+  const hideMeasurements = useStoreDrawerHideMeasurements();
   const drawerController = useDrawerController();
 
   /**

--- a/packages/geoview-drawer/src/buttons/measurements.tsx
+++ b/packages/geoview-drawer/src/buttons/measurements.tsx
@@ -1,5 +1,5 @@
 import { createSvgIcon } from '@mui/material/utils';
-import { type TypeWindow } from 'geoview-core';
+import type { TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';

--- a/packages/geoview-drawer/src/buttons/redo.tsx
+++ b/packages/geoview-drawer/src/buttons/redo.tsx
@@ -1,8 +1,8 @@
 import { type TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
-import { useDrawerRedoDisabled } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreDrawerRedoDisabled } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
 
 import { IconButton, RedoIcon } from 'geoview-core/ui';
 import { logger } from 'geoview-core/core/utils/logger';
@@ -24,10 +24,10 @@ export default function Redo(): JSX.Element {
   // Get store values
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const displayLanguage = useAppDisplayLanguage();
+  const displayLanguage = useStoreAppDisplayLanguage();
 
   // Store actions
-  const redoDisabled = useDrawerRedoDisabled();
+  const redoDisabled = useStoreDrawerRedoDisabled();
   const drawerController = useDrawerController();
 
   /**

--- a/packages/geoview-drawer/src/buttons/redo.tsx
+++ b/packages/geoview-drawer/src/buttons/redo.tsx
@@ -26,7 +26,7 @@ export default function Redo(): JSX.Element {
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
   const displayLanguage = useStoreAppDisplayLanguage();
 
-  // Store actions
+  // Store
   const redoDisabled = useStoreDrawerRedoDisabled();
   const drawerController = useDrawerController();
 

--- a/packages/geoview-drawer/src/buttons/redo.tsx
+++ b/packages/geoview-drawer/src/buttons/redo.tsx
@@ -1,4 +1,4 @@
-import { type TypeWindow } from 'geoview-core';
+import type { TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';

--- a/packages/geoview-drawer/src/buttons/snap.tsx
+++ b/packages/geoview-drawer/src/buttons/snap.tsx
@@ -1,5 +1,5 @@
 import { createSvgIcon } from '@mui/material/utils';
-import { type TypeWindow } from 'geoview-core';
+import type { TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';

--- a/packages/geoview-drawer/src/buttons/snap.tsx
+++ b/packages/geoview-drawer/src/buttons/snap.tsx
@@ -2,8 +2,8 @@ import { createSvgIcon } from '@mui/material/utils';
 import { type TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
-import { useDrawerIsSnapping } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreDrawerIsSnapping } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
 
 import { IconButton } from 'geoview-core/ui';
 import { logger } from 'geoview-core/core/utils/logger';
@@ -35,8 +35,8 @@ export default function Snapping(): JSX.Element {
   // Get store values
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const displayLanguage = useAppDisplayLanguage();
-  const isSnapping = useDrawerIsSnapping();
+  const displayLanguage = useStoreAppDisplayLanguage();
+  const isSnapping = useStoreDrawerIsSnapping();
   const drawerController = useDrawerController();
 
   /**

--- a/packages/geoview-drawer/src/buttons/style.tsx
+++ b/packages/geoview-drawer/src/buttons/style.tsx
@@ -1,4 +1,4 @@
-import { type TypeWindow } from 'geoview-core';
+import type { TypeWindow } from 'geoview-core';
 import { MuiColorInput } from 'mui-color-input';
 import type { ChangeEvent } from 'react';
 import { useState } from 'react';

--- a/packages/geoview-drawer/src/buttons/style.tsx
+++ b/packages/geoview-drawer/src/buttons/style.tsx
@@ -3,11 +3,11 @@ import { MuiColorInput } from 'mui-color-input';
 import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 import {
-  useDrawerStyle,
-  useDrawerActiveGeom,
-  useDrawerSelectedDrawingType,
+  useStoreDrawerStyle,
+  useStoreDrawerActiveGeom,
+  useStoreDrawerSelectedDrawing,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 import { logger } from 'geoview-core/core/utils/logger';
 
@@ -63,15 +63,15 @@ export function StylePanel(): JSX.Element {
   const { Box, List, ListItem, Typography, TextField, IconButton, FormatBoldIcon, FormatItalicIcon } = ui.elements;
 
   // Get store values
-  const style = useDrawerStyle();
-  const activeGeom = useDrawerActiveGeom();
-  const selectedDrawingType = useDrawerSelectedDrawingType();
-  const displayLanguage = useAppDisplayLanguage();
+  const style = useStoreDrawerStyle();
+  const activeGeom = useStoreDrawerActiveGeom();
+  const selectedDrawing = useStoreDrawerSelectedDrawing();
+  const displayLanguage = useStoreAppDisplayLanguage();
   const drawerController = useDrawerController();
 
   const memoCurrentGeomType = useMemo(() => {
-    return selectedDrawingType ?? activeGeom;
-  }, [activeGeom, selectedDrawingType]);
+    return selectedDrawing ?? activeGeom;
+  }, [activeGeom, selectedDrawing]);
 
   // Local state for color inputs
   const [localFillColor, setLocalFillColor] = useState(style.fillColor);

--- a/packages/geoview-drawer/src/buttons/undo.tsx
+++ b/packages/geoview-drawer/src/buttons/undo.tsx
@@ -1,8 +1,8 @@
 import type { TypeWindow } from 'geoview-core/core/types/global-types';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
-import { useDrawerUndoDisabled } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreDrawerUndoDisabled } from 'geoview-core/core/stores/store-interface-and-intial-values/drawer-state';
 
 import { IconButton, UndoIcon } from 'geoview-core/ui';
 import { logger } from 'geoview-core/core/utils/logger';
@@ -24,11 +24,11 @@ export default function Redo(): JSX.Element {
   // Get store values
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const displayLanguage = useAppDisplayLanguage();
+  const displayLanguage = useStoreAppDisplayLanguage();
   const drawerController = useDrawerController();
 
   // Store actions
-  const undoDisabled = useDrawerUndoDisabled();
+  const undoDisabled = useStoreDrawerUndoDisabled();
 
   /**
    * Handles a click on the undo button

--- a/packages/geoview-drawer/src/buttons/undo.tsx
+++ b/packages/geoview-drawer/src/buttons/undo.tsx
@@ -27,7 +27,7 @@ export default function Redo(): JSX.Element {
   const displayLanguage = useStoreAppDisplayLanguage();
   const drawerController = useDrawerController();
 
-  // Store actions
+  // Store
   const undoDisabled = useStoreDrawerUndoDisabled();
 
   /**

--- a/packages/geoview-drawer/src/buttons/upload.tsx
+++ b/packages/geoview-drawer/src/buttons/upload.tsx
@@ -1,4 +1,4 @@
-import { type TypeWindow } from 'geoview-core';
+import type { TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';

--- a/packages/geoview-drawer/src/buttons/upload.tsx
+++ b/packages/geoview-drawer/src/buttons/upload.tsx
@@ -1,7 +1,7 @@
 import { type TypeWindow } from 'geoview-core';
 import { getSxClasses } from 'geoview-core/core/components/nav-bar/nav-bar-style';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 
 import { IconButton, UploadIcon } from 'geoview-core/ui';
 import { logger } from 'geoview-core/core/utils/logger';
@@ -23,7 +23,7 @@ export default function Upload(): JSX.Element {
   // Get store values
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const displayLanguage = useAppDisplayLanguage();
+  const displayLanguage = useStoreAppDisplayLanguage();
   const drawerController = useDrawerController();
 
   /**

--- a/packages/geoview-geochart/src/geochart-panel.tsx
+++ b/packages/geoview-geochart/src/geochart-panel.tsx
@@ -6,20 +6,20 @@ import { checkSelectedLayerPathList } from 'geoview-core/core/components/common/
 import { Typography } from 'geoview-core/ui/typography/typography';
 import { Box } from 'geoview-core/ui';
 import {
-  useMapClickCoordinates,
-  useMapAllVisibleandInRangeLayers,
-  getStoreMapIsLayerHiddenOnMap,
+  useStoreMapClickCoordinates,
+  useStoreMapAllVisibleandInRangeLayers,
+  useStoreMapIsLayerHiddenOnMapSet,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
-import { useLayerNames, useLayerStatuses } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerNameSet, useStoreLayerStatusSet } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 import type { TypeGeochartResultSetEntry } from 'geoview-core/core/stores/store-interface-and-intial-values/geochart-state';
 import {
-  useGeochartConfigs,
-  useGeochartLayerDataArrayBatch,
-  useGeochartSelectedLayerPath,
+  useStoreGeochartChartsConfig,
+  useStoreGeochartLayerDataArrayBatch,
+  useStoreGeochartSelectedLayerPath,
   setStoreGeochartLayerDataArrayBatchLayerPathBypass,
   setStoreGeochartSelectedLayerPath,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/geochart-state';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 import { logger } from 'geoview-core/core/utils/logger';
 import { CONTAINER_TYPE, TABS } from 'geoview-core/core/utils/constant';
@@ -50,14 +50,15 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
   const { useState, useCallback, useMemo, useEffect, useRef } = reactUtilities.react;
 
   // Get states and actions from store
-  const configObj = useGeochartConfigs();
-  const visibleInRangeLayers = useMapAllVisibleandInRangeLayers();
-  const storeArrayOfLayerData = useGeochartLayerDataArrayBatch();
-  const selectedLayerPath = useGeochartSelectedLayerPath();
-  const displayLanguage = useAppDisplayLanguage();
-  const mapClickCoordinates = useMapClickCoordinates();
-  const layerNames = useLayerNames();
-  const layerStatuses = useLayerStatuses();
+  const configObj = useStoreGeochartChartsConfig();
+  const displayLanguage = useStoreAppDisplayLanguage();
+  const visibleInRangeLayers = useStoreMapAllVisibleandInRangeLayers();
+  const mapClickCoordinates = useStoreMapClickCoordinates();
+  const layerHiddenSet = useStoreMapIsLayerHiddenOnMapSet();
+  const layerNames = useStoreLayerNameSet();
+  const layerStatuses = useStoreLayerStatusSet();
+  const storeArrayOfLayerData = useStoreGeochartLayerDataArrayBatch();
+  const selectedLayerPath = useStoreGeochartSelectedLayerPath();
 
   // Create the validator shared for all the charts in the footer
   const [schemaValidator] = useState<SchemaValidator>(new SchemaValidator());
@@ -162,10 +163,7 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
 
     // Set the layers list
     return visibleInRangeLayers.reduce<LayerListEntry[]>((acc, layerPath) => {
-      // TODO: CHECK -This should likely go through a Zustand hook instead of a state getter
-      const layer = storeArrayOfLayerData.find(
-        (layerData) => layerData.layerPath === layerPath && !getStoreMapIsLayerHiddenOnMap(mapId, layerData.layerPath)
-      );
+      const layer = storeArrayOfLayerData.find((layerData) => layerData.layerPath === layerPath && !layerHiddenSet[layerData.layerPath]);
 
       if (layer && memoConfigObj[layer.layerPath]) {
         acc.push({
@@ -182,7 +180,7 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
 
       return acc;
     }, []);
-  }, [storeArrayOfLayerData, visibleInRangeLayers, memoConfigObj, layerNames, layerStatuses, getNumFeaturesLabel, mapId]);
+  }, [storeArrayOfLayerData, visibleInRangeLayers, memoConfigObj, layerNames, layerStatuses, layerHiddenSet, getNumFeaturesLabel, mapId]);
 
   /** Memoizes the selected layer for the LayerList component. */
   const memoLayerSelectedItem = useMemo(() => {

--- a/packages/geoview-geochart/src/geochart.tsx
+++ b/packages/geoview-geochart/src/geochart.tsx
@@ -1,8 +1,11 @@
 import type { GeoChartConfig, ChartType, GeoChartDefaultColors, SchemaValidator, GeoChartAction } from 'geochart';
 import { GeoChart as GeoChartComponent } from 'geochart';
 
-import { useAppDisplayLanguageById, useDisplayDateTimezone } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
-import { useLayerDisplayDateFormatShort } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
+import {
+  useStoreAppDisplayLanguageById,
+  useStoreDisplayDateTimezone,
+} from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreLayerDisplayDateFormatShort } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 import type { TypeGeochartResultSetEntry } from 'geoview-core/core/stores/store-interface-and-intial-values/geochart-state';
 import { useUIController } from 'geoview-core/core/controllers/ui-controller';
 import { useLayerController } from 'geoview-core/core/controllers/layer-controller';
@@ -54,9 +57,9 @@ export function GeoChart(props: GeoChartProps): JSX.Element {
   const [action, setAction] = useState<GeoChartAction>();
 
   // Use Store
-  const displayLanguage = useAppDisplayLanguageById(mapId);
-  const displayDateFormatShort = useLayerDisplayDateFormatShort(layerPath);
-  const displayDateTimezone = useDisplayDateTimezone();
+  const displayLanguage = useStoreAppDisplayLanguageById(mapId);
+  const displayDateFormatShort = useStoreLayerDisplayDateFormatShort(layerPath);
+  const displayDateTimezone = useStoreDisplayDateTimezone();
   const uiController = useUIController();
   const layerController = useLayerController();
 

--- a/packages/geoview-geochart/src/index-appbar.tsx
+++ b/packages/geoview-geochart/src/index-appbar.tsx
@@ -85,7 +85,7 @@ export class GeoChartAppBarPlugin extends AppBarPlugin {
    * @returns The content JSX element
    */
   override onCreateContent(): JSX.Element {
-    // TODO: GEOCHART IN APPBAR - Create a geochart-appbar-panel equivalent to geochart-panel to hold the GeoChart itself and hook on the useGeochartConfigs store the same way geochart-panel does it
+    // TODO: GEOCHART IN APPBAR - Create a geochart-appbar-panel equivalent to geochart-panel to hold the GeoChart itself and hook on the useStoreGeochartChartsConfig store the same way geochart-panel does it
     // return <GeoChartAppBarPanel mapId={this.mapViewer.mapId} schemaValidator={new SchemaValidator()} />;
     return <div>Not implemented</div>;
   }

--- a/packages/geoview-swiper/src/swiper.tsx
+++ b/packages/geoview-swiper/src/swiper.tsx
@@ -1,4 +1,5 @@
 import Draggable from 'react-draggable';
+import { useMemo } from 'react';
 
 import { getRenderPixel } from 'ol/render';
 import type RenderEvent from 'ol/render/Event';
@@ -17,9 +18,8 @@ import { debounce } from 'geoview-core/core/utils/debounce';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import { useStoreMapSize, useStoreMapVisibleLayers } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
 import type { MapViewer } from 'geoview-core/geo/map/map-viewer';
-import { getSxClasses } from './swiper-style';
-import { useMemo } from 'react';
 import { TIMEOUT } from 'geoview-core/core/utils/constant';
+import { getSxClasses } from './swiper-style';
 
 /** Properties for the Swiper component. */
 type SwiperProps = {

--- a/packages/geoview-swiper/src/swiper.tsx
+++ b/packages/geoview-swiper/src/swiper.tsx
@@ -7,12 +7,15 @@ import type { EventTypes } from 'ol/Observable';
 import type BaseEvent from 'ol/events/Event';
 
 import type { SwipeOrientation } from 'geoview-core/core/stores/store-interface-and-intial-values/swiper-state';
-import { useSwiperLayerPaths, useSwiperOrientation } from 'geoview-core/core/stores/store-interface-and-intial-values/swiper-state';
+import {
+  useStoreSwiperLayerPaths,
+  useStoreSwiperOrientation,
+} from 'geoview-core/core/stores/store-interface-and-intial-values/swiper-state';
 import { logger } from 'geoview-core/core/utils/logger';
 import { getLocalizedMessage, delay } from 'geoview-core/core/utils/utilities';
 import { debounce } from 'geoview-core/core/utils/debounce';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
-import { useMapSize, useMapVisibleLayers } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreMapSize, useStoreMapVisibleLayers } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
 import type { MapViewer } from 'geoview-core/geo/map/map-viewer';
 import { getSxClasses } from './swiper-style';
 import { useMemo } from 'react';
@@ -61,7 +64,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
   const swiperRef = useRef<HTMLElement>();
 
   // SxClasses
-  const mapHeight = useMapSize()[1];
+  const mapHeight = useStoreMapSize()[1];
   const sxClasses = useMemo(() => getSxClasses(mapHeight), [mapHeight]);
 
   // States
@@ -72,10 +75,10 @@ export function Swiper(props: SwiperProps): JSX.Element {
   const [yPositionHorizontal, setYPositionHorizontal] = useState(mapSize.current[1] / 2);
 
   // Get store values
-  const layerPaths = useSwiperLayerPaths();
-  const displayLanguage = useAppDisplayLanguage();
-  const visibleLayers = useMapVisibleLayers();
-  const orientation = useSwiperOrientation();
+  const layerPaths = useStoreSwiperLayerPaths();
+  const displayLanguage = useStoreAppDisplayLanguage();
+  const visibleLayers = useStoreMapVisibleLayers();
+  const orientation = useStoreSwiperOrientation();
 
   // Grab reference
   const theSwiper = swiperRef.current;

--- a/packages/geoview-test-suite/src/tests/testers/abstract-gv-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/abstract-gv-tester.ts
@@ -7,7 +7,7 @@ import type { TypeGeoviewLayerType } from 'geoview-core/api/types/layer-schema-t
 import type { TypeLegendItem } from 'geoview-core/core/components/layers/types';
 import type { ControllerRegistry } from 'geoview-core/core/controllers/base/controller-registry';
 import { Test } from '../core/test';
-import { getStoreLayerStateLegendLayers } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
+import { getStoreLayerLegendLayers } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 import type { GeometryApi } from 'geoview-core/geo/layer/geometry/geometry';
 
 /**
@@ -553,7 +553,7 @@ export abstract class GVAbstractTester extends AbstractTester {
 
     // Check the removal worked
     test.addStep(`Check that the layer is indeed removed...`);
-    const legendLayers = getStoreLayerStateLegendLayers(this.getMapId());
+    const legendLayers = getStoreLayerLegendLayers(this.getMapId());
     Test.assertArrayExcludes(
       legendLayers.map((legendLayer) => legendLayer.layerPath),
       layerPath

--- a/packages/geoview-test-suite/src/tests/testers/details-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/details-tester.ts
@@ -5,7 +5,7 @@ import { GVAbstractTester } from './abstract-gv-tester';
 import { delay } from 'geoview-core/core/utils/utilities';
 import type { TypeFeatureInfoEntry } from 'geoview-core/api/types/map-schema-types';
 import { logger } from 'geoview-core/core/utils/logger';
-import { getStoreActiveFooterBarTab } from 'geoview-core/core/stores/store-interface-and-intial-values/ui-state';
+import { getStoreUIActiveFooterBarTab } from 'geoview-core/core/stores/store-interface-and-intial-values/ui-state';
 import { setStoreDetailsSelectedLayerPath } from 'geoview-core/core/stores/store-interface-and-intial-values/feature-info-state';
 import { getStoreLayerItemVisibility } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 import type { AbstractGVLayer } from 'geoview-core/geo/layer/gv-layers/abstract-gv-layer';
@@ -101,7 +101,7 @@ export class DetailsTester extends GVAbstractTester {
 
         // Check that details is the active footer bar
         test.addStep("Verifying 'details' is the selected footer tab...");
-        Test.assertIsEqual(getStoreActiveFooterBarTab(this.getMapId()).tabId, 'details');
+        Test.assertIsEqual(getStoreUIActiveFooterBarTab(this.getMapId()).tabId, 'details');
 
         logger.logDebug(results);
       }

--- a/packages/geoview-test-suite/src/tests/testers/geochart-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/geochart-tester.ts
@@ -3,7 +3,7 @@ import { Test } from '../core/test';
 import { GVAbstractTester } from './abstract-gv-tester';
 import { delay } from 'geoview-core/core/utils/utilities';
 import type { AbstractGVLayer } from 'geoview-core/geo/layer/gv-layers/abstract-gv-layer';
-import { getStoreActiveFooterBarTab } from 'geoview-core/core/stores/store-interface-and-intial-values/ui-state';
+import { getStoreUIActiveFooterBarTab } from 'geoview-core/core/stores/store-interface-and-intial-values/ui-state';
 import {
   getStoreGeochartChartsConfig,
   getStoreGeochartSelectedLayerPath,
@@ -42,7 +42,7 @@ export class GeochartTester extends GVAbstractTester {
         // Perform assertions
         // Check that geochart is the active footer bar
         test.addStep("Verifying 'geochart' is the selected footer tab...");
-        Test.assertIsEqual(getStoreActiveFooterBarTab(this.getMapId()).tabId, 'geochart');
+        Test.assertIsEqual(getStoreUIActiveFooterBarTab(this.getMapId()).tabId, 'geochart');
 
         // Check that layer path is selected
         test.addStep(`Verifying ${layerPath} is the selected layer for the geochart...`);
@@ -136,7 +136,7 @@ export class GeochartTester extends GVAbstractTester {
 
         // Check that geochart is the active footer bar
         test.addStep("Verifying 'geochart' is the selected footer tab...");
-        Test.assertIsEqual(getStoreActiveFooterBarTab(this.getMapId()).tabId, 'geochart');
+        Test.assertIsEqual(getStoreUIActiveFooterBarTab(this.getMapId()).tabId, 'geochart');
 
         // Check that layer path is selected
         test.addStep(`Verifying ${layerPathAdd} is the selected layer for the geochart...`);

--- a/packages/geoview-test-suite/src/tests/testers/layer-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/layer-tester.ts
@@ -20,7 +20,7 @@ import { KML } from 'geoview-core/geo/layer/geoview-layers/vector/kml';
 import type { GeoViewLayerAddedResult } from 'geoview-core/core/controllers/layer-creator-controller';
 import type { TypeMapFeaturesInstance, TypeFeatureInfoResult, codedValueType } from 'geoview-core/api/types/map-schema-types';
 import type { TypeLegendItem } from 'geoview-core/core/components/layers/types';
-import { getStoreLayerStateLegendLayerByPath } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
+import { getStoreLayerLegendLayerByPath } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 
 /**
  * Main Layer testing class.
@@ -1815,7 +1815,7 @@ export class LayerTester extends GVAbstractTester {
     checkIconsList?: Partial<TypeLegendItem>[]
   ): void {
     // Get the layer legend
-    const legendLayer = getStoreLayerStateLegendLayerByPath(mapId, layerPath);
+    const legendLayer = getStoreLayerLegendLayerByPath(mapId, layerPath);
 
     // Verify the layer has a legend information
     test.addStep(`Verify the layer ${layerPath} has legend information...`);
@@ -1852,7 +1852,7 @@ export class LayerTester extends GVAbstractTester {
     checkIconsList?: Partial<TypeLegendItem>[]
   ): void {
     // Get the layer legend from the store
-    const legendLayer = getStoreLayerStateLegendLayerByPath(mapId, layerPath);
+    const legendLayer = getStoreLayerLegendLayerByPath(mapId, layerPath);
 
     // Verify the icon were also loaded for the layer
     test.addStep(`Verify the icons were loaded for the layer...`);

--- a/packages/geoview-test-suite/src/tests/testers/map-config-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/map-config-tester.ts
@@ -4,17 +4,17 @@ import { Test } from '../core/test';
 import { GVAbstractTester } from './abstract-gv-tester';
 import { delay } from 'geoview-core/core/utils/utilities';
 import {
-  getStoreActiveAppBarTab,
-  getStoreActiveFooterBarTab,
-  getStoreAppBarComponents,
-  getStoreFooterBarComponents,
-  getStoreNavBarComponents,
+  getStoreUIActiveAppBarTab,
+  getStoreUIActiveFooterBarTab,
+  getStoreUIAppBarComponents,
+  getStoreUIFooterBarComponents,
+  getStoreUINavBarComponents,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/ui-state';
 import {
-  getStoreDataTableAllFeaturesArray,
+  getStoreDataTableAllFeaturesDataArray,
   getStoreDataTableSelectedLayerPath,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/data-table-state';
-import { getStoreLayerStateLayerBounds } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
+import { getStoreLayerBounds } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 import { getStoreMapPointMarkers } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
 
 /**
@@ -57,7 +57,7 @@ export class MapConfigTester extends GVAbstractTester {
       (test) => {
         // Verify the footer bar tab is selected
         test.addStep('Verifying data-table tab is selected in footer bar...');
-        const { tabId } = getStoreActiveFooterBarTab(mapId);
+        const { tabId } = getStoreUIActiveFooterBarTab(mapId);
         Test.assertIsEqual(tabId, 'data-table');
 
         // Verify the selected layer path in data table store
@@ -67,7 +67,7 @@ export class MapConfigTester extends GVAbstractTester {
 
         // Verify that layer data exists (table was created)
         test.addStep('Verifying data table is defined...');
-        const allFeaturesData = getStoreDataTableAllFeaturesArray(mapId);
+        const allFeaturesData = getStoreDataTableAllFeaturesDataArray(mapId);
         Test.assertIsDefined('allFeaturesDataArray', allFeaturesData);
 
         // Verify if there is an array of data tables with content
@@ -113,7 +113,7 @@ export class MapConfigTester extends GVAbstractTester {
       (test) => {
         // Verify that data-table is not in footer tabs
         test.addStep('Verifying data-table is selected in app bar...');
-        const activeTab = getStoreActiveAppBarTab(mapId);
+        const activeTab = getStoreUIActiveAppBarTab(mapId);
         Test.assertIsEqual(activeTab.tabId, 'data-table');
 
         // Verify the selected layer path in data table store
@@ -123,7 +123,7 @@ export class MapConfigTester extends GVAbstractTester {
 
         // Verify that layer data exists (table was created)
         test.addStep('Verifying data table is defined...');
-        const allFeaturesData = getStoreDataTableAllFeaturesArray(mapId);
+        const allFeaturesData = getStoreDataTableAllFeaturesDataArray(mapId);
         Test.assertIsDefined('allFeaturesDataArray', allFeaturesData);
 
         // Verify if there is an array of data tables with content
@@ -166,7 +166,7 @@ export class MapConfigTester extends GVAbstractTester {
       (test) => {
         // Verify that footer bar exists with default tabs
         test.addStep('Verifying footer bar has default tabs...');
-        const footerBarTabs = getStoreFooterBarComponents(mapId);
+        const footerBarTabs = getStoreUIFooterBarComponents(mapId);
         Test.assertIsDefined('footerBarTabs', footerBarTabs);
 
         // Verify default tabs are present (layers, data-table)
@@ -175,7 +175,7 @@ export class MapConfigTester extends GVAbstractTester {
 
         // Verify that app bar exists with default tabs
         test.addStep('Verifying app bar has default tabs...');
-        const appBarTabs = getStoreAppBarComponents(mapId);
+        const appBarTabs = getStoreUIAppBarComponents(mapId);
         Test.assertIsDefined('appBarTabs', appBarTabs);
 
         // Verify default tabs are present (geolocator, legend, details, export)
@@ -209,12 +209,12 @@ export class MapConfigTester extends GVAbstractTester {
       (test) => {
         // Verify that footer bar has no tabs
         test.addStep('Verifying footer bar has no tabs...');
-        const footerBarTabs = getStoreFooterBarComponents(mapId);
+        const footerBarTabs = getStoreUIFooterBarComponents(mapId);
         Test.assertIsArrayLengthEqual(footerBarTabs, 0);
 
         // Verify that app bar has no tabs
         test.addStep('Verifying app bar has no tabs...');
-        const appBarTabs = getStoreAppBarComponents(mapId);
+        const appBarTabs = getStoreUIAppBarComponents(mapId);
         Test.assertIsArrayLengthEqual(appBarTabs, 0);
       }
     );
@@ -240,7 +240,7 @@ export class MapConfigTester extends GVAbstractTester {
       (test) => {
         // Verify that navBar exists with default controls
         test.addStep('Verifying navBar has default controls...');
-        const navBarComponents = getStoreNavBarComponents(mapId);
+        const navBarComponents = getStoreUINavBarComponents(mapId);
         Test.assertIsDefined('navBarComponents', navBarComponents);
 
         // Verify default controls are present
@@ -270,7 +270,7 @@ export class MapConfigTester extends GVAbstractTester {
       (test) => {
         // Verify that navBar exists
         test.addStep('Verifying navBar exists...');
-        const navBarComponents = getStoreNavBarComponents(mapId);
+        const navBarComponents = getStoreUINavBarComponents(mapId);
         Test.assertIsDefined('navBarComponents', navBarComponents);
 
         // Verify no buttons are present
@@ -308,7 +308,7 @@ export class MapConfigTester extends GVAbstractTester {
         test.addStep('Getting layer bound extent...');
         const geoviewLayer = newMapViewer.controllers.layerController.getGeoviewLayerRegular('geojsonLYR5/polygons.json');
         Test.assertIsDefined('geoviewLayer', geoviewLayer);
-        const layerExtent = getStoreLayerStateLayerBounds(this.getMapId(), 'geojsonLYR5/polygons.json');
+        const layerExtent = getStoreLayerBounds(this.getMapId(), 'geojsonLYR5/polygons.json');
         Test.assertIsArray(layerExtent);
 
         await delay(2000);

--- a/packages/geoview-test-suite/src/tests/testers/map-config-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/map-config-tester.ts
@@ -514,7 +514,7 @@ export class MapConfigTester extends GVAbstractTester {
 
     // Wait for layer to load and data table to initialize
     test.addStep('Creating the map from config...');
-    const mapViewer = await this.getApi().createMapFromConfig(mapId, JSON.stringify(baseConfig), 500);
+    const mapViewer = await this.getApi().createMapFromConfigFast(mapId, JSON.stringify(baseConfig), 500);
 
     // Replace the map viewer in the tester with the new one created from config
     this.setMapViewer(mapViewer);

--- a/packages/geoview-test-suite/src/tests/testers/map-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/map-tester.ts
@@ -14,8 +14,11 @@ import {
 } from 'geoview-core/core/stores/store-interface-and-intial-values/feature-info-state';
 import type { AbstractGVLayer } from 'geoview-core/geo/layer/gv-layers/abstract-gv-layer';
 import { Projection } from 'geoview-core/geo/utils/projection';
-import { getStoreActiveAppBarTab, getStoreActiveFooterBarTab } from 'geoview-core/core/stores/store-interface-and-intial-values/ui-state';
-import { getStoreDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import {
+  getStoreUIActiveAppBarTab,
+  getStoreUIActiveFooterBarTab,
+} from 'geoview-core/core/stores/store-interface-and-intial-values/ui-state';
+import { getStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import {
   getStoreMapConfigViewSettingsProjection,
   getStoreMapHoverFeatureInfo,
@@ -329,7 +332,7 @@ export class MapTester extends GVAbstractTester {
       },
       (test, result) => {
         test.addStep('Verifying tab is selected...');
-        const { tabId } = getStoreActiveFooterBarTab(this.getMapId());
+        const { tabId } = getStoreUIActiveFooterBarTab(this.getMapId());
         Test.assertIsEqual(tabId, result);
       }
     );
@@ -358,7 +361,7 @@ export class MapTester extends GVAbstractTester {
       },
       (test, result) => {
         test.addStep('Verifying tab is selected...');
-        const activeTab = getStoreActiveAppBarTab(this.getMapId());
+        const activeTab = getStoreUIActiveAppBarTab(this.getMapId());
         Test.assertIsEqual(activeTab?.tabId, result);
       }
     );
@@ -419,7 +422,7 @@ export class MapTester extends GVAbstractTester {
 
         // If either the domain or the store language is set to 'fr'.
         // We typically only need to check the domain, but in this test we can check both too as we'll be asserting the result in the store later.
-        if (this.getMapViewer().getDisplayLanguage() === 'fr' || getStoreDisplayLanguage(this.getMapId()) === 'fr') {
+        if (this.getMapViewer().getDisplayLanguage() === 'fr' || getStoreAppDisplayLanguage(this.getMapId()) === 'fr') {
           throw new TestError(`False precondition, language is already set to '${targetLanguage}'`);
         }
 
@@ -427,7 +430,7 @@ export class MapTester extends GVAbstractTester {
         await this.getMapViewer().setLanguage(targetLanguage);
 
         // Return the display language as read from the store
-        return getStoreDisplayLanguage(this.getMapId());
+        return getStoreAppDisplayLanguage(this.getMapId());
       },
       (test, result) => {
         test.addStep('Verifying language changed...');

--- a/packages/geoview-test-suite/src/tests/testers/ui-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/ui-tester.ts
@@ -1,7 +1,7 @@
 import { Test } from '../core/test';
 import { GVAbstractTester } from './abstract-gv-tester';
 import { delay } from 'geoview-core/core/utils/utilities';
-import { getStoreGeoviewHTMLElement } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { getStoreAppGeoviewHTMLElement } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 
 /**
  * Main UI testing class.
@@ -36,7 +36,7 @@ export class UITester extends GVAbstractTester {
 
         // Get the GeoView HTML element
         test.addStep('Getting GeoView HTML element...');
-        const geoviewElement = getStoreGeoviewHTMLElement(mapId);
+        const geoviewElement = getStoreAppGeoviewHTMLElement(mapId);
 
         // Find the guide-container div
         test.addStep('Finding guide-container div...');

--- a/packages/geoview-time-slider/src/time-slider-panel.tsx
+++ b/packages/geoview-time-slider/src/time-slider-panel.tsx
@@ -4,21 +4,21 @@ import { Layout } from 'geoview-core/core/components/common';
 import type { TypeDisplayLanguage } from 'geoview-core/api/types/map-schema-types';
 import type { TypeTimeSliderValues } from 'geoview-core/core/stores/store-interface-and-intial-values/time-slider-state';
 import {
-  useTimeSliderLayers,
-  useTimeSliderSelectedLayerPath,
+  useStoreTimeSliderLayers,
+  useStoreTimeSliderSelectedLayerPath,
   setStoreTimeSliderSelectedLayerPath,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/time-slider-state';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import {
-  getStoreMapIsLayerHiddenOnMap,
-  useMapAllVisibleandInRangeLayers,
+  useStoreMapAllVisibleandInRangeLayers,
+  useStoreMapIsLayerHiddenOnMapSet,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
 import {
-  useLayerDateTemporalModes,
-  useLayerDisplayDateFormats,
-  useLayerDisplayDateTimezones,
-  useLayerNames,
-  useLayerStatuses,
+  useStoreLayerDateTemporalModeSet,
+  useStoreLayerDisplayDateFormatSet,
+  useStoreLayerDisplayDateTimezoneSet,
+  useStoreLayerNameSet,
+  useStoreLayerStatusSet,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 import { Box } from 'geoview-core/ui';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
@@ -49,15 +49,16 @@ export function TimeSliderPanel(props: TypeTimeSliderProps): JSX.Element {
   const { useCallback, useMemo, useEffect } = reactUtilities.react;
 
   // get values from store
-  const displayLanguage = useAppDisplayLanguage();
-  const visibleInRangeLayers = useMapAllVisibleandInRangeLayers();
-  const timeSliderLayers = useTimeSliderLayers()!;
-  const selectedLayerPath = useTimeSliderSelectedLayerPath();
-  const layerNames = useLayerNames();
-  const layerStatuses = useLayerStatuses();
-  const layerDisplayDateFormats = useLayerDisplayDateFormats();
-  const layerDisplayDateTimezones = useLayerDisplayDateTimezones();
-  const layerTemporalModes = useLayerDateTemporalModes();
+  const displayLanguage = useStoreAppDisplayLanguage();
+  const layerHiddenSet = useStoreMapIsLayerHiddenOnMapSet();
+  const visibleInRangeLayers = useStoreMapAllVisibleandInRangeLayers();
+  const layerNames = useStoreLayerNameSet();
+  const layerStatuses = useStoreLayerStatusSet();
+  const layerDisplayDateFormats = useStoreLayerDisplayDateFormatSet();
+  const layerDisplayDateTimezones = useStoreLayerDisplayDateTimezoneSet();
+  const layerTemporalModes = useStoreLayerDateTemporalModeSet();
+  const timeSliderLayers = useStoreTimeSliderLayers()!;
+  const selectedLayerPath = useStoreTimeSliderSelectedLayerPath();
 
   // #region Handlers
 
@@ -143,16 +144,12 @@ export function TimeSliderPanel(props: TypeTimeSliderProps): JSX.Element {
           return false;
         }
 
-        // TODO: CHECK -This should likely go through a Zustand hook instead of a state getter
         // Check if main layer is hidden (includes out of scale check)
-        const mainLayerHidden = getStoreMapIsLayerHiddenOnMap(mapId, layer.layerPath);
+        const mainLayerHidden = layerHiddenSet[layer.layerPath];
 
         // For custom time slider with additional layers, check if any additional layer is visible
         if (layer.timeSliderLayerInfo.additionalLayerpaths && layer.timeSliderLayerInfo.additionalLayerpaths.length > 0) {
-          const hasVisibleAdditionalLayer = layer.timeSliderLayerInfo.additionalLayerpaths.some(
-            (layerPath) => !getStoreMapIsLayerHiddenOnMap(mapId, layerPath)
-          );
-          // TODO: CHECK -This should likely go through a Zustand hook instead of a state getter (line above)
+          const hasVisibleAdditionalLayer = layer.timeSliderLayerInfo.additionalLayerpaths.some((layerPath) => !layerHiddenSet[layerPath]);
 
           // Show if main layer is visible OR any additional layer is visible
           if (mainLayerHidden && !hasVisibleAdditionalLayer) {
@@ -191,7 +188,7 @@ export function TimeSliderPanel(props: TypeTimeSliderProps): JSX.Element {
           layerUniqueId: `${mapId}-${TABS.TIME_SLIDER}-${layer.layerPath}`,
         } as LayerListEntry;
       });
-  }, [timeSliderLayers, visibleInRangeLayers, getFilterInfo, layerStatuses, layerNames, displayLanguage, mapId]);
+  }, [timeSliderLayers, visibleInRangeLayers, getFilterInfo, layerStatuses, layerNames, layerHiddenSet, displayLanguage, mapId]);
 
   /**
    * Unselects the layer if it's removed from the visibility array.

--- a/packages/geoview-time-slider/src/time-slider.tsx
+++ b/packages/geoview-time-slider/src/time-slider.tsx
@@ -5,7 +5,7 @@ import {
   setStoreTimeSliderLocked,
   setStoreTimeSliderReversed,
   setStoreTimeSliderStep,
-  useStoreTimeSliderLayers,
+  useStoreTimeSliderLayer,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/time-slider-state';
 import {
   useStoreLayerDateTemporalMode,
@@ -92,8 +92,7 @@ export function TimeSlider(props: TimeSliderProps): JSX.Element {
     displayDateFormatShort: displayDateFormatShortFromStore,
     displayDateTimezone: displayDateTimezoneFromStore,
     serviceDateTemporalMode: serviceDateTemporalModeFromStore,
-  } = useStoreTimeSliderLayers()![layerPath];
-  // TODO: CHECK - The above should probably use the 'useStoreTimeSliderLayer' hook, cleaner
+  } = useStoreTimeSliderLayer(layerPath)!;
 
   const timeSliderController = useTimeSliderController();
 

--- a/packages/geoview-time-slider/src/time-slider.tsx
+++ b/packages/geoview-time-slider/src/time-slider.tsx
@@ -1,21 +1,21 @@
 import { Box } from 'geoview-core/ui';
-import { useGeoViewMapId } from 'geoview-core/core/stores/geoview-store';
+import { useStoreGeoViewMapId } from 'geoview-core/core/stores/geoview-store';
 import {
   setStoreTimeSliderDelay,
   setStoreTimeSliderLocked,
   setStoreTimeSliderReversed,
   setStoreTimeSliderStep,
-  useTimeSliderLayers,
+  useStoreTimeSliderLayers,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/time-slider-state';
 import {
-  useLayerDateTemporalMode,
-  useLayerDisplayDateFormat,
-  useLayerDisplayDateFormatShort,
-  useLayerDisplayDateTimezone,
-  useLayerNames,
+  useStoreLayerDateTemporalMode,
+  useStoreLayerDisplayDateFormat,
+  useStoreLayerDisplayDateFormatShort,
+  useStoreLayerDisplayDateTimezone,
+  useStoreLayerNameSet,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
-import { useAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import { logger } from 'geoview-core/core/utils/logger';
 
 import { DateMgt } from 'geoview-core/core/utils/date-mgt';
@@ -71,8 +71,8 @@ export function TimeSlider(props: TimeSliderProps): JSX.Element {
   const sliderValueRef = useRef<number>();
   const sliderDeltaRef = useRef<number>();
 
-  const mapId = useGeoViewMapId();
-  const displayLanguage = useAppDisplayLanguage();
+  const mapId = useStoreGeoViewMapId();
+  const displayLanguage = useStoreAppDisplayLanguage();
 
   const {
     title,
@@ -92,28 +92,29 @@ export function TimeSlider(props: TimeSliderProps): JSX.Element {
     displayDateFormatShort: displayDateFormatShortFromStore,
     displayDateTimezone: displayDateTimezoneFromStore,
     serviceDateTemporalMode: serviceDateTemporalModeFromStore,
-  } = useTimeSliderLayers()![layerPath];
+  } = useStoreTimeSliderLayers()![layerPath];
+  // TODO: CHECK - The above should probably use the 'useStoreTimeSliderLayer' hook, cleaner
 
   const timeSliderController = useTimeSliderController();
 
   // The display date format as specified by the layer
-  const layerDisplayDateFormat = useLayerDisplayDateFormat(layerPath);
+  const layerDisplayDateFormat = useStoreLayerDisplayDateFormat(layerPath);
   const displayDateFormat = displayDateFormatFromStore ?? layerDisplayDateFormat;
 
   // The display date format as specified by the layer
-  const layerDisplayDateFormatShort = useLayerDisplayDateFormatShort(layerPath);
+  const layerDisplayDateFormatShort = useStoreLayerDisplayDateFormatShort(layerPath);
   const displayDateFormatShort = displayDateFormatShortFromStore ?? layerDisplayDateFormatShort ?? displayDateFormat;
 
   // The display date timezone as specified by the layer
-  const layerDisplayDateTimezone = useLayerDisplayDateTimezone(layerPath);
+  const layerDisplayDateTimezone = useStoreLayerDisplayDateTimezone(layerPath);
   const displayDateTimezone = displayDateTimezoneFromStore ?? layerDisplayDateTimezone;
 
   // The temporal mode as specified by the layer
-  const layerTemporalMode = useLayerDateTemporalMode(layerPath);
+  const layerTemporalMode = useStoreLayerDateTemporalMode(layerPath);
   const serviceDateTemporalMode = serviceDateTemporalModeFromStore ?? layerTemporalMode;
 
   // Get name from legend layers
-  const names = useLayerNames();
+  const names = useStoreLayerNameSet();
   const name = names[layerPath];
   const additionalNames = additionalLayerpaths?.map((additionalLayerPath) => names[additionalLayerPath]);
   const combinedNames = additionalNames ? `${name}, ${additionalNames.join(', ')}` : name;


### PR DESCRIPTION
# Description

- Enforcing a naming convention for the store states (getters vs users) such as `getStoreUINavBarComponents` and `useStoreUINavbarComponents` to facilitate reading when the value comes from a get vs when it's a hook on state.
- Now properly handling the layer message thrown by the layer domain to show notifications (the fetch message in https://canadian-geospatial-platform.github.io/geoview/public/outlier-GeoAI.html).
- Removed the spread and the mutations happening in the legendLayers when assigning values (very impacting, much cleaner immutable pattern following Zustand best-practices).
- Performance gains by removing the useStoreLayerLegendLayers hook and review its prior use in left-panel, layers-list, layers-toolbar, single-layer, legend-fullscreen and legend components.
- Removed the spread happening in setOrderedLayerInfo to prevent over-triggering renders.
- IMPORTANT: Not propagating to the store the whole legendsLayer anymore on every layer status change.
- TypeScript typing fix when an item label is truly optional, better handling of the scenario too.
- Improved stability of the show coordinate info when the external services are slow or unresponsive + added notification.
- Improved the store hooks in the details panel component notably with regards to the query status which was pointing to the batched result (delayed) - now it's more responsive.
- Improved rendering performance of the details panel with the show coordinate info switch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

~~Hosted March 7 @ 11h30 : https://alex-nrcan.github.io/geoview/~~
~~Hosted March 7 @ 17h00 : https://alex-nrcan.github.io/geoview/~~
~~Hosted March 8 @ 17h45 : https://alex-nrcan.github.io/geoview/~~
Hosted March 9 @ 17h45 : https://alex-nrcan.github.io/geoview/

# Checklist:

- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3400)
<!-- Reviewable:end -->
