### PR TITLE
optimization(controllers-store) - Various enhancements regarding the controllers/store separation of concerns and bug fixes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -296,6 +296,15 @@ const handleClickWrapper = useCallback(
 - Reduces unnecessary re-renders of memoized child components
 - Module-level constants (`const FADE_DURATION = 200`) belong **outside** the component function to avoid re-creation on every render
 
+**Dependency Array Hygiene:**
+
+**Remove any variable from a `useEffect`/`useCallback`/`useMemo` dependency array that is not actually used inside the hook body.** Do this proactively — do not wait to be asked. This includes:
+- Stable `useCallback(fn, [])` references listed out of habit
+- `useState` setters (always stable, never needed as deps)
+- Ref objects (`useRef` — always stable)
+
+The one legitimate exception is a "trigger token" — a value whose identity change drives re-execution even though its value isn't consumed inside the body. In that case, add an explicit comment explaining why.
+
 **useMemo Naming Convention:**
 
 When using `useMemo`, prefix the variable name with `memo` followed by camelCase:

--- a/packages/geoview-core/public/configs/navigator/layers/esri-dynamic.json
+++ b/packages/geoview-core/public/configs/navigator/layers/esri-dynamic.json
@@ -40,7 +40,12 @@
         "listOfLayerEntryConfig": [
           {
             "layerId": "4",
-            "layerName": "Test"
+            "layerName": "Test",
+            "initialSettings": {
+              "states": {
+                "legendCollapsed": false
+              }
+            }
           },
           {
             "layerId": "1",

--- a/packages/geoview-core/public/configs/navigator/layers/vector-tile.json
+++ b/packages/geoview-core/public/configs/navigator/layers/vector-tile.json
@@ -5,8 +5,8 @@
       "projection": 3978
     },
     "basemapOptions": {
-      "basemapId": "transport",
-      "shaded": true,
+      "basemapId": "imagery",
+      "shaded": false,
       "labeled": false
     },
     "listOfGeoviewLayerConfig": [

--- a/packages/geoview-core/public/configs/navigator/layers/vector-tile.json
+++ b/packages/geoview-core/public/configs/navigator/layers/vector-tile.json
@@ -5,8 +5,8 @@
       "projection": 3978
     },
     "basemapOptions": {
-      "basemapId": "nogeom",
-      "shaded": false,
+      "basemapId": "transport",
+      "shaded": true,
       "labeled": false
     },
     "listOfGeoviewLayerConfig": [

--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -550,7 +550,7 @@
       "loadingLayers": "Loading layers..."
     },
     "geocore": {
-      "uuidNotFound": "GeoCore layer identifier '__param__' does not exist on the server.",
+      "serviceFail": "GeoCore service is unresponsive for UUID '__param__'.",
       "invalidResponse": "Invalid response '__param__' from GeoCore service for UUID '__param__'.",
       "noLayer": "No layers returned by GeoCore service for UUID '__param__'."
     },

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -550,7 +550,7 @@
       "loadingLayers": "Chargement des couches..."
     },
     "geocore": {
-      "uuidNotFound": "L'identifiant de couche GeoCore '__param__' n'existe pas sur le serveur.",
+      "serviceFail": "Le service Geocore ne répond pas pour UUID '__param__'.",
       "invalidResponse": "Réponse invalide '__param__' retournée par le service GeoCore pour UUID '__param__'.",
       "noLayer": "Aucune couche retournée par le service GeoCore pour UUID '__param__'."
     },

--- a/packages/geoview-core/src/api/config/config-api.ts
+++ b/packages/geoview-core/src/api/config/config-api.ts
@@ -437,7 +437,10 @@ export class ConfigApi {
    * @param mapId - Optional map id, used for the geocore layer types, to determine the layer id
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
    * @returns A promise that resolves with a fully initialized TypeGeoviewLayerConfig
-   * @throws {NotSupportedError} When the provided layer type is not recognized or supported
+   * @throws {LayerGeoCoreServiceFailError} When the Geocore service fails to respond
+   * @throws {LayerGeoCoreInvalidResponseError} When the Geocore service fails to respond with a valid payload
+   * @throws {LayerGeoCoreNoLayersError} When the Geocore service responds a 'valid' payload with missing layers information
+   * @throws {NotSupportedError} When the provided layer type or the layer type read in the layerType property from Geocore payload isn't a supported type
    */
   static async createInitConfigFromType(
     layerType: TypeInitialGeoviewLayerType,

--- a/packages/geoview-core/src/api/config/geocore.ts
+++ b/packages/geoview-core/src/api/config/geocore.ts
@@ -6,7 +6,7 @@ import { generateId } from '@/core/utils/utilities';
 
 import type { TypeDisplayLanguage } from '@/api/types/map-schema-types';
 import { DEFAULT_MAP_FEATURE_CONFIG } from '@/api/types/map-schema-types';
-import type { GeoCoreLayerConfig, RCSLayerConfig, TypeGeoviewLayerConfig } from '@/api/types/layer-schema-types';
+import type { GeoCoreLayerConfig, TypeGeoviewLayerConfig } from '@/api/types/layer-schema-types';
 import type { GeoViewError } from '@/core/exceptions/geoview-exceptions';
 import { getStoreMapConfigServiceUrls, getStoreMapConfigState } from '@/core/stores/store-interface-and-intial-values/map-state';
 
@@ -21,6 +21,10 @@ export class GeoCore {
    * @param layerConfig - Optional layer configuration
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
    * @returns A promise that resolves with the layer configuration and associated geocharts
+   * @throws {LayerGeoCoreServiceFailError} When the Geocore service fails to respond
+   * @throws {LayerGeoCoreInvalidResponseError} When the Geocore service fails to respond with a valid payload
+   * @throws {LayerGeoCoreNoLayersError} When the Geocore service responds a 'valid' payload with missing layers information
+   * @throws {NotSupportedError} When the layer type read in the layerType property from Geocore payload isn't a supported type
    */
   static async createLayerConfigFromUUID(
     uuid: string,
@@ -106,15 +110,17 @@ export class GeoCore {
    * @param uuid - The UUID of the layer
    * @param language - The language
    * @param mapId - The map identifier
-   * @param layerConfig - Optional layer configuration
    * @param abortSignal - Optional {@link AbortSignal} used to handle cancelling of fetch
    * @returns A promise that resolves with the layer configuration to add to the map
+   * @throws {LayerGeoCoreServiceFailError} When the Geocore service fails to respond
+   * @throws {LayerGeoCoreInvalidResponseError} When the Geocore service fails to respond with a valid payload
+   * @throws {LayerGeoCoreNoLayersError} When the Geocore service responds a 'valid' payload with missing layers information
+   * @throws {NotSupportedError} When the layer type read in the layerType property from Geocore payload isn't a supported type
    */
   static async createLayerConfigFromRCSUUID(
     uuid: string,
     language: TypeDisplayLanguage,
     mapId: string,
-    layerConfig?: RCSLayerConfig,
     abortSignal?: AbortSignal
   ): Promise<TypeGeoviewLayerConfig> {
     // Get the map config and rcsUrl if it overrides the default

--- a/packages/geoview-core/src/api/config/map-feature-config.ts
+++ b/packages/geoview-core/src/api/config/map-feature-config.ts
@@ -21,7 +21,7 @@ import {
   VALID_BASEMAP_ID,
   MAP_CENTER,
   MAP_ZOOM_LEVEL,
-  MAX_EXTENTS_RESTRICTION,
+  MAX_EXTENTS_RESTRICTION_LONLAT,
 } from '@/api/types/map-schema-types';
 import { deepMerge } from '@/core/utils/utilities';
 import { logger } from '@/core/utils/logger';
@@ -102,7 +102,7 @@ export class MapFeatureConfig {
     if (!VALID_PROJECTION_CODES.includes(this.map.viewSettings.projection)) {
       logger.logWarning(`Invalid projection code '${this.map.viewSettings.projection}', defaulting to 3978`);
       this.map.viewSettings.projection = DEFAULT_MAP_FEATURE_CONFIG.map.viewSettings.projection;
-      this.map.viewSettings.maxExtent = MAX_EXTENTS_RESTRICTION[this.map.viewSettings.projection];
+      this.map.viewSettings.maxExtent = MAX_EXTENTS_RESTRICTION_LONLAT[this.map.viewSettings.projection];
       this.map.viewSettings.initialView = {
         zoomAndCenter: [MAP_ZOOM_LEVEL[this.map.viewSettings.projection], MAP_CENTER[this.map.viewSettings.projection]],
       };
@@ -152,7 +152,7 @@ export class MapFeatureConfig {
       projection && VALID_PROJECTION_CODES.includes(projection) ? projection : DEFAULT_MAP_FEATURE_CONFIG.map.viewSettings.projection;
 
     // Set values specific to projection
-    mapConfig.viewSettings.maxExtent = MAX_EXTENTS_RESTRICTION[proj];
+    mapConfig.viewSettings.maxExtent = MAX_EXTENTS_RESTRICTION_LONLAT[proj];
     mapConfig.viewSettings.initialView = { zoomAndCenter: [MAP_ZOOM_LEVEL[proj], MAP_CENTER[proj]] };
 
     // Return it

--- a/packages/geoview-core/src/api/config/reader/uuid-config-reader.ts
+++ b/packages/geoview-core/src/api/config/reader/uuid-config-reader.ts
@@ -17,9 +17,9 @@ import { WMTS } from '@/geo/layer/geoview-layers/raster/wmts';
 import { XYZTiles } from '@/geo/layer/geoview-layers/raster/xyz-tiles';
 
 import {
+  LayerGeoCoreServiceFailError,
   LayerGeoCoreInvalidResponseError,
   LayerGeoCoreNoLayersError,
-  LayerGeoCoreUUIDNotFoundError,
 } from '@/core/exceptions/geocore-exceptions';
 import { Fetch } from '@/core/utils/fetch-helper';
 import { formatError, NotSupportedError } from '@/core/exceptions/core-exceptions';
@@ -35,6 +35,10 @@ export class UUIDmapConfigReader {
    * @param uuids - A list of uuids to get the configurations for
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
    * @returns A promise that resolves with the layers and geocharts parsed from GeoCore
+   * @throws {LayerGeoCoreServiceFailError} When the Geocore service fails to respond
+   * @throws {LayerGeoCoreInvalidResponseError} When the Geocore service fails to respond with a valid payload
+   * @throws {LayerGeoCoreNoLayersError} When the Geocore service responds a 'valid' payload with missing layers information
+   * @throws {NotSupportedError} When the layer type read in the layerType property from Geocore payload isn't a supported type
    */
   static async getGVConfigFromUUIDs(
     baseUrl: string,
@@ -57,7 +61,7 @@ export class UUIDmapConfigReader {
       };
     } catch (error: unknown) {
       // If the promise had failed
-      if (!result) throw new LayerGeoCoreUUIDNotFoundError(uuids, formatError(error));
+      if (!result) throw new LayerGeoCoreServiceFailError(uuids, formatError(error));
 
       // Re-throw the original error otherwise
       throw error;
@@ -72,6 +76,10 @@ export class UUIDmapConfigReader {
    * @param uuids - A list of uuids to get the configurations for
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
    * @returns A promise that resolves with the layers parsed from Geonetwork RCS
+   * @throws {LayerGeoCoreServiceFailError} When the Geocore service fails to respond
+   * @throws {LayerGeoCoreInvalidResponseError} When the Geocore service fails to respond with a valid payload
+   * @throws {LayerGeoCoreNoLayersError} When the Geocore service responds a 'valid' payload with missing layers information
+   * @throws {NotSupportedError} When the layer type read in the layerType property from Geocore payload isn't a supported type
    */
   static async getGVConfigFromUUIDsRCS(
     baseUrl: string,
@@ -100,7 +108,7 @@ export class UUIDmapConfigReader {
       };
     } catch (error: unknown) {
       // If the promise had failed
-      if (!result) throw new LayerGeoCoreUUIDNotFoundError(uuids, formatError(error));
+      if (!result) throw new LayerGeoCoreServiceFailError(uuids, formatError(error));
 
       // Re-throw the original error otherwise
       throw error;
@@ -114,6 +122,9 @@ export class UUIDmapConfigReader {
    * @param resultData - The uuid request result
    * @param lang - The language to use
    * @returns The layers parsed from uuid result
+   * @throws {LayerGeoCoreInvalidResponseError} When the Geocore service fails to respond with a valid payload
+   * @throws {LayerGeoCoreNoLayersError} When the Geocore service responds a 'valid' payload with missing layers information
+   * @throws {NotSupportedError} When the layer type read in the layerType property from Geocore payload isn't a supported type
    */
   static #getLayerConfigFromResponse(
     uuids: string[],
@@ -121,16 +132,15 @@ export class UUIDmapConfigReader {
     lang: TypeDisplayLanguage
   ): TypeGeoviewLayerConfig[] {
     // If invalid response
-    if (
-      !resultData ||
-      !resultData.response ||
-      !resultData.response.rcs ||
-      !resultData.response.rcs[lang] ||
-      resultData.response.rcs[lang].length === 0
-    ) {
+    if (!resultData || !resultData.response || !resultData.response.rcs || !resultData.response.rcs[lang]) {
       const errorMessage = resultData?.errorMessage || '<no error description>';
       throw new LayerGeoCoreInvalidResponseError(uuids, errorMessage);
     }
+
+    // Make sure it's an array
+    if (!Array.isArray(resultData.response.rcs[lang])) throw new LayerGeoCoreInvalidResponseError(uuids, 'empty object in rcs response');
+
+    // It's an array, it has to contain something
     if (resultData.response.rcs[lang].length === 0) throw new LayerGeoCoreNoLayersError(uuids);
 
     const listOfGeoviewLayerConfig: TypeGeoviewLayerConfig[] = [];
@@ -310,7 +320,8 @@ export type GeoCoreConfigResponseRoot = {
 };
 
 export type GeoCoreConfigResponse = {
-  rcs: Record<TypeDisplayLanguage, GeoCoreConfigResponseRCSLayers[]>;
+  // GV When Geocore fails, the payload may have an object in the rcs.en property, hence the 'GeoCoreConfigResponseRCSLayers[] | object' typing here
+  rcs: Record<TypeDisplayLanguage, GeoCoreConfigResponseRCSLayers[] | object>;
   gcs: Record<TypeDisplayLanguage, GeoCoreConfigResponseGCSLayers>[];
 };
 

--- a/packages/geoview-core/src/api/plugin/abstract-plugin.ts
+++ b/packages/geoview-core/src/api/plugin/abstract-plugin.ts
@@ -3,6 +3,7 @@ import type { createRoot } from 'react-dom/client';
 import type i18next from 'react-i18next';
 import type { useTheme } from '@mui/material/styles';
 
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
 import type { MapViewer } from '@/geo/map/map-viewer';
 import { logger } from '@/core/utils/logger';
 
@@ -15,6 +16,9 @@ export abstract class AbstractPlugin {
 
   /** The map viewer for the plugin */
   mapViewer: MapViewer;
+
+  /** The controller registry for the plugin */
+  controllerRegistry: ControllerRegistry;
 
   /** The plugin properties */
   pluginProps?: unknown;
@@ -39,12 +43,14 @@ export abstract class AbstractPlugin {
    *
    * @param pluginId - Unique identifier for the plugin instance
    * @param mapViewer - The map viewer
+   * @param controllerRegistry - The controller registry
    * @param props - Optional plugin options and properties
    */
-  // GV Do not edit the constructor params without editing the plugin.ts dynamic constructor call looking like 'new (constructor as any)'
-  constructor(pluginId: string, mapViewer: MapViewer, props: unknown | undefined) {
+  // GV Do not edit the constructor params without editing the plugin-controller.addPlugin dynamic constructor call looking like 'new (constructor as any)'
+  constructor(pluginId: string, mapViewer: MapViewer, controllerRegistry: ControllerRegistry, props: unknown | undefined) {
     this.pluginId = pluginId;
     this.mapViewer = mapViewer;
+    this.controllerRegistry = controllerRegistry;
     this.pluginProps = props;
     this.react = window.cgpv.reactUtilities.react;
     this.createRoot = window.cgpv.reactUtilities.createRoot;

--- a/packages/geoview-core/src/api/plugin/appbar-plugin.ts
+++ b/packages/geoview-core/src/api/plugin/appbar-plugin.ts
@@ -92,6 +92,12 @@ export abstract class AppBarPlugin extends AbstractPlugin {
 
     // Create a new button panel on the app-bar
     this.buttonPanel = this.mapViewer.appBarApi.createAppbarPanel(this.buttonProps, this.panelProps) || undefined;
+
+    // If it should be opened from the start
+    if (this.getConfig().isOpen) {
+      // Make sure the app bar is open if the config says it should be
+      this.controllerRegistry.uiController.setActiveAppBarTab(this.pluginId, true, false);
+    }
   }
 
   /**

--- a/packages/geoview-core/src/api/plugin/footer-plugin.ts
+++ b/packages/geoview-core/src/api/plugin/footer-plugin.ts
@@ -1,6 +1,7 @@
 import type { TypeTabs } from '@/ui/tabs/tabs';
 import { logger } from '@/core/utils/logger';
 import { AbstractPlugin } from './abstract-plugin';
+import { getStoreUIFooterTabs } from '@/core/stores/store-interface-and-intial-values/ui-state';
 
 /**
  * Footer Plugin abstract class.
@@ -45,8 +46,8 @@ export abstract class FooterPlugin extends AbstractPlugin {
     // Log
     // No need to log, parent class does it well already via added() function.
 
-    // Set value to length of tabs(?)
-    this.value = this.mapViewer.footerBarApi.tabs.length;
+    // Set value to length of tabs from the store
+    this.value = getStoreUIFooterTabs(this.mapViewer.mapId).length;
 
     // Create props
     this.footerProps = this.onCreateContentProps();

--- a/packages/geoview-core/src/api/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/types/map-schema-types.ts
@@ -76,8 +76,29 @@ export type TypeValidNavBarProps =
   | 'projection'
   | 'drawer';
 
+/** Built-in nav bar core components that are not plugins. */
+export const DEFAULT_NAVBAR_CORE = {
+  ZOOM: 'zoom',
+  ROTATION: 'rotation',
+  FULLSCREEN: 'fullscreen',
+  HOME: 'home',
+  LOCATION: 'location',
+  BASEMAP_SELECT: 'basemap-select',
+  MEASUREMENT: 'measurement',
+  PROJECTION: 'projection',
+} as const;
+
 /** Supported footer bar tabs */
 export type TypeValidFooterBarTabsCoreProps = 'legend' | 'layers' | 'details' | 'data-table' | 'time-slider' | 'geochart' | 'guide';
+
+/** Built-in footer bar core components that are not plugins. */
+export const DEFAULT_FOOTERBAR_CORE = {
+  LEGEND: 'legend',
+  LAYERS: 'layers',
+  DETAILS: 'details',
+  DATA_TABLE: 'data-table',
+  GUIDE: 'guide',
+} as const;
 
 /** Default tabs order */
 export const DEFAULT_FOOTER_TABS_ORDER = ['legend', 'layers', 'details', 'geochart', 'time-slider', 'data-table', 'guide'];

--- a/packages/geoview-core/src/api/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/types/map-schema-types.ts
@@ -379,13 +379,13 @@ export const VALID_MAP_CENTER: Record<TypeValidMapProjectionCodes, Record<string
 // Map view extents for each projection
 export const MAP_EXTENTS: Record<TypeValidMapProjectionCodes, number[]> = {
   3857: [-180, 0, 80, 84],
-  // TODO: tighten these up for initial view now that we have a separate MAX_EXTENTS_RESTRICTION
+  // TODO: tighten these up for initial view now that we have a separate MAX_EXTENTS_RESTRICTION_LONLAT
   3978: [-150, -10, -30, 90],
   3573: [-180, 45, 180, 90],
 };
 
 // Extent restrictions for each projection
-export const MAX_EXTENTS_RESTRICTION: Record<TypeValidMapProjectionCodes, number[]> = {
+export const MAX_EXTENTS_RESTRICTION_LONLAT: Record<TypeValidMapProjectionCodes, number[]> = {
   3857: [-180, -85.05112877980659, 180, 85.05112877980659],
   3978: [-150, -10, -30, 90],
   3573: [-180, 45, 180, 90],

--- a/packages/geoview-core/src/core/components/app-bar/app-bar-api.ts
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar-api.ts
@@ -3,8 +3,6 @@ import { CONST_PANEL_TYPES } from '@/ui/panel/panel-types';
 import type { IconButtonPropsExtend } from '@/ui/icon-button/icon-button';
 
 import { generateId } from '@/core/utils/utilities';
-import type { EventDelegateBase } from '@/api/events/event-helper';
-import EventHelper from '@/api/events/event-helper';
 import { getStoreUIActiveAppBarTab, type ActiveAppBarTabType } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import type { UIController } from '@/core/controllers/ui-controller';
 import { logger } from '@/core/utils/logger';
@@ -13,17 +11,11 @@ import { logger } from '@/core/utils/logger';
  * Class to manage buttons on the app-bar.
  */
 export class AppBarApi {
-  /** The UI controller */
+  /** The UI controller. */
   #uiController: UIController;
 
-  /** Button panels registered on the app-bar, keyed by panel id. */
+  /** Button panels registered on the app-bar, keyed by panel id (content registry — ReactNodes stay outside the store). */
   buttons: Record<string, TypeButtonPanel> = {};
-
-  /** Callback handlers for the AppBar created event. */
-  #onAppBarCreatedHandlers: AppBarCreatedDelegate[] = [];
-
-  /** Callback handlers for the AppBar removed event. */
-  #onAppBarRemovedHandlers: AppBarRemovedDelegate[] = [];
 
   /**
    * Instantiates an AppBarApi class.
@@ -36,66 +28,6 @@ export class AppBarApi {
   }
 
   /**
-   * Emits an event to all registered AppBar created event handlers.
-   *
-   * @param event - The event to emit
-   */
-  #emitAppBarCreated(event: AppBarCreatedEvent): void {
-    // Emit the AppBar created event
-    EventHelper.emitEvent(this, this.#onAppBarCreatedHandlers, event);
-  }
-
-  /**
-   * Registers an event handler for AppBar created events.
-   *
-   * @param callback - The callback to be executed whenever the event is emitted
-   */
-  onAppBarCreated(callback: AppBarCreatedDelegate): void {
-    // Register the AppBar created event callback
-    EventHelper.onEvent(this.#onAppBarCreatedHandlers, callback);
-  }
-
-  /**
-   * Unregisters an event handler for AppBar created events.
-   *
-   * @param callback - The callback to stop being called whenever the event is emitted
-   */
-  offAppBarCreated(callback: AppBarCreatedDelegate): void {
-    // Unregister the AppBar created event callback
-    EventHelper.offEvent(this.#onAppBarCreatedHandlers, callback);
-  }
-
-  /**
-   * Emits an event to all registered AppBar removed event handlers.
-   *
-   * @param event - The event to emit
-   */
-  #emitAppBarRemoved(event: AppBarRemovedEvent): void {
-    // Emit the AppBar removed event
-    EventHelper.emitEvent(this, this.#onAppBarRemovedHandlers, event);
-  }
-
-  /**
-   * Registers an event handler for AppBar removed events.
-   *
-   * @param callback - The callback to be executed whenever the event is emitted
-   */
-  onAppBarRemoved(callback: AppBarRemovedDelegate): void {
-    // Register the AppBar removed event callback
-    EventHelper.onEvent(this.#onAppBarRemovedHandlers, callback);
-  }
-
-  /**
-   * Unregisters an event handler for AppBar removed events.
-   *
-   * @param callback - The callback to stop being called whenever the event is emitted
-   */
-  offAppBarRemoved(callback: AppBarRemovedDelegate): void {
-    // Unregister the AppBar removed event callback
-    EventHelper.offEvent(this.#onAppBarRemovedHandlers, callback);
-  }
-
-  /**
    * Creates a button on the app-bar that will open a panel.
    *
    * @param buttonProps - Button properties (icon, tooltip)
@@ -105,6 +37,9 @@ export class AppBarApi {
   createAppbarPanel(buttonProps: IconButtonPropsExtend, panelProps: TypePanelProps): TypeButtonPanel | null {
     if (buttonProps && panelProps) {
       const buttonPanelId = buttonProps.id || generateId(18);
+
+      // Skip if already registered
+      if (this.buttons[buttonPanelId]) return this.buttons[buttonPanelId];
 
       const button: IconButtonPropsExtend = {
         ...buttonProps,
@@ -124,11 +59,11 @@ export class AppBarApi {
         button,
       };
 
-      // add the new button panel
+      // Register in the content registry
       if (buttonPanelId !== '__proto__') this.buttons[buttonPanelId] = buttonPanel;
 
-      // trigger an event that a new button panel has been created to update the state and re-render
-      this.#emitAppBarCreated({ buttonPanelId, buttonPanel });
+      // Write panel id to the store so the UI reacts immediately
+      this.#uiController.addAppBarPanelId(buttonPanelId);
 
       return buttonPanel;
     }
@@ -143,22 +78,13 @@ export class AppBarApi {
    * @returns The matching button panel, or null if not found
    */
   getAppBarButtonPanelById(buttonPanelId: string): TypeButtonPanel | null {
-    // loop through groups of app-bar button panels
-    for (let i = 0; i < Object.keys(this.buttons).length; i++) {
-      const buttonPanel: TypeButtonPanel = this.buttons[i];
-
-      if (buttonPanel.buttonPanelId === buttonPanelId) {
-        return buttonPanel;
-      }
-    }
-
-    return null;
+    return this.buttons[buttonPanelId] ?? null;
   }
 
   /**
    * Gets the active app bar tab.
    *
-   * @returns The active app bar tab info.
+   * @returns The active app bar tab info
    * @deprecated Legacy support. Should be removed.
    */
   getActiveAppBarTab(): ActiveAppBarTabType {
@@ -172,14 +98,14 @@ export class AppBarApi {
    */
   removeAppbarPanel(buttonPanelId: string): void {
     try {
-      // delete the panel from the group
+      // Delete from content registry
       delete this.buttons[buttonPanelId];
 
-      // trigger an event that a panel has been removed to update the state and re-render
-      this.#emitAppBarRemoved({ buttonPanelId });
+      // Remove from the store
+      this.#uiController.removeAppBarPanelId(buttonPanelId);
     } catch (error: unknown) {
       // Log
-      logger.logError(`Failed to get app bar panel button ${buttonPanelId}`, error);
+      logger.logError(`Failed to remove app bar panel button ${buttonPanelId}`, error);
     }
   }
 
@@ -196,20 +122,3 @@ export class AppBarApi {
     this.#uiController.setActiveAppBarTab(tabId, open, isFocusTrapped);
   }
 }
-
-/** Event payload emitted when an AppBar button panel is created. */
-export type AppBarCreatedEvent = {
-  buttonPanelId: string;
-  buttonPanel: TypeButtonPanel;
-};
-
-/** Delegate type for AppBar created event handlers. */
-type AppBarCreatedDelegate = EventDelegateBase<AppBarApi, AppBarCreatedEvent, void>;
-
-/** Event payload emitted when an AppBar button panel is removed. */
-export type AppBarRemovedEvent = {
-  buttonPanelId: string;
-};
-
-/** Delegate type for AppBar removed event handlers. */
-type AppBarRemovedDelegate = EventDelegateBase<AppBarApi, AppBarRemovedEvent, void>;

--- a/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { ReactNode, KeyboardEvent } from 'react';
-import { useState, useEffect, useCallback, Fragment, useMemo } from 'react';
+import { useEffect, useCallback, Fragment, useMemo } from 'react';
 import { useTheme } from '@mui/material/styles';
 import type { IconButtonPropsExtend } from '@/ui';
 import {
@@ -16,7 +16,7 @@ import {
   LayersOutlinedIcon,
 } from '@/ui';
 
-import { usePluginController, useUIController } from '@/core/controllers/use-controllers';
+import { useMapController, useUIController } from '@/core/controllers/use-controllers';
 import { Geolocator } from '@/core/components/geolocator/geolocator';
 import type { TypeButtonPanel, TypePanelProps } from '@/ui/panel/panel-types';
 import ExportButton from '@/core/components/export/export-modal-button';
@@ -26,21 +26,21 @@ import {
   useStoreUIAppbarComponents,
   useStoreUIActiveAppBarTab,
   useStoreUIHiddenTabs,
+  useStoreUIAppBarPanelIds,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import { useStoreMapInteraction, setStoreMapClickMarkerIconHide } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapInteraction } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { useStoreAppGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { useStoreGeoViewConfig, useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
-import type { AppBarApi, AppBarCreatedEvent, AppBarRemovedEvent } from '@/core/components';
+import type { AppBarApi } from '@/core/components';
 import { Guide, Legend, DetailsPanel, Datapanel, LayersPanel } from '@/core/components';
 import Notifications from '@/core/components/notifications/notifications';
 
 import Version from './buttons/version';
 import Share from './buttons/share';
 import { getSxClasses } from './app-bar-style';
-import { enforceArrayOrder, helpClosePanelById, helpOpenPanelById } from './app-bar-helper';
+import { enforceArrayOrder } from './app-bar-helper';
 import { CONTAINER_TYPE, LIGHTBOX_SELECTORS, TIMEOUT } from '@/core/utils/constant';
-import type { TypeValidAppBarCoreProps } from '@/api/types/map-schema-types';
 import { DEFAULT_APPBAR_CORE, DEFAULT_APPBAR_TABS_ORDER } from '@/api/types/map-schema-types';
 import { camelCase, handleEscapeKey } from '@/core/utils/utilities';
 import { IconButton } from '@/ui/icon-button/icon-button';
@@ -76,9 +76,6 @@ export function AppBar(props: AppBarProps): JSX.Element {
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
 
-  // internal component state
-  const [buttonPanels, setButtonPanels] = useState<ButtonPanelType>({});
-
   // get store values and action
   const mapId = useStoreGeoViewMapId();
   const activeModalId = useStoreUIActiveFocusItem().activeElementId;
@@ -87,14 +84,44 @@ export function AppBar(props: AppBarProps): JSX.Element {
   const { tabId, isOpen, isFocusTrapped } = useStoreUIActiveAppBarTab();
   const hiddenTabs = useStoreUIHiddenTabs();
   const activeTrapGeoView = useStoreUIActiveTrapGeoView();
-  const pluginController = usePluginController();
   const uiController = useUIController();
+  const mapController = useMapController();
 
   const geoviewElement = useStoreAppGeoviewHTMLElement().querySelector('[id^="mapTargetElement-"]') as HTMLElement;
 
   // get store config for app bar to add (similar logic as in footer-bar)
   const appBarConfig = useStoreGeoViewConfig()?.appBar;
   const footerBarConfig = useStoreGeoViewConfig()?.footerBar;
+
+  // Read app-bar panel ids from the store (reactive — no event handlers needed)
+  const appBarPanelIds = useStoreUIAppBarPanelIds();
+
+  /**
+   * Builds the button panels record from store panel ids and api registry, with open/focus state derived from the active tab.
+   */
+  const buttonPanels = useMemo((): ButtonPanelType => {
+    // Log
+    logger.logTraceUseMemo('APP-BAR - buttonPanels', appBarPanelIds, tabId, isOpen, isFocusTrapped);
+
+    const panels: ButtonPanelType = {};
+    appBarPanelIds.forEach((id) => {
+      const panel = appBarApi.buttons[id];
+      if (panel) {
+        // Derive panel status from the store's active app bar tab
+        panels[id] = {
+          ...panel,
+          ...(panel.panel && {
+            panel: {
+              ...panel.panel,
+              status: id === tabId && isOpen,
+              isFocusTrapped: id === tabId ? isFocusTrapped : false,
+            },
+          }),
+        };
+      }
+    });
+    return panels;
+  }, [appBarPanelIds, appBarApi, tabId, isOpen, isFocusTrapped]);
 
   // #region REACT HOOKS
 
@@ -133,43 +160,6 @@ export function AppBar(props: AppBarProps): JSX.Element {
   // #region Handlers
 
   /**
-   * Handles closing a panel by id and returning focus.
-   *
-   * @param buttonId - The id of the panel button to close
-   */
-  const closePanelById = useCallback(
-    (buttonId: string): void => {
-      // Callback when removing and focus is lost
-      const focusWhenNoElementCallback = (): void => {
-        const mapCont = geoviewElement;
-        mapCont?.focus();
-
-        // if in focus trap mode, trigger the event
-        if (mapCont?.closest('.geoview-map')?.classList.contains('map-focus-trap')) {
-          mapCont.classList.add('keyboard-focus');
-        }
-      };
-
-      // Redirect to helper
-      helpClosePanelById(mapId, buttonId, setButtonPanels, focusWhenNoElementCallback);
-    },
-    [geoviewElement, mapId]
-  );
-
-  /**
-   * Handles opening a panel by id.
-   *
-   * @param buttonId - The id of the panel button to open
-   */
-  const openPanelById = useCallback(
-    (buttonId: string): void => {
-      // Redirect to helper
-      helpOpenPanelById(buttonId, setButtonPanels, isFocusTrapped);
-    },
-    [isFocusTrapped]
-  );
-
-  /**
    * Handles when an app-bar button is clicked.
    *
    * @param buttonId - The id of the clicked button
@@ -202,47 +192,6 @@ export function AppBar(props: AppBarProps): JSX.Element {
     [uiController, isFocusTrapped, getButtonElementId]
   );
 
-  /**
-   * Handles when a new button panel is added to the AppBar.
-   *
-   * @param sender - The AppBar API instance
-   * @param event - The creation event containing the new button panel
-   */
-  const handleAddButtonPanel = useCallback(
-    (sender: AppBarApi, event: AppBarCreatedEvent): void => {
-      setButtonPanels((prevState) => {
-        return {
-          ...prevState,
-          [event.buttonPanelId]: event.buttonPanel,
-        };
-      });
-
-      if (isOpen && tabId === event.buttonPanelId) openPanelById(tabId);
-    },
-    // Don't want to update every time active tab changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [buttonPanels]
-  );
-
-  /**
-   * Handles when a button panel is removed from the AppBar.
-   *
-   * @param sender - The AppBar API instance
-   * @param event - The removal event containing the removed button panel id
-   */
-  const handleRemoveButtonPanel = useCallback(
-    (sender: AppBarApi, event: AppBarRemovedEvent): void => {
-      setButtonPanels((prevState) => {
-        const state = { ...prevState };
-
-        delete state[event.buttonPanelId];
-
-        return state;
-      });
-    },
-    [setButtonPanels]
-  );
-
   // #endregion
 
   /**
@@ -265,75 +214,35 @@ export function AppBar(props: AppBarProps): JSX.Element {
   }, []);
 
   /**
-   * Handles when the panel closes
+   * Handles when the panel closes.
    */
   const handlePanelClose = useCallback(() => {
-    // Save to the store
-    setStoreMapClickMarkerIconHide(mapId);
-  }, [mapId]);
+    // Hide the marker icon
+    mapController.clickMarkerIconHide();
+  }, [mapController]);
 
   /**
-   * Registers and unregisters AppBar created/removed event handlers.
+   * Restores focus when a panel is closed.
    */
   useEffect(() => {
     // Log
-    logger.logTraceUseEffect('APP-BAR - mount');
+    logger.logTraceUseEffect('APP-BAR - focus restore on close', isOpen, tabId);
 
-    // Register AppBar created/removed handlers
-    appBarApi.onAppBarCreated(handleAddButtonPanel);
-    appBarApi.onAppBarRemoved(handleRemoveButtonPanel);
-
-    return () => {
-      // Unregister events
-      appBarApi.offAppBarCreated(handleAddButtonPanel);
-      appBarApi.offAppBarRemoved(handleRemoveButtonPanel);
-    };
-  }, [appBarApi, handleAddButtonPanel, handleRemoveButtonPanel]);
-
-  /**
-   * Opens or closes the active panel when isOpen or tabId changes.
-   */
-  useEffect(() => {
-    // Log
-    logger.logTraceUseEffect('APP-BAR - PANEL - OPEN/CLOSE ', isOpen);
-
-    // Open and close of the panel.
-    if (isOpen) {
-      openPanelById(tabId);
-    } else {
-      closePanelById(tabId);
-    }
-    // NOTE: Run this effect when isOpen, tabId changes
-    // should not re-render when openPanelById, closePanelById changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, tabId]);
-
-  /**
-   * Create default tabs from configuration parameters (similar logic as in footer-bar).
-   */
-  useEffect(() => {
-    // Log
-    logger.logTraceUseEffect('APP-BAR - appBarConfig');
-
-    // Get built-in core components
-    const builtInCoreComponents = Object.values(DEFAULT_APPBAR_CORE) as TypeValidAppBarCoreProps[];
-
-    // Process all configured plugins dynamically
-    if (appBarConfig?.tabs.core) {
-      appBarConfig.tabs.core.forEach((pluginName) => {
-        // Skip built-in components
-        if (builtInCoreComponents.includes(pluginName)) {
-          return;
+    if (!isOpen && tabId) {
+      const buttonElementId = `${mapId}-${CONTAINER_TYPE.APP_BAR}-${tabId}-panel-btn`;
+      const buttonElement = document.getElementById(buttonElementId);
+      if (buttonElement) {
+        buttonElement.focus();
+      } else {
+        const mapCont = geoviewElement;
+        mapCont?.focus();
+        if (mapCont?.closest('.geoview-map')?.classList.contains('map-focus-trap')) {
+          mapCont.classList.add('keyboard-focus');
         }
-
-        // Load and add the plugin
-        pluginController.loadAndAddPlugin(pluginName).catch((error: unknown) => {
-          // Log
-          logger.logPromiseFailed('loadAndAddPlugin(time-slider) in processPlugin in app-bar', error);
-        });
-      });
+      }
     }
-  }, [appBarConfig, pluginController]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
 
   /**
    * Creates AppBar button panels from configuration tabs.

--- a/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/app-bar.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { ReactNode, KeyboardEvent } from 'react';
-import { useEffect, useCallback, Fragment, useMemo } from 'react';
+import { useEffect, useCallback, Fragment, useMemo, useRef } from 'react';
 import { useTheme } from '@mui/material/styles';
 import type { IconButtonPropsExtend } from '@/ui';
 import {
@@ -95,6 +95,10 @@ export function AppBar(props: AppBarProps): JSX.Element {
 
   // Read app-bar panel ids from the store (reactive — no event handlers needed)
   const appBarPanelIds = useStoreUIAppBarPanelIds();
+
+  // Ref so the focus-restore effect can read the latest geoviewElement without it being a dep
+  const geoviewElementRef = useRef(geoviewElement);
+  geoviewElementRef.current = geoviewElement;
 
   /**
    * Builds the button panels record from store panel ids and api registry, with open/focus state derived from the active tab.
@@ -234,15 +238,14 @@ export function AppBar(props: AppBarProps): JSX.Element {
       if (buttonElement) {
         buttonElement.focus();
       } else {
-        const mapCont = geoviewElement;
+        const mapCont = geoviewElementRef.current;
         mapCont?.focus();
         if (mapCont?.closest('.geoview-map')?.classList.contains('map-focus-trap')) {
           mapCont.classList.add('keyboard-focus');
         }
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
+  }, [isOpen, tabId, mapId]);
 
   /**
    * Creates AppBar button panels from configuration tabs.

--- a/packages/geoview-core/src/core/components/app-bar/buttons/share.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/buttons/share.tsx
@@ -9,8 +9,8 @@ import {
   useStoreMapCenterCoordinates,
   useStoreMapCurrentProjection,
   useStoreMapCurrentBasemapOptions,
-  useStoreMapOrderedLayers,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreLayerOrderedLayerPaths } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { Projection } from '@/geo/utils/projection';
 
 import type { Coordinate } from 'ol/coordinate';
@@ -105,7 +105,7 @@ export default function Share(): JSX.Element | null {
   const center = useStoreMapCenterCoordinates();
   const projection = useStoreMapCurrentProjection();
   const basemap = useStoreMapCurrentBasemapOptions();
-  const layers = useStoreMapOrderedLayers();
+  const layers = useStoreLayerOrderedLayerPaths();
 
   // State
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/packages/geoview-core/src/core/components/app-bar/buttons/share.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/buttons/share.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ShareIcon, IconButton, Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Box } from '@/ui';
@@ -151,14 +151,9 @@ export default function Share(): JSX.Element | null {
 
   // #endregion
 
-  // Memoize visibility check
-  const memoIsVisible = useMemo(() => {
-    logger.logTraceUseMemo('SHARE - memoIsVisible', sharedMode);
-    return sharedMode === true;
-  }, [sharedMode]);
-
   // If shared mode is not enabled, don't render the button
-  if (!memoIsVisible) return null;
+  const isVisible = sharedMode === true;
+  if (!isVisible) return null;
 
   return (
     <>

--- a/packages/geoview-core/src/core/components/app-bar/buttons/share.tsx
+++ b/packages/geoview-core/src/core/components/app-bar/buttons/share.tsx
@@ -153,6 +153,7 @@ export default function Share(): JSX.Element | null {
 
   // Memoize visibility check
   const memoIsVisible = useMemo(() => {
+    logger.logTraceUseMemo('SHARE - memoIsVisible', sharedMode);
     return sharedMode === true;
   }, [sharedMode]);
 

--- a/packages/geoview-core/src/core/components/click-marker/click-marker.tsx
+++ b/packages/geoview-core/src/core/components/click-marker/click-marker.tsx
@@ -3,11 +3,7 @@ import { useEffect, useRef, memo } from 'react';
 import type { Coordinate } from 'ol/coordinate';
 import { Box, ClickMapMarker } from '@/ui';
 
-import {
-  useStoreMapClickMarker,
-  useStoreMapClickCoordinates,
-  setStoreMapOverlayClickMarkerRef,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapClickMarker, useStoreMapClickCoordinates } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { useMapController } from '@/core/controllers/use-controllers';
@@ -29,7 +25,6 @@ export const ClickMarker = memo(function ClickMarker(): JSX.Element {
   // State
   const mapId = useStoreGeoViewMapId();
   const clickMarkerRef = useRef<HTMLDivElement>(null);
-  const clickMarkerId = `${mapId}-clickmarker`;
 
   // Store
   const clickMarker = useStoreMapClickMarker();
@@ -43,9 +38,9 @@ export const ClickMarker = memo(function ClickMarker(): JSX.Element {
     // Log
     logger.logTraceUseEffect('CLICK-MARKER - setOverlayClickMarkerRef');
 
-    // Update the store
-    setStoreMapOverlayClickMarkerRef(mapId, clickMarkerRef.current as HTMLElement);
-  }, [mapId]);
+    // Set the click marker overlay
+    mapController.setClickMarkerOverlayRef(clickMarkerRef.current!);
+  }, [mapController]);
 
   /**
    * Shows the click marker when click coordinates change.
@@ -62,7 +57,7 @@ export const ClickMarker = memo(function ClickMarker(): JSX.Element {
   return (
     <Box
       ref={clickMarkerRef}
-      id={clickMarkerId}
+      id={`${mapId}-clickmarker`}
       sx={{ position: 'absolute', visibility: clickMarker !== undefined ? 'visible' : 'hidden' }}
     >
       <ClickMapMarker

--- a/packages/geoview-core/src/core/components/common/comp-common.ts
+++ b/packages/geoview-core/src/core/components/common/comp-common.ts
@@ -13,9 +13,8 @@ import type { LayerListEntry } from '@/core/components/common';
  * @param memoLayersList - The list of layers available for selection
  */
 export function checkSelectedLayerPathList(
-  mapId: string,
-  callbackSetStoreLayerDataArrayBatch: (mapId: string, layerPath: string) => void,
-  callbackSetStoreSelectedLayerPath: (mapId: string, layerPath: string) => void,
+  callbackSetStoreLayerDataArrayBatch: (layerPath: string) => void,
+  callbackSetStoreSelectedLayerPath: (layerPath: string) => void,
   memoLayerSelectedItem: LayerListEntry | undefined,
   memoLayersList: LayerListEntry[]
 ): void {
@@ -27,7 +26,7 @@ export function checkSelectedLayerPathList(
   if (memoLayerSelectedItem?.numOffeatures) {
     // All good, keep selection
     // Reset the bypass for next time
-    callbackSetStoreLayerDataArrayBatch(mapId, memoLayerSelectedItem.layerPath);
+    callbackSetStoreLayerDataArrayBatch(memoLayerSelectedItem.layerPath);
   } else {
     // Find the first layer with features
     const anotherLayerEntry = memoLayersList.find((layer) => {
@@ -37,11 +36,11 @@ export function checkSelectedLayerPathList(
     // If found
     if (anotherLayerEntry) {
       // Select that one
-      callbackSetStoreSelectedLayerPath(mapId, anotherLayerEntry.layerPath);
+      callbackSetStoreSelectedLayerPath(anotherLayerEntry.layerPath);
     } else {
       // TODO: Investigate infinite loop in AppBar for statement. (Not sure if still relevant to check or how to check it?)
       // None found, select none
-      callbackSetStoreSelectedLayerPath(mapId, '');
+      callbackSetStoreSelectedLayerPath('');
     }
   }
 }

--- a/packages/geoview-core/src/core/components/common/hooks/use-light-box.tsx
+++ b/packages/geoview-core/src/core/components/common/hooks/use-light-box.tsx
@@ -27,7 +27,7 @@ interface UseLightBoxReturnType {
 // TODO: Unmemoize this component, probably, because it's in 'common' folder
 /**
  * Base component for the lightbox, separated to avoid unnecessary re-renders of the lightbox when parent components update but lightbox props have not changed.
- * 
+ *
  * @param props - The properties defined in BaseLightBoxProps interface
  * @returns The base lightbox component
  */
@@ -92,7 +92,7 @@ export function useLightBox(): UseLightBoxReturnType {
   const [isLightBoxOpen, setIsLightBoxOpen] = useState(false);
   const [slides, setSlides] = useState<LightBoxSlides[]>([]);
   const [slidesIndex, setSlidesIndex] = useState(0);
-  const [storedReturnFocusId, setStoredReturnFocusId] = useState('0');
+  const [stateReturnFocusId, setReturnFocusId] = useState('0');
 
   /**
    * Creates the slides list from an image string.
@@ -135,7 +135,7 @@ export function useLightBox(): UseLightBoxReturnType {
       setIsLightBoxOpen(true);
       setSlides(createSlidesList(images, altText));
       setSlidesIndex(index ?? 0);
-      setStoredReturnFocusId(returnFocusId);
+      setReturnFocusId(returnFocusId);
     },
     [createSlidesList]
   );
@@ -146,11 +146,11 @@ export function useLightBox(): UseLightBoxReturnType {
         isLightBoxOpen={isLightBoxOpen}
         slides={slides}
         slidesIndex={slidesIndex}
-        returnFocusId={storedReturnFocusId}
+        returnFocusId={stateReturnFocusId}
         onExit={handleExit}
       />
     );
-  }, [isLightBoxOpen, slides, slidesIndex, storedReturnFocusId, handleExit]);
+  }, [isLightBoxOpen, slides, slidesIndex, stateReturnFocusId, handleExit]);
 
   return {
     initLightBox,

--- a/packages/geoview-core/src/core/components/common/hooks/use-navigate-to-tab.ts
+++ b/packages/geoview-core/src/core/components/common/hooks/use-navigate-to-tab.ts
@@ -9,7 +9,6 @@ import { logger } from '@/core/utils/logger';
 import type { TypeValidAppBarCoreProps, TypeValidFooterBarTabsCoreProps } from '@/api/types/map-schema-types';
 import { TIMEOUT } from '@/core/utils/constant';
 import { useUIController } from '@/core/controllers/use-controllers';
-import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 
 /** Options for navigating to a tab. */
 interface NavigateToTabOptions {
@@ -24,9 +23,8 @@ interface NavigateToTabOptions {
  *
  * Handles opening the tab, collapsing/expanding footer, and scrolling behavior.
  */
-export function useNavigateToTab(tabId: string, onNavigate?: (mapId: string, layerPath: string) => void): (options?: NavigateToTabOptions) => void {
+export function useNavigateToTab(tabId: string, onNavigate?: (layerPath: string) => void): (options?: NavigateToTabOptions) => void {
   // Store
-  const mapId = useStoreGeoViewMapId();
   const uiController = useUIController();
   const { isOpen: isFooterOpen } = useStoreUIActiveFooterBarTab();
   const footerBarComponents = useStoreUIFooterBarComponents();
@@ -56,7 +54,7 @@ export function useNavigateToTab(tabId: string, onNavigate?: (mapId: string, lay
         setTimeout(() => {
           // Execute callback if provided
           if (onNavigate && layerPath) {
-            onNavigate(mapId, layerPath);
+            onNavigate(layerPath);
           }
 
           // Scroll the footer into view
@@ -72,13 +70,12 @@ export function useNavigateToTab(tabId: string, onNavigate?: (mapId: string, lay
         setTimeout(() => {
           // Execute callback if provided
           if (onNavigate && layerPath) {
-            onNavigate(mapId, layerPath);
+            onNavigate(layerPath);
           }
         }, delay);
       }
     },
     [
-      mapId,
       hasTab,
       hasFooterTab,
       hasAppBarTab,

--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -58,7 +58,10 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
   // Hooks
   const { t } = useTranslation<string>();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('LAYER-LIST - LayerListItem - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // Store
   // TODO: REFACTOR - The whole 'layer' parameter received in the component parameters list should be reviewed and turned obsolete.
@@ -144,7 +147,7 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
         <ListItemButton
           id={id}
           component="button"
-          sx={sxClasses.listItemButton}
+          sx={memoSxClasses.listItemButton}
           onKeyDown={(e) => handleLayerKeyDown(e, layer)}
           onClick={() => onListItemClick(layer)}
           selected={isSelected}
@@ -156,7 +159,7 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
           ) : (
             layer.layerPath && !layer.content && <LayerIcon layerPath={layer.layerPath} />
           )}
-          <Box component="span" sx={sxClasses.listPrimaryText} className="layerInfo">
+          <Box component="span" sx={memoSxClasses.listPrimaryText} className="layerInfo">
             <Typography component="span" className="layerTitle">
               {layer.layerName}
             </Typography>
@@ -171,7 +174,7 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
               badgeContent={layer.numOffeatures}
               max={99}
               color="info"
-              sx={sxClasses.layerCount}
+              sx={memoSxClasses.layerCount}
               className="layer-count"
               aria-hidden="true"
             ></Badge>
@@ -179,7 +182,7 @@ export const LayerListItem = memo(function LayerListItem({ id, isSelected, layer
         </ListItemButton>
       </Tooltip>
       {layerStatus === 'loading' && (
-        <Box component="span" sx={sxClasses.progressBar}>
+        <Box component="span" sx={memoSxClasses.progressBar}>
           <ProgressBar aria-label={t('layers.status.layerLoadingDescriptive', { layerName: layer.layerName })!} />
         </Box>
       )}
@@ -201,10 +204,13 @@ export const LayerList = memo(function LayerList({ layerList, selectedLayerPath,
   // Hooks
   const { t } = useTranslation<string>();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('LAYER-LIST - LayerList - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   return (
-    <List sx={sxClasses.list}>
+    <List sx={memoSxClasses.list}>
       {!!layerList.length &&
         layerList.map((layer) => (
           <LayerListItem

--- a/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
@@ -130,22 +130,39 @@ const ResponsiveGridLayout = forwardRef(
      * Notifies parent when right panel visibility changes.
      */
     useEffect(() => {
+      logger.logTraceUseEffect('RESPONSIVE-GRID-LAYOUT - right panel visibility changed', isRightPanelVisible);
       onRightPanelVisibilityChanged?.(isRightPanelVisible);
     }, [isRightPanelVisible, onRightPanelVisibilityChanged]);
 
-    // sxClasses
-    const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-    const guideSxClasses = useMemo(() => getGuideSxClasses(theme), [theme]);
+    /** Memoized sx class definitions for the responsive layout. */
+    const memoSxClasses = useMemo(() => {
+      logger.logTraceUseMemo('RESPONSIVE-GRID-LAYOUT - memoSxClasses', theme);
+      return getSxClasses(theme);
+    }, [theme]);
+
+    /** Memoized sx class definitions for the guide panel. */
+    const memoGuideSxClasses = useMemo(() => {
+      logger.logTraceUseMemo('RESPONSIVE-GRID-LAYOUT - memoGuideSxClasses', theme);
+      return getGuideSxClasses(theme);
+    }, [theme]);
 
     /** Memoized sxProps for the left-top panel. */
-    const memoLeftTopSxProps = useMemo(() => ({ zIndex: isFullScreen ? 'unset' : 200 }), [isFullScreen]);
+    const memoLeftTopSxProps = useMemo(() => {
+      logger.logTraceUseMemo('RESPONSIVE-GRID-LAYOUT - memoLeftTopSxProps', isFullScreen);
+      return { zIndex: isFullScreen ? 'unset' : 200 };
+    }, [isFullScreen]);
 
     /** Memoized sxProps for the right-top panel. */
-    const memoRightTopSxProps = useMemo(() => ({ zIndex: isFullScreen ? 'unset' : 100, alignContent: 'flex-end' }), [isFullScreen]);
+    const memoRightTopSxProps = useMemo(() => {
+      logger.logTraceUseMemo('RESPONSIVE-GRID-LAYOUT - memoRightTopSxProps', isFullScreen);
+      return { zIndex: isFullScreen ? 'unset' : 100, alignContent: 'flex-end' };
+    }, [isFullScreen]);
 
     /** Memoized sx for the right-top content box layout. */
     const memoRightTopContentSx = useMemo(
-      () => ({
+      () => {
+        logger.logTraceUseMemo('RESPONSIVE-GRID-LAYOUT - memoRightTopContentSx', containerType, theme.breakpoints);
+        return {
         display: 'flex',
         alignItems: containerType === CONTAINER_TYPE.APP_BAR ? 'end' : 'center',
         flexDirection: containerType === CONTAINER_TYPE.APP_BAR ? 'column' : 'row',
@@ -156,8 +173,9 @@ const ResponsiveGridLayout = forwardRef(
         [theme.breakpoints.down('sm')]: {
           justifyContent: 'space-between',
         },
-        width: '100%',
-      }),
+          width: '100%',
+        };
+      },
       [containerType, theme.breakpoints]
     );
 
@@ -187,6 +205,7 @@ const ResponsiveGridLayout = forwardRef(
      * Toggles guide visibility based on rightMain content availability.
      */
     useEffect(() => {
+      logger.logTraceUseEffect('RESPONSIVE-GRID-LAYOUT - guide visibility toggle', rightMain, guideContentIds);
       if (rightMain) {
         setIsGuideOpen(false);
       } else if (guideContentIds) {
@@ -200,6 +219,7 @@ const ResponsiveGridLayout = forwardRef(
      * Notifies parent when guide open state changes.
      */
     useEffect(() => {
+      logger.logTraceUseEffect('RESPONSIVE-GRID-LAYOUT - guide open state changed', isGuideOpen);
       onGuideIsOpen?.(isGuideOpen);
     }, [isGuideOpen, onGuideIsOpen]);
 
@@ -207,6 +227,7 @@ const ResponsiveGridLayout = forwardRef(
      * Resets enlarged state when the enlarge button is hidden.
      */
     useEffect(() => {
+      logger.logTraceUseEffect('RESPONSIVE-GRID-LAYOUT - reset enlarged state', hideEnlargeBtn, isEnlarged);
       // if hideEnlargeBtn changes to true and isEnlarged is true, set isEnlarged to false
       if (hideEnlargeBtn && isEnlarged) {
         setIsEnlarged(false);
@@ -303,6 +324,7 @@ const ResponsiveGridLayout = forwardRef(
      * Focuses the close button when the right panel becomes visible with content.
      */
     useEffect(() => {
+      logger.logTraceUseEffect('RESPONSIVE-GRID-LAYOUT - focus close button when right panel visible', isRightPanelVisible, hasContent);
       if (isRightPanelVisible && hasContent && !isGuideOpen && closeBtnRef.current) {
         requestAnimationFrame(() => {
           closeBtnRef.current?.focus();
@@ -554,14 +576,14 @@ const ResponsiveGridLayout = forwardRef(
           ref={guideContainerRef}
           tabIndex={0}
           className="panel-content-container"
-          sx={guideSxClasses.guideContainer}
+          sx={memoGuideSxClasses.guideContainer}
           onKeyDown={handleGuideKeyDown}
         >
           <Box
             className="guideBox"
             sx={{
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              ...(guideSxClasses.guideContainer as any)?.['& .guideBox'],
+              ...(memoGuideSxClasses.guideContainer as any)?.['& .guideBox'],
             }}
           >
             {/* Close button inside guide - shown when WCAG is enabled, not fullscreen, and no feature content is selected */}
@@ -609,11 +631,11 @@ const ResponsiveGridLayout = forwardRef(
           <Box
             ref={isGuideOpen ? undefined : rightMainRef}
             tabIndex={shouldTrapFocus ? -1 : undefined} // MUI will throw an error and automatically set this to -1 when box is focused
-            sx={sxClasses.rightMainContent}
+            sx={memoSxClasses.rightMainContent}
             className={`responsive-layout-right-main-content ${isGuideOpen ? 'guide-container' : ''}`}
             onKeyDown={handlePanelKeyDown}
           >
-            <Box sx={sxClasses.rightButtonsContainer} className="guide-button-container">
+            <Box sx={memoSxClasses.rightButtonsContainer} className="guide-button-container">
               <ButtonGroup size="small" variant="outlined" aria-label={t('details.guideControls')!} className="guide-button-group">
                 {!toggleMode && !hideEnlargeBtn && renderEnlargeButton()}
                 {!!guideContentIds?.length && renderGuideButton()}
@@ -659,7 +681,7 @@ const ResponsiveGridLayout = forwardRef(
             container={shellContainer}
             disableEnforceFocus={true}
           >
-            <Box sx={sxClasses.rightMainContent} className="responsive-layout-right-main-content fullscreen-mode">
+            <Box sx={memoSxClasses.rightMainContent} className="responsive-layout-right-main-content fullscreen-mode">
               {content}
             </Box>
           </FullScreenDialog>
@@ -669,8 +691,8 @@ const ResponsiveGridLayout = forwardRef(
     };
 
     return (
-      <Box ref={ref} sx={sxClasses.container} className="responsive-layout-container">
-        <ResponsiveGrid.Root sx={sxClasses.topRow} className="responsive-layout-top-row">
+      <Box ref={ref} sx={memoSxClasses.container} className="responsive-layout-container">
+        <ResponsiveGrid.Root sx={memoSxClasses.topRow} className="responsive-layout-top-row">
           <ResponsiveGrid.Left
             isRightPanelVisible={isRightPanelVisible}
             isEnlarged={isEnlarged}
@@ -696,7 +718,7 @@ const ResponsiveGridLayout = forwardRef(
             isEnlarged={isEnlarged}
             isRightPanelVisible={isRightPanelVisible}
             toggleMode={toggleMode}
-            sxProps={sxClasses.gridLeftMain as SxProps}
+            sxProps={memoSxClasses.gridLeftMain as SxProps}
             className="responsive-layout-left-main"
           >
             {leftMain}
@@ -705,7 +727,7 @@ const ResponsiveGridLayout = forwardRef(
             isEnlarged={isEnlarged}
             isRightPanelVisible={isRightPanelVisible}
             toggleMode={toggleMode}
-            sxProps={sxClasses.gridRightMain as SxProps}
+            sxProps={memoSxClasses.gridRightMain as SxProps}
             className="responsive-layout-right-main"
           >
             {renderRightContent()}

--- a/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
@@ -156,18 +156,19 @@ const ResponsiveGridLayout = forwardRef(
     const memoRightTopContentSx = useMemo(
       () => {
         logger.logTraceUseMemo('RESPONSIVE-GRID-LAYOUT - memoRightTopContentSx', containerType, theme.breakpoints);
+
         return {
-        display: 'flex',
-        alignItems: containerType === CONTAINER_TYPE.APP_BAR ? 'end' : 'center',
-        flexDirection: containerType === CONTAINER_TYPE.APP_BAR ? 'column' : 'row',
-        gap: containerType === CONTAINER_TYPE.APP_BAR ? '10px' : '0',
-        [theme.breakpoints.up('sm')]: {
-          justifyContent: containerType === CONTAINER_TYPE.APP_BAR ? 'space-between' : 'right',
-        },
-        [theme.breakpoints.down('sm')]: {
-          justifyContent: 'space-between',
-        },
-          width: '100%',
+          display: 'flex',
+          alignItems: containerType === CONTAINER_TYPE.APP_BAR ? 'end' : 'center',
+          flexDirection: containerType === CONTAINER_TYPE.APP_BAR ? 'column' : 'row',
+          gap: containerType === CONTAINER_TYPE.APP_BAR ? '10px' : '0',
+          [theme.breakpoints.up('sm')]: {
+            justifyContent: containerType === CONTAINER_TYPE.APP_BAR ? 'space-between' : 'right',
+          },
+          [theme.breakpoints.down('sm')]: {
+            justifyContent: 'space-between',
+          },
+            width: '100%',
         };
       },
       [containerType, theme.breakpoints]

--- a/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
+++ b/packages/geoview-core/src/core/components/common/responsive-grid-layout.tsx
@@ -146,17 +146,11 @@ const ResponsiveGridLayout = forwardRef(
       return getGuideSxClasses(theme);
     }, [theme]);
 
-    /** Memoized sxProps for the left-top panel. */
-    const memoLeftTopSxProps = useMemo(() => {
-      logger.logTraceUseMemo('RESPONSIVE-GRID-LAYOUT - memoLeftTopSxProps', isFullScreen);
-      return { zIndex: isFullScreen ? 'unset' : 200 };
-    }, [isFullScreen]);
+    /** Sx props for the left-top panel. */
+    const leftTopSxProps = { zIndex: isFullScreen ? 'unset' : 200 };
 
-    /** Memoized sxProps for the right-top panel. */
-    const memoRightTopSxProps = useMemo(() => {
-      logger.logTraceUseMemo('RESPONSIVE-GRID-LAYOUT - memoRightTopSxProps', isFullScreen);
-      return { zIndex: isFullScreen ? 'unset' : 100, alignContent: 'flex-end' };
-    }, [isFullScreen]);
+    /** Sx props for the right-top panel. */
+    const rightTopSxProps = { zIndex: isFullScreen ? 'unset' : 100, alignContent: 'flex-end' };
 
     /** Memoized sx for the right-top content box layout. */
     const memoRightTopContentSx = useMemo(
@@ -697,7 +691,7 @@ const ResponsiveGridLayout = forwardRef(
             isRightPanelVisible={isRightPanelVisible}
             isEnlarged={isEnlarged}
             toggleMode={toggleMode}
-            sxProps={memoLeftTopSxProps}
+            sxProps={leftTopSxProps}
             className="responsive-layout-left-top"
           >
             {/* This panel is hidden from screen readers when not visible */}
@@ -707,7 +701,7 @@ const ResponsiveGridLayout = forwardRef(
             isRightPanelVisible={isRightPanelVisible}
             isEnlarged={isEnlarged}
             toggleMode={toggleMode}
-            sxProps={memoRightTopSxProps}
+            sxProps={rightTopSxProps}
             className="responsive-layout-right-top"
           >
             <Box sx={memoRightTopContentSx}>{rightTop ?? <Box />}</Box>

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -270,7 +270,7 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
       // Get the features already loaded in the store, if any
       const features = getStoreDataTableFeaturesByPath(mapId, selectedLayerPath);
 
-      // If no features were already loaded (not event an empty array)
+      // If no features were already loaded (not even an empty array)
       if (!features) {
         // Check if the layer is visible and in range (stable check that doesn't change when features load)
         const isLayerAvailable = visibleInRangeLayers.includes(selectedLayerPath);
@@ -278,7 +278,7 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
         if (isLayerAvailable) {
           setIsLoading(true);
           layerSetController
-            .triggerGetAllFeatureInfo(selectedLayerPath)
+            .triggerGetAllFeatureInfo(selectedLayerPath, true)
             .catch((error: unknown) => {
               // Log error
               logger.logError(`Data panel has failed to get all feature info, error: ${error}`);

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -8,15 +8,15 @@ import {
   useStoreDataTableSelectedLayerPath,
   useStoreDataTableAllFeaturesDataArray,
   useStoreDataTableLayerSettings,
-  setStoreSelectedLayerPath,
+  getStoreDataTableFeaturesByPath,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { useStoreAppShowUnsymbolizedFeatures } from '@/core/stores/store-interface-and-intial-values/app-state';
 import {
-  useStoreMapAllVisibleandInRangeLayers,
-  useStoreMapIsLayerHiddenOnMapSet,
-  useStoreMapExtent,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
-import { useStoreLayerNameSet, useStoreLayerStatusSet } from '@/core/stores/store-interface-and-intial-values/layer-state';
+  useStoreLayerAllVisibleAndInRangeLayers,
+  useStoreLayerIsHiddenOnMapSet,
+  useStoreLayerNameSet,
+  useStoreLayerStatusSet,
+} from '@/core/stores/store-interface-and-intial-values/layer-state';
 import {
   useStoreUIActiveAppBarTab,
   useStoreUIActiveFooterBarTab,
@@ -32,7 +32,7 @@ import type { MappedLayerDataType } from './data-table-types';
 import { DEFAULT_APPBAR_CORE } from '@/api/types/map-schema-types';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import DataSkeleton from './data-skeleton';
-import { useLayerSetController, useUIController } from '@/core/controllers/use-controllers';
+import { useDataTableController, useLayerSetController, useUIController } from '@/core/controllers/use-controllers';
 
 /** Properties for the Datapanel component. */
 interface DataPanelType {
@@ -54,23 +54,24 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
 
   const dataTableRef = useRef<HTMLDivElement>();
   const [isLoading, setIsLoading] = useState(false);
-  const isFirstLoad = useRef<Record<string, boolean>>({});
 
   const mapId = useStoreGeoViewMapId();
   const mapExtent = useStoreMapExtent();
   const uiController = useUIController();
   const layerSetController = useLayerSetController();
+  const dataTableController = useDataTableController();
   const layerData = useStoreDataTableAllFeaturesDataArray();
   const selectedLayerPath = useStoreDataTableSelectedLayerPath();
   const datatableSettings = useStoreDataTableLayerSettings();
-  const visibleInRangeLayers = useStoreMapAllVisibleandInRangeLayers();
+  const visibleInRangeLayers = useStoreLayerAllVisibleAndInRangeLayers();
   const activeFooterBarTab = useStoreUIActiveFooterBarTab();
   const activeAppBarTab = useStoreUIActiveAppBarTab();
   const appBarComponents = useStoreUIAppbarComponents();
   const showUnsymbolizedFeatures = useStoreAppShowUnsymbolizedFeatures();
   const layerNames = useStoreLayerNameSet();
   const layerStatuses = useStoreLayerStatusSet();
-  const layerHiddenSet = useStoreMapIsLayerHiddenOnMapSet();
+  const layerHiddenSet = useStoreLayerIsHiddenOnMapSet();
+  const uiController = useUIController();
 
   // Create columns for data table.
   const mappedLayerData = useFeatureFieldInfos(layerData);
@@ -116,10 +117,10 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
    */
   const handleLayerChange = useCallback(
     (_layer: LayerListEntry): void => {
-      setStoreSelectedLayerPath(mapId, _layer.layerPath); // This will trigger the useEffect below to call tiggerGetAllFeatureInfo()
+      dataTableController.setSelectedLayerPath(_layer.layerPath); // This will trigger the useEffect below to call tiggerGetAllFeatureInfo()
       setIsLoading(true);
     },
-    [mapId]
+    [dataTableController]
   );
 
   /**
@@ -234,10 +235,10 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
     // NOTE: Reason for not using component unmount, because we are not mounting and unmounting components
     // when we switch tabs.
     if (activeFooterBarTab.tabId !== TABS.DATA_TABLE && containerType !== CONTAINER_TYPE.APP_BAR) {
-      setStoreSelectedLayerPath(mapId, '');
+      dataTableController.setSelectedLayerPath('');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapId, activeFooterBarTab]);
+  }, [dataTableController, activeFooterBarTab]);
 
   /**
    * Resets the selected layer path when the app bar data table tab is closed.
@@ -250,9 +251,9 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
       (activeAppBarTab.tabId !== DEFAULT_APPBAR_CORE.DATA_TABLE || !activeAppBarTab.isOpen) &&
       appBarComponents.includes(DEFAULT_APPBAR_CORE.DATA_TABLE)
     ) {
-      setStoreSelectedLayerPath(mapId, '');
+      dataTableController.setSelectedLayerPath('');
     }
-  }, [mapId, activeAppBarTab, appBarComponents]);
+  }, [dataTableController, activeAppBarTab, appBarComponents]);
 
   /**
    * Triggers feature info query on first load of the selected layer.
@@ -262,28 +263,33 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
    */
   useEffect(() => {
     // Log
-    logger.logTraceUseEffect('DATA-PANEL - selectedLayerPath', selectedLayerPath, isFirstLoad.current[selectedLayerPath]);
+    logger.logTraceUseEffect('DATA-PANEL - selectedLayerPath', selectedLayerPath);
 
-    // Only trigger on first load when we have a selectedLayerPath
-    if (selectedLayerPath && !isFirstLoad.current[selectedLayerPath]) {
-      // Check if the layer is now available in memoOrderedLayerData
-      const foundLayer = memoOrderedLayerData.find((lyr) => lyr.layerPath === selectedLayerPath);
+    // If any selected layer path
+    if (selectedLayerPath) {
+      // Get the features already loaded in the store, if any
+      const features = getStoreDataTableFeaturesByPath(mapId, selectedLayerPath);
 
-      if (foundLayer) {
-        isFirstLoad.current[selectedLayerPath] = true;
-        setIsLoading(true);
-        layerSetController
-          .triggerGetAllFeatureInfo(selectedLayerPath)
-          .catch((error: unknown) => {
-            // Log error
-            logger.logError(`Data panel has failed to get all feature info, error: ${error}`);
-          })
-          .finally(() => {
-            setIsLoading(false);
-          });
+      // If no features were already loaded (not event an empty array)
+      if (!features) {
+        // Check if the layer is visible and in range (stable check that doesn't change when features load)
+        const isLayerAvailable = visibleInRangeLayers.includes(selectedLayerPath);
+
+        if (isLayerAvailable) {
+          setIsLoading(true);
+          layerSetController
+            .triggerGetAllFeatureInfo(selectedLayerPath)
+            .catch((error: unknown) => {
+              // Log error
+              logger.logError(`Data panel has failed to get all feature info, error: ${error}`);
+            })
+            .finally(() => {
+              setIsLoading(false);
+            });
+        }
       }
     }
-  }, [memoOrderedLayerData, selectedLayerPath, layerSetController]);
+  }, [selectedLayerPath, visibleInRangeLayers, layerSetController, mapId]);
 
   /**
    * Checks if any layer query status is processing.

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -80,6 +80,9 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
    * Orders the layers by visible layer order.
    */
   const memoOrderedLayerData = useMemo(() => {
+    // Log
+    logger.logTraceUseMemo('DATA-PANEL - memoOrderedLayerData', visibleInRangeLayers, mappedLayerData);
+
     return visibleInRangeLayers
       .map((layerPath) => mappedLayerData.filter((data) => data.layerPath === layerPath)[0])
       .filter((layer) => layer !== undefined && !layerHiddenSet[layer.layerPath]);

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -233,15 +233,14 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
    */
   useEffect(() => {
     // Log
-    logger.logTraceUseEffect('DATA-PANEL - unmount', selectedLayerPath);
+    logger.logTraceUseEffect('DATA-PANEL - unmount');
 
     // NOTE: Reason for not using component unmount, because we are not mounting and unmounting components
     // when we switch tabs.
     if (activeFooterBarTab.tabId !== TABS.DATA_TABLE && containerType !== CONTAINER_TYPE.APP_BAR) {
       dataTableController.setSelectedLayerPath('');
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataTableController, activeFooterBarTab]);
+  }, [dataTableController, activeFooterBarTab, containerType]);
 
   /**
    * Resets the selected layer path when the app bar data table tab is closed.

--- a/packages/geoview-core/src/core/components/data-table/data-panel.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-panel.tsx
@@ -11,6 +11,7 @@ import {
   getStoreDataTableFeaturesByPath,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { useStoreAppShowUnsymbolizedFeatures } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useStoreMapExtent } from '@/core/stores/store-interface-and-intial-values/map-state';
 import {
   useStoreLayerAllVisibleAndInRangeLayers,
   useStoreLayerIsHiddenOnMapSet,
@@ -71,7 +72,6 @@ export function Datapanel({ containerType }: DataPanelType): JSX.Element {
   const layerNames = useStoreLayerNameSet();
   const layerStatuses = useStoreLayerStatusSet();
   const layerHiddenSet = useStoreLayerIsHiddenOnMapSet();
-  const uiController = useUIController();
 
   // Create columns for data table.
   const mappedLayerData = useFeatureFieldInfos(layerData);

--- a/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
@@ -29,6 +29,19 @@ import { sanitizeHtmlContent, enhanceLinksAccessibility } from '@/core/utils/uti
 import { getSxClasses } from './data-table-style';
 import { useFeatureFieldInfos } from './hooks';
 
+/** Linkify configuration options for URL detection and formatting. */
+const linkifyOptions = {
+  attributes: {
+    target: '_blank',
+    rel: 'noopener noreferrer',
+  },
+  defaultProtocol: 'https',
+  format: {
+    url: (value: string) => (value.length > 50 ? `${value.slice(0, 40)}…${value.slice(value.length - 10)}` : value),
+  },
+  ignoreTags: ['script', 'style', 'img'],
+};
+
 /**
  * Renders a lightweight read-only data table in a modal window.
  *
@@ -84,25 +97,6 @@ export default function DataTableModal(): JSX.Element {
   }, [mappedLayerData, selectedLayerPath]);
 
   /**
-   * Linkify configuration options for URL detection and formatting.
-   */
-  const memoLinkifyOptions = useMemo(() => {
-    logger.logTraceUseMemo('DATA-TABLE-MODAL - memoLinkifyOptions');
-
-    return {
-      attributes: {
-        target: '_blank',
-        rel: 'noopener noreferrer',
-      },
-      defaultProtocol: 'https',
-      format: {
-        url: (value: string) => (value.length > 50 ? `${value.slice(0, 40)}…${value.slice(value.length - 10)}` : value),
-      },
-      ignoreTags: ['script', 'style', 'img'],
-    };
-  }, []);
-
-  /**
    * Creates a data table body cell.
    *
    * @param cellValue - Cell value to be displayed
@@ -114,7 +108,7 @@ export default function DataTableModal(): JSX.Element {
         <Box component="div" sx={sxClasses.tableCell}>
           <UseHtmlToReact
             htmlContent={sanitizeHtmlContent(
-              enhanceLinksAccessibility(linkifyHtml(cellValue.toString(), memoLinkifyOptions), t('general.opensInNewTab'))
+              enhanceLinksAccessibility(linkifyHtml(cellValue.toString(), linkifyOptions), t('general.opensInNewTab'))
             )}
             itemOptions={{ tabIndex: 0 }}
           />
@@ -125,7 +119,7 @@ export default function DataTableModal(): JSX.Element {
         </Box>
       );
     },
-    [sxClasses.tableCell, memoLinkifyOptions, t]
+    [sxClasses.tableCell, t]
   );
 
   /**

--- a/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table-modal.tsx
@@ -10,11 +10,11 @@ import { MRT_Localization_EN as MRTLocalizationEN } from 'material-react-table/l
 import linkifyHtml from 'linkify-html';
 
 import { Modal, MRTTable as Table, type MRT_ColumnDef as MRTColumnDef, Box, CircularProgress, Button } from '@/ui';
+import { useDataTableController, useUIController } from '@/core/controllers/use-controllers';
 import { TableViewIcon } from '@/ui/icons';
 import type { TypeFieldEntry } from '@/api/types/map-schema-types';
 import { UseHtmlToReact } from '@/core/components/common/hooks/use-html-to-react';
 import { useNavigateToTab } from '@/core/components/common/hooks/use-navigate-to-tab';
-import { useUIController } from '@/core/controllers/use-controllers';
 import {
   useStoreUIActiveFocusItem,
   useStoreUIFooterBarComponents,
@@ -22,10 +22,7 @@ import {
   useStoreUIActiveTrapGeoView,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { useStoreAppDisplayLanguage, useStoreAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
-import {
-  setStoreSelectedLayerPath,
-  useStoreDataTableAllFeaturesDataArray,
-} from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { useStoreDataTableAllFeaturesDataArray } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { useStoreLayerNameSet, useStoreLayerSelectedLayerPath } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { logger } from '@/core/utils/logger';
 import { sanitizeHtmlContent, enhanceLinksAccessibility } from '@/core/utils/utilities';
@@ -49,7 +46,6 @@ export default function DataTableModal(): JSX.Element {
   const [isLoading, setIsLoading] = useState(true);
 
   // get store function
-  const uiController = useUIController();
   const activeModalId = useStoreUIActiveFocusItem().activeElementId;
   const selectedLayerPath = useStoreLayerSelectedLayerPath();
   const layersData = useStoreDataTableAllFeaturesDataArray();
@@ -59,6 +55,8 @@ export default function DataTableModal(): JSX.Element {
   const appBarComponents = useStoreUIAppbarComponents();
   const isFocusTrap = useStoreUIActiveTrapGeoView();
   const layerNames = useStoreLayerNameSet();
+  const uiController = useUIController();
+  const dataTableController = useDataTableController();
 
   const dataTableLocalization = language === 'fr' ? MRTLocalizationFR : MRTLocalizationEN;
 
@@ -68,7 +66,9 @@ export default function DataTableModal(): JSX.Element {
   const hasDataTableTab = hasFooterDataTableTab || hasAppBarDataTableTab;
 
   // Use navigate hook with scrollToFooter disabled since modal closes
-  const navigateToDataTable = useNavigateToTab('data-table', setStoreSelectedLayerPath);
+  const navigateToDataTable = useNavigateToTab('data-table', (lyrPath) => {
+    dataTableController.setSelectedLayerPath(lyrPath);
+  });
 
   // Create columns for data table.
   const mappedLayerData = useFeatureFieldInfos(layersData);

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -164,11 +164,14 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
   /**
    * Handles toggling column filters visibility.
    */
-  const handleToggleColumnFilters = useCallback((updaterOrValue: boolean | ((prev: boolean) => boolean)): void => {
-    const newValue = typeof updaterOrValue === 'function' ? updaterOrValue(showColumnFilters) : updaterOrValue;
-    setShowColumnFilters(newValue);
-    dataTableController.setColumnsFiltersVisibility(layerPath, newValue);
-  }, [dataTableController, layerPath, showColumnFilters]);
+  const handleToggleColumnFilters = useCallback(
+    (updaterOrValue: boolean | ((prev: boolean) => boolean)): void => {
+      const newValue = typeof updaterOrValue === 'function' ? updaterOrValue(showColumnFilters) : updaterOrValue;
+      setShowColumnFilters(newValue);
+      dataTableController.setColumnsFiltersVisibility(layerPath, newValue);
+    },
+    [dataTableController, layerPath, showColumnFilters]
+  );
 
   // #endregion HANDLERS
 

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -81,6 +81,19 @@ const DATE_FIELD_FILTERS = NUMERIC_FIELD_FILTERS;
 /** The possible filters for string columns */
 const STRING_FIELD_FILTERS = ['contains', 'startsWith', 'endsWith'];
 
+/** Linkify configuration options for URL detection and formatting. */
+const linkifyOptions = {
+  attributes: {
+    target: '_blank',
+    rel: 'noopener noreferrer',
+  },
+  defaultProtocol: 'https',
+  format: {
+    url: (value: string) => (value.length > 50 ? `${value.slice(0, 40)}\u2026${value.slice(value.length - 10)}` : value),
+  },
+  ignoreTags: ['script', 'style', 'img'],
+};
+
 /**
  * Renders the interactive data table for a single layer.
  *
@@ -182,21 +195,6 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
     );
   }, []);
 
-  const linkifyOptions = useMemo(
-    () => ({
-      attributes: {
-        target: '_blank',
-        rel: 'noopener noreferrer',
-      },
-      defaultProtocol: 'https',
-      format: {
-        url: (value: string) => (value.length > 50 ? `${value.slice(0, 40)}…${value.slice(value.length - 10)}` : value),
-      },
-      ignoreTags: ['script', 'style', 'img'],
-    }),
-    []
-  );
-
   /**
    * Creates an image button that triggers the lightbox.
    *
@@ -234,7 +232,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
         cellValue
       );
     },
-    [initLightBox, t, containerType, mapId, linkifyOptions]
+    [initLightBox, t, containerType, mapId]
   );
 
   /**

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -49,7 +49,6 @@ import { useStoreAppDisplayLanguage } from '@/core/stores/store-interface-and-in
 import { DateMgt } from '@/core/utils/date-mgt';
 import linkifyHtml from 'linkify-html';
 import { isImage, delay, sanitizeHtmlContent, enhanceLinksAccessibility } from '@/core/utils/utilities';
-import { debounce } from '@/core/utils/debounce';
 import { logger } from '@/core/utils/logger';
 import type { TypeFeatureInfoEntry } from '@/api/types/map-schema-types';
 import { useFilterRows, useGlobalFilter } from './hooks';
@@ -81,6 +80,12 @@ const DATE_FIELD_FILTERS = NUMERIC_FIELD_FILTERS;
 /** The possible filters for string columns */
 const STRING_FIELD_FILTERS = ['contains', 'startsWith', 'endsWith'];
 
+/** Checks if a value is a Dayjs instance. */
+const isDayjs = (v: unknown): v is Dayjs => typeof v === 'object' && v !== null && 'isValid' in v;
+
+/** Checks if a value is a date range tuple containing at least one Dayjs element. */
+const isDateRange = (v: unknown): v is [Dayjs | null, Dayjs | null] => Array.isArray(v) && (v as unknown[]).some(isDayjs);
+
 /** Linkify configuration options for URL detection and formatting. */
 const linkifyOptions = {
   attributes: {
@@ -110,7 +115,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
   const { t } = useTranslation();
 
   const sxtheme = useTheme();
-  const sxClasses = getSxClasses(sxtheme);
+  const memoSxClasses = useMemo(() => getSxClasses(sxtheme), [sxtheme]);
 
   // get store actions and values
   const mapId = useStoreGeoViewMapId();
@@ -127,6 +132,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
   const layerController = useLayerController();
   const mapController = useMapController();
   const uiController = useUIController();
+  const { mapFilteredRecord } = datatableSettings[layerPath];
 
   // internal state
   const [density, setDensity] = useState<MRTDensityState>('compact');
@@ -139,12 +145,6 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
   );
 
   const dataTableLocalization = language === 'fr' ? MRTLocalizationFR : MRTLocalizationEN;
-
-  // #region PINNED Datatable columns
-  const iconColumn = { alias: t('dataTable.icon'), dataType: 'string', id: 'icon' };
-  const zoomColumn = { alias: t('dataTable.zoom'), dataType: 'string', id: 'zoom' };
-  const detailColumn = { alias: t('dataTable.details'), dataType: 'string', id: 'details' };
-  // #endregion
 
   // #region REACT CUSTOM HOOKS
   const { initLightBox, LightBoxComponent } = useLightBox();
@@ -174,12 +174,6 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
   );
 
   // #endregion HANDLERS
-
-  /** Checks if a value is a Dayjs instance. */
-  const isDayjs = (v: unknown): v is Dayjs => typeof v === 'object' && v !== null && 'isValid' in v;
-
-  /** Checks if a value is a date range tuple. */
-  const isDateRange = useCallback((v: unknown): v is [Dayjs | null, Dayjs | null] => Array.isArray(v) && v.some(isDayjs), []);
 
   /**
    * Creates a table header cell with tooltip.
@@ -249,17 +243,17 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
     (cellValue: string | number | JSX.Element, cellId: string): JSX.Element => {
       return typeof cellValue === 'string' || typeof cellValue === 'number' ? (
         <Tooltip title={cellValue} placement="top" arrow>
-          <Box component="div" sx={density === 'compact' ? sxClasses.tableCell : {}}>
+          <Box component="div" sx={density === 'compact' ? memoSxClasses.tableCell : {}}>
             {createLightBoxButton(cellValue, cellId)}
           </Box>
         </Tooltip>
       ) : (
-        <Box component="div" sx={density === 'compact' ? sxClasses.tableCell : {}}>
+        <Box component="div" sx={density === 'compact' ? memoSxClasses.tableCell : {}}>
           {cellValue}
         </Box>
       );
     },
-    [createLightBoxButton, density, sxClasses.tableCell]
+    [createLightBoxButton, density, memoSxClasses.tableCell]
   );
 
   /**
@@ -326,6 +320,11 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
     // Log
     logger.logTraceUseMemo('DATA-TABLE - memoColumns', density);
 
+    // Pinned data table columns
+    const iconColumn = { alias: t('dataTable.icon'), dataType: 'string', id: 'icon' };
+    const zoomColumn = { alias: t('dataTable.zoom'), dataType: 'string', id: 'zoom' };
+    const detailColumn = { alias: t('dataTable.details'), dataType: 'string', id: 'details' };
+
     const entries = Object.entries({ ICON: iconColumn, ZOOM: zoomColumn, DETAILS: detailColumn, ...data.fieldInfos });
     const columnList = [] as MRTColumnDef<ColumnsType>[];
     entries.forEach(([key, value]) => {
@@ -345,7 +344,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
           return '';
         },
         header: value.alias,
-        visibleInShowHideMenu: value.id === 'icon' || value.id === 'zoom' || value.id === 'details' ? false : true,
+        visibleInShowHideMenu: value.id !== 'icon' && value.id !== 'zoom' && value.id !== 'details',
 
         Header: ({ column }) => getTableHeader(column.columnDef.header),
         Cell: ({ cell }) => getCellValueWithTooltip(cell.getValue() as string | number | JSX.Element, cell.id),
@@ -367,31 +366,39 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
 
         // Spread in the extra config for the special columns (icon/zoom/details)
         ...([t('dataTable.icon'), t('dataTable.zoom'), t('dataTable.details')].includes(value.alias)
-          ? (() => {
-              return {
-                size: 60,
-                grow: false,
-                enableColumnFilter: false,
-                enableColumnActions: false,
-                enableSorting: false,
-                enableResizing: false,
-                enableGlobalFilter: false,
-                muiTableBodyCellProps: {
-                  sx: sxClasses.pinnedColumn,
-                },
-                muiTableHeadCellProps: {
-                  sx: sxClasses.pinnedColumn,
-                },
-              };
-            })()
+          ? {
+              size: 60,
+              grow: false,
+              enableColumnFilter: false,
+              enableColumnActions: false,
+              enableSorting: false,
+              enableResizing: false,
+              enableGlobalFilter: false,
+              muiTableBodyCellProps: {
+                sx: memoSxClasses.pinnedColumn,
+              },
+              muiTableHeadCellProps: {
+                sx: memoSxClasses.pinnedColumn,
+              },
+            }
           : {}),
       });
     });
 
     return columnList;
-    // TODO: CLEANUP REACT - Uncomment all disable react-hooks/exhaustive-deps from this file and fix all dependencies!
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [density, getFilterConfig, getCellContentDate, displayDateTimezone]);
+  }, [
+    density,
+    getFilterConfig,
+    getCellContentDate,
+    getCellValueWithTooltip,
+    getTableHeader,
+    data.fieldInfos,
+    displayDateTimezoneUniversal,
+    displayDateFormat,
+    language,
+    memoSxClasses,
+    t,
+  ]);
 
   /**
    * Initializes default filter modes for columns using the first available option.
@@ -564,8 +571,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
 
       return featureInfo;
     }) as unknown as ColumnsType[];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data.features, layerClassFilter, layerTimeFilter, handleZoomIn]);
+  }, [data.features, layerClassFilter, layerTimeFilter, handleZoomIn, mapId, containerType, t, dataTableController, uiController]);
 
   // TODO: Cleanup - remove  dead code
   // TODO: The table is triggering many useless callback. With max-height of 5000px, it is slower to create but faster scroll.
@@ -580,14 +586,17 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
   // hook.js:608 Warning: A component is changing a controlled input to be uncontrolled. This is likely caused by the value changing from a defined to undefined, which should not happen.
   // Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components Error Component Stack
 
-  let useTable: MRTTableInstance<ColumnsType> | null = null;
-  // Ref to the table wrapper element - used to scope search input DOM queries to a specific table instance
+  /** Ref to the table wrapper element — scopes search input DOM queries to this table instance. */
   const dataTableWrapperRef = useRef<HTMLDivElement>(null);
-  // Ref to track previous globalFilter value - used to detect when clear button is pressed (transition from text to empty)
+
+  /** Ref to track the previous globalFilter value — detects when the clear button is pressed (transition from text to empty). */
   const prevGlobalFilterRef = useRef<string | null>(null);
 
+  /** Ref to the table instance — used to access state in callbacks without adding the table instance to effect deps. */
+  const tableInstanceRef = useRef<MRTTableInstance<ColumnsType> | null>(null);
+
   // Create the Material React Table
-  useTable = useMaterialReactTable({
+  const useTable = useMaterialReactTable({
     columns: memoColumns,
     data: memoRows,
     enableDensityToggle: true,
@@ -624,7 +633,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
     renderTopToolbar: useCallback(
       (props: { table: MRTTableInstance<ColumnsType> }): ReactNode => (
         <TopToolbar
-          sxClasses={sxClasses}
+          sxClasses={memoSxClasses}
           layerPath={layerPath}
           t={t}
           globalFilter={globalFilter}
@@ -635,7 +644,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
           unfilteredFeaturesCount={unfilteredFeaturesCount}
         />
       ),
-      [sxClasses, layerPath, t, globalFilter, memoColumns, data, unfilteredFeaturesCount] // Include dependencies
+      [memoSxClasses, layerPath, t, globalFilter, memoColumns, data, unfilteredFeaturesCount] // Include dependencies
     ),
     enableFilterMatchHighlighting: true,
     enableColumnResizing: true,
@@ -654,10 +663,10 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
     columnVirtualizerOptions: { overscan: 2 },
     localization: dataTableLocalization,
     muiTableHeadCellProps: {
-      sx: sxClasses.tableHeadCell,
+      sx: memoSxClasses.tableHeadCell,
     },
     muiTableHeadProps: {
-      sx: sxClasses.tableHead,
+      sx: memoSxClasses.tableHead,
     },
     defaultColumn: {
       muiFilterTextFieldProps: {
@@ -699,6 +708,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
       'aria-label': t('dataTable.tableAriaLabelWithLayer', { layerName })!,
     },
   });
+  tableInstanceRef.current = useTable;
 
   /**
    * Scrolls to top of table when sorting changes.
@@ -708,7 +718,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
     logger.logTraceUseEffect('DATA-TABLE - sorting', sorting);
 
     // update scroll index when there are some rows in the table.
-    const rowsCount = useTable.getRowCount();
+    const rowsCount = tableInstanceRef.current?.getRowCount() ?? 0;
     // scroll to the top of the table when the sorting changes
     try {
       if (rowsCount > 0) {
@@ -717,7 +727,6 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
     } catch (error: unknown) {
       logger.logError('Data table error on sorting action', error);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sorting]);
 
   /**
@@ -728,21 +737,20 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
     logger.logTraceUseEffect('DATA-TABLE - memoInitialColumnFilterModes', memoInitialColumnFilterModes);
 
     // Only set defaults if we don't have stored values and columns are now available
-    if (Object.keys(columnFilterFns).length === 0 && Object.keys(memoInitialColumnFilterModes).length > 0) {
-      setColumnFilterFns(memoInitialColumnFilterModes);
+    if (Object.keys(memoInitialColumnFilterModes).length > 0) {
+      setColumnFilterFns((prev) => (Object.keys(prev).length === 0 ? memoInitialColumnFilterModes : prev));
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [memoInitialColumnFilterModes]);
 
   /**
-   * Converts column filter state into filter strings for the map.
+   * Builds filter expression strings from the current column filter state.
    *
-   * @param columnFilter - The column filters state
-   * @returns The list of filter strings
+   * @param columnFilter - The column filters to convert
+   * @returns The list of SQL-like filter expression strings, one per active filter
    */
   const buildFilterList = useCallback(
     (columnFilter: MRTColumnFiltersState): string[] => {
-      const tableState = useTable.getState();
+      const tableState = tableInstanceRef.current?.getState();
       if (!columnFilter.length) return [''];
 
       return columnFilter.map(({ id: filterId, value }) => {
@@ -826,7 +834,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
         if (isColumnFilterNumeric(filterId)) {
           const num = Number(value);
           if (Number.isNaN(num)) return '';
-          return `${filterId} ${NUMBER_FILTER[filterFn]} ${num}`;
+          return `${filterId} ${NUMBER_FILTER[filterFn ?? 'equals']} ${num}`;
         }
 
         /* -------------------------
@@ -838,47 +846,35 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
         return strFilter?.replace('filterId', filterId).replace('value', value as string) ?? '';
       });
     },
-    [useTable, isDateRange, isColumnFilterNumeric]
+    [isColumnFilterNumeric]
   );
 
   /**
-   * Filters the map based on the data table filter strings.
+   * Applies column filters to the map layer.
    *
-   * @param filters - The column filters to apply
-   */
-  const filterMap = debounce((filters: MRTColumnFiltersState) => {
-    const filterStrings = buildFilterList(filters)
-      .filter((filterValue) => filterValue.length)
-      .join(' and ');
-    dataTableController.applyMapFilters(filterStrings);
-  }, 500);
-
-  /**
-   * Debounces column filter changes before applying them to the map.
+   * Passing an empty array clears the map filter.
    *
-   * @param filters - The column filters to apply
+   * @param filters - The column filters to apply, or an empty array to clear
    */
-  const debouncedColumnFilters = useCallback(
+  const filterMap = useCallback(
     (filters: MRTColumnFiltersState): void => {
-      return filterMap(filters);
+      const filterStrings = buildFilterList(filters)
+        .filter((filterValue) => filterValue.length)
+        .join(' and ');
+      dataTableController.applyMapFilters(filterStrings);
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [datatableSettings[layerPath]?.mapFilteredRecord]
+    [buildFilterList, dataTableController]
   );
 
   /**
-   * Updates the map when column filters change.
+   * Applies map filters when column filters or the filter-map toggle changes.
    */
-  // update map when column filters change
   useEffect(() => {
     // Log
     logger.logTraceUseEffect('DATA-TABLE - columnFilters', columnFilters);
 
-    if (columnFilters && datatableSettings[layerPath].mapFilteredRecord) {
-      debouncedColumnFilters(columnFilters);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [columnFilters]);
+    filterMap(mapFilteredRecord ? columnFilters : []);
+  }, [columnFilters, filterMap, mapFilteredRecord]);
 
   /**
    * Saves column filter modes to the store when they change.
@@ -889,17 +885,6 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
 
     dataTableController.setColumnFilterModesEntry(layerPath, columnFilterFns);
   }, [dataTableController, columnFilterFns, layerPath]);
-
-  /**
-   * Updates the map when the filter map switch is toggled.
-   */
-  useEffect(() => {
-    // Log
-    logger.logTraceUseEffect('DATA-TABLE - mapFilteredRecord', datatableSettings[layerPath].mapFilteredRecord);
-
-    filterMap(columnFilters);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [datatableSettings[layerPath].mapFilteredRecord]);
 
   /**
    * Restores focus to the search input when the clear search button is pressed.
@@ -918,7 +903,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
   }, [globalFilter]);
 
   return (
-    <Box ref={dataTableWrapperRef} sx={sxClasses.dataTableWrapper} className="data-table-wrapper">
+    <Box ref={dataTableWrapperRef} sx={memoSxClasses.dataTableWrapper} className="data-table-wrapper">
       <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={language}>
         <MaterialReactTable table={useTable} />
       </LocalizationProvider>

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -139,25 +139,25 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
   const { globalFilter, setGlobalFilter } = useGlobalFilter({ layerPath });
   // #endregion
 
-  // #region Handlers
+  // #region HANDLERS
 
   /**
    * Handles density change for the data table.
    */
-  const handleDensityChange = (updaterOrValue: MRTDensityState | ((prevState: MRTDensityState) => MRTDensityState)): void => {
+  const handleDensityChange = useCallback((updaterOrValue: MRTDensityState | ((prevState: MRTDensityState) => MRTDensityState)): void => {
     setDensity(updaterOrValue);
-  };
+  }, []);
 
   /**
    * Handles toggling column filters visibility.
    */
-  const handleToggleColumnFilters = (updaterOrValue: boolean | ((prev: boolean) => boolean)): void => {
+  const handleToggleColumnFilters = useCallback((updaterOrValue: boolean | ((prev: boolean) => boolean)): void => {
     const newValue = typeof updaterOrValue === 'function' ? updaterOrValue(showColumnFilters) : updaterOrValue;
     setShowColumnFilters(newValue);
     dataTableController.setColumnsFiltersVisibility(layerPath, newValue);
-  };
+  }, [dataTableController, layerPath, showColumnFilters]);
 
-  // #endregion
+  // #endregion HANDLERS
 
   /** Checks if a value is a Dayjs instance. */
   const isDayjs = (v: unknown): v is Dayjs => typeof v === 'object' && v !== null && 'isValid' in v;

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -51,7 +51,7 @@ import linkifyHtml from 'linkify-html';
 import { isImage, delay, sanitizeHtmlContent, enhanceLinksAccessibility } from '@/core/utils/utilities';
 import { logger } from '@/core/utils/logger';
 import type { TypeFeatureInfoEntry } from '@/api/types/map-schema-types';
-import { useFilterRows, useGlobalFilter } from './hooks';
+import { useFilterRows, useGlobalFilter, useColumnVisibility } from './hooks';
 import { getSxClasses } from './data-table-style';
 import { useLightBox } from '@/core/components/common';
 import { NUMBER_FILTER, DATE_FILTER, STRING_FILTER } from '@/core/utils/constant';
@@ -150,6 +150,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
   const { initLightBox, LightBoxComponent } = useLightBox();
   const { columnFilters, setColumnFilters } = useFilterRows({ layerPath });
   const { globalFilter, setGlobalFilter } = useGlobalFilter({ layerPath });
+  const { columnVisibility, onColumnVisibilityChange } = useColumnVisibility({ layerPath });
   // #endregion
 
   // #region HANDLERS
@@ -374,6 +375,9 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
               enableSorting: false,
               enableResizing: false,
               enableGlobalFilter: false,
+              // GV Pinned columns must never be hidden — Hide All / Show All would put MRT in a
+              // GV contradictory pinned+hidden state that triggers repeated onColumnVisibilityChange calls.
+              enableHiding: false,
               muiTableBodyCellProps: {
                 sx: memoSxClasses.pinnedColumn,
               },
@@ -382,6 +386,9 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
               },
             }
           : {}),
+
+        // GV geoviewID is an internal column that must always remain hidden from the user.
+        ...(value.alias === 'geoviewID' ? { enableHiding: false } : {}),
       });
     });
 
@@ -607,7 +614,6 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
     initialState: {
       showColumnFilters: datatableSettings[layerPath].columnsFiltersVisibility,
       showGlobalFilter: true,
-      columnVisibility: { geoviewID: false },
     },
     state: {
       sorting,
@@ -617,6 +623,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
       columnPinning: { left: ['ICON', 'ZOOM', 'DETAILS'] },
       globalFilter,
       columnFilterFns,
+      columnVisibility,
     },
     icons: {
       FilterListOffIcon: ClearFiltersIcon,
@@ -628,6 +635,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
     onColumnFiltersChange: setColumnFilters,
     onGlobalFilterChange: setGlobalFilter,
     onColumnFilterFnsChange: setColumnFilterFns,
+    onColumnVisibilityChange,
     enableBottomToolbar: false,
     positionToolbarAlertBanner: 'none', // hide existing row count
     renderTopToolbar: useCallback(
@@ -883,7 +891,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
     // Log
     logger.logTraceUseEffect('DATA-TABLE - columnFilterFns', columnFilterFns);
 
-    dataTableController.setColumnFilterModesEntry(layerPath, columnFilterFns);
+    dataTableController.setColumnFilterModesRecord(layerPath, columnFilterFns);
   }, [dataTableController, columnFilterFns, layerPath]);
 
   /**

--- a/packages/geoview-core/src/core/components/data-table/data-table.tsx
+++ b/packages/geoview-core/src/core/components/data-table/data-table.tsx
@@ -43,12 +43,7 @@ import {
   useStoreLayerFilterClass,
   useStoreLayerName,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import {
-  useStoreDataTableLayerSettings,
-  setStoreColumnFilterModesEntry,
-  setStoreColumnsFiltersVisibility,
-  setStoreSelectedFeature,
-} from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { useStoreDataTableLayerSettings } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { useStoreTimeSliderFilter } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
 import { useStoreAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { DateMgt } from '@/core/utils/date-mgt';
@@ -159,7 +154,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
   const handleToggleColumnFilters = (updaterOrValue: boolean | ((prev: boolean) => boolean)): void => {
     const newValue = typeof updaterOrValue === 'function' ? updaterOrValue(showColumnFilters) : updaterOrValue;
     setShowColumnFilters(newValue);
-    setStoreColumnsFiltersVisibility(mapId, newValue, layerPath);
+    dataTableController.setColumnsFiltersVisibility(layerPath, newValue);
   };
 
   // #endregion
@@ -556,7 +551,7 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
             aria-label={t('dataTable.details')}
             tooltipPlacement="top"
             onClick={() => {
-              setStoreSelectedFeature(mapId, feature);
+              dataTableController.setSelectedFeature(feature);
               uiController.enableFocusTrap({ activeElementId: 'featureDetailDataTable', callbackElementId: featureDetailsButtonId });
             }}
           >
@@ -891,8 +886,8 @@ function DataTable({ data, layerPath, containerType, unfilteredFeaturesCount }: 
     // Log
     logger.logTraceUseEffect('DATA-TABLE - columnFilterFns', columnFilterFns);
 
-    setStoreColumnFilterModesEntry(mapId, columnFilterFns, layerPath);
-  }, [mapId, columnFilterFns, layerPath]);
+    dataTableController.setColumnFilterModesEntry(layerPath, columnFilterFns);
+  }, [dataTableController, columnFilterFns, layerPath]);
 
   /**
    * Updates the map when the filter map switch is toggled.

--- a/packages/geoview-core/src/core/components/data-table/filter-data-extent.tsx
+++ b/packages/geoview-core/src/core/components/data-table/filter-data-extent.tsx
@@ -4,12 +4,8 @@ import { useCallback } from 'react';
 
 import { getSxClasses } from './data-table-style';
 import { Switch } from '@/ui';
-import {
-  useStoreDataTableLayerSettings,
-  setStoreFilterDataToExtent,
-} from '@/core/stores/store-interface-and-intial-values/data-table-state';
-import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
-import { useMapController } from '@/core/controllers/use-controllers';
+import { useStoreDataTableLayerSettings } from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { useMapController, useDataTableController } from '@/core/controllers/use-controllers';
 
 import { logger } from '@/core/utils/logger';
 
@@ -33,9 +29,9 @@ function FilterDataToExtent(props: FilterDataToExtentProps): JSX.Element {
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
 
-  const mapId = useStoreGeoViewMapId();
   const datatableSettings = useStoreDataTableLayerSettings();
   const mapController = useMapController();
+  const dataTableController = useDataTableController();
 
   /**
    * Handles when the filter toggle is changed.
@@ -45,13 +41,13 @@ function FilterDataToExtent(props: FilterDataToExtentProps): JSX.Element {
   const handleFilterToggle = useCallback((): void => {
     // Toggle the filter state
     const newFilterState = !datatableSettings[layerPath].filterDataToExtent;
-    setStoreFilterDataToExtent(mapId, newFilterState, layerPath);
+    dataTableController.setFilterDataToExtent(layerPath, newFilterState);
 
     // Very slightly nudge the map center to trigger extent-based filtering
     // Alternate direction to prevent long-term drift
     const offset = newFilterState ? 0.00001 : -0.00001;
     mapController.nudgeMapCenter(offset, 0);
-  }, [mapId, layerPath, datatableSettings, mapController]);
+  }, [dataTableController, layerPath, datatableSettings, mapController]);
 
   return (
     <Switch

--- a/packages/geoview-core/src/core/components/data-table/filter-map.tsx
+++ b/packages/geoview-core/src/core/components/data-table/filter-map.tsx
@@ -38,7 +38,7 @@ function FilterMap({ layerPath, isGlobalFilterOn }: FilterMapProps): JSX.Element
    * This function toggles the filtered entry state for the specified layer in the data table.
    */
   const handleFilterdEntryChanged = useCallback(() => {
-    dataTableController.setFilteredEntry(layerPath, !datatableSettings[layerPath].mapFilteredRecord);
+    dataTableController.setMapFilteredRecord(layerPath, !datatableSettings[layerPath].mapFilteredRecord);
   }, [dataTableController, datatableSettings, layerPath]);
 
   return (

--- a/packages/geoview-core/src/core/components/data-table/filter-map.tsx
+++ b/packages/geoview-core/src/core/components/data-table/filter-map.tsx
@@ -1,11 +1,12 @@
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
 
 import { getSxClasses } from './data-table-style';
 import { Switch } from '@/ui';
-import { useStoreDataTableLayerSettings, setStoreMapFilteredEntry } from '@/core/stores/store-interface-and-intial-values/data-table-state';
-import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreDataTableLayerSettings } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { logger } from '@/core/utils/logger';
+import { useDataTableController } from '@/core/controllers/use-controllers';
 
 /** Properties for the FilterMap component. */
 interface FilterMapProps {
@@ -28,13 +29,22 @@ function FilterMap({ layerPath, isGlobalFilterOn }: FilterMapProps): JSX.Element
   const theme = useTheme();
   const sxClasses = getSxClasses(theme);
 
-  const mapId = useStoreGeoViewMapId();
   const datatableSettings = useStoreDataTableLayerSettings();
+  const dataTableController = useDataTableController();
+
+  /**
+   * Handles the change event for the filter map toggle switch.
+   *
+   * This function toggles the filtered entry state for the specified layer in the data table.
+   */
+  const handleFilterdEntryChanged = useCallback(() => {
+    dataTableController.setFilteredEntry(layerPath, !datatableSettings[layerPath].mapFilteredRecord);
+  }, [dataTableController, datatableSettings, layerPath]);
 
   return (
     <Switch
       size="medium"
-      onChange={() => setStoreMapFilteredEntry(mapId, !datatableSettings[layerPath].mapFilteredRecord, layerPath)}
+      onChange={handleFilterdEntryChanged}
       checked={!!datatableSettings[layerPath].mapFilteredRecord}
       sx={sxClasses.filterMap}
       disabled={isGlobalFilterOn}

--- a/packages/geoview-core/src/core/components/data-table/hooks/index.ts
+++ b/packages/geoview-core/src/core/components/data-table/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './useFilterRows';
 export * from './useToolbarActionMessage';
 export * from './useFeatureFieldInfos';
 export * from './useGlobalFilter';
+export * from './useColumnVisibility';

--- a/packages/geoview-core/src/core/components/data-table/hooks/useColumnVisibility.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useColumnVisibility.tsx
@@ -1,0 +1,78 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+import { useStoreDataTableLayerSettings } from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { useDataTableController } from '@/core/controllers/use-controllers';
+
+/** Properties for the useColumnVisibility hook. */
+export interface UseColumnVisibilityProps {
+  layerPath: string;
+}
+
+/**
+ * Custom hook to manage column visibility state for the data table.
+ *
+ * Uses a normalization guard in the change handler to prevent the re-render loop
+ * caused by MRT calling onColumnVisibilityChange during its own render cycle to
+ * register default visibility for columns it has not yet seen.
+ *
+ * @param props - Hook properties containing the layer path
+ * @returns The column visibility state, its setter, and a change handler to pass to MRT
+ */
+export function useColumnVisibility({ layerPath }: UseColumnVisibilityProps): {
+  columnVisibility: Record<string, boolean>;
+  setColumnVisibility: Dispatch<SetStateAction<Record<string, boolean>>>;
+  onColumnVisibilityChange: (
+    updaterOrValue: Record<string, boolean> | ((prev: Record<string, boolean>) => Record<string, boolean>)
+  ) => void;
+} {
+  const datatableSettings = useStoreDataTableLayerSettings();
+  const dataTableController = useDataTableController();
+
+  const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>(
+    datatableSettings[layerPath]?.columnVisibilityRecord ?? { geoviewID: false }
+  );
+
+  /** Tracks the latest columnVisibility value so the unmount cleanup can persist it without depending on state. */
+  const columnVisibilityRef = useRef(columnVisibility);
+
+  /**
+   * Handles column visibility changes from MRT.
+   *
+   * MRT calls this during its render cycle to register default visible state for
+   * columns it has not yet seen (normalization). Normalization only ever adds new
+   * keys set to true — it never changes existing keys. We detect that case and skip
+   * the state update to break the potential re-render loop.
+   *
+   * @param updaterOrValue - The new visibility record or an updater function
+   */
+  const onColumnVisibilityChange = (
+    updaterOrValue: Record<string, boolean> | ((prev: Record<string, boolean>) => Record<string, boolean>)
+  ): void => {
+    setColumnVisibility((prev) => {
+      const next = typeof updaterOrValue === 'function' ? updaterOrValue(prev) : updaterOrValue;
+      // MRT normalization only adds previously unknown columns as visible (true).
+      // If every key in `next` is either new-with-true or unchanged, this is normalization — skip.
+      const isNormalization = Object.keys(next).every((key) => (key in prev ? next[key] === prev[key] : next[key] === true));
+      const resolved = isNormalization ? prev : next;
+      columnVisibilityRef.current = resolved;
+      return resolved;
+    });
+  };
+
+  /**
+   * Persists column visibility to the store on unmount only.
+   *
+   * Writing to Zustand on every visibility change triggers a DataTable re-render,
+   * which causes MRT to re-normalize controlled state and fire onColumnVisibilityChange
+   * again — creating a loop on repeated Hide All / Show All clicks. Persisting only on
+   * unmount is safe because DataTable remounts (keyed by layerPath) on each layer switch.
+   */
+  useEffect(() => {
+    return (): void => {
+      dataTableController.setColumnVisibilityRecord(layerPath, columnVisibilityRef.current);
+    };
+  }, [dataTableController, layerPath]);
+
+  return { columnVisibility, setColumnVisibility, onColumnVisibilityChange };
+}

--- a/packages/geoview-core/src/core/components/data-table/hooks/useFilterRows.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useFilterRows.tsx
@@ -1,12 +1,9 @@
 import type { Dispatch, SetStateAction } from 'react';
 import { useEffect, useState } from 'react';
 import type { TypeColumnFiltersState } from '@/core/stores/store-interface-and-intial-values/data-table-state';
-import {
-  useStoreDataTableLayerSettings,
-  setStoreColumnFiltersEntry,
-} from '@/core/stores/store-interface-and-intial-values/data-table-state';
-import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreDataTableLayerSettings } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { logger } from '@/core/utils/logger';
+import { useDataTableController } from '@/core/controllers/use-controllers';
 
 /** Properties for the useFilterRows hook. */
 export interface UseFilterRowsProps {
@@ -23,8 +20,8 @@ export function useFilterRows({ layerPath }: UseFilterRowsProps): {
   columnFilters: TypeColumnFiltersState;
   setColumnFilters: Dispatch<SetStateAction<TypeColumnFiltersState>>;
 } {
-  const mapId = useStoreGeoViewMapId();
   const datatableSettings = useStoreDataTableLayerSettings();
+  const dataTableController = useDataTableController();
 
   const [columnFilters, setColumnFilters] = useState<TypeColumnFiltersState>(datatableSettings[layerPath].columnFiltersRecord || []);
 
@@ -35,8 +32,8 @@ export function useFilterRows({ layerPath }: UseFilterRowsProps): {
     // Log
     logger.logTraceUseEffect('USEFILTERROWS - columnFilters', columnFilters);
 
-    setStoreColumnFiltersEntry(mapId, columnFilters, layerPath);
-  }, [mapId, columnFilters, layerPath]);
+    dataTableController.setColumnFiltersEntry(layerPath, columnFilters);
+  }, [dataTableController, columnFilters, layerPath]);
 
   return { columnFilters, setColumnFilters };
 }

--- a/packages/geoview-core/src/core/components/data-table/hooks/useFilterRows.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useFilterRows.tsx
@@ -32,7 +32,7 @@ export function useFilterRows({ layerPath }: UseFilterRowsProps): {
     // Log
     logger.logTraceUseEffect('USEFILTERROWS - columnFilters', columnFilters);
 
-    dataTableController.setColumnFiltersEntry(layerPath, columnFilters);
+    dataTableController.setColumnFiltersRecord(layerPath, columnFilters);
   }, [dataTableController, columnFilters, layerPath]);
 
   return { columnFilters, setColumnFilters };

--- a/packages/geoview-core/src/core/components/data-table/hooks/useGlobalFilter.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useGlobalFilter.tsx
@@ -30,7 +30,7 @@ export function useGlobalFilter({ layerPath }: UseGlobalFilterProps): {
     // Log
     logger.logTraceUseEffect('USEGLOBALFILTERS - globalFilters', globalFilter);
 
-    dataTableController.setGlobalFilteredEntry(layerPath, globalFilter);
+    dataTableController.setGlobalFilterRecord(layerPath, globalFilter);
   }, [dataTableController, globalFilter, layerPath]);
 
   return { globalFilter, setGlobalFilter };

--- a/packages/geoview-core/src/core/components/data-table/hooks/useGlobalFilter.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useGlobalFilter.tsx
@@ -1,11 +1,8 @@
 import type { Dispatch, SetStateAction } from 'react';
 import { useEffect, useState } from 'react';
-import {
-  useStoreDataTableLayerSettings,
-  setStoreGlobalFilteredEntry,
-} from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { useStoreDataTableLayerSettings } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { logger } from '@/core/utils/logger';
-import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
+import { useDataTableController } from '@/core/controllers/use-controllers';
 
 /** Properties for the useGlobalFilter hook. */
 export interface UseGlobalFilterProps {
@@ -23,8 +20,7 @@ export function useGlobalFilter({ layerPath }: UseGlobalFilterProps): {
   setGlobalFilter: Dispatch<SetStateAction<string>>;
 } {
   const datatableSettings = useStoreDataTableLayerSettings();
-
-  const mapId = useStoreGeoViewMapId();
+  const dataTableController = useDataTableController();
   const [globalFilter, setGlobalFilter] = useState(datatableSettings[layerPath].globalFilterRecord ?? '');
 
   /**
@@ -34,8 +30,8 @@ export function useGlobalFilter({ layerPath }: UseGlobalFilterProps): {
     // Log
     logger.logTraceUseEffect('USEGLOBALFILTERS - globalFilters', globalFilter);
 
-    setStoreGlobalFilteredEntry(mapId, globalFilter, layerPath);
-  }, [mapId, globalFilter, layerPath]);
+    dataTableController.setGlobalFilteredEntry(layerPath, globalFilter);
+  }, [dataTableController, globalFilter, layerPath]);
 
   return { globalFilter, setGlobalFilter };
 }

--- a/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
@@ -5,7 +5,7 @@ import { setStoreRowsFilteredEntry } from '@/core/stores/store-interface-and-int
 import { logger } from '@/core/utils/logger';
 import type { ColumnsType } from '@/core/components/data-table/data-table-types';
 import type { TypeFeatureInfoEntry } from '@/api/types/map-schema-types';
-import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
+import { useDataTableController } from '@/core/controllers/use-controllers';
 
 /** Properties for the useToolbarActionMessage hook. */
 interface UseSelectedRowMessageProps {
@@ -37,7 +37,7 @@ export function useToolbarActionMessage({
   const { t } = useTranslation();
 
   // Get store values
-  const mapId = useStoreGeoViewMapId();
+  const dataTableController = useDataTableController();
 
   /**
    * Computes the toolbar message based on current filters and feature data.
@@ -70,6 +70,8 @@ export function useToolbarActionMessage({
         message = `${data.features?.length} ${t('dataTable.features')}`;
         length = 0;
       }
+
+      dataTableController.setRowsFilteredEntry(layerPath, length);
     }
 
     return { message, filteredRowCount: length };

--- a/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
@@ -79,7 +79,7 @@ export function useToolbarActionMessage({
     logger.logTraceUseEffect('USETOOLBARACTIONMESSAGE - set store toolbar message', memoToolbarMessage.filteredRowCount);
 
     // Update the store with the current filtered row count for the layer
-    dataTableController.setRowsFilteredEntry(layerPath, memoToolbarMessage.filteredRowCount);
+    dataTableController.setRowsFilteredRecord(layerPath, memoToolbarMessage.filteredRowCount);
   }, [dataTableController, layerPath, memoToolbarMessage.filteredRowCount, memoToolbarMessage.message]);
 
   return memoToolbarMessage.message;

--- a/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
+++ b/packages/geoview-core/src/core/components/data-table/hooks/useToolbarActionMessage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import type { MRT_TableInstance as MRTTableInstance, MRT_ColumnFiltersState as MRTColumnFiltersState } from 'material-react-table';
 import { useTranslation } from 'react-i18next';
-import { setStoreRowsFilteredEntry } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { logger } from '@/core/utils/logger';
 import type { ColumnsType } from '@/core/components/data-table/data-table-types';
 import type { TypeFeatureInfoEntry } from '@/api/types/map-schema-types';
@@ -70,8 +69,6 @@ export function useToolbarActionMessage({
         message = `${data.features?.length} ${t('dataTable.features')}`;
         length = 0;
       }
-
-      dataTableController.setRowsFilteredEntry(layerPath, length);
     }
 
     return { message, filteredRowCount: length };
@@ -82,8 +79,8 @@ export function useToolbarActionMessage({
     logger.logTraceUseEffect('USETOOLBARACTIONMESSAGE - set store toolbar message', memoToolbarMessage.filteredRowCount);
 
     // Update the store with the current filtered row count for the layer
-    setStoreRowsFilteredEntry(mapId, memoToolbarMessage.filteredRowCount, layerPath);
-  }, [mapId, layerPath, memoToolbarMessage.filteredRowCount, memoToolbarMessage.message]);
+    dataTableController.setRowsFilteredEntry(layerPath, memoToolbarMessage.filteredRowCount);
+  }, [dataTableController, layerPath, memoToolbarMessage.filteredRowCount, memoToolbarMessage.message]);
 
   return memoToolbarMessage.message;
 }

--- a/packages/geoview-core/src/core/components/data-table/top-toolbar.tsx
+++ b/packages/geoview-core/src/core/components/data-table/top-toolbar.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable camelcase */
-import { memo } from 'react';
 
 import type { MRT_TableInstance as MRTTableInstance, MRT_ColumnDef } from 'material-react-table';
 import {
@@ -155,4 +154,4 @@ function TopToolbar(props: TopToolbarProps<ColumnsType>): JSX.Element {
   );
 }
 
-export default memo(TopToolbar);
+export default TopToolbar;

--- a/packages/geoview-core/src/core/components/details/coordinate-info.tsx
+++ b/packages/geoview-core/src/core/components/details/coordinate-info.tsx
@@ -80,6 +80,7 @@ export function CoordinateInfoSwitch({ disabled }: CoordinateInfoSwitchProps): J
    * Aborts the previous coordinate info request on unmount.
    */
   useEffect(() => {
+    logger.logTraceUseEffect('COORDINATE-INFO - abort on unmount');
     return (): void => {
       abortControllerRef.current?.abort();
     };
@@ -108,7 +109,10 @@ export function CoordinateInfoSwitch({ disabled }: CoordinateInfoSwitchProps): J
 export function CoordinateInfo(): JSX.Element {
   const { t } = useTranslation();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('COORDINATE-INFO - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // Store
   const clickCoordinates = useStoreMapClickCoordinates();
@@ -120,6 +124,7 @@ export function CoordinateInfo(): JSX.Element {
    * Memoizes the parsed coordinate data from the feature.
    */
   const memoCoordinateData = useMemo((): CoordinateData => {
+    logger.logTraceUseMemo('COORDINATE-INFO - memoCoordinateData', clickCoordinates);
     return {
       lat: parseFloat(clickCoordinates?.lonlat[1]?.toString() || '0'),
       lng: parseFloat(clickCoordinates?.lonlat[0]?.toString() || '0'),
@@ -134,20 +139,20 @@ export function CoordinateInfo(): JSX.Element {
   const { lat, lng, utmZone, easting, northing, ntsMapsheet, elevation } = memoCoordinateData;
 
   return (
-    <Box sx={sxClasses.rightPanelContainer} className="guide-content-container">
-      <Box sx={sxClasses.coordinateInfoContainer}>
-        <Typography component="h4" variant="h6" sx={sxClasses.coordinateInfoTitle}>
+    <Box sx={memoSxClasses.rightPanelContainer} className="guide-content-container">
+      <Box sx={memoSxClasses.coordinateInfoContainer}>
+        <Typography component="h4" variant="h6" sx={memoSxClasses.coordinateInfoTitle}>
           {t('details.coordinateInfoTitle')}
         </Typography>
 
         <List>
-          <ListItem sx={sxClasses.coordinateInfoSection} disablePadding>
-            <Typography variant="subtitle1" sx={sxClasses.coordinateInfoSectionTitle}>
+          <ListItem sx={memoSxClasses.coordinateInfoSection} disablePadding>
+            <Typography variant="subtitle1" sx={memoSxClasses.coordinateInfoSectionTitle}>
               {t('details.geographicCoordinates')}
             </Typography>
-            <Box sx={sxClasses.coordinateInfoContent}>
+            <Box sx={memoSxClasses.coordinateInfoContent}>
               <Typography>{t('details.degreesDecimal')}:</Typography>
-              <Box sx={sxClasses.coordinateInfoSubContent}>
+              <Box sx={memoSxClasses.coordinateInfoSubContent}>
                 <Typography>
                   {t('details.latitude')}: {lat.toFixed(6)}° {lat >= 0 ? 'N' : 'S'}
                 </Typography>
@@ -156,7 +161,7 @@ export function CoordinateInfo(): JSX.Element {
                 </Typography>
               </Box>
               <Typography>{t('details.degreesMinutesSeconds')}:</Typography>
-              <Box sx={sxClasses.coordinateInfoSubContent}>
+              <Box sx={memoSxClasses.coordinateInfoSubContent}>
                 <Typography>
                   {t('details.latitude')}: {GeoUtilities.coordFormatDMS(lat)}
                 </Typography>
@@ -167,13 +172,13 @@ export function CoordinateInfo(): JSX.Element {
             </Box>
           </ListItem>
 
-          <ListItem sx={sxClasses.coordinateInfoSection} disablePadding>
-            <Typography variant="subtitle1" sx={sxClasses.coordinateInfoSectionTitle}>
+          <ListItem sx={memoSxClasses.coordinateInfoSection} disablePadding>
+            <Typography variant="subtitle1" sx={memoSxClasses.coordinateInfoSectionTitle}>
               {t('details.utmCoordinates')}
             </Typography>
             {spinning && <CircularProgressBase size={20} />}
             {!spinning && utmZone && (
-              <Box sx={sxClasses.coordinateInfoContent}>
+              <Box sx={memoSxClasses.coordinateInfoContent}>
                 <Typography>
                   {t('details.zone')}: {utmZone}
                 </Typography>
@@ -187,13 +192,13 @@ export function CoordinateInfo(): JSX.Element {
             )}
           </ListItem>
 
-          <ListItem sx={sxClasses.coordinateInfoSection} disablePadding>
-            <Typography variant="subtitle1" sx={sxClasses.coordinateInfoSectionTitle}>
+          <ListItem sx={memoSxClasses.coordinateInfoSection} disablePadding>
+            <Typography variant="subtitle1" sx={memoSxClasses.coordinateInfoSectionTitle}>
               {t('details.ntsMapsheet')}
             </Typography>
             {spinning && <CircularProgressBase size={20} />}
             {!spinning && ntsMapsheet && (
-              <Box sx={sxClasses.coordinateInfoContent}>
+              <Box sx={memoSxClasses.coordinateInfoContent}>
                 {ntsMapsheet.split('\n').map((line) => (
                   <Typography key={line}>{line}</Typography>
                 ))}
@@ -201,13 +206,13 @@ export function CoordinateInfo(): JSX.Element {
             )}
           </ListItem>
 
-          <ListItem sx={sxClasses.coordinateInfoSection} disablePadding>
-            <Typography variant="subtitle1" sx={sxClasses.coordinateInfoSectionTitle}>
+          <ListItem sx={memoSxClasses.coordinateInfoSection} disablePadding>
+            <Typography variant="subtitle1" sx={memoSxClasses.coordinateInfoSectionTitle}>
               {t('details.elevation')}
             </Typography>
             {spinning && <CircularProgressBase size={20} />}
             {!spinning && elevation && (
-              <Box sx={sxClasses.coordinateInfoContent}>
+              <Box sx={memoSxClasses.coordinateInfoContent}>
                 <Typography>{elevation}</Typography>
               </Box>
             )}

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -11,22 +11,20 @@ import {
   useStoreDetailsSelectedLayerPath,
   useStoreDetailsCoordinateInfoEnabled,
   useStoreDetailsHideCoordinateInfoSwitch,
-  setStoreDetailsLayerDataArrayBatchLayerPathBypass,
-  setStoreDetailsSelectedLayerPath,
-  removeStoreDetailsCheckedFeature,
   LAYER_PATH_COORDINATE_INFO,
 } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import { useStoreUIActiveAppBarTab, useStoreUIActiveFooterBarTab } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import { useStoreLayerNameSet, useStoreLayerStatusSet } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import {
-  useStoreMapClickCoordinates,
-  useStoreMapAllVisibleandInRangeLayers,
-  useStoreMapOrderedLayers,
-  useStoreMapLayerQueryable,
-  useStoreMapIsParentLayerHiddenOnMapSet,
-  useStoreMapIsLayerHiddenOnMapSet,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
+  useStoreLayerNameSet,
+  useStoreLayerStatusSet,
+  useStoreLayerQueryableByPaths,
+  useStoreLayerIsHiddenOnMapSet,
+  useStoreLayerIsParentHiddenOnMapSet,
+  useStoreLayerAllVisibleAndInRangeLayers,
+  useStoreLayerOrderedLayerPaths,
+} from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
+import { useStoreMapClickCoordinates } from '@/core/stores/store-interface-and-intial-values/map-state';
 import type { TypeFeatureInfoEntry, TypeLayerData, TypeMapMouseInfo } from '@/api/types/map-schema-types';
 
 import type { LayerListEntry, LayoutExposedMethods } from '@/core/components/common';
@@ -38,7 +36,7 @@ import { CONTAINER_TYPE, FEATURE_INFO_STATUS, TABS, TIMEOUT } from '@/core/utils
 import { DetailsSkeleton } from './details-skeleton';
 import { CoordinateInfo, CoordinateInfoSwitch } from './coordinate-info';
 import { logger } from '@/core/utils/logger';
-import { useMapController, useUIController } from '@/core/controllers/use-controllers';
+import { useMapController, useUIController, useDetailsController } from '@/core/controllers/use-controllers';
 
 /** Properties for the details panel component. */
 interface DetailsPanelType {
@@ -67,18 +65,19 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
   const checkedFeatures = useStoreDetailsCheckedFeatures();
   const coordinateInfoEnabled = useStoreDetailsCoordinateInfoEnabled();
   const hideCoordinateInfoSwitch = useStoreDetailsHideCoordinateInfoSwitch();
-  const visibleInRangeLayers = useStoreMapAllVisibleandInRangeLayers();
-  const orderedLayers = useStoreMapOrderedLayers();
+  const visibleInRangeLayers = useStoreLayerAllVisibleAndInRangeLayers();
+  const orderedLayers = useStoreLayerOrderedLayerPaths();
   const mapClickCoordinates = useStoreMapClickCoordinates();
   const { tabId: appBarTabId, isOpen: appBarIsOpen } = useStoreUIActiveAppBarTab();
   const { tabId: footerBarTabId, isOpen: footerBarIsOpen } = useStoreUIActiveFooterBarTab();
-  const queryableByLayerPath = useStoreMapLayerQueryable(visibleInRangeLayers);
+  const queryableByLayerPath = useStoreLayerQueryableByPaths(visibleInRangeLayers);
   const layerNames = useStoreLayerNameSet();
   const layerStatuses = useStoreLayerStatusSet();
-  const layerHiddenSet = useStoreMapIsLayerHiddenOnMapSet();
-  const layerParentHiddenSet = useStoreMapIsParentLayerHiddenOnMapSet();
+  const layerHiddenSet = useStoreLayerIsHiddenOnMapSet();
+  const layerParentHiddenSet = useStoreLayerIsParentHiddenOnMapSet();
   const uiController = useUIController();
   const mapController = useMapController();
+  const detailsController = useDetailsController();
 
   // States
   const [currentFeatureIndex, setCurrentFeatureIndex] = useState<number>(0);
@@ -372,8 +371,8 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
     logger.logTraceUseEffect('DETAILS-PANEL - memoLayersList changed', memoLayersList);
 
     // Unselect the layer path if no more layers in the list
-    if (!memoLayersList.length) setStoreDetailsSelectedLayerPath(mapId, '');
-  }, [memoLayersList, mapId]);
+    if (!memoLayersList.length) detailsController.setSelectedLayerPath('');
+  }, [memoLayersList, detailsController]);
 
   /**
    * Effect used when the layers list changes.
@@ -423,8 +422,8 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
     logger.logTraceUseEffect('DETAILS-PANEL - update layer data bypass', selectedLayerPath);
 
     // Set the layer data array batch bypass to the currently selected layer
-    setStoreDetailsLayerDataArrayBatchLayerPathBypass(mapId, selectedLayerPath);
-  }, [mapId, selectedLayerPath]);
+    detailsController.setLayerDataArrayBatchLayerPathBypass(selectedLayerPath);
+  }, [detailsController, selectedLayerPath]);
 
   /**
    * Effect used to persist or alter the current layer selection based on the layers list changes
@@ -438,14 +437,13 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
     if (selectedLayerPath) {
       // Redirect to the keep selected layer path logic
       checkSelectedLayerPathList(
-        mapId,
-        setStoreDetailsLayerDataArrayBatchLayerPathBypass,
-        setStoreDetailsSelectedLayerPath,
+        (lyrPath) => detailsController.setLayerDataArrayBatchLayerPathBypass(lyrPath),
+        (lyrPath) => detailsController.setSelectedLayerPath(lyrPath),
         memoLayerSelectedItem,
         memoLayersList
       );
     }
-  }, [mapId, memoLayerSelectedItem, memoLayersList, selectedLayerPath]);
+  }, [detailsController, memoLayerSelectedItem, memoLayersList, selectedLayerPath]);
 
   // #endregion
 
@@ -459,10 +457,10 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
     // clear all highlights from features on the map in all layers
     mapController.removeHighlightedFeature('all');
     // clear checked features array
-    removeStoreDetailsCheckedFeature(mapId, 'all');
+    detailsController.removeCheckedFeature('all');
     // add the highlight to the current feature
     mapController.addHighlightedFeature(memoSelectedLayerData?.features?.[currentFeatureIndex] as TypeFeatureInfoEntry);
-  }, [checkedFeatures, currentFeatureIndex, mapId, mapController, memoSelectedLayerData?.features]);
+  }, [checkedFeatures, currentFeatureIndex, detailsController, mapController, memoSelectedLayerData?.features]);
 
   /**
    * Handles when the right panel is closed in responsive layout.
@@ -535,7 +533,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
   const handleLayerChange = useCallback(
     (layerEntry: LayerListEntry): void => {
       // Set the selected layer path in the store which will in turn trigger the store listeners on this component
-      setStoreDetailsSelectedLayerPath(mapId, layerEntry.layerPath);
+      detailsController.setSelectedLayerPath(layerEntry.layerPath);
 
       // Re-highlight the current feature when panel becomes visible (layer selection makes panel visible)
       // Use setTimeout to ensure the layer data is updated first
@@ -547,7 +545,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
         }
       }, TIMEOUT.deferExecution);
     },
-    [mapId, mapController, arrayOfLayerDataBatch, hasValidGeometry]
+    [detailsController, mapController, arrayOfLayerDataBatch, hasValidGeometry]
   );
   // #endregion
 
@@ -608,7 +606,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
       // if we don't have a selected layer path with features select the first layer path with features
       if (!selectedLayerPath.length) {
         const selectedLayer = memoLayersList.find((layer) => !!layer.numOffeatures);
-        setStoreDetailsSelectedLayerPath(mapId, selectedLayer?.layerPath ?? '');
+        detailsController.setSelectedLayerPath(selectedLayer?.layerPath ?? '');
         // Ensure the info panel is visible
         layoutRef.current?.showRightPanel(true);
       }
@@ -621,9 +619,12 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
 
     // On new map click (coordinates changed), clear all highlights, checked features, and layer features
     if (coordinatesChanged) {
+      // Clear all highlights
       mapController.removeHighlightedFeature('all');
 
-      removeStoreDetailsCheckedFeature(mapId, 'all');
+      // Clear all checked features
+      detailsController.removeCheckedFeature('all');
+
       // Clear features from all layers to remove out-of-range layers from display
       arrayOfLayerDataBatch.forEach((layer) => {
         // eslint-disable-next-line no-param-reassign
@@ -633,7 +634,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
       prevMapClickCoordinates.current = mapClickCoordinates;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapId, mapController, mapClickCoordinates, memoLayersList, coordinateInfoEnabled]);
+  }, [detailsController, mapController, mapClickCoordinates, memoLayersList, coordinateInfoEnabled]);
 
   /**
    * Clear highlights and checked features when the details panel is closed
@@ -657,10 +658,11 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
 
       // Clear all highlights
       mapController.removeHighlightedFeature('all');
+
       // Clear all checked features
-      removeStoreDetailsCheckedFeature(mapId, 'all');
+      detailsController.removeCheckedFeature('all');
     }
-  }, [mapId, mapController, footerBarTabId, footerBarIsOpen, appBarTabId, appBarIsOpen, containerType]);
+  }, [detailsController, mapController, footerBarTabId, footerBarIsOpen, appBarTabId, appBarIsOpen, containerType]);
 
   /**
    * Checks if all layers query status is processed.
@@ -702,7 +704,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
         logger.logDebug('DETAILS-PANEL - All layers have no features and coordinate info is disabled, showing right panel with guide');
 
         // Clear selection to show the guide
-        setStoreDetailsSelectedLayerPath(mapId, '');
+        detailsController.setSelectedLayerPath('');
 
         // Make sure the right panel is visible
         if (!isRightPanelVisible) {
@@ -711,7 +713,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
       }
     }
   }, [
-    mapId,
+    detailsController,
     appBarTabId,
     appBarIsOpen,
     footerBarTabId,

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -56,7 +56,10 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
   // Hooks
   const { t } = useTranslation<string>();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('DETAILS-PANEL - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // Store
   const mapId = useStoreGeoViewMapId();
@@ -99,6 +102,9 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
    */
   // Create a memoized Set of checked feature IDs
   const memoIsCheckedFeaturesSet = useMemo(() => {
+    // Log
+    logger.logTraceUseMemo('DETAILS-PANEL - memoIsCheckedFeaturesSet', checkedFeatures);
+
     return new Set(checkedFeatures.map((feature) => feature?.uid));
   }, [checkedFeatures]);
 
@@ -166,6 +172,9 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
    * Memoizes whether the panel is currently open.
    */
   const memoIsPanelOpen = useMemo(() => {
+    // Log
+    logger.logTraceUseMemo('DETAILS-PANEL - memoIsPanelOpen', containerType, footerBarTabId, footerBarIsOpen, appBarTabId, appBarIsOpen, isRightPanelVisible);
+
     if (containerType === CONTAINER_TYPE.FOOTER_BAR) {
       return footerBarTabId === TABS.DETAILS && footerBarIsOpen && isRightPanelVisible;
     }
@@ -755,8 +764,8 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
       const isNextDisabled = !memoSelectedLayerData?.features || currentFeatureIndex + 1 >= memoSelectedLayerData.features.length;
 
       return (
-        <Box sx={sxClasses.rightPanelContainer} className="guide-content-container">
-          <Grid container sx={sxClasses.rightPanelBtnHolder}>
+        <Box sx={memoSxClasses.rightPanelContainer} className="guide-content-container">
+          <Grid container sx={memoSxClasses.rightPanelBtnHolder}>
             <Grid size={{ xs: 6 }} sx={{ alignSelf: 'center' }}>
               <Box role="status" aria-live="polite" aria-atomic="true">
                 {t('details.featureDetailsTitle')
@@ -823,7 +832,7 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
       containerType={containerType}
       titleFullscreen={t('details.title')}
       layoutSwitch={
-        <Box sx={sxClasses.layoutSwitch}>
+        <Box sx={memoSxClasses.layoutSwitch}>
           {!hideCoordinateInfoSwitch && <CoordinateInfoSwitch disabled={!mapClickCoordinates} />}
           <IconButton
             aria-label={t('details.clearAllfeatures')}

--- a/packages/geoview-core/src/core/components/details/details-panel.tsx
+++ b/packages/geoview-core/src/core/components/details/details-panel.tsx
@@ -173,7 +173,15 @@ export function DetailsPanel({ containerType }: DetailsPanelType): JSX.Element {
    */
   const memoIsPanelOpen = useMemo(() => {
     // Log
-    logger.logTraceUseMemo('DETAILS-PANEL - memoIsPanelOpen', containerType, footerBarTabId, footerBarIsOpen, appBarTabId, appBarIsOpen, isRightPanelVisible);
+    logger.logTraceUseMemo(
+      'DETAILS-PANEL - memoIsPanelOpen',
+      containerType,
+      footerBarTabId,
+      footerBarIsOpen,
+      appBarTabId,
+      appBarIsOpen,
+      isRightPanelVisible
+    );
 
     if (containerType === CONTAINER_TYPE.FOOTER_BAR) {
       return footerBarTabId === TABS.DETAILS && footerBarIsOpen && isRightPanelVisible;

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -12,13 +12,8 @@ import {
   Typography,
   ZoomInSearchIcon,
 } from '@/ui';
+import { useStoreDetailsCheckedFeatures } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import {
-  addStoreDetailsCheckedFeature,
-  removeStoreDetailsCheckedFeature,
-  useStoreDetailsCheckedFeatures,
-} from '@/core/stores/store-interface-and-intial-values/feature-info-state';
-import {
-  setStoreGeochartSelectedLayerPath,
   useStoreGeochartChartsConfig,
   useStoreGeochartLayerDataArrayBatch,
 } from '@/core/stores/store-interface-and-intial-values/geochart-state';
@@ -30,8 +25,7 @@ import type { TypeContainerBox } from '@/core/types/global-types';
 import { FeatureInfoTable } from './feature-info-table';
 import { getSxClasses } from './details-style';
 import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
-import { useMapController } from '@/core/controllers/use-controllers';
+import { useDetailsController, useGeoChartControllerIfExists, useMapController } from '@/core/controllers/use-controllers';
 
 /** Properties for the FeatureInfo component. */
 interface FeatureInfoProps {
@@ -211,14 +205,17 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
   const [checked, setChecked] = useState<boolean>(false);
 
   // Store
-  const mapId = useStoreGeoViewMapId();
   const checkedFeatures = useStoreDetailsCheckedFeatures();
   const geochartLayerDataArrayBatch = useStoreGeochartLayerDataArrayBatch();
   const geochartConfigs = useStoreGeochartChartsConfig();
   const mapController = useMapController();
+  const detailsController = useDetailsController();
+  const geoChartController = useGeoChartControllerIfExists();
 
   // Use navigate hook for geochart (only if geochart state exists)
-  const navigateToGeochart = useNavigateToTab('geochart', setStoreGeochartSelectedLayerPath);
+  const navigateToGeochart = useNavigateToTab('geochart', (lyrPath) => {
+    geoChartController?.setSelectedLayerPath(lyrPath);
+  });
 
   /**
    * Memoizes the feature name.
@@ -273,13 +270,13 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
       // If feature is checked
       if (checkedState) {
         // Add
-        addStoreDetailsCheckedFeature(mapId, feature);
+        detailsController.addCheckedFeature(feature);
       } else {
         // Remove
-        removeStoreDetailsCheckedFeature(mapId, feature);
+        detailsController.removeCheckedFeature(feature);
       }
     },
-    [mapId, feature]
+    [detailsController, feature]
   );
 
   /**

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -106,7 +106,10 @@ const FeatureHeader = memo(function FeatureHeader({
   // Hooks
   const { t } = useTranslation();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('FEATURE-INFO - FeatureHeader - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
   const isFocusTrap = useStoreUIActiveTrapGeoView();
 
   /**
@@ -119,7 +122,7 @@ const FeatureHeader = memo(function FeatureHeader({
 
   return (
     <Box sx={HEADER_STYLES.container}>
-      <Box sx={sxClasses.flexBoxAlignCenter}>
+      <Box sx={memoSxClasses.flexBoxAlignCenter}>
         {iconSrc ? (
           <Box component="img" src={iconSrc} alt="" className="layer-icon" />
         ) : (
@@ -143,7 +146,7 @@ const FeatureHeader = memo(function FeatureHeader({
       <Box
         role="group"
         sx={{
-          ...sxClasses.flexBoxAlignCenter,
+          ...memoSxClasses.flexBoxAlignCenter,
           [theme.breakpoints.down('sm')]: { display: 'none' },
         }}
         aria-label={t('details.featureActions')!}
@@ -199,7 +202,10 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
 
   // Hooks
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('FEATURE-INFO - FeatureInfo - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // State
   const [checked, setChecked] = useState<boolean>(false);
@@ -221,6 +227,7 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
    * Memoizes the feature name.
    */
   const memoFeatureName = useMemo(() => {
+    logger.logTraceUseMemo('FEATURE-INFO - memoFeatureName', feature.nameField);
     // Try to get the value at the fieldName
     const value = feature.nameField && (feature.fieldInfo?.[feature.nameField]?.value as string);
     return value ?? 'No name / Sans nom';
@@ -230,6 +237,7 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
    * Memoizes whether the feature has a geometry.
    */
   const memoFeatureHasGeometry = useMemo(() => {
+    logger.logTraceUseMemo('FEATURE-INFO - memoFeatureHasGeometry', feature.geometry);
     return !!feature.geometry;
   }, [feature.geometry]);
 
@@ -237,6 +245,7 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
    * Memoizes the feature info list.
    */
   const memoFeatureInfoList: TypeFieldEntry[] = useMemo(() => {
+    logger.logTraceUseMemo('FEATURE-INFO - memoFeatureInfoList', feature.fieldInfo);
     if (!feature?.fieldInfo) return [];
 
     return Object.entries(feature.fieldInfo)
@@ -256,6 +265,7 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
    * Memoizes whether the feature has a geochart.
    */
   const memoHasGeochart = useMemo(() => {
+    logger.logTraceUseMemo('FEATURE-INFO - memoHasGeochart', feature.layerPath);
     return (
       !!geochartConfigs?.[feature.layerPath] &&
       (geochartLayerDataArrayBatch?.some((entry) => entry.layerPath === feature.layerPath && (entry.features?.length ?? 0) > 0) ?? false)
@@ -345,7 +355,7 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
         onGeochart={handleGeochart}
       />
 
-      <Box sx={sxClasses.featureInfoListContainer}>
+      <Box sx={memoSxClasses.featureInfoListContainer}>
         <FeatureInfoTable layerPath={feature.layerPath} featureInfoList={memoFeatureInfoList} containerType={containerType} />
       </Box>
     </Paper>

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -233,13 +233,8 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
     return value ?? 'No name / Sans nom';
   }, [feature]);
 
-  /**
-   * Memoizes whether the feature has a geometry.
-   */
-  const memoFeatureHasGeometry = useMemo(() => {
-    logger.logTraceUseMemo('FEATURE-INFO - memoFeatureHasGeometry', feature.geometry);
-    return !!feature.geometry;
-  }, [feature.geometry]);
+  /** Whether the feature has a geometry. */
+  const featureHasGeometry = !!feature.geometry;
 
   /**
    * Memoizes the feature info list.
@@ -347,7 +342,7 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
       <FeatureHeader
         iconSrc={feature.featureIcon}
         name={memoFeatureName}
-        hasGeometry={memoFeatureHasGeometry}
+        hasGeometry={featureHasGeometry}
         hasGeochart={memoHasGeochart}
         checked={checked}
         onCheckChange={handleFeatureChecked}

--- a/packages/geoview-core/src/core/components/export/utilities.ts
+++ b/packages/geoview-core/src/core/components/export/utilities.ts
@@ -3,7 +3,7 @@ import { Buffer } from 'buffer';
 import { renderToString } from 'react-dom/server';
 
 import type { TypeDisplayLanguage } from '@/api/types/map-schema-types';
-import type { TypeNorthArrow, TypeScaleInfo, TypeOrderedLayerInfo } from '@/core/stores/store-interface-and-intial-values/map-state';
+import type { TypeNorthArrow, TypeScaleInfo } from '@/core/stores/store-interface-and-intial-values/map-state';
 import type { TypeLegendLayer } from '@/core/components/layers/types';
 import {
   type TypeTimeSliderValues,
@@ -11,7 +11,7 @@ import {
   getStoreTimeSliderLayers,
   isStoreTimeSliderInitialized,
 } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
-import { getStoreMapOrderedLayerInfo, getStoreMapStateForExportLayout } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { getStoreMapStateForExportLayout } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { getStoreAppGeoviewHTMLElement } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { getStoreLayerLegendLayers } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
@@ -691,7 +691,7 @@ export class ExportUtilities {
    * Preserves depth information and parent-child relationships for proper rendering.
    *
    * Processing steps:
-   * 1. Filters layers by visibility (orderedLayerInfo)
+   * 1. Filters layers by visibility (legendLayers)
    * 2. Checks for meaningful content (items, icons, time dimensions, children)
    * 3. Recursively processes children to prevent empty parent headers
    * 4. Flattens structure while preserving depth and parentName
@@ -705,15 +705,10 @@ export class ExportUtilities {
    * - item: Individual legend icon + label
    *
    * @param layers - The legend layers from the map state
-   * @param orderedLayerInfo - Layer visibility info for filtering
    * @param timeSliderLayers - Optional time-enabled layers with dimension data
    * @returns Flattened array of all legend items with depth/parent info
    */
-  static #processLegendLayers(
-    layers: TypeLegendLayer[],
-    orderedLayerInfo: TypeOrderedLayerInfo[],
-    timeSliderLayers?: TimeSliderLayerSet
-  ): FlattenedLegendItem[] {
+  static #processLegendLayers(layers: TypeLegendLayer[], timeSliderLayers?: TimeSliderLayerSet): FlattenedLegendItem[] {
     const allItems: FlattenedLegendItem[] = [];
 
     const flattenLayer = (layer: TypeLegendLayer, depth = 0, rootLayerName?: string): FlattenedLegendItem[] => {
@@ -721,7 +716,7 @@ export class ExportUtilities {
       const currentRootName = rootLayerName || layer.layerName;
 
       // Check if layer is visible on the map
-      const layerInfo = orderedLayerInfo.find((info) => info.layerPath === layer.layerPath);
+      const layerInfo = layers.find((info) => info.layerPath === layer.layerPath);
       if (!layerInfo?.visible) {
         return items;
       }
@@ -997,7 +992,6 @@ export class ExportUtilities {
     const legendLayers = getStoreLayerLegendLayers(mapId).filter(
       (layer) => layer.layerStatus === 'loaded' && (layer.items.length === 0 || layer.items.some((item) => item.isVisible))
     );
-    const orderedLayerInfo = getStoreMapOrderedLayerInfo(mapId);
     let timeSliderLayers = undefined;
     if (isStoreTimeSliderInitialized(mapId)) {
       timeSliderLayers = getStoreTimeSliderLayers(mapId);
@@ -1049,7 +1043,7 @@ export class ExportUtilities {
     }));
 
     // Process legend data
-    const allItems = this.#processLegendLayers(cleanLegendLayers, orderedLayerInfo, timeSliderLayers);
+    const allItems = this.#processLegendLayers(cleanLegendLayers, timeSliderLayers);
 
     // Calculate scale factor for WMS images based on document width
     const wmsScale = mapImageWidth / 612;

--- a/packages/geoview-core/src/core/components/export/utilities.ts
+++ b/packages/geoview-core/src/core/components/export/utilities.ts
@@ -716,8 +716,9 @@ export class ExportUtilities {
       const currentRootName = rootLayerName || layer.layerName;
 
       // Check if layer is visible on the map
-      const layerInfo = layers.find((info) => info.layerPath === layer.layerPath);
-      if (!layerInfo?.visible) {
+      // For root layers, check the root layers array; for nested layers, use the layer object directly
+      const isVisible = depth === 0 ? layers.find((info) => info.layerPath === layer.layerPath)?.visible : layer.visible;
+      if (!isVisible) {
         return items;
       }
 

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar-api.ts
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar-api.ts
@@ -1,25 +1,27 @@
+import type { ReactNode } from 'react';
+
 import type { TypeTabs } from '@/ui/tabs/tabs';
 
-import type { EventDelegateBase } from '@/api/events/event-helper';
-import EventHelper from '@/api/events/event-helper';
 import type { UIController } from '@/core/controllers/ui-controller';
 import { sanitizeHtmlContent } from '@/core/utils/utilities';
+
+/** Content entry for a footer tab (icon and content are ReactNodes kept outside the store). */
+export type FooterTabContent = {
+  /** The tab icon element. */
+  icon?: ReactNode;
+  /** The tab content element. */
+  content?: ReactNode;
+};
 
 /**
  * API to manage tabs on the footer bar component.
  */
 export class FooterBarApi {
-  /** The UI controller */
+  /** The UI controller. */
   #uiController: UIController;
 
-  /** Array that holds added tabs. */
-  tabs: TypeTabs[] = [];
-
-  /** Callback handlers for the footerbar tab created event. */
-  #onFooterTabCreatedHandlers: FooterTabCreatedDelegate[] = [];
-
-  /** Callback handlers for the footerbar tab removed event. */
-  #onFooterTabRemovedHandlers: FooterTabRemovedDelegate[] = [];
+  /** Registry of tab content keyed by tab id (kept outside the store because ReactNodes are not serializable). */
+  #contentRegistry: Map<string, FooterTabContent> = new Map();
 
   /**
    * Instantiates a FooterBarApi class.
@@ -32,87 +34,24 @@ export class FooterBarApi {
   }
 
   /**
-   * Emits an event to all registered footerbar tab created event handlers.
-   *
-   * @param event - The event to emit
-   */
-  #emitFooterTabCreated(event: FooterTabCreatedEvent): void {
-    // Emit the footerbar tab created event
-    EventHelper.emitEvent(this, this.#onFooterTabCreatedHandlers, event);
-  }
-
-  /**
-   * Registers an event handler for footerbar tab created events.
-   *
-   * @param callback - The callback to be executed whenever the event is emitted
-   */
-  onFooterTabCreated(callback: FooterTabCreatedDelegate): void {
-    // Register the footerbar tab created event callback
-    EventHelper.onEvent(this.#onFooterTabCreatedHandlers, callback);
-  }
-
-  /**
-   * Unregisters an event handler for footerbar tab created events.
-   *
-   * @param callback - The callback to stop being called whenever the event is emitted
-   */
-  offFooterTabCreated(callback: FooterTabCreatedDelegate): void {
-    // Unregister the footerbar tab created event callback
-    EventHelper.offEvent(this.#onFooterTabCreatedHandlers, callback);
-  }
-
-  /**
-   * Emits an event to all registered footerbar tab removed event handlers.
-   *
-   * @param event - The event to emit
-   */
-  #emitFooterTabRemoved(event: FooterTabRemovedEvent): void {
-    // Emit the footerbar tab removed event
-    EventHelper.emitEvent(this, this.#onFooterTabRemovedHandlers, event);
-  }
-
-  /**
-   * Registers an event handler for footerbar tab removed events.
-   *
-   * @param callback - The callback to be executed whenever the event is emitted
-   */
-  onFooterTabRemoved(callback: FooterTabRemovedDelegate): void {
-    // Register the footerbar tab removed event callback
-    EventHelper.onEvent(this.#onFooterTabRemovedHandlers, callback);
-  }
-
-  /**
-   * Unregisters an event handler for footerbar removed events.
-   *
-   * @param callback - The callback to stop being called whenever the event is emitted
-   */
-  offFooterTabRemoved(callback: FooterTabRemovedDelegate): void {
-    // Unregister the footerbar removed event callback
-    EventHelper.offEvent(this.#onFooterTabRemovedHandlers, callback);
-  }
-
-  /**
    * Creates a tab on the footer bar.
    *
    * @param tabProps - The properties of the tab to be created
    */
   createTab(tabProps: TypeTabs): void {
     if (tabProps) {
-      // find if tab value exists
-      const tab = this.tabs.find((t) => t.id === tabProps.id);
+      // Check if tab already exists in registry
+      if (this.#contentRegistry.has(tabProps.id)) return;
 
-      // if tab does not exist, create it
-      if (!tab) {
-        // if tab content is string HTML, sanitize
-        // eslint-disable-next-line no-param-reassign
-        if (typeof tabProps.content === 'string') tabProps.content = sanitizeHtmlContent(tabProps.content);
+      // if tab content is string HTML, sanitize
+      // eslint-disable-next-line no-param-reassign
+      if (typeof tabProps.content === 'string') tabProps.content = sanitizeHtmlContent(tabProps.content);
 
-        // add the new tab to the footer tabs array
-        this.tabs.push(tabProps);
+      // Register content in the side registry (ReactNodes stay outside the store)
+      this.#contentRegistry.set(tabProps.id, { icon: tabProps.icon, content: tabProps.content });
 
-        // trigger an event that a new tab has been created
-        this.#emitFooterTabCreated({ tab: tabProps });
-      }
+      // Write serializable metadata to the store so the UI reacts immediately
+      this.#uiController.addFooterTab({ id: tabProps.id, label: tabProps.label });
     }
   }
 
@@ -122,16 +61,23 @@ export class FooterBarApi {
    * @param id - The id of the tab to be removed
    */
   removeTab(id: string): void {
-    // find the tab to be removed
-    const tabToRemove = this.tabs.find((tab) => tab.id === id);
+    if (this.#contentRegistry.has(id)) {
+      // Remove from content registry
+      this.#contentRegistry.delete(id);
 
-    if (tabToRemove) {
-      // remove the tab from the footer tabs array
-      this.tabs = this.tabs.filter((tab) => tab.id !== id);
-
-      // trigger an event that a tab has been removed
-      this.#emitFooterTabRemoved({ tabid: id });
+      // Remove from the store
+      this.#uiController.removeFooterTab(id);
     }
+  }
+
+  /**
+   * Gets the content entry for a tab by id.
+   *
+   * @param id - The tab id to look up
+   * @returns The tab content entry, or undefined if not registered
+   */
+  getTabContent(id: string): FooterTabContent | undefined {
+    return this.#contentRegistry.get(id);
   }
 
   /**
@@ -156,21 +102,3 @@ export class FooterBarApi {
     this.#uiController.setActiveFooterBarTab(id);
   }
 }
-
-/** Event emitted when a footer tab is created. */
-export type FooterTabCreatedEvent = {
-  /** The tab that was created. */
-  tab: TypeTabs;
-};
-
-/** Delegate for the footer tab created event handler. */
-type FooterTabCreatedDelegate = EventDelegateBase<FooterBarApi, FooterTabCreatedEvent, void>;
-
-/** Event emitted when a footer tab is removed. */
-export type FooterTabRemovedEvent = {
-  /** The id of the tab that was removed. */
-  tabid: string;
-};
-
-/** Delegate for the footer tab removed event handler. */
-type FooterTabRemovedDelegate = EventDelegateBase<FooterBarApi, FooterTabRemovedEvent, void>;

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -83,6 +83,9 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
   // get store config for footer bar tabs to add (similar logic as in app-bar)
   const footerBarTabsConfig = useStoreGeoViewConfig()?.footerBar;
 
+  // Ref so the seed effect reads the initial config without it being a dep (must only run once on mount)
+  const footerBarTabsConfigRef = useRef(footerBarTabsConfig);
+
   // #region HANDLERS
 
   /**
@@ -111,10 +114,10 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
    */
   useEffect(() => {
     // Log
-    logger.logTraceUseEffect('FOOTER-BAR - seed custom footer tabs from config', footerBarTabsConfig?.tabs?.custom);
+    logger.logTraceUseEffect('FOOTER-BAR - seed custom footer tabs from config', footerBarTabsConfigRef.current?.tabs?.custom);
 
     // Seed custom tabs and register their content (core tabs are seeded in setDefaultConfigValues)
-    (footerBarTabsConfig?.tabs?.custom ?? []).forEach((customTab) => {
+    (footerBarTabsConfigRef.current?.tabs?.custom ?? []).forEach((customTab) => {
       footerBarApi.createTab({
         id: customTab.id,
         value: 0,
@@ -123,8 +126,7 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
         content: <UseHtmlToReact htmlContent={customTab.contentHTML ?? ''} />,
       });
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [footerBarApi]);
 
   // Read footer tabs from the store (reactive — no event handlers needed)
   const footerTabs = useStoreUIFooterTabs();
@@ -198,8 +200,7 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
       // Uncollapse it
       uiController.setFooterBarIsOpen(true);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [arrayOfLayerDataBatch, activeFooterBarTab, uiController]);
+  }, [arrayOfLayerDataBatch, activeFooterBarTab, uiController, footerBarTabsConfig]);
   // Don't add isCollapsed in the dependency array, because it'll retrigger the useEffect
 
   /**

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -1,5 +1,5 @@
 import type { MutableRefObject } from 'react';
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTheme } from '@mui/material/styles';
 
 import type { TypeTabs } from '@/ui';
@@ -58,7 +58,10 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
 
   // Hooks
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('FOOTER-BAR - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // State & ref
   const tabsContainerRef = useRef<HTMLDivElement>();
@@ -80,6 +83,29 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
   // get store config for footer bar tabs to add (similar logic as in app-bar)
   const footerBarTabsConfig = useStoreGeoViewConfig()?.footerBar;
 
+  // #region HANDLERS
+
+  /**
+   * Handles the collapse/expand toggle.
+   */
+  const handleToggleCollapse = useCallback((): void => {
+    if (activeFooterBarTab.isOpen) uiController.setActiveFooterBarTab(undefined);
+    uiController.setFooterBarIsOpen(!activeFooterBarTab.isOpen);
+  }, [activeFooterBarTab.isOpen, uiController]);
+
+  /**
+   * Handles when the selected tab changes.
+   */
+  const handleSelectedTabChanged = useCallback(
+    (tab: TypeTabs): void => {
+      uiController.setActiveFooterBarTab(tab.id);
+      uiController.setFooterBarIsOpen(true);
+    },
+    [uiController]
+  );
+
+  // #endregion HANDLERS
+
   /**
    * Registers custom footer tab entries from configuration on mount.
    */
@@ -100,7 +126,7 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Read footer tabs from the store (reactive — no event handlers needed)
+  // Read footer tabs from the store (reactive â€” no event handlers needed)
   const footerTabs = useStoreUIFooterTabs();
 
   /**
@@ -152,10 +178,10 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
         value: index,
         label,
         icon,
-        content: <Box sx={sxClasses.tabContent}>{content}</Box>,
+        content: <Box sx={memoSxClasses.tabContent}>{content}</Box>,
       } as TypeTabs;
     });
-  }, [memoTabs, footerTabs, sxClasses, footerBarApi]);
+  }, [memoTabs, footerTabs, memoSxClasses, footerBarApi]);
 
   /**
    * Whenever the array layer data batch changes if we're on 'details' tab and it's collapsed, make sure we uncollapse it
@@ -194,22 +220,6 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
       tabsContainerRef.current = tabsContainer;
     }
   }, [activeFooterBarTab.isOpen, uiController]);
-
-  /**
-   * Handles the collapse/expand toggle.
-   */
-  const handleToggleCollapse = (): void => {
-    if (activeFooterBarTab.isOpen) uiController.setActiveFooterBarTab(undefined);
-    uiController.setFooterBarIsOpen(!activeFooterBarTab.isOpen);
-  };
-
-  /**
-   * Handles when the selected tab changes.
-   */
-  const handleSelectedTabChanged = (tab: TypeTabs): void => {
-    uiController.setActiveFooterBarTab(tab.id);
-    uiController.setFooterBarIsOpen(true);
-  };
 
   /**
    * Handles resizing the footerbar when toggling fullscreen.
@@ -295,7 +305,7 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
   return memoFooterBarTabs.length > 0 ? (
     <Box
       ref={tabsContainerRef as MutableRefObject<HTMLDivElement>}
-      sx={sxClasses.tabsContainer}
+      sx={memoSxClasses.tabsContainer}
       className="tabsContainer"
       id={`${mapId}-tabsContainer`}
     >

--- a/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
+++ b/packages/geoview-core/src/core/components/footer-bar/footer-bar.tsx
@@ -1,5 +1,5 @@
-import type { MutableRefObject, ReactNode } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { MutableRefObject } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useTheme } from '@mui/material/styles';
 
 import type { TypeTabs } from '@/ui';
@@ -21,8 +21,8 @@ import {
   useStoreUIFooterPanelResizeValue,
   useStoreUIActiveTrapGeoView,
   useStoreUIHiddenTabs,
+  useStoreUIFooterTabs,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import type { FooterBarApi, FooterTabCreatedEvent, FooterTabRemovedEvent } from '@/core/components';
 import { DEFAULT_FOOTER_TABS_ORDER } from '@/api/types/map-schema-types';
 import { CONTAINER_TYPE, TABS } from '@/core/utils/constant';
 import { useStoreGeoViewConfig, useStoreGeoViewMapId } from '@/core/stores/geoview-store';
@@ -35,16 +35,7 @@ import { camelCase, delay, scrollIfNotVisible } from '@/core/utils/utilities';
 import { logger } from '@/core/utils/logger';
 import { Guide } from '@/core/components/guide/guide';
 import { FooterPlugin } from '@/api/plugin/footer-plugin';
-
-/** Tab definition with icon, content, and optional label. */
-interface Tab {
-  /** The tab icon element. */
-  icon: ReactNode;
-  /** The tab content element. */
-  content: ReactNode;
-  /** Optional tab label. */
-  label?: string;
-}
+import type { FooterBarApi, FooterTabContent } from './footer-bar-api';
 
 /** Props for the FooterBar component. */
 type FooterBarProps = {
@@ -90,58 +81,27 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
   const footerBarTabsConfig = useStoreGeoViewConfig()?.footerBar;
 
   /**
-   * Builds the footer bar tab keys from configuration.
-   */
-  const memoFooterBarTabKeys = useMemo(() => {
-    // Log
-    logger.logTraceUseMemo('FOOTER-BAR - memoFooterBarTabKeys', footerBarTabsConfig?.tabs?.core);
-
-    const coreTabs = (footerBarTabsConfig?.tabs?.core ?? []).reduce(
-      (acc, curr) => {
-        // eslint-disable-next-line no-param-reassign
-        acc[curr] = {} as Tab;
-        return acc;
-      },
-      {} as Record<string, Tab>
-    );
-
-    // Add custom tabs
-    const customTabs = (footerBarTabsConfig?.tabs?.custom ?? []).reduce(
-      (acc, curr) => {
-        // eslint-disable-next-line no-param-reassign
-        acc[curr.id] = {} as Tab;
-        return acc;
-      },
-      {} as Record<string, Tab>
-    );
-
-    return { ...coreTabs, ...customTabs };
-  }, [footerBarTabsConfig?.tabs]);
-
-  // List of Footer Tabs created from config file.
-  const [tabsList, setTabsList] = useState<Record<string, Tab>>(memoFooterBarTabKeys);
-
-  /**
-   * Creates custom tabs from configuration.
+   * Registers custom footer tab entries from configuration on mount.
    */
   useEffect(() => {
-    if (footerBarTabsConfig?.tabs?.custom) {
-      footerBarTabsConfig.tabs.custom.forEach((customTab) => {
-        const newTab = {
-          [customTab.id]: {
-            icon: <InfoIcon />, // TODO: Make it configurable if needed
-            label: customTab.label,
-            content: <UseHtmlToReact htmlContent={customTab.contentHTML ?? ''} />,
-          },
-        } as Record<string, Tab>;
+    // Log
+    logger.logTraceUseEffect('FOOTER-BAR - seed custom footer tabs from config', footerBarTabsConfig?.tabs?.custom);
 
-        // Add the custom tab to the tabs list
-        setTabsList((prevState: Record<string, Tab>) => {
-          return { ...prevState, ...newTab };
-        });
+    // Seed custom tabs and register their content (core tabs are seeded in setDefaultConfigValues)
+    (footerBarTabsConfig?.tabs?.custom ?? []).forEach((customTab) => {
+      footerBarApi.createTab({
+        id: customTab.id,
+        value: 0,
+        label: customTab.label ?? '',
+        icon: <InfoIcon />,
+        content: <UseHtmlToReact htmlContent={customTab.contentHTML ?? ''} />,
       });
-    }
-  }, [footerBarTabsConfig]);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Read footer tabs from the store (reactive — no event handlers needed)
+  const footerTabs = useStoreUIFooterTabs();
 
   /**
    * Builds the panel definitions for each core tab.
@@ -156,7 +116,7 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
       details: { icon: <InfoIcon />, content: <DetailsPanel containerType={CONTAINER_TYPE.FOOTER_BAR} /> },
       'data-table': { icon: <StorageIcon />, content: <Datapanel containerType={CONTAINER_TYPE.FOOTER_BAR} /> },
       guide: { icon: <QuestionMarkIcon />, content: <Guide containerType={CONTAINER_TYPE.FOOTER_BAR} /> },
-    } as Record<string, Tab>;
+    } as Record<string, FooterTabContent>;
   }, []);
 
   /**
@@ -164,70 +124,38 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
    */
   const memoFooterBarTabs = useMemo(() => {
     // Log
-    logger.logTraceUseMemo('FOOTER-BAR - memoFooterBarTabs', tabsList, memoTabs);
+    logger.logTraceUseMemo('FOOTER-BAR - memoFooterBarTabs', footerTabs, memoTabs);
 
     // Early return if no footer tab provided
-    if (!tabsList || Object.keys(tabsList).length === 0) return [];
+    if (!footerTabs || footerTabs.length === 0) return [];
 
-    // Set the allTabs (union of all footer tabs) and get the needed keys
-    const allTabs = { ...tabsList, ...memoTabs };
-    const tabsListKeys = Object.keys(tabsList);
-    const availableTabKeys: string[] = tabsListKeys.includes('guide') ? tabsListKeys : [...tabsListKeys, 'guide'];
+    // Build lookup of tab ids from the store
+    const tabIds = footerTabs.map((t) => t.id);
+    const tabLabelMap = new Map(footerTabs.map((t) => [t.id, t.label]));
+    const availableTabKeys: string[] = tabIds.includes('guide') ? tabIds : [...tabIds, 'guide'];
 
     // Custom tabs first, then core tabs in DEFAULT_FOOTER_TABS_ORDER ... last guide
     const customTabKeys = availableTabKeys.filter((tabKey) => !DEFAULT_FOOTER_TABS_ORDER.includes(tabKey));
     const coreTabKeys = DEFAULT_FOOTER_TABS_ORDER.filter((tabKey) => availableTabKeys.includes(tabKey));
     const orderedTabKeys = customTabKeys.concat(coreTabKeys);
 
-    return orderedTabKeys.map((tab, index) => {
+    return orderedTabKeys.map((tabId, index) => {
+      // Look up content: first from core memoTabs, then from the API content registry
+      const coreTab = memoTabs[tabId];
+      const registryContent = footerBarApi.getTabContent(tabId);
+      const icon = coreTab?.icon ?? registryContent?.icon ?? '';
+      const content = coreTab?.content ?? registryContent?.content ?? '';
+      const label = tabLabelMap.get(tabId) || `${camelCase(tabId)}.title`;
+
       return {
-        id: tab,
+        id: tabId,
         value: index,
-        label: allTabs[tab].label ? allTabs[tab].label : `${camelCase(tab)}.title`,
-        icon: allTabs[tab]?.icon ?? '',
-        content: <Box sx={sxClasses.tabContent}>{allTabs[tab]?.content ?? ''}</Box>,
+        label,
+        icon,
+        content: <Box sx={sxClasses.tabContent}>{content}</Box>,
       } as TypeTabs;
     });
-  }, [memoTabs, tabsList, sxClasses]);
-
-  /**
-   * Handles adding a tab from the API.
-   */
-  const handleAddTab = useCallback((sender: FooterBarApi, event: FooterTabCreatedEvent): void => {
-    const newTab = {
-      [event.tab.id]: {
-        icon: event.tab.icon || <InfoIcon />,
-        label: event.tab.label,
-        content: typeof event.tab.content === 'string' ? <UseHtmlToReact htmlContent={event.tab.content ?? ''} /> : event.tab.content,
-      },
-    } as Record<string, Tab>;
-
-    // NOTE: we need prevState because of an async nature of adding plugins.
-    setTabsList((prevState: Record<string, Tab>) => {
-      return { ...prevState, ...newTab };
-    });
-  }, []);
-
-  /**
-   * Handles removing a tab from the API.
-   */
-  const handleRemoveTab = useCallback((sender: FooterBarApi, event: FooterTabRemovedEvent): void => {
-    // remove the tab from the list
-    setTabsList((prevState) => {
-      const state = { ...prevState };
-      delete state[event.tabid];
-      return state;
-    });
-  }, []);
-
-  /**
-   * Updates the active footer tab based on footer tabs created from configuration.
-   */
-  useEffect(() => {
-    if (!activeFooterBarTab.tabId && activeFooterBarTab.isOpen) uiController.setActiveFooterBarTab(memoFooterBarTabs?.[0]?.id ?? '');
-    // No need to update when selected tab changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [memoFooterBarTabs, uiController]);
+  }, [memoTabs, footerTabs, sxClasses, footerBarApi]);
 
   /**
    * Whenever the array layer data batch changes if we're on 'details' tab and it's collapsed, make sure we uncollapse it
@@ -329,61 +257,6 @@ export function FooterBar(props: FooterBarProps): JSX.Element | null {
         });
     }
   }, [pluginController, activeFooterBarTab]);
-
-  /**
-   * Registers and unregisters tab create/remove event handlers on mount.
-   */
-  useEffect(() => {
-    // Log
-    logger.logTraceUseEffect('FOOTER-BAR - mount');
-
-    // TODO: Refactor - Registering those handlers only when the component has been mounted can cause issues if 'someone' calls
-    // TO.DOCONT: mapViewer('map1').footerBarApi.createTab() before the component is actually mounted.
-    // TO.DOCONT: The handler when tabs are created should happen earlier and the ui component should only 'react' to store tabs values.
-    // TO.DOCONT: We had an issue where a custom footer tab was never appearing, because the 'createTab()' call was happening before
-    // TO.DOCONT: this FooterBar component was actually mounted. That being said, removing the 'mapLoaded' condition, before mounting
-    // TO.DOCONT: the FooterBar (in Footer-bar.tsx), was sufficient to fix the issue for now, but it should be addressed eventually.
-
-    // Register footerbar tab created/removed handlers
-    footerBarApi.onFooterTabCreated(handleAddTab);
-    footerBarApi.onFooterTabRemoved(handleRemoveTab);
-
-    return () => {
-      // Unregister events
-      footerBarApi.offFooterTabCreated(handleAddTab);
-      footerBarApi.offFooterTabRemoved(handleRemoveTab);
-    };
-  }, [footerBarApi, handleAddTab, handleRemoveTab]);
-
-  /**
-   * Creates default tabs from configuration parameters (similar logic as in app-bar).
-   */
-  useEffect(() => {
-    // Log
-    logger.logTraceUseEffect('FOOTER-BAR - footerBarTabsConfig');
-
-    // TODO: Refactor Footer-bar - This loadScript shouldn't be part of a useEffect, because those happen everytime their depedencies change.
-    // TO.DOCONT: In development with StrictMode this is triggered twice to prevent developers from doing stuff like that here.
-    // TO.DOCONT: Also, important, the dependencies of this useEffect (and the code herein) isn't meant to be part of a useEffect in the first place.
-    // TO.DOCONT: Looking at the other useEffects, it's clear there's a lot of refactoring that should be done in the Footer-bar in general.
-
-    // Packages tab
-    if (footerBarTabsConfig && footerBarTabsConfig.tabs.core.includes('time-slider')) {
-      // Load and add the plugin
-      pluginController.loadAndAddPlugin('time-slider').catch((error: unknown) => {
-        // Log
-        logger.logPromiseFailed('loadAndAddPlugin(time-slider) in useEffect in FooterBar', error);
-      });
-    }
-
-    if (footerBarTabsConfig && footerBarTabsConfig.tabs.core.includes('geochart')) {
-      // Load and add the plugin
-      pluginController.loadAndAddPlugin('geochart').catch((error: unknown) => {
-        // Log
-        logger.logPromiseFailed('loadAndAddPlugin(geochart) in useEffect in FooterBar', error);
-      });
-    }
-  }, [footerBarTabsConfig, pluginController]);
 
   /**
    * Scrolls the footer into view on mouse click.

--- a/packages/geoview-core/src/core/components/geolocator/geolocator.tsx
+++ b/packages/geoview-core/src/core/components/geolocator/geolocator.tsx
@@ -55,7 +55,10 @@ export function Geolocator(): JSX.Element {
 
   // Hooks
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('GEOLOCATOR - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
@@ -76,15 +79,36 @@ export function Geolocator(): JSX.Element {
   const prevLoadingRef = useRef<boolean>(false);
   const [statusMessage, setStatusMessage] = useState<string>('');
 
+  // #region HANDLERS
+
   // Create debounced version of getGeolocations
-  const debouncedRequest = useMemo(
-    () =>
-      debounce((value: string) => {
-        if (value.length >= MIN_SEARCH_LENGTH) {
-          getGeolocations(value);
-        }
-      }, DEBOUNCE_DELAY),
-    [getGeolocations]
+  const debouncedRequest = useMemo(() => {
+    logger.logTraceUseMemo('GEOLOCATOR - debouncedRequest', getGeolocations);
+    return debounce((value: string) => {
+      if (value.length >= MIN_SEARCH_LENGTH) {
+        getGeolocations(value);
+      }
+    }, DEBOUNCE_DELAY);
+  }, [getGeolocations]);
+
+  /**
+   * Handles search input value changes.
+   */
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>): void => {
+      const { value } = event.target;
+      setSearchValue(value);
+
+      if (!value.length || value.length < MIN_SEARCH_LENGTH) {
+        resetState();
+        return;
+      }
+
+      if (value.length >= MIN_SEARCH_LENGTH) {
+        debouncedRequest(value);
+      }
+    },
+    [debouncedRequest, resetState, setSearchValue]
   );
 
   /**
@@ -95,6 +119,8 @@ export function Geolocator(): JSX.Element {
       debouncedRequest(searchValue);
     }
   }, [searchValue, debouncedRequest]);
+
+  // #endregion HANDLERS
 
   /**
    * Resets the search and closes the geolocator panel.
@@ -108,26 +134,12 @@ export function Geolocator(): JSX.Element {
   }, [setSearchValue, uiController, mapId]);
 
   /**
-   * Handles search input value changes.
-   */
-  const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
-    const { value } = event.target;
-    setSearchValue(value);
-
-    if (!value.length || value.length < MIN_SEARCH_LENGTH) {
-      resetState();
-      return;
-    }
-
-    if (value.length >= MIN_SEARCH_LENGTH) {
-      debouncedRequest(value);
-    }
-  };
-
-  /**
    * Cancels the debounced request on unmount.
    */
   useEffect(() => {
+    // Log
+    logger.logTraceUseEffect('GEOLOCATOR - cancel debounced request on unmount');
+
     return () => {
       debouncedRequest.cancel();
     };
@@ -190,13 +202,13 @@ export function Geolocator(): JSX.Element {
       aria-modal={isPanelOpen && activeTrapGeoView ? true : undefined}
       aria-hidden={!isPanelOpen}
       aria-label={t('geolocator.panelTitle')!}
-      sx={sxClasses.root}
+      sx={memoSxClasses.root}
       visibility={isPanelOpen ? 'visible' : 'hidden'}
       id={`${mapId}-${CONTAINER_TYPE.APP_BAR}-${DEFAULT_APPBAR_CORE.GEOLOCATOR}-panel`}
     >
       <FocusTrapContainer open={isPanelOpen && activeTrapGeoView} id="geolocator-focus-trap" containerType={CONTAINER_TYPE.APP_BAR}>
-        <Box sx={sxClasses.geolocator}>
-          <Typography component="h2" sx={sxClasses.visuallyHidden}>
+        <Box sx={memoSxClasses.geolocator}>
+          <Typography component="h2" sx={memoSxClasses.visuallyHidden}>
             {t('geolocator.panelTitle')}
           </Typography>
 
@@ -211,18 +223,18 @@ export function Geolocator(): JSX.Element {
         </Box>
 
         {/* WCAG - ARIA live region for screen reader announcements */}
-        <Box sx={sxClasses.visuallyHidden} role="status" aria-live="polite" aria-atomic="true">
+        <Box sx={memoSxClasses.visuallyHidden} role="status" aria-live="polite" aria-atomic="true">
           {statusMessage}
         </Box>
 
         {isLoading && (
-          <Box sx={sxClasses.progressBar}>
+          <Box sx={memoSxClasses.progressBar}>
             <ProgressBar aria-label={t('geolocator.loadingResults')!} />
           </Box>
         )}
 
         {(error || (!!data && searchValue?.length >= MIN_SEARCH_LENGTH)) && (
-          <Box sx={sxClasses.searchResult}>
+          <Box sx={memoSxClasses.searchResult}>
             <GeolocatorResult geoLocationData={!data ? [] : data} searchValue={searchValue} error={error} />
           </Box>
         )}

--- a/packages/geoview-core/src/core/components/geolocator/hooks/use-geolocator.ts
+++ b/packages/geoview-core/src/core/components/geolocator/hooks/use-geolocator.ts
@@ -44,7 +44,8 @@ export const useGeolocator = (): UseGeolocatorReturn => {
   const geolocatorServiceURL = useStoreAppGeolocatorServiceURL();
 
   // Refs
-  const displayLanguageRef = useRef(displayLanguage);
+  const searchValueRef = useRef(searchValue);
+  searchValueRef.current = searchValue;
   const abortControllerRef = useRef<AbortController | null>(null);
   const fetchTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>();
 
@@ -122,7 +123,7 @@ export const useGeolocator = (): UseGeolocatorReturn => {
         const newAbortController = new AbortController();
         abortControllerRef.current = newAbortController;
 
-        const currentUrl = `${geolocatorServiceURL}&lang=${displayLanguageRef.current}`;
+        const currentUrl = `${geolocatorServiceURL}&lang=${displayLanguage}`;
         const result = await Fetch.fetchJson<GeoListItem[]>(`${currentUrl}&q=${encodeURIComponent(`${cleanSearchTerm}*`)}`, {
           signal: abortControllerRef.current.signal,
         });
@@ -137,7 +138,7 @@ export const useGeolocator = (): UseGeolocatorReturn => {
         clearTimeout(fetchTimerRef.current);
       }
     },
-    [geolocatorServiceURL]
+    [geolocatorServiceURL, displayLanguage]
   );
 
   /**
@@ -167,14 +168,10 @@ export const useGeolocator = (): UseGeolocatorReturn => {
    * Re-fetches results when the display language changes.
    */
   useEffect(() => {
-    logger.logTraceUseEffect('GEOLOCATOR - change language', displayLanguage, searchValue);
+    logger.logTraceUseEffect('GEOLOCATOR - change language', displayLanguage);
 
-    // Set language and redo request
-    displayLanguageRef.current = displayLanguage;
-    getGeolocations(searchValue);
-
-    // Only listen to change in language and getGeolocations to request new value with updated language
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Re-fetch with the current search value using the updated language
+    getGeolocations(searchValueRef.current);
   }, [displayLanguage, getGeolocations]);
 
   return {

--- a/packages/geoview-core/src/core/components/geolocator/hooks/use-geolocator.ts
+++ b/packages/geoview-core/src/core/components/geolocator/hooks/use-geolocator.ts
@@ -91,7 +91,7 @@ export const useGeolocator = (): UseGeolocatorReturn => {
     }
 
     return () => {};
-  }, [isLoading, resetState]);
+  }, [isLoading]);
 
   /**
    * Cleans up state on unmount.

--- a/packages/geoview-core/src/core/components/guide/guide-search.tsx
+++ b/packages/geoview-core/src/core/components/guide/guide-search.tsx
@@ -50,7 +50,10 @@ export function GuideSearch({ containerType, guide, onSectionChange, onSearchSta
   // Hooks
   const { t } = useTranslation();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('GUIDE-SEARCH - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // State
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -553,9 +556,9 @@ export function GuideSearch({ containerType, guide, onSectionChange, onSearchSta
   // #endregion Handlers
 
   return (
-    <Box sx={sxClasses.guideSearch}>
+    <Box sx={memoSxClasses.guideSearch}>
       {/* WCAG - Live region announces search results and navigation state to screen readers */}
-      <Box role="status" aria-live="polite" aria-atomic="true" sx={sxClasses.visuallyHidden}>
+      <Box role="status" aria-live="polite" aria-atomic="true" sx={memoSxClasses.visuallyHidden}>
         {srAnnouncement}
       </Box>
       <form onSubmit={handleFormSubmit} role="search" aria-label={t('guide.searchFormLabel')!}>
@@ -644,7 +647,7 @@ export function GuideSearch({ containerType, guide, onSectionChange, onSearchSta
           }}
         />
       </form>
-      <Box id={searchInstructionsId} sx={sxClasses.visuallyHidden}>
+      <Box id={searchInstructionsId} sx={memoSxClasses.visuallyHidden}>
         {t('guide.searchInstructions')!}
       </Box>
     </Box>

--- a/packages/geoview-core/src/core/components/guide/guide.tsx
+++ b/packages/geoview-core/src/core/components/guide/guide.tsx
@@ -51,7 +51,10 @@ export const Guide = memo(function GuidePanel({ containerType }: GuideType): JSX
   // Hooks
   const { t } = useTranslation<string>();
   const theme = useTheme();
-  const sxClasses = useMemo((): SxStyles => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo((): SxStyles => {
+    logger.logTraceUseMemo('GUIDE - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // State
   const [selectedLayerPath, setSelectedLayerPath] = useState<string>('loadingStatus');
@@ -241,7 +244,7 @@ export const Guide = memo(function GuidePanel({ containerType }: GuideType): JSX
 
   const ariaLabel = t('guide.title');
   return (
-    <Box sx={sxClasses.guideContainer}>
+    <Box sx={memoSxClasses.guideContainer}>
       <Box sx={{ flex: 1, minHeight: 0 }}>
         <Layout
           containerType={containerType}
@@ -259,7 +262,7 @@ export const Guide = memo(function GuidePanel({ containerType }: GuideType): JSX
           onLayerListClicked={handleGuideItemClick}
           aria-label={ariaLabel}
         >
-          <Box sx={sxClasses.rightPanelContainer} className="guidebox-container">
+          <Box sx={memoSxClasses.rightPanelContainer} className="guidebox-container">
             <Box className="guideBox">{memoCurrentGuideContent}</Box>
           </Box>
         </Layout>

--- a/packages/geoview-core/src/core/components/layers/layers-toolbar.tsx
+++ b/packages/geoview-core/src/core/components/layers/layers-toolbar.tsx
@@ -6,15 +6,12 @@ import { useTheme } from '@mui/material';
 
 import { Box, AddCircleOutlineIcon, Button } from '@/ui';
 import { ToggleAll } from '@/core/components/toggle-all/toggle-all';
-import {
-  useStoreLayerDisplayState,
-  useStoreLayerLayerPaths,
-  setStoreLayerDisplayState,
-} from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerDisplayState, useStoreLayerTopLevelLayerPaths } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import type { TypeLayersViewDisplayState } from './types';
 import { logger } from '@/core/utils/logger';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
+import { useLayerController } from '@/core/controllers/use-controllers';
 
 interface TypeLayersToolbar {
   containerType: TypeContainerBox;
@@ -41,7 +38,8 @@ export function LayersToolbar({ containerType }: TypeLayersToolbar): JSX.Element
   // Store
   const mapId = useStoreGeoViewMapId();
   const displayState = useStoreLayerDisplayState();
-  const layerPaths = useStoreLayerLayerPaths();
+  const layerPaths = useStoreLayerTopLevelLayerPaths();
+  const layerController = useLayerController();
 
   // State
   const lastDisplayState = useRef<TypeLayersViewDisplayState | null>(null);
@@ -59,9 +57,9 @@ export function LayersToolbar({ containerType }: TypeLayersToolbar): JSX.Element
         userClickedAdd.current = false;
       }
 
-      setStoreLayerDisplayState(mapId, displayStateParam);
+      layerController.setLayerDisplayState(displayStateParam);
     },
-    [mapId]
+    [layerController]
   );
 
   /**
@@ -74,7 +72,7 @@ export function LayersToolbar({ containerType }: TypeLayersToolbar): JSX.Element
   useEffect(() => {
     // Always show 'add' panel when there are no layers
     if (layerPaths.length === 0 && displayState !== 'add') {
-      setStoreLayerDisplayState(mapId, 'add');
+      layerController.setLayerDisplayState('add');
     }
 
     // Track display state changes to handle transitions
@@ -93,7 +91,7 @@ export function LayersToolbar({ containerType }: TypeLayersToolbar): JSX.Element
         userClickedAdd.current = false;
       }
     }
-  }, [displayState, layerPaths.length, mapId]);
+  }, [displayState, layerPaths.length, layerController]);
 
   /**
    * Secondary effect specifically for auto-switching to view mode.
@@ -105,10 +103,10 @@ export function LayersToolbar({ containerType }: TypeLayersToolbar): JSX.Element
    */
   useEffect(() => {
     if (layerPaths.length > 0 && displayState === 'add' && !userClickedAdd.current) {
-      setStoreLayerDisplayState(mapId, 'view');
+      layerController.setLayerDisplayState('view');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [layerPaths.length, mapId]); // Only depend on layerPaths.length and mapId
+  }, [layerPaths.length, layerController]); // Only depend on layerPaths.length and layerController
 
   return (
     <Box id={`${mapId}-${containerType}-layers-toolbar`} sx={layerToolbarStyle}>

--- a/packages/geoview-core/src/core/components/layers/layers-toolbar.tsx
+++ b/packages/geoview-core/src/core/components/layers/layers-toolbar.tsx
@@ -70,6 +70,7 @@ export function LayersToolbar({ containerType }: TypeLayersToolbar): JSX.Element
    * - Restores focus when user cancels
    */
   useEffect(() => {
+    logger.logTraceUseEffect('LAYERS-TOOLBAR - display state logic', displayState, layerPaths.length);
     // Always show 'add' panel when there are no layers
     if (layerPaths.length === 0 && displayState !== 'add') {
       layerController.setLayerDisplayState('add');
@@ -102,6 +103,7 @@ export function LayersToolbar({ containerType }: TypeLayersToolbar): JSX.Element
    * 3. User didn't explicitly click the Add button
    */
   useEffect(() => {
+    logger.logTraceUseEffect('LAYERS-TOOLBAR - auto-switch to view mode', layerPaths.length);
     if (layerPaths.length > 0 && displayState === 'add' && !userClickedAdd.current) {
       layerController.setLayerDisplayState('view');
     }

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -5,7 +5,6 @@ import type { SelectChangeEvent } from '@mui/material';
 import type { ButtonPropsLayerPanel } from '@/ui';
 import { Box, Button, IconButton, ButtonGroup, CircularProgressBase, FileUploadIcon, Paper, Select, Stepper, TextField } from '@/ui';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
-import { setStoreLayerDisplayState } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import {
   useStoreAppDisabledLayerTypes,
   useStoreAppDisplayLanguage,
@@ -373,7 +372,7 @@ export function AddNewLayer(): JSX.Element {
   const doneAdding = (): void => {
     // Done adding
     setIsLoading(false);
-    setStoreLayerDisplayState(mapId, 'view');
+    layerController.setLayerDisplayState('view');
     layerController.setLayerZIndices();
   };
 
@@ -886,7 +885,7 @@ export function AddNewLayer(): JSX.Element {
             className="buttonOutlineFilled"
             size="small"
             type="text"
-            onClick={() => setStoreLayerDisplayState(mapId, 'view')}
+            onClick={() => layerController.setLayerDisplayState('view')}
           >
             {t('general.cancel')}
           </Button>

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -760,7 +760,11 @@ export function AddNewLayer(): JSX.Element {
 
   // #endregion
 
+  /**
+   * Validates the URL and manages step button enabled state based on active step.
+   */
   useEffect(() => {
+    logger.logTraceUseEffect('ADD-NEW-LAYER - URL validation and step button state', activeStep, layerURL);
     if (activeStep === 0) {
       // Validate URL for step 1
       const validateUrl = async (): Promise<void> => {
@@ -815,7 +819,11 @@ export function AddNewLayer(): JSX.Element {
     if (activeStep === 2 && !layerIdsToAdd.length) setStepButtonEnabled(false);
   }, [layerURL, activeStep, layerIdsToAdd, layerType, uiController]);
 
+  /**
+   * Manages focus when the active step changes.
+   */
   useEffect(() => {
+    logger.logTraceUseEffect('ADD-NEW-LAYER - focus management on step change', activeStep);
     if (activeStep === 1) {
       (serviceTypeRef.current?.getElementsByTagName('input')[0].previousSibling as HTMLDivElement).focus();
     }

--- a/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
@@ -5,7 +5,7 @@ import { logger } from '@/core/utils/logger';
 import { SingleLayer } from './single-layer';
 import { getSxClasses } from './left-panel-styles';
 import type { TypeContainerBox } from '@/core/types/global-types';
-import { useStoreMapOrderedLayers } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreLayerOrderedLayerPaths } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 interface LayerListProps {
   depth: number;
@@ -24,7 +24,7 @@ export function LayersList({ layerPaths, showLayerDetailsPanel, isLayoutEnlarged
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // Store
-  const layerPathOrder = useStoreMapOrderedLayers();
+  const layerPathOrder = useStoreLayerOrderedLayerPaths();
 
   // ? I doubt we want to define an explicit type for style properties?
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/layers-list.tsx
@@ -21,7 +21,10 @@ export function LayersList({ layerPaths, showLayerDetailsPanel, isLayoutEnlarged
 
   // Hook
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('LAYERS-LIST - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // Store
   const layerPathOrder = useStoreLayerOrderedLayerPaths();
@@ -30,10 +33,10 @@ export function LayersList({ layerPaths, showLayerDetailsPanel, isLayoutEnlarged
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const getListClass = useCallback((): any => {
     if (depth === 0) {
-      return sxClasses.list;
+      return memoSxClasses.list;
     }
-    return sxClasses.listSubitem;
-  }, [depth, sxClasses]);
+    return memoSxClasses.listSubitem;
+  }, [depth, memoSxClasses]);
 
   // Memoize the legend items
   const memoLegendItems = useMemo(() => {

--- a/packages/geoview-core/src/core/components/layers/left-panel/left-panel.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/left-panel.tsx
@@ -1,4 +1,4 @@
-import { useStoreLayerDisplayState, useStoreLayerLayerPaths } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerDisplayState, useStoreLayerTopLevelLayerPaths } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { LayersList } from './layers-list';
 import { AddNewLayer } from './add-new-layer/add-new-layer';
 import { logger } from '@/core/utils/logger';
@@ -15,7 +15,7 @@ export function LeftPanel({ showLayerDetailsPanel, isLayoutEnlarged, containerTy
   logger.logTraceRender('components/layers/left-panel/left-panel');
 
   // get from the store
-  const layerPaths = useStoreLayerLayerPaths();
+  const layerPaths = useStoreLayerTopLevelLayerPaths();
   const displayState = useStoreLayerDisplayState();
 
   if (displayState === 'add') {

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -27,15 +27,11 @@ import {
   useStoreLayerChildPaths,
   useStoreLayerItems,
   useStoreLayerHasDisabledVisibility,
-  setStoreLayerSelectedLayersTabLayer,
+  useStoreLayerVisible,
+  useStoreLayerInVisibleRange,
+  useStoreLayerIsParentHiddenOnMap,
+  useStoreLayerLegendCollapsed,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import {
-  useStoreMapLegendCollapsedByPath,
-  useStoreMapLayerVisibility,
-  useStoreMapLayerInVisibleRange,
-  useStoreMapIsParentLayerHiddenOnMap,
-  setStoreMapToggleLegendCollapsed,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
 import { DeleteUndoButton } from '@/core/components/layers/delete-undo-button';
 import { LayersList } from './layers-list';
 import { LayerIcon } from '@/core/components/common/layer-icon';
@@ -110,10 +106,10 @@ export function SingleLayer({
   const layerIsSelected = layerPath === selectedLayerPath && displayState === 'view';
   const isKeyboardNavigationMode = useStoreUIActiveTrapGeoView();
 
-  const isVisible = useStoreMapLayerVisibility(layerPath);
-  const inVisibleRange = useStoreMapLayerInVisibleRange(layerPath);
-  const legendExpanded = !useStoreMapLegendCollapsedByPath(layerPath);
-  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layerPath);
+  const isVisible = useStoreLayerVisible(layerPath);
+  const inVisibleRange = useStoreLayerInVisibleRange(layerPath);
+  const legendExpanded = !useStoreLayerLegendCollapsed(layerPath);
+  const parentHidden = useStoreLayerIsParentHiddenOnMap(layerPath);
 
   const layerId = useStoreLayerId(layerPath);
   const layerName = useStoreLayerName(layerPath);
@@ -202,13 +198,13 @@ export function SingleLayer({
   const selectLayerIfNeeded = useCallback(
     (openPanel: boolean = true): void => {
       if (!layerIsSelected && ['processed', 'loaded'].includes(layerStatus!)) {
-        setStoreLayerSelectedLayersTabLayer(mapId, layerPath);
+        layerController.setSelectedLayerPath(layerPath);
         if (openPanel) {
           showLayerDetailsPanel?.(layerId || '');
         }
       }
     },
-    [mapId, layerIsSelected, layerStatus, layerPath, layerId, showLayerDetailsPanel]
+    [layerController, layerIsSelected, layerStatus, layerPath, layerId, showLayerDetailsPanel]
   );
 
   /**
@@ -222,8 +218,8 @@ export function SingleLayer({
     selectLayerIfNeeded();
 
     // Set legend collapse value
-    setStoreMapToggleLegendCollapsed(mapId, layerPath);
-  }, [layerPath, selectLayerIfNeeded, mapId, blurOtherLayerButtons]);
+    layerController.toggleLegendCollapsed(layerPath);
+  }, [layerPath, selectLayerIfNeeded, layerController, blurOtherLayerButtons]);
 
   const handleExpandGroupKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLButtonElement>): void => {
@@ -235,13 +231,13 @@ export function SingleLayer({
         selectLayerIfNeeded(false);
 
         // Set legend collapse value
-        setStoreMapToggleLegendCollapsed(mapId, layerPath);
+        layerController.toggleLegendCollapsed(layerPath);
 
         // Allow the toggle expansion action to work
         event.preventDefault();
       }
     },
-    [layerPath, mapId, blurOtherLayerButtons, selectLayerIfNeeded]
+    [layerPath, layerController, blurOtherLayerButtons, selectLayerIfNeeded]
   );
 
   const handleLayerClick = useCallback((): void => {
@@ -254,9 +250,9 @@ export function SingleLayer({
     blurOtherLayerButtons();
 
     // Set selected layer path
-    setStoreLayerSelectedLayersTabLayer(mapId, layerPath);
+    layerController.setSelectedLayerPath(layerPath);
     showLayerDetailsPanel?.(layerId || '');
-  }, [mapId, layerPath, layerId, layerStatus, showLayerDetailsPanel, blurOtherLayerButtons]);
+  }, [layerController, layerPath, layerId, layerStatus, showLayerDetailsPanel, blurOtherLayerButtons]);
 
   const handleArrowClick = useCallback(
     (direction: number) => {
@@ -342,7 +338,7 @@ export function SingleLayer({
     selectLayerIfNeeded();
 
     // Toggle visibility
-    layerController.setOrToggleMapLayerVisibility(layerPath);
+    layerController.setOrToggleLayerVisibilityIfExists(layerPath);
   }, [layerPath, layerController, selectLayerIfNeeded, inVisibleRange, parentHidden]);
 
   const handleToggleVisibilityKeyDown = useCallback(
@@ -359,7 +355,7 @@ export function SingleLayer({
         selectLayerIfNeeded(false);
 
         // Toggle visibility
-        layerController.setOrToggleMapLayerVisibility(layerPath);
+        layerController.setOrToggleLayerVisibilityIfExists(layerPath);
 
         // Allow the toggle visibility action to work
         event.preventDefault();

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -91,7 +91,10 @@ export function SingleLayer({
   // Hook
   const { t } = useTranslation<string>();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('SINGLE-LAYER - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // Create ref for scrolling into view
   const layerListItemRef = useRef<HTMLLIElement>(null);
@@ -489,7 +492,7 @@ export function SingleLayer({
             size="small"
             onKeyDown={handleArrowKeyDownWrapper}
             onClick={handleArrowClickWrapper}
-            sx={isFirst ? sxClasses.orderButtonDisabled : sxClasses.orderButtonEnabled}
+            sx={isFirst ? memoSxClasses.orderButtonDisabled : memoSxClasses.orderButtonEnabled}
             aria-label={t('layers.moveLayerUp')}
             aria-disabled={isFirst} // WCAG - used instead of disabled to allow button retain focus and be discoverable by screen readers
           >
@@ -502,13 +505,13 @@ export function SingleLayer({
             size="small"
             onKeyDown={handleArrowKeyDownWrapper}
             onClick={handleArrowClickWrapper}
-            sx={isLast ? sxClasses.orderButtonDisabled : sxClasses.orderButtonEnabled}
+            sx={isLast ? memoSxClasses.orderButtonDisabled : memoSxClasses.orderButtonEnabled}
             aria-label={t('layers.moveLayerDown')}
             aria-disabled={isLast} // WCAG - used instead of disabled to allow button retain focus and be discoverable by screen readers
           >
             <ArrowDownwardIcon />
           </IconButton>
-          <Divider orientation="vertical" sx={sxClasses.dividerVertical} variant="middle" flexItem />
+          <Divider orientation="vertical" sx={memoSxClasses.dividerVertical} variant="middle" flexItem />
         </>
       );
     }
@@ -522,9 +525,9 @@ export function SingleLayer({
     isLast,
     layerPath,
     t,
-    sxClasses.orderButtonDisabled,
-    sxClasses.orderButtonEnabled,
-    sxClasses.dividerVertical,
+    memoSxClasses.orderButtonDisabled,
+    memoSxClasses.orderButtonEnabled,
+    memoSxClasses.dividerVertical,
     hasFocusWithin,
     orderDownButtonId,
     orderUpButtonId,
@@ -598,7 +601,7 @@ export function SingleLayer({
           <IconButton
             edge="end"
             size="small"
-            sx={sxClasses.zoomButton}
+            sx={memoSxClasses.zoomButton}
             className="buttonOutline"
             onClick={handleZoomToLayerVisibleScale}
             onKeyDown={handleZoomToLayerVisibleScaleKeyDown}
@@ -649,7 +652,7 @@ export function SingleLayer({
     parentHidden,
     reloadButtonId,
     panelCloseButtonId,
-    sxClasses.zoomButton,
+    memoSxClasses.zoomButton,
   ]);
 
   // Memoize the arrow buttons component section
@@ -754,11 +757,16 @@ export function SingleLayer({
 
   /** Memoized sx for the list item button. */
   const memoListItemButtonSx = useMemo(
-    () => ({
-      minHeight: '4.51rem',
-      ...(!inVisibleRange || parentHidden || !isVisible || layerStatus === 'error' ? sxClasses.outOfRange : {}),
-    }),
-    [inVisibleRange, parentHidden, isVisible, layerStatus, sxClasses.outOfRange]
+    () => {
+      // Log
+      logger.logTraceUseMemo('SINGLE-LAYER - memoListItemButtonSx', inVisibleRange, parentHidden, isVisible, layerStatus);
+
+      return {
+        minHeight: '4.51rem',
+        ...(!inVisibleRange || parentHidden || !isVisible || layerStatus === 'error' ? memoSxClasses.outOfRange : {}),
+      };
+    },
+    [inVisibleRange, parentHidden, isVisible, layerStatus, memoSxClasses.outOfRange]
   );
 
   return (
@@ -771,7 +779,7 @@ export function SingleLayer({
       onFocusCapture={handleFocusWithin}
       onBlurCapture={handleBlurWithin}
     >
-      <Box sx={sxClasses.containerBox}>
+      <Box sx={memoSxClasses.containerBox}>
         <Tooltip
           title={t('layers.selectLayer', { layerName })}
           placement="top"
@@ -800,7 +808,7 @@ export function SingleLayer({
           </Box>
         )}
         {layerStatus === 'loading' && (
-          <Box sx={sxClasses.progressBarSingleLayer}>
+          <Box sx={memoSxClasses.progressBarSingleLayer}>
             <ProgressBar aria-label={t('layers.status.layerLoadingDescriptive', { layerName })!} />
           </Box>
         )}

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -338,7 +338,7 @@ export function SingleLayer({
     selectLayerIfNeeded();
 
     // Toggle visibility
-    layerController.setOrToggleLayerVisibilityIfExists(layerPath);
+    layerController.setOrToggleLayerVisibility(layerPath);
   }, [layerPath, layerController, selectLayerIfNeeded, inVisibleRange, parentHidden]);
 
   const handleToggleVisibilityKeyDown = useCallback(
@@ -355,7 +355,7 @@ export function SingleLayer({
         selectLayerIfNeeded(false);
 
         // Toggle visibility
-        layerController.setOrToggleLayerVisibilityIfExists(layerPath);
+        layerController.setOrToggleLayerVisibility(layerPath);
 
         // Allow the toggle visibility action to work
         event.preventDefault();

--- a/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/single-layer.tsx
@@ -756,18 +756,15 @@ export function SingleLayer({
   }, [layerStatus, layerPath, reloadButtonId, layerListItemButtonId]);
 
   /** Memoized sx for the list item button. */
-  const memoListItemButtonSx = useMemo(
-    () => {
-      // Log
-      logger.logTraceUseMemo('SINGLE-LAYER - memoListItemButtonSx', inVisibleRange, parentHidden, isVisible, layerStatus);
+  const memoListItemButtonSx = useMemo(() => {
+    // Log
+    logger.logTraceUseMemo('SINGLE-LAYER - memoListItemButtonSx', inVisibleRange, parentHidden, isVisible, layerStatus);
 
-      return {
-        minHeight: '4.51rem',
-        ...(!inVisibleRange || parentHidden || !isVisible || layerStatus === 'error' ? memoSxClasses.outOfRange : {}),
-      };
-    },
-    [inVisibleRange, parentHidden, isVisible, layerStatus, memoSxClasses.outOfRange]
-  );
+    return {
+      minHeight: '4.51rem',
+      ...(!inVisibleRange || parentHidden || !isVisible || layerStatus === 'error' ? memoSxClasses.outOfRange : {}),
+    };
+  }, [inVisibleRange, parentHidden, isVisible, layerStatus, memoSxClasses.outOfRange]);
 
   return (
     <ListItem

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -234,17 +234,17 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   /**
    * Handles resetting the layer to its initial state.
    */
-  const handleResetLayer = (): void => {
+  const handleResetLayer = useCallback((): void => {
     layerController.resetLayer(layerPath).catch((error: unknown) => {
       // Log
       logger.logPromiseFailed('in layerController.resetLayer in layer-details.handleResetLayer', error);
     });
-  };
+  }, [layerController, layerPath]);
 
   /**
    * Handles zooming to the layer's extent.
    */
-  const handleZoomTo = (): void => {
+  const handleZoomTo = useCallback((): void => {
     // Early return if zoom button is disabled
     if (isZoomDisabled) {
       return;
@@ -253,12 +253,12 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
       // Log
       logger.logPromiseFailed('in zoomToLayerExtent in layer-details.handleZoomTo', error);
     });
-  };
+  }, [isZoomDisabled, layerController, layerPath]);
 
   /**
    * Handles opening the data table for the layer.
    */
-  const handleOpenTable = (): void => {
+  const handleOpenTable = useCallback((): void => {
     // Early return if table button is disabled
     if (isTableButtonDisabled) {
       return;
@@ -274,18 +274,18 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
       });
     }
     uiController.enableFocusTrap({ activeElementId: 'layerDataTable', callbackElementId: tableDetailsButtonId });
-  };
+  }, [isTableButtonDisabled, layerPath, layerSetController, layerStatus, layersData, tableDetailsButtonId, uiController]);
 
   /**
    * Handles highlighting the layer on the map.
    */
-  const handleHighlightLayer = (): void => {
+  const handleHighlightLayer = useCallback((): void => {
     // Early return if highlight button is disabled
     if (layerHidden) {
       return;
     }
     layerController.setHighlightLayer(layerPath);
-  };
+  }, [layerController, layerHidden, layerPath]);
 
   /**
    * Handles navigation to the Time Slider panel when the button is clicked.

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -28,7 +28,7 @@ import {
   ZoomInSearchIcon,
 } from '@/ui';
 import { ArrowBackIcon } from '@/ui/icons';
-import { useUIController } from '@/core/controllers/use-controllers';
+import { useTimeSliderControllerIfExists, useUIController } from '@/core/controllers/use-controllers';
 import type { TypeLegendItem } from '@/core/components/layers/types';
 import { getSxClasses } from './layer-details-style';
 import {
@@ -48,6 +48,10 @@ import {
   useStoreLayerSchemaTag,
   useStoreLayerIcons,
   useStoreLayerAttribution,
+  useStoreLayerVisible,
+  useStoreLayerIsParentHiddenOnMap,
+  useStoreLayerIsHiddenOnMap,
+  useStoreLayerVisibleLayers,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { useStoreUIActiveTrapGeoView } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import {
@@ -61,16 +65,7 @@ import { LayerInfoPanel } from './layer-info/layer-info';
 import { logger } from '@/core/utils/logger';
 import { LAYER_STATUS, TABS, TIMEOUT } from '@/core/utils/constant';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
-import {
-  useStoreMapVisibleLayers,
-  useStoreMapIsLayerHiddenOnMap,
-  useStoreMapLayerVisibility,
-  useStoreMapIsParentLayerHiddenOnMap,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
-import {
-  useStoreTimeSliderLayers,
-  setStoreTimeSliderSelectedLayerPath,
-} from '@/core/stores/store-interface-and-intial-values/time-slider-state';
+import { useStoreTimeSliderLayers } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
 import { useNavigateToTab } from '@/core/components/common/hooks/use-navigate-to-tab';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { DeleteUndoButton } from '@/core/components/layers/delete-undo-button';
@@ -105,9 +100,9 @@ const Sublayer = memo(function Sublayer({ layerPath }: SubLayerProps): JSX.Eleme
   // Hooks
   const layerName = useStoreLayerName(layerPath);
   const childPaths = useStoreLayerChildPaths(layerPath);
-  const layerHidden = useStoreMapIsLayerHiddenOnMap(layerPath);
-  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layerPath);
-  const layerVisible = useStoreMapLayerVisibility(layerPath);
+  const layerHidden = useStoreLayerIsHiddenOnMap(layerPath);
+  const parentHidden = useStoreLayerIsParentHiddenOnMap(layerPath);
+  const layerVisible = useStoreLayerVisible(layerPath);
   const layerController = useLayerController();
 
   // Return the ui
@@ -119,7 +114,7 @@ const Sublayer = memo(function Sublayer({ layerPath }: SubLayerProps): JSX.Eleme
           <Checkbox
             color="primary"
             checked={layerVisible === true}
-            onChange={() => layerController.setOrToggleMapLayerVisibility(layerPath)}
+            onChange={() => layerController.setOrToggleLayerVisibilityIfExists(layerPath)}
             disabled={parentHidden}
           />
         }
@@ -191,22 +186,25 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   const allSublayersVisible = useStoreLayerAllChildrenVisible(layerPath);
   const highlightedLayer = useStoreLayerHighlightedLayer();
   const hasText = useStoreLayerHasText(layerPath);
-  const visibleLayers = useStoreMapVisibleLayers();
+  const visibleLayers = useStoreLayerVisibleLayers();
   const datatableSettings = useStoreDataTableLayerSettings();
   const layersData = useStoreDataTableAllFeaturesDataArray();
   const bounds = useStoreLayerBounds(layerPath);
-  const layerVisible = useStoreMapLayerVisibility(layerPath);
-  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layerPath);
-  const layerHidden = useStoreMapIsLayerHiddenOnMap(layerPath);
+  const layerVisible = useStoreLayerVisible(layerPath);
+  const parentHidden = useStoreLayerIsParentHiddenOnMap(layerPath);
+  const layerHidden = useStoreLayerIsHiddenOnMap(layerPath);
   const availableSettings = useStoreLayerStyleSettings(layerPath);
   const timeSliderLayers = useStoreTimeSliderLayers();
   const isFocusTrap = useStoreUIActiveTrapGeoView();
   const uiController = useUIController();
   const layerController = useLayerController();
   const layerSetController = useLayerSetController();
+  const timeSliderController = useTimeSliderControllerIfExists();
 
   // Use navigate hook for time slider (only if time slider state exists)
-  const navigateToTimeSlider = useNavigateToTab('time-slider', setStoreTimeSliderSelectedLayerPath);
+  const navigateToTimeSlider = useNavigateToTab('time-slider', (lyrPath) => {
+    timeSliderController?.setSelectedLayerPathTimeSlider(lyrPath);
+  });
 
   // Is highlight button disabled?
   const isLayerHighlightCapable = layerControls?.highlight;
@@ -369,8 +367,8 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
     const setRecursive = (legendLayer: typeof layer, newVisibility: boolean): void => {
       legendLayer.children.forEach((child) => {
         if (newVisibility) {
-          if (!visibleLayers.includes(child.layerPath)) layerController.setOrToggleMapLayerVisibility(child.layerPath, true);
-        } else if (visibleLayers.includes(child.layerPath)) layerController.setOrToggleMapLayerVisibility(child.layerPath, false);
+          if (!visibleLayers.includes(child.layerPath)) layerController.setOrToggleLayerVisibilityIfExists(child.layerPath, true);
+        } else if (visibleLayers.includes(child.layerPath)) layerController.setOrToggleLayerVisibilityIfExists(child.layerPath, false);
         if (child.children.length) setRecursive(child, newVisibility);
       });
     };

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -114,7 +114,7 @@ const Sublayer = memo(function Sublayer({ layerPath }: SubLayerProps): JSX.Eleme
           <Checkbox
             color="primary"
             checked={layerVisible === true}
-            onChange={() => layerController.setOrToggleLayerVisibilityIfExists(layerPath)}
+            onChange={() => layerController.setOrToggleLayerVisibility(layerPath)}
             disabled={parentHidden}
           />
         }
@@ -367,8 +367,8 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
     const setRecursive = (legendLayer: typeof layer, newVisibility: boolean): void => {
       legendLayer.children.forEach((child) => {
         if (newVisibility) {
-          if (!visibleLayers.includes(child.layerPath)) layerController.setOrToggleLayerVisibilityIfExists(child.layerPath, true);
-        } else if (visibleLayers.includes(child.layerPath)) layerController.setOrToggleLayerVisibilityIfExists(child.layerPath, false);
+          if (!visibleLayers.includes(child.layerPath)) layerController.setOrToggleLayerVisibility(child.layerPath, true);
+        } else if (visibleLayers.includes(child.layerPath)) layerController.setOrToggleLayerVisibility(child.layerPath, false);
         if (child.children.length) setRecursive(child, newVisibility);
       });
     };

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-info/layer-info.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-info/layer-info.tsx
@@ -12,7 +12,7 @@ import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import { UtilAddLayer } from '@/core/components/layers/left-panel/add-new-layer/add-layer-utils';
 import { useStoreAppDisplayLanguage, useStoreAppMetadataServiceURL } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { useStoreMapCurrentProjectionEPSG } from '@/core/stores/store-interface-and-intial-values/map-state';
-import { useStoreTableFilter } from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { useStoreDataTableFilter } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import {
   useStoreLayerDateTemporalMode,
   useStoreLayerDisplayDateFormat,
@@ -62,7 +62,7 @@ export function LayerInfoPanel({ layerPath }: LayerInfoPanelProps): JSX.Element 
   const mapProjectionEPSG = useStoreMapCurrentProjectionEPSG();
   const layerFilter = useStoreLayerFilter(layerPath);
   const classFilter = useStoreLayerFilterClass(layerPath);
-  const dataFilter = useStoreTableFilter(layerPath);
+  const dataFilter = useStoreDataTableFilter(layerPath);
   const timeFilter = useStoreTimeSliderFilter(layerPath);
   const schemaTag = useStoreLayerSchemaTag(layerPath);
   const url = useStoreLayerUrl(layerPath);

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-info/layer-info.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-info/layer-info.tsx
@@ -54,7 +54,10 @@ export function LayerInfoPanel({ layerPath }: LayerInfoPanelProps): JSX.Element 
   // Hooks
   const { t } = useTranslation<string>();
   const theme = useTheme();
-  const sxClasses = getSxClasses(theme);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('LAYER-INFO - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // Store hooks
   const language = useStoreAppDisplayLanguage();
@@ -80,12 +83,16 @@ export function LayerInfoPanel({ layerPath }: LayerInfoPanelProps): JSX.Element 
   const layerNativeProjection = layerController.getLayerMetatadaProjectionEPSG(layerPath);
 
   // Derived values
-  const memoLocalizedLayerType = useMemo(() => UtilAddLayer.getLocalizeLayerType(language, true), [language]);
+  const memoLocalizedLayerType = useMemo(() => {
+    logger.logTraceUseMemo('LAYER-INFO - memoLocalizedLayerType', language);
+    return UtilAddLayer.getLocalizeLayerType(language, true);
+  }, [language]);
   const boundsRounded = bounds?.map((value) => Math.round(value));
   const boundsRounded4326 = bounds4326?.map((value) => Math.round(value * 100) / 100);
 
   // Build resource URL based on layer type
   const memoResources = useMemo((): string => {
+    logger.logTraceUseMemo('LAYER-INFO - memoResources', url, schemaTag, layerPath);
     if (!url) return '';
     const leafSegment = layerPath.split('/').slice(-1)[0];
 
@@ -118,6 +125,7 @@ export function LayerInfoPanel({ layerPath }: LayerInfoPanelProps): JSX.Element 
 
   // Find the localized name for the current layer type
   const memoLocalizedTypeName = useMemo((): string => {
+    logger.logTraceUseMemo('LAYER-INFO - memoLocalizedTypeName', schemaTag, url);
     const localizedTypeEntry = memoLocalizedLayerType.find(([memoType]) => memoType === schemaTag);
     let name = localizedTypeEntry ? localizedTypeEntry[1] : t('layers.serviceGroup');
 
@@ -129,13 +137,13 @@ export function LayerInfoPanel({ layerPath }: LayerInfoPanelProps): JSX.Element 
   }, [memoLocalizedLayerType, schemaTag, url, t]);
 
   return (
-    <Box sx={sxClasses.layerInfo}>
+    <Box sx={memoSxClasses.layerInfo}>
       <Divider sx={{ height: 'auto', marginTop: '10px', marginBottom: '10px' }} variant="middle" />
 
       {/* Service Information */}
-      <Box sx={sxClasses.infoSection}>
-        <Typography sx={sxClasses.infoSectionTitle}>{t('layers.layerInfoServiceInfo')}</Typography>
-        <Box sx={sxClasses.infoSectionContent}>
+      <Box sx={memoSxClasses.infoSection}>
+        <Typography sx={memoSxClasses.infoSectionTitle}>{t('layers.layerInfoServiceInfo')}</Typography>
+        <Box sx={memoSxClasses.infoSectionContent}>
           <Box>{`${t('layers.layerType')}${memoLocalizedTypeName}`}</Box>
           {layerNativeProjection && <Box>{`${t('layers.layerServiceProjection')}${layerNativeProjection}`}</Box>}
           {memoResources !== '' && (
@@ -160,32 +168,32 @@ export function LayerInfoPanel({ layerPath }: LayerInfoPanelProps): JSX.Element 
       </Box>
 
       {/* Active Filters */}
-      <Box sx={sxClasses.infoSection}>
-        <Typography sx={sxClasses.infoSectionTitle}>{t('layers.layerInfoActiveFilters')}</Typography>
-        <Box sx={sxClasses.infoSectionContent}>
-          <List sx={sxClasses.layerDetailsListGroup}>
+      <Box sx={memoSxClasses.infoSection}>
+        <Typography sx={memoSxClasses.infoSectionTitle}>{t('layers.layerInfoActiveFilters')}</Typography>
+        <Box sx={memoSxClasses.infoSectionContent}>
+          <List sx={memoSxClasses.layerDetailsListGroup}>
             {layerFilter && (
-              <ListItem sx={sxClasses.layerDetailsListItem}>
+              <ListItem sx={memoSxClasses.layerDetailsListItem}>
                 <ListItemText primary={`${t('layers.layerDefaultFilter')}${layerFilter}`} />
               </ListItem>
             )}
             {classFilter && (
-              <ListItem sx={sxClasses.layerDetailsListItem}>
+              <ListItem sx={memoSxClasses.layerDetailsListItem}>
                 <ListItemText primary={`${t('layers.layerClassFilter')}${classFilter}`} />
               </ListItem>
             )}
             {dataFilter && (
-              <ListItem sx={sxClasses.layerDetailsListItem}>
+              <ListItem sx={memoSxClasses.layerDetailsListItem}>
                 <ListItemText primary={`${t('layers.layerDataTableFilter')}${dataFilter}`} />
               </ListItem>
             )}
             {timeFilter && (
-              <ListItem sx={sxClasses.layerDetailsListItem}>
+              <ListItem sx={memoSxClasses.layerDetailsListItem}>
                 <ListItemText primary={`${t('layers.layerTimeFilter')}${timeFilter}`} />
               </ListItem>
             )}
             {!layerFilter && !classFilter && !dataFilter && !timeFilter && (
-              <ListItem sx={sxClasses.layerDetailsListItem}>
+              <ListItem sx={memoSxClasses.layerDetailsListItem}>
                 <ListItemText primary={t('layers.layerActiveFiltersNone')} />
               </ListItem>
             )}
@@ -199,37 +207,37 @@ export function LayerInfoPanel({ layerPath }: LayerInfoPanelProps): JSX.Element 
         layerDateTemporalMode ||
         layerDisplayDateTimezone ||
         layerTimeDimension?.field) && (
-        <Box sx={sxClasses.infoSection}>
-          <Typography sx={sxClasses.infoSectionTitle}>{t('layers.layerInfoTemporalSettings')}</Typography>
-          <Box sx={sxClasses.infoSectionContent}>
-            <List sx={sxClasses.layerDetailsListGroup}>
+        <Box sx={memoSxClasses.infoSection}>
+          <Typography sx={memoSxClasses.infoSectionTitle}>{t('layers.layerInfoTemporalSettings')}</Typography>
+          <Box sx={memoSxClasses.infoSectionContent}>
+            <List sx={memoSxClasses.layerDetailsListGroup}>
               {layerDisplayDateFormat && (
-                <ListItem sx={sxClasses.layerDetailsListItem}>
+                <ListItem sx={memoSxClasses.layerDetailsListItem}>
                   <ListItemText primary={`${t('layers.layerDisplayDateFormat')}${layerDisplayDateFormat[language]}`} />
                 </ListItem>
               )}
               {layerDisplayDateFormatShort && (
-                <ListItem sx={sxClasses.layerDetailsListItem}>
+                <ListItem sx={memoSxClasses.layerDetailsListItem}>
                   <ListItemText primary={`${t('layers.layerDisplayDateFormatShort')}${layerDisplayDateFormatShort[language]}`} />
                 </ListItem>
               )}
               {layerDateTemporalMode && (
-                <ListItem sx={sxClasses.layerDetailsListItem}>
+                <ListItem sx={memoSxClasses.layerDetailsListItem}>
                   <ListItemText primary={`${t('layers.layerDateTemporalMode')}${layerDateTemporalMode}`} />
                 </ListItem>
               )}
               {layerDisplayDateTimezone && (
-                <ListItem sx={sxClasses.layerDetailsListItem}>
+                <ListItem sx={memoSxClasses.layerDetailsListItem}>
                   <ListItemText primary={`${t('layers.layerDisplayDateTimezone')}${layerDisplayDateTimezone}`} />
                 </ListItem>
               )}
               {layerTimeDimension?.field && (
-                <ListItem sx={sxClasses.layerDetailsListItem}>
+                <ListItem sx={memoSxClasses.layerDetailsListItem}>
                   <ListItemText primary={`${t('layers.layerTimeDimensionField')}${layerTimeDimension.field}`} />
                 </ListItem>
               )}
               {layerTimeDimension?.rangeItems?.range?.[0] && (
-                <ListItem sx={sxClasses.layerDetailsListItem}>
+                <ListItem sx={memoSxClasses.layerDetailsListItem}>
                   <ListItemText
                     primary={`${'Min/Max: '}${layerTimeDimension.rangeItems.range[0]} / ${layerTimeDimension.rangeItems.range[layerTimeDimension.rangeItems.range.length - 1]}`}
                   />
@@ -242,32 +250,32 @@ export function LayerInfoPanel({ layerPath }: LayerInfoPanelProps): JSX.Element 
 
       {/* Temporal Dimension (Time Slider) */}
       {timeSliderDimension && (
-        <Box sx={sxClasses.infoSection}>
-          <Typography sx={sxClasses.infoSectionTitle}>{t('layers.layerInfoTemporalDimension')}</Typography>
-          <Box sx={sxClasses.infoSectionContent}>
-            <List sx={sxClasses.layerDetailsListGroup}>
+        <Box sx={memoSxClasses.infoSection}>
+          <Typography sx={memoSxClasses.infoSectionTitle}>{t('layers.layerInfoTemporalDimension')}</Typography>
+          <Box sx={memoSxClasses.infoSectionContent}>
+            <List sx={memoSxClasses.layerDetailsListGroup}>
               {timeSliderDimension.displayDateFormat?.[language] && (
-                <ListItem sx={sxClasses.layerDetailsListItem}>
+                <ListItem sx={memoSxClasses.layerDetailsListItem}>
                   <ListItemText primary={`${t('layers.layerDisplayDateFormat')}${timeSliderDimension.displayDateFormat[language]}`} />
                 </ListItem>
               )}
               {timeSliderDimension.serviceDateTemporalMode && (
-                <ListItem sx={sxClasses.layerDetailsListItem}>
+                <ListItem sx={memoSxClasses.layerDetailsListItem}>
                   <ListItemText primary={`${t('layers.layerDateTemporalMode')}${timeSliderDimension.serviceDateTemporalMode}`} />
                 </ListItem>
               )}
               {timeSliderDimension.displayDateTimezone && (
-                <ListItem sx={sxClasses.layerDetailsListItem}>
+                <ListItem sx={memoSxClasses.layerDetailsListItem}>
                   <ListItemText primary={`${t('layers.layerDisplayDateTimezone')}${timeSliderDimension.displayDateTimezone}`} />
                 </ListItem>
               )}
               {timeSliderDimension?.field && timeSliderDimension?.field !== layerTimeDimension?.field && (
-                <ListItem sx={sxClasses.layerDetailsListItem}>
+                <ListItem sx={memoSxClasses.layerDetailsListItem}>
                   <ListItemText primary={`${t('layers.layerTimeDimensionField')}${timeSliderDimension.field}`} />
                 </ListItem>
               )}
               {timeSliderDimension?.range?.[0] && (
-                <ListItem sx={sxClasses.layerDetailsListItem}>
+                <ListItem sx={memoSxClasses.layerDetailsListItem}>
                   <ListItemText
                     primary={`${'Min/Max: '}${timeSliderDimension.range[0]} / ${timeSliderDimension.range[timeSliderDimension.range.length - 1]}`}
                   />

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-opacity-control/layer-opacity-control.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-opacity-control/layer-opacity-control.tsx
@@ -7,8 +7,11 @@ import type { Mark } from '@mui/base';
 
 import { getSxClasses } from './layer-opacity-control-styles';
 import { Box, Slider, Typography } from '@/ui';
-import { useStoreLayerOpacity, useStoreLayerOpacityMaxFromParent } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import { useStoreMapIsLayerHiddenOnMap } from '@/core/stores/store-interface-and-intial-values/map-state';
+import {
+  useStoreLayerIsHiddenOnMap,
+  useStoreLayerOpacity,
+  useStoreLayerOpacityMaxFromParent,
+} from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { logger } from '@/core/utils/logger';
 import { useLayerController } from '@/core/controllers/use-controllers';
 
@@ -30,7 +33,7 @@ export function LayerOpacityControl({ layerPath }: LayerOpacityControlProps): JS
   const sxClasses = getSxClasses(theme);
 
   // Store
-  const layerHidden = useStoreMapIsLayerHiddenOnMap(layerPath);
+  const layerHidden = useStoreLayerIsHiddenOnMap(layerPath);
   const layerController = useLayerController();
   const labelId = useId();
 

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/layer-settings.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-settings/layer-settings.tsx
@@ -57,15 +57,13 @@ export function LayerSettingsPanel({ layerPath }: LayerSettingsPanelProps): JSX.
   const isLayerHoverable = layerControls?.hover;
   const isLayerQueryable = layerControls?.query;
 
-  // TODO: CHECK - Change the use of hooks in those callbacks to use state getters instead?
-
   // Stable handlers for hover/query toggles
   const handleToggleHoverable = useCallback((): void => {
-    layerController.setLayerHoverable(layerPath, !hoverable!);
+    layerController.setLayerHoverable(layerPath, !hoverable);
   }, [layerPath, hoverable, layerController]);
 
   const handleToggleQueryable = useCallback((): void => {
-    layerController.setLayerQueryable(layerPath, !queryable!);
+    layerController.setLayerQueryable(layerPath, !queryable);
   }, [layerPath, queryable, layerController]);
 
   const handleToggleText = useCallback((): void => {

--- a/packages/geoview-core/src/core/components/layers/types.ts
+++ b/packages/geoview-core/src/core/components/layers/types.ts
@@ -56,6 +56,15 @@ export interface TypeLegendLayer {
   hoverable?: boolean;
   queryable?: boolean;
 
+  /** Whether the layer is visible. */
+  visible: boolean;
+
+  /** Whether the layer is visible at the current map zoom. */
+  inVisibleRange: boolean;
+
+  /** Whether the layer legend is collapsed. */
+  legendCollapsed: boolean;
+
   hasText?: boolean;
   textVisible?: boolean;
 

--- a/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
@@ -202,7 +202,7 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
       savedCollapseStateRef.current = getStoreLayerLegendCollapsedSet(mapId);
 
       // Save to the store
-      layerController.setAllMapLayerCollapsed(false);
+      layerController.setAllLayerCollapsed(false);
     } else {
       // Exiting fullscreen: restore saved collapse state
       const savedState = savedCollapseStateRef.current;

--- a/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
@@ -3,21 +3,18 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Box, List, Typography, IconButton, FullscreenIcon } from '@/ui';
-import { logger } from '@/core/utils/logger';
-import {
-  getStoreMapLegendCollapsedSet,
-  setStoreMapAllMapLayerCollapsed,
-  setStoreMapLegendCollapsed,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
 
+import { DEFAULT_APPBAR_CORE } from '@/api/types/map-schema-types';
 import { getSxClasses } from './legend-styles';
 import { LegendLayer } from './legend-layer';
+import { logger } from '@/core/utils/logger';
 import { CONTAINER_TYPE } from '@/core/utils/constant';
 import type { TypeContainerBox } from '@/core/types/global-types';
+import { useStoreAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { getStoreLayerLegendCollapsedSet } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { useEventListener } from '@/core/components/common/hooks/use-event-listener';
 import { FullScreenDialog } from '@/core/components/common/full-screen-dialog';
-import { DEFAULT_APPBAR_CORE } from '@/api/types/map-schema-types';
-import { useStoreAppShellContainer } from '@/core/stores/store-interface-and-intial-values/app-state';
+import { useLayerController } from '@/core/controllers/use-controllers';
 
 /**
  * Properties for the LegendFullscreen component.
@@ -123,6 +120,7 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
   // State
   const [fullscreenLegendLayerList, setFullscreenLegendLayersList] = useState<string[][]>([]);
   const savedCollapseStateRef = useRef<Record<string, boolean>>({});
+  const layerController = useLayerController();
 
   // Memoize breakpoint values
   const breakpoints = useMemo(() => {
@@ -201,21 +199,21 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
     if (isOpen) {
       // Entering fullscreen: snapshot collapse state from the store and expand all
       // GV Here we use a store getter, because we actually want to snapshot the values to reuse them later, we don't want to hook on them
-      savedCollapseStateRef.current = getStoreMapLegendCollapsedSet(mapId);
+      savedCollapseStateRef.current = getStoreLayerLegendCollapsedSet(mapId);
 
       // Save to the store
-      setStoreMapAllMapLayerCollapsed(mapId, false);
+      layerController.setAllMapLayerCollapsed(false);
     } else {
       // Exiting fullscreen: restore saved collapse state
       const savedState = savedCollapseStateRef.current;
       if (Object.keys(savedState).length > 0) {
         Object.entries(savedState).forEach(([layerPath, collapsed]) => {
-          // Save to the store
-          setStoreMapLegendCollapsed(mapId, layerPath, collapsed);
+          // Perform collapse action
+          layerController.setLegendCollapsed(layerPath, collapsed);
         });
       }
     }
-  }, [isOpen, mapId]);
+  }, [isOpen, layerController, mapId]);
 
   // Memoize the no layers content
   const noLayersContent = useMemo(() => {

--- a/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
@@ -114,7 +114,10 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
   // Hooks
   const { t } = useTranslation<string>();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('LEGEND-FULLSCREEN - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
   const shellContainer = useStoreAppShellContainer();
 
   // State
@@ -123,7 +126,7 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
   const layerController = useLayerController();
 
   // Memoize breakpoint values
-  const breakpoints = useMemo(() => {
+  const memoBreakpoints = useMemo(() => {
     // Log
     logger.logTraceUseMemo('LEGEND FULLSCREEN - breakpoints', theme.breakpoints.values);
 
@@ -145,11 +148,11 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
    */
   const getFullscreenLayerListSize = useCallback(() => {
     const { innerWidth } = window;
-    if (innerWidth < breakpoints.sm) return 1;
-    if (innerWidth < breakpoints.md) return 2;
-    if (innerWidth < breakpoints.lg) return 3;
+    if (innerWidth < memoBreakpoints.sm) return 1;
+    if (innerWidth < memoBreakpoints.md) return 2;
+    if (innerWidth < memoBreakpoints.lg) return 3;
     return 4;
-  }, [breakpoints]);
+  }, [memoBreakpoints]);
 
   /**
    * Distributes legend layers across multiple columns for fullscreen display.
@@ -216,30 +219,30 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
   }, [isOpen, layerController, mapId]);
 
   // Memoize the no layers content
-  const noLayersContent = useMemo(() => {
+  const memoNoLayersContent = useMemo(() => {
     // Log
     logger.logTraceUseMemo('components/legend-fullscreen - noLayersContent');
 
     return (
       <Box sx={styles.noLayersContainer}>
-        <Typography component="div" gutterBottom sx={sxClasses.legendInstructionsTitle}>
+        <Typography component="div" gutterBottom sx={memoSxClasses.legendInstructionsTitle}>
           {t('legend.noLayersAdded')}
         </Typography>
-        <Typography component="p" sx={sxClasses.legendInstructionsBody}>
+        <Typography component="p" sx={memoSxClasses.legendInstructionsBody}>
           {t('legend.noLayersAddedDescription')}
         </Typography>
       </Box>
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- sxClasses is memoized from theme which is stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- memoSxClasses is memoized from theme which is stable
   }, [t]);
 
   // Memoize fullscreen content
-  const fullscreenContent = useMemo(() => {
+  const memoFullscreenContent = useMemo(() => {
     // Log
     logger.logTraceUseMemo('components/legend-fullscreen - fullscreenContent', fullscreenLegendLayerList.length);
 
     if (!fullscreenLegendLayerList.length) {
-      return noLayersContent;
+      return memoNoLayersContent;
     }
 
     return fullscreenLegendLayerList.map((paths, idx) => (
@@ -249,7 +252,7 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
         key={`fullscreen-${idx}`}
         sx={{
           width: responsiveWidths.responsive,
-          ...sxClasses.legendList,
+          ...memoSxClasses.legendList,
         }}
       >
         {paths.map((layerPath) => (
@@ -257,8 +260,8 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
         ))}
       </List>
     ));
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- sxClasses is memoized from theme which is stable
-  }, [fullscreenLegendLayerList, noLayersContent]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- memoSxClasses is memoized from theme which is stable
+  }, [fullscreenLegendLayerList, memoNoLayersContent]);
 
   return (
     <FullScreenDialog
@@ -274,7 +277,7 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
       disableEnforceFocus={true}
     >
       <Box
-        sx={sxClasses.fullscreenContainer}
+        sx={memoSxClasses.fullscreenContainer}
         id={`${mapId}-${containerType}-${DEFAULT_APPBAR_CORE.LEGEND}-panel-fullscreen-container`}
         {...({
           // To set the content behind the dialog as inert to remove access to content
@@ -283,7 +286,7 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any)}
       >
-        {fullscreenContent}
+        {memoFullscreenContent}
       </Box>
     </FullScreenDialog>
   );

--- a/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
@@ -233,8 +233,7 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
         </Typography>
       </Box>
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- memoSxClasses is memoized from theme which is stable
-  }, [t]);
+  }, [t, memoSxClasses]);
 
   // Memoize fullscreen content
   const memoFullscreenContent = useMemo(() => {
@@ -260,8 +259,7 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
         ))}
       </List>
     ));
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- memoSxClasses is memoized from theme which is stable
-  }, [fullscreenLegendLayerList, memoNoLayersContent]);
+  }, [fullscreenLegendLayerList, memoNoLayersContent, memoSxClasses]);
 
   return (
     <FullScreenDialog

--- a/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-fullscreen.tsx
@@ -259,7 +259,7 @@ export function LegendFullscreen({ layerPaths, mapId, containerType, isOpen, onC
         ))}
       </List>
     ));
-  }, [fullscreenLegendLayerList, memoNoLayersContent, memoSxClasses]);
+  }, [fullscreenLegendLayerList, memoNoLayersContent, containerType, memoSxClasses]);
 
   return (
     <FullScreenDialog

--- a/packages/geoview-core/src/core/components/legend/legend-layer-container.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-container.tsx
@@ -55,6 +55,9 @@ const WMSLegendImage = memo(
     containerType,
     collapseContainerId,
   }: WMSLegendImageProps): JSX.Element => {
+    // Log
+    logger.logTraceRender('components/legend/legend-layer-container - WMSLegendImage');
+
     const { t } = useTranslation();
     const id = useId();
     const buttonId = `${mapId}-${containerType}-legend-image-btn-${id}`; // Create unique ID for focus management after lightbox closes
@@ -89,10 +92,16 @@ export const CollapsibleContent = memo(function CollapsibleContent({
   collapseContainerId,
   layerNameId,
 }: CollapsibleContentProps): JSX.Element | null {
+  // Log
+  logger.logTraceRender('components/legend/legend-layer-container - CollapsibleContent', layerPath);
+
   // Hooks
   const mapId = useStoreGeoViewMapId();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const sxClasses = useMemo(() => {
+    logger.logTraceUseMemo('components/legend/legend-layer-container - CollapsibleContent - sxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
   const isCollapsed = useStoreLayerLegendCollapsed(layerPath);
   const schemaTag = useStoreLayerSchemaTag(layerPath);
   const layerItems = useStoreLayerItems(layerPath);
@@ -100,9 +109,6 @@ export const CollapsibleContent = memo(function CollapsibleContent({
   const layerIcons = useStoreLayerIcons(layerPath);
   const layerStatus = useStoreLayerStatus(layerPath);
   const layerName = useStoreLayerName(layerPath);
-
-  // Log
-  logger.logTraceUseMemo('components/legend/legend-layer-container - CollapsibleContent', layerPath, layerChildPaths?.length);
 
   // Early returns
   if ((layerChildPaths?.length === 0 && layerItems?.length === 1) || layerStatus === 'error') return null;

--- a/packages/geoview-core/src/core/components/legend/legend-layer-container.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-container.tsx
@@ -150,8 +150,7 @@ export const CollapsibleContent = memo(function CollapsibleContent({
             <LegendLayerComponent layerPath={childPath} key={childPath} showControls={showControls} containerType={containerType} />
           ))}
       </List>
-      {/* TODO: Remove this recent fix layerItems.length > 1, because Johann fixed it another way? */}
-      {layerItems && layerItems.length > 1 && <ItemsList items={layerItems || []} layerPath={layerPath} />}
+      <ItemsList items={layerItems || []} layerPath={layerPath} />
     </Collapse>
   );
 });

--- a/packages/geoview-core/src/core/components/legend/legend-layer-container.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-container.tsx
@@ -13,9 +13,7 @@ import { logger } from '@/core/utils/logger';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import {
-  useStoreLayerCanToggle,
   useStoreLayerChildPaths,
-  useStoreLayerControls,
   useStoreLayerIcons,
   useStoreLayerItems,
   useStoreLayerName,
@@ -102,19 +100,12 @@ export const CollapsibleContent = memo(function CollapsibleContent({
   const layerIcons = useStoreLayerIcons(layerPath);
   const layerStatus = useStoreLayerStatus(layerPath);
   const layerName = useStoreLayerName(layerPath);
-  const canToggle = useStoreLayerCanToggle(layerPath);
-  const layerControls = useStoreLayerControls(layerPath);
-  const canToggleItemVisibility = canToggle && layerControls?.visibility !== false;
 
   // Log
   logger.logTraceUseMemo('components/legend/legend-layer-container - CollapsibleContent', layerPath, layerChildPaths?.length);
 
   // Early returns
   if ((layerChildPaths?.length === 0 && layerItems?.length === 1) || layerStatus === 'error') return null;
-
-  // GV Hide the collapsible when all items share the same icon and none can be toggled — nothing useful to display
-  const allSameIcon = layerItems && layerItems.length > 0 && layerItems.every((item): boolean => item.icon === layerItems[0].icon);
-  if (layerChildPaths?.length === 0 && allSameIcon && !canToggleItemVisibility) return null;
 
   const isWMSWithLegend = schemaTag === CONST_LAYER_TYPES.WMS && layerIcons?.[0]?.iconImage && layerIcons[0].iconImage !== 'no data';
 
@@ -150,7 +141,7 @@ export const CollapsibleContent = memo(function CollapsibleContent({
             <LegendLayerComponent layerPath={childPath} key={childPath} showControls={showControls} containerType={containerType} />
           ))}
       </List>
-      <ItemsList items={layerItems || []} layerPath={layerPath} />
+      {layerItems && layerItems.length > 1 && <ItemsList items={layerItems || []} layerPath={layerPath} />}
     </Collapse>
   );
 });

--- a/packages/geoview-core/src/core/components/legend/legend-layer-container.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-container.tsx
@@ -9,6 +9,9 @@ import { getSxClasses } from './legend-styles';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import { ItemsList } from './legend-layer-items';
 import type { LegendLayerProps } from './legend-layer';
+import { logger } from '@/core/utils/logger';
+import type { TypeContainerBox } from '@/core/types/global-types';
+import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import {
   useStoreLayerCanToggle,
   useStoreLayerChildPaths,
@@ -18,11 +21,8 @@ import {
   useStoreLayerName,
   useStoreLayerStatus,
   useStoreLayerSchemaTag,
+  useStoreLayerLegendCollapsed,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
-import { logger } from '@/core/utils/logger';
-import { useStoreMapLegendCollapsedByPath } from '@/core/stores/store-interface-and-intial-values/map-state';
-import type { TypeContainerBox } from '@/core/types/global-types';
 
 interface CollapsibleContentProps {
   layerPath: string;
@@ -95,7 +95,7 @@ export const CollapsibleContent = memo(function CollapsibleContent({
   const mapId = useStoreGeoViewMapId();
   const theme = useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
-  const isCollapsed = useStoreMapLegendCollapsedByPath(layerPath);
+  const isCollapsed = useStoreLayerLegendCollapsed(layerPath);
   const schemaTag = useStoreLayerSchemaTag(layerPath);
   const layerItems = useStoreLayerItems(layerPath);
   const layerChildPaths = useStoreLayerChildPaths(layerPath);
@@ -150,7 +150,8 @@ export const CollapsibleContent = memo(function CollapsibleContent({
             <LegendLayerComponent layerPath={childPath} key={childPath} showControls={showControls} containerType={containerType} />
           ))}
       </List>
-      <ItemsList items={layerItems || []} layerPath={layerPath} />
+      {/* TODO: Remove this recent fix layerItems.length > 1, because Johann fixed it another way? */}
+      {layerItems && layerItems.length > 1 && <ItemsList items={layerItems || []} layerPath={layerPath} />}
     </Collapse>
   );
 });

--- a/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
@@ -104,7 +104,7 @@ const useControlActions = (layerPath: string): ControlActions => {
         if (!isInVisibleRange || parentHidden || layer?.layerStatus === 'error') {
           return false;
         }
-        return layerController.setOrToggleLayerVisibilityIfExists(layerPath);
+        return layerController.setOrToggleLayerVisibility(layerPath);
       },
 
       /**

--- a/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
@@ -71,8 +71,9 @@ const useControlActions = (layerPath: string): ControlActions => {
   /**
    * Builds the memoized control action handlers.
    */
-  return useMemo(
-    () => ({
+  return useMemo(() => {
+    logger.logTraceUseMemo('LEGEND-LAYER-CTRL - useCtrlActions', layerPath, mapId);
+    return {
       /**
        * Handles zooming to the layer's visible scale range.
        */
@@ -143,9 +144,8 @@ const useControlActions = (layerPath: string): ControlActions => {
           logger.logPromiseFailed('in zoomToLayerExtent in legend-layer.handleZoomTo', error);
         });
       },
-    }),
-    [layerPath, mapId, layerController]
-  );
+    };
+  }, [layerPath, mapId, layerController]);
 };
 
 // Create subtitle
@@ -155,6 +155,7 @@ const useSubtitle = (layerPath: string, childPaths: string[], items: TypeLegendI
   const parentHidden = useStoreLayerIsParentHiddenOnMap(layerPath);
 
   return useMemo(() => {
+    logger.logTraceUseMemo('LEGEND-LAYER-CTRL - useSubtitle', childPaths.length, items);
     if (parentHidden) return t('layers.parentHidden');
 
     if (childPaths.length) {
@@ -207,7 +208,10 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
   // Hooks
   const { t } = useTranslation<string>();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('LEGEND-LAYER-CTRL - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
   const layerEntryType = useStoreLayerEntryType(layerPath);
   const layerChildPaths = useStoreLayerChildPaths(layerPath);
   const layerItems = useStoreLayerItems(layerPath);
@@ -241,14 +245,14 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
   const subTitle = useSubtitle(layerPath, layerChildPaths || [], layerItems || []);
 
   return (
-    <Stack direction="row" alignItems="center" sx={sxClasses.layerStackIcons}>
+    <Stack direction="row" alignItems="center" sx={memoSxClasses.layerStackIcons}>
       {!!subTitle.length && <Typography fontSize={14}>{subTitle}</Typography>}
-      <Box role="group" aria-label={t('layers.layerControls')!} sx={{ ...sxClasses.subtitle, display: 'flex', alignItems: 'center' }}>
+      <Box role="group" aria-label={t('layers.layerControls')!} sx={{ ...memoSxClasses.subtitle, display: 'flex', alignItems: 'center' }}>
         {/* Button to select layer in panel and scroll to footer
             Hidden in WCAG mode - keyboard users can Tab to layer panel instead
           */}
         {hasLayersTab && !isFocusTrap && (
-          <Box sx={sxClasses.buttonDivider}>
+          <Box sx={memoSxClasses.buttonDivider}>
             <IconButton
               tooltip={t('legend.selectLayerAndScroll')}
               className="buttonOutline"

--- a/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-ctrl.tsx
@@ -24,21 +24,17 @@ import {
   useStoreLayerStatus,
   useStoreLayerEntryType,
   useStoreLayerName,
-  setStoreLayerSelectedLayersTabLayer,
   getStoreLayerLegendLayerByPath,
+  getStoreLayerParentHidden,
+  useStoreLayerIsParentHiddenOnMap,
+  useStoreLayerInVisibleRange,
+  useStoreLayerVisible,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import {
   useStoreUIFooterBarComponents,
   useStoreUIAppbarComponents,
   useStoreUIActiveTrapGeoView,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import {
-  getStoreMapLayerParentHidden,
-  getStoreMapOrderedLayerInfoByPath,
-  useStoreMapLayerInVisibleRange,
-  useStoreMapIsParentLayerHiddenOnMap,
-  useStoreMapLayerVisibility,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
 import type { TypeLegendItem } from '@/core/components/layers/types';
 import { getSxClasses } from './legend-styles';
 import { logger } from '@/core/utils/logger';
@@ -85,9 +81,8 @@ const useControlActions = (layerPath: string): ControlActions => {
         // Read current state values when handler executes
         const layer = getStoreLayerLegendLayerByPath(mapId, layerPath);
 
-        // Use orderedLayerInfo to check visibility range
-        const layerInfo = getStoreMapOrderedLayerInfoByPath(mapId, layerPath);
-        const isInVisibleRange = layerInfo?.inVisibleRange || false;
+        // Check visibility range
+        const isInVisibleRange = layer?.inVisibleRange || false;
 
         const isZoomToVisibleScaleCapable = !isInVisibleRange && layer?.entryType !== 'group';
         if (!isZoomToVisibleScaleCapable) {
@@ -103,14 +98,13 @@ const useControlActions = (layerPath: string): ControlActions => {
         event.stopPropagation();
         // Read current state values when handler executes
         const layer = getStoreLayerLegendLayerByPath(mapId, layerPath);
-        const layerInfo = getStoreMapOrderedLayerInfoByPath(mapId, layerPath);
-        const isInVisibleRange = layerInfo?.inVisibleRange || false;
-        const parentHidden = getStoreMapLayerParentHidden(mapId, layerPath);
+        const isInVisibleRange = layer?.inVisibleRange;
+        const parentHidden = getStoreLayerParentHidden(mapId, layerPath);
 
         if (!isInVisibleRange || parentHidden || layer?.layerStatus === 'error') {
           return false;
         }
-        return layerController.setOrToggleMapLayerVisibility(layerPath);
+        return layerController.setOrToggleLayerVisibilityIfExists(layerPath);
       },
 
       /**
@@ -120,10 +114,9 @@ const useControlActions = (layerPath: string): ControlActions => {
         event.stopPropagation();
         // Read current state values when handler executes
         const layer = getStoreLayerLegendLayerByPath(mapId, layerPath);
-        const layerInfo = getStoreMapOrderedLayerInfoByPath(mapId, layerPath);
-        const isInVisibleRange = layerInfo?.inVisibleRange || false;
-        const parentHidden = getStoreMapLayerParentHidden(mapId, layerPath);
-        const isVisible = layerInfo?.visible || false;
+        const isInVisibleRange = layer?.inVisibleRange || false;
+        const parentHidden = getStoreLayerParentHidden(mapId, layerPath);
+        const isVisible = layer?.visible || false;
 
         if (!isInVisibleRange || parentHidden || !isVisible || layer?.layerStatus === 'error') {
           return;
@@ -138,10 +131,9 @@ const useControlActions = (layerPath: string): ControlActions => {
         event.stopPropagation();
         // Read current state values when handler executes
         const layer = getStoreLayerLegendLayerByPath(mapId, layerPath);
-        const layerInfo = getStoreMapOrderedLayerInfoByPath(mapId, layerPath);
-        const isInVisibleRange = layerInfo?.inVisibleRange || false;
-        const parentHidden = getStoreMapLayerParentHidden(mapId, layerPath);
-        const isVisible = layerInfo?.visible || false;
+        const isInVisibleRange = layer?.inVisibleRange || false;
+        const parentHidden = getStoreLayerParentHidden(mapId, layerPath);
+        const isVisible = layer?.visible || false;
 
         const isZoomToLayerDisabled = !isInVisibleRange || parentHidden || !isVisible || layer?.layerStatus === 'error';
         if (isZoomToLayerDisabled) {
@@ -160,7 +152,7 @@ const useControlActions = (layerPath: string): ControlActions => {
 const useSubtitle = (layerPath: string, childPaths: string[], items: TypeLegendItem[]): string => {
   // Hooks
   const { t } = useTranslation();
-  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layerPath);
+  const parentHidden = useStoreLayerIsParentHiddenOnMap(layerPath);
 
   return useMemo(() => {
     if (parentHidden) return t('layers.parentHidden');
@@ -192,9 +184,12 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
   const hasFooterLayersTab = footerBarComponents.includes('layers');
   const hasAppBarLayersTab = appBarComponents.includes('layers');
   const hasLayersTab = hasFooterLayersTab || hasAppBarLayersTab;
+  const layerController = useLayerController();
 
   // Use navigate hook
-  const navigateToLayers = useNavigateToTab('layers', setStoreLayerSelectedLayersTabLayer);
+  const navigateToLayers = useNavigateToTab('layers', (lyrPath) => {
+    layerController.setSelectedLayerPath(lyrPath);
+  });
 
   // Create stable handler for layer navigation
   const handleNavigateToLayers = useCallback(
@@ -218,9 +213,9 @@ export function SecondaryControls({ layerPath }: SecondaryControlsProps): JSX.El
   const layerItems = useStoreLayerItems(layerPath);
   const layerControls = useStoreLayerControls(layerPath);
   const layerStatus = useStoreLayerStatus(layerPath);
-  const isVisible = useStoreMapLayerVisibility(layerPath);
-  const isInVisibleRange = useStoreMapLayerInVisibleRange(layerPath);
-  const parentHidden = useStoreMapIsParentLayerHiddenOnMap(layerPath);
+  const isVisible = useStoreLayerVisible(layerPath);
+  const isInVisibleRange = useStoreLayerInVisibleRange(layerPath);
+  const parentHidden = useStoreLayerIsParentHiddenOnMap(layerPath);
   const highlightedLayer = useStoreLayerHighlightedLayer();
   const isFocusTrap = useStoreUIActiveTrapGeoView();
   const layerName = useStoreLayerName(layerPath) ?? layerPath;

--- a/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
@@ -28,7 +28,7 @@ const LegendListItem = memo(
     canToggle,
     showNameTooltip,
     onToggle,
-    sxClasses,
+    memoSxClasses,
     id,
   }: {
     item: TypeLegendItem;
@@ -36,7 +36,7 @@ const LegendListItem = memo(
     canToggle: boolean;
     showNameTooltip: boolean;
     onToggle?: () => void;
-    sxClasses: Record<string, object>;
+    memoSxClasses: Record<string, object>;
     id: string;
   }): JSX.Element => {
     const { t } = useTranslation<string>();
@@ -49,7 +49,7 @@ const LegendListItem = memo(
     const itemClassName = getItemClassName();
 
     return (
-      <ListItem sx={sxClasses.layerListItem} disablePadding className={`layerListItem ${itemClassName || ''}`}>
+      <ListItem sx={memoSxClasses.layerListItem} disablePadding className={`layerListItem ${itemClassName || ''}`}>
         <Tooltip
           title={tooltipTitle || (showNameTooltip ? name : '')}
           placement="top"
@@ -73,7 +73,7 @@ const LegendListItem = memo(
             onClick={canToggle && onToggle ? onToggle : undefined}
             disabled={!canToggle || !onToggle}
             disableRipple
-            sx={sxClasses.layerListItemButton}
+            sx={memoSxClasses.layerListItemButton}
             className={`layerListItemButton ${itemClassName || ''}`}
             aria-pressed={isVisible && layerVisible}
             aria-label={`${t('layers.toggleVisibility')} - ${name}`} // WCAG - Provide descriptive aria-label for accessibility
@@ -101,7 +101,10 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
 
   // Hooks
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('LEGEND-LAYER-ITEMS - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
   const lastToggledRef = useRef<string | null>(null);
   const itemIdMapRef = useRef<Map<string, string>>(new Map());
 
@@ -146,6 +149,7 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
 
   // Keep focus on layers when they are toggled using keyboard
   useEffect(() => {
+    logger.logTraceUseEffect('LEGEND-LAYER-ITEMS - keep focus on toggled layer', items);
     if (lastToggledRef.current) {
       document.getElementById(lastToggledRef.current)?.focus();
       lastToggledRef.current = null;
@@ -160,7 +164,7 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
   // GV this is specifically because of esriFeature layers. This also causes focus to be lost when using a keyboard to toggle layer visibility
   // TODO Add a visibility hook for the individual classes to update this in the future
   return (
-    <List className="layerList" sx={sxClasses.layerList}>
+    <List className="layerList" sx={memoSxClasses.layerList}>
       {items.map((item) => {
         const itemId = getItemId(item);
         const canReallyToggle = Boolean(
@@ -181,7 +185,7 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
             id={itemId}
             {...commonProps}
             onToggle={canToggle ? () => handleToggleItemVisibility(item, itemId) : undefined}
-            sxClasses={sxClasses}
+            memoSxClasses={memoSxClasses}
           />
         );
       })}

--- a/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
@@ -28,7 +28,7 @@ const LegendListItem = memo(
     canToggle,
     showNameTooltip,
     onToggle,
-    memoSxClasses,
+    sxClasses,
     id,
   }: {
     item: TypeLegendItem;
@@ -36,7 +36,7 @@ const LegendListItem = memo(
     canToggle: boolean;
     showNameTooltip: boolean;
     onToggle?: () => void;
-    memoSxClasses: Record<string, object>;
+    sxClasses: Record<string, object>;
     id: string;
   }): JSX.Element => {
     const { t } = useTranslation<string>();
@@ -49,7 +49,7 @@ const LegendListItem = memo(
     const itemClassName = getItemClassName();
 
     return (
-      <ListItem sx={memoSxClasses.layerListItem} disablePadding className={`layerListItem ${itemClassName || ''}`}>
+      <ListItem sx={sxClasses.layerListItem} disablePadding className={`layerListItem ${itemClassName || ''}`}>
         <Tooltip
           title={tooltipTitle || (showNameTooltip ? name : '')}
           placement="top"
@@ -73,7 +73,7 @@ const LegendListItem = memo(
             onClick={canToggle && onToggle ? onToggle : undefined}
             disabled={!canToggle || !onToggle}
             disableRipple
-            sx={memoSxClasses.layerListItemButton}
+            sx={sxClasses.layerListItemButton}
             className={`layerListItemButton ${itemClassName || ''}`}
             aria-pressed={isVisible && layerVisible}
             aria-label={`${t('layers.toggleVisibility')} - ${name}`} // WCAG - Provide descriptive aria-label for accessibility
@@ -185,7 +185,7 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
             id={itemId}
             {...commonProps}
             onToggle={canToggle ? () => handleToggleItemVisibility(item, itemId) : undefined}
-            memoSxClasses={memoSxClasses}
+            sxClasses={memoSxClasses}
           />
         );
       })}

--- a/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
@@ -6,12 +6,12 @@ import type { TypeLegendItem } from '@/core/components/layers/types';
 import {
   useStoreLayerCanToggle,
   useStoreLayerControls,
+  useStoreLayerIsHiddenOnMap,
   useStoreLayerStyleConfig,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { getSxClasses } from './legend-styles';
 import { logger } from '@/core/utils/logger';
 import { generateId } from '@/core/utils/utilities';
-import { useStoreMapIsLayerHiddenOnMap } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { useLayerController } from '@/core/controllers/use-controllers';
 
@@ -112,7 +112,7 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
   // Store
   const mapId = useStoreGeoViewMapId();
   const layerControls = useStoreLayerControls(layerPath);
-  const layerHidden = useStoreMapIsLayerHiddenOnMap(layerPath);
+  const layerHidden = useStoreLayerIsHiddenOnMap(layerPath);
   const canToggle = useStoreLayerCanToggle(layerPath);
   const canToggleItemVisibility = canToggle && layerControls?.visibility !== false;
   const styleConfig = useStoreLayerStyleConfig(layerPath);

--- a/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
@@ -27,7 +27,6 @@ const LegendListItem = memo(
     layerVisible,
     canToggle,
     showNameTooltip,
-    showIcon,
     onToggle,
     sxClasses,
     id,
@@ -36,7 +35,6 @@ const LegendListItem = memo(
     layerVisible: boolean;
     canToggle: boolean;
     showNameTooltip: boolean;
-    showIcon: boolean;
     onToggle?: () => void;
     sxClasses: Record<string, object>;
     id: string;
@@ -80,13 +78,11 @@ const LegendListItem = memo(
             aria-pressed={isVisible && layerVisible}
             aria-label={`${t('layers.toggleVisibility')} - ${name}`} // WCAG - Provide descriptive aria-label for accessibility
           >
-            {showIcon && (
-              <ListItemIcon>
-                <Box sx={{ display: 'flex', padding: '0 18px 0 18px', margin: '0 -18px 0 -18px' }}>
-                  {icon ? <Box component="img" alt="" src={icon} /> : <BrowserNotSupportedIcon />}
-                </Box>
-              </ListItemIcon>
-            )}
+            <ListItemIcon>
+              <Box sx={{ display: 'flex', padding: '0 18px 0 18px', margin: '0 -18px 0 -18px' }}>
+                {icon ? <Box component="img" alt="" src={icon} /> : <BrowserNotSupportedIcon />}
+              </Box>
+            </ListItemIcon>
             <ListItemText primary={name} />
           </ListItemButton>
         </Tooltip>
@@ -159,9 +155,6 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
   // Early returns
   if (!items?.length) return null;
 
-  // GV Hide item icons when all items share the same icon (redundant with the layer header icon)
-  const allSameIcon = items.every((item): boolean => item.icon === items[0].icon);
-
   // Direct mapping since we only reach this code if items has content
   // GV isVisible is part of key so that it forces a re-render when it changes
   // GV this is specifically because of esriFeature layers. This also causes focus to be lost when using a keyboard to toggle layer visibility
@@ -187,7 +180,6 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
             key={`${item.name}-${item.isVisible}-${item.icon}`}
             id={itemId}
             {...commonProps}
-            showIcon={!allSameIcon}
             onToggle={canToggle ? () => handleToggleItemVisibility(item, itemId) : undefined}
             sxClasses={sxClasses}
           />

--- a/packages/geoview-core/src/core/components/legend/legend-layer.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer.tsx
@@ -54,7 +54,7 @@ const LegendLayerHeader = memo(
     collapseContainerId,
   }: LegendLayerHeaderProps): JSX.Element => {
     // Log
-    logger.logTraceUseMemo('components/legend/legend-layer - LegendLayerHeader', layerPath);
+    logger.logTraceRender('components/legend/legend-layer - LegendLayerHeader', layerPath);
 
     // Hooks
     const isCollapsed = useStoreLayerLegendCollapsed(layerPath);
@@ -121,7 +121,11 @@ export function LegendLayer({ layerPath, showControls, containerType }: LegendLa
   // Hooks
   const { t } = useTranslation<string>();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  /** Memoized sx class definitions for the legend layer. */
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('LEGEND-LAYER - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // Stores
   const mapId = useStoreGeoViewMapId();
@@ -137,6 +141,9 @@ export function LegendLayer({ layerPath, showControls, containerType }: LegendLa
   const prevStatusRef = useRef<string | undefined>(undefined); // Ref to track previous status for status change detection
   const [statusMessage, setStatusMessage] = useState<string>('');
 
+  /**
+   * Handles click on the layer expand/collapse toggle button.
+   */
   const handleExpandGroupClick = useCallback(
     (event: React.MouseEvent): void => {
       event.stopPropagation();
@@ -147,8 +154,12 @@ export function LegendLayer({ layerPath, showControls, containerType }: LegendLa
     [layerPath, layerController]
   );
 
+  /**
+   * Tracks layer status changes for screen reader announcements.
+   */
   // WCAG - Track layer status changes for screen reader announcements
   useEffect(() => {
+    logger.logTraceUseEffect('LEGEND-LAYER - WCAG track layer status changes', layerStatus);
     if (layerStatus === 'loading' && prevStatusRef.current !== 'loading') {
       // Announce when loading starts
       setStatusMessage(t('layers.status.layerLoadingDescriptive', { layerName }) || '');
@@ -168,22 +179,22 @@ export function LegendLayer({ layerPath, showControls, containerType }: LegendLa
   }, [layerStatus, layerName, t]);
 
   return (
-    <ListItem className="legendListItem" sx={sxClasses.legendListItem} key={layerPath}>
+    <ListItem className="legendListItem" sx={memoSxClasses.legendListItem} key={layerPath}>
       <LegendLayerHeader
         layerPath={layerPath}
         tooltip={t('layers.toggleCollapse')}
         onExpandClick={handleExpandGroupClick}
-        sxClasses={sxClasses}
+        sxClasses={memoSxClasses}
         showControls={showControls}
         layerNameId={layerNameId}
         collapseContainerId={collapseContainerId}
       />
       {/* WCAG - ARIA live region for screen reader announcements */}
-      <Box sx={sxClasses.visuallyHidden} role="status" aria-live="polite" aria-atomic="true">
+      <Box sx={memoSxClasses.visuallyHidden} role="status" aria-live="polite" aria-atomic="true">
         {statusMessage}
       </Box>
       {layerStatus === 'loading' && (
-        <Box sx={sxClasses.loading}>
+        <Box sx={memoSxClasses.loading}>
           <ProgressBar aria-label={t('layers.status.layerLoadingDescriptive', { layerName })!} />
         </Box>
       )}

--- a/packages/geoview-core/src/core/components/legend/legend-layer.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer.tsx
@@ -12,12 +12,9 @@ import {
   useStoreLayerName,
   useStoreLayerStatus,
   useStoreLayerSchemaTag,
+  useStoreLayerIsHiddenOnMap,
+  useStoreLayerLegendCollapsed,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import {
-  useStoreMapLegendCollapsedByPath,
-  useStoreMapIsLayerHiddenOnMap,
-  setStoreMapToggleLegendCollapsed,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
 import { useLightBox } from '@/core/components/common';
 import { LayerIcon } from '@/core/components/common/layer-icon';
 import { SecondaryControls } from './legend-layer-ctrl';
@@ -27,6 +24,7 @@ import { getSxClasses } from './legend-styles';
 import { logger } from '@/core/utils/logger';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { Typography } from '@/ui/typography/typography';
+import { useLayerController } from '@/core/controllers/use-controllers';
 
 export interface LegendLayerProps {
   layerPath: string;
@@ -59,8 +57,8 @@ const LegendLayerHeader = memo(
     logger.logTraceUseMemo('components/legend/legend-layer - LegendLayerHeader', layerPath);
 
     // Hooks
-    const isCollapsed = useStoreMapLegendCollapsedByPath(layerPath);
-    const layerHidden = useStoreMapIsLayerHiddenOnMap(layerPath);
+    const isCollapsed = useStoreLayerLegendCollapsed(layerPath);
+    const layerHidden = useStoreLayerIsHiddenOnMap(layerPath);
     const layerName = useStoreLayerName(layerPath) ?? layerPath;
     const layerItems = useStoreLayerItems(layerPath);
     const layerChildPaths = useStoreLayerChildPaths(layerPath);
@@ -133,6 +131,7 @@ export function LegendLayer({ layerPath, showControls, containerType }: LegendLa
   const layerStatus = useStoreLayerStatus(layerPath);
   const layerName = useStoreLayerName(layerPath) ?? layerPath;
   const { initLightBox, LightBoxComponent } = useLightBox();
+  const layerController = useLayerController();
 
   // Internal state
   const prevStatusRef = useRef<string | undefined>(undefined); // Ref to track previous status for status change detection
@@ -142,10 +141,10 @@ export function LegendLayer({ layerPath, showControls, containerType }: LegendLa
     (event: React.MouseEvent): void => {
       event.stopPropagation();
 
-      // Save to the store
-      setStoreMapToggleLegendCollapsed(mapId, layerPath);
+      // Toggle the legend collapse
+      layerController.toggleLegendCollapsed(layerPath);
     },
-    [layerPath, mapId]
+    [layerPath, layerController]
   );
 
   // WCAG - Track layer status changes for screen reader announcements

--- a/packages/geoview-core/src/core/components/legend/legend.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend.tsx
@@ -15,7 +15,7 @@ import { CONTAINER_TYPE } from '@/core/utils/constant';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { useEventListener } from '@/core/components/common/hooks/use-event-listener';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
-import { useStoreLayerLayerPaths } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { useStoreLayerTopLevelLayerPaths } from '@/core/stores/store-interface-and-intial-values/layer-state';
 
 interface LegendType {
   containerType: TypeContainerBox;
@@ -65,7 +65,7 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
 
   // Store
   const mapId = useStoreGeoViewMapId();
-  const layerPaths = useStoreLayerLayerPaths();
+  const layerPaths = useStoreLayerTopLevelLayerPaths();
 
   // Memoize breakpoint values
   const breakpoints = useMemo(() => {

--- a/packages/geoview-core/src/core/components/legend/legend.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend.tsx
@@ -152,8 +152,7 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
         </Typography>
       </Box>
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- memoSxClasses is memoized from theme which is stable
-  }, [t]);
+  }, [t, memoSxClasses]);
 
   // Memoize the rendered content based on whether there are legend layers
   const memoContent = useMemo(() => {
@@ -179,8 +178,7 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
         ))}
       </List>
     ));
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- memoSxClasses is memoized from theme which is stable
-  }, [formattedLegendLayerList, memoNoLayersContent, containerType]);
+  }, [formattedLegendLayerList, memoNoLayersContent, containerType, memoSxClasses]);
 
   // TODO: CLEANUP - Remove the commented code, we're trying to not unmount the Legend panel anymore to check performance 2026-04-07
   // Early return with empty fragment if not the active tab

--- a/packages/geoview-core/src/core/components/legend/legend.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend.tsx
@@ -49,14 +49,19 @@ const responsiveWidths = {
   },
 } as const;
 
+/** Main container styles for the legend component. */
+const sxClassesMain = getSxClassesMain();
+
 export function Legend({ containerType }: LegendType): JSX.Element | null {
   logger.logTraceRender('components/legend/legend');
 
   // Hooks
   const { t } = useTranslation<string>();
   const theme = useTheme();
-  const sxClassesMain = useMemo(() => getSxClassesMain(), []);
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('LEGEND - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // State
   const [formattedLegendLayerList, setFormattedLegendLayersList] = useState<string[][]>([]);
@@ -68,7 +73,7 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
   const layerPaths = useStoreLayerTopLevelLayerPaths();
 
   // Memoize breakpoint values
-  const breakpoints = useMemo(() => {
+  const memoBreakpoints = useMemo(() => {
     // Log
     logger.logTraceUseMemo('LEGEND - breakpoints', theme.breakpoints.values);
 
@@ -86,11 +91,11 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
     if (containerType === CONTAINER_TYPE.APP_BAR) return 1;
 
     const { innerWidth } = window;
-    if (innerWidth < breakpoints.sm) return 1;
-    if (innerWidth < breakpoints.md) return 2;
-    if (innerWidth < breakpoints.lg) return 3;
+    if (innerWidth < memoBreakpoints.sm) return 1;
+    if (innerWidth < memoBreakpoints.md) return 2;
+    if (innerWidth < memoBreakpoints.lg) return 3;
     return 4;
-  }, [breakpoints, containerType]);
+  }, [memoBreakpoints, containerType]);
 
   /**
    * Transform the list of the legends into subsets of lists.
@@ -133,30 +138,30 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
   }, [layerPaths, updateLegendLayerListByWindowSize]);
 
   // Memoize the no layers content
-  const noLayersContent = useMemo(() => {
+  const memoNoLayersContent = useMemo(() => {
     // Log
     logger.logTraceUseMemo('components/legend - noLayersContent');
 
     return (
       <Box sx={styles.noLayersContainer}>
-        <Typography variant="h3" gutterBottom sx={sxClasses.legendInstructionsTitle}>
+        <Typography variant="h3" gutterBottom sx={memoSxClasses.legendInstructionsTitle}>
           {t('legend.noLayersAdded')}
         </Typography>
-        <Typography component="p" sx={sxClasses.legendInstructionsBody}>
+        <Typography component="p" sx={memoSxClasses.legendInstructionsBody}>
           {t('legend.noLayersAddedDescription')}
         </Typography>
       </Box>
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- sxClasses is memoized from theme which is stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- memoSxClasses is memoized from theme which is stable
   }, [t]);
 
   // Memoize the rendered content based on whether there are legend layers
-  const content = useMemo(() => {
+  const memoContent = useMemo(() => {
     // Log
     logger.logTraceUseMemo('components/legend - content', formattedLegendLayerList.length);
 
     if (!formattedLegendLayerList.length) {
-      return noLayersContent;
+      return memoNoLayersContent;
     }
 
     return formattedLegendLayerList.map((paths, idx) => (
@@ -166,7 +171,7 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
         key={`${idx}`}
         sx={{
           width: containerType === CONTAINER_TYPE.APP_BAR ? responsiveWidths.full : responsiveWidths.responsive,
-          ...sxClasses.legendList,
+          ...memoSxClasses.legendList,
         }}
       >
         {paths.map((layerPath) => (
@@ -174,8 +179,8 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
         ))}
       </List>
     ));
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- sxClasses is memoized from theme which is stable
-  }, [formattedLegendLayerList, noLayersContent, containerType]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- memoSxClasses is memoized from theme which is stable
+  }, [formattedLegendLayerList, memoNoLayersContent, containerType]);
 
   // TODO: CLEANUP - Remove the commented code, we're trying to not unmount the Legend panel anymore to check performance 2026-04-07
   // Early return with empty fragment if not the active tab
@@ -192,7 +197,7 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
         buttonRef={fullScreenBtnRef}
       />
 
-      <Box sx={sxClasses.toggleBar}>
+      <Box sx={memoSxClasses.toggleBar}>
         <ToggleAll containerType={containerType} source="legend" />
         <LegendFullscreenButton containerType={containerType} onClick={() => setIsFullScreen(true)} buttonRef={fullScreenBtnRef} />
       </Box>
@@ -200,7 +205,7 @@ export function Legend({ containerType }: LegendType): JSX.Element | null {
         sx={{ background: theme.palette.geoViewColor.bgColor.main, ...sxClassesMain.container }}
         id={`${mapId}-${containerType}-legendContainer`}
       >
-        <Box sx={styles.flexContainer}>{content}</Box>
+        <Box sx={styles.flexContainer}>{memoContent}</Box>
       </Box>
     </>
   );

--- a/packages/geoview-core/src/core/components/map/map.tsx
+++ b/packages/geoview-core/src/core/components/map/map.tsx
@@ -46,7 +46,10 @@ export function Map(props: MapProps): JSX.Element {
   const { t } = useTranslation();
 
   const defaultTheme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(), []);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('MAP - memoSxClasses');
+    return getSxClasses();
+  }, []);
 
   // internal state - get ref to div element
   const mapElement = useRef<HTMLElement | undefined>();
@@ -81,7 +84,7 @@ export function Map(props: MapProps): JSX.Element {
 
   return (
     // ? the map is focusable and needs to be tabbable for keyboard navigation (only when interaction is dynamic)
-    <Box id={`mapTargetElement-${mapId}`} ref={mapElement} sx={sxClasses.mapContainer} tabIndex={mapInteraction === 'static' ? -1 : 0}>
+    <Box id={`mapTargetElement-${mapId}`} ref={mapElement} sx={memoSxClasses.mapContainer} tabIndex={mapInteraction === 'static' ? -1 : 0}>
       {mapLoaded && (
         <>
           {northArrow && <NorthArrow />}
@@ -93,7 +96,7 @@ export function Map(props: MapProps): JSX.Element {
         </>
       )}
       {layersAreLoading && (
-        <Box sx={{ ...sxClasses.progressBar, bottom: mapInteraction === 'static' ? 0 : 40 }}>
+        <Box sx={{ ...memoSxClasses.progressBar, bottom: mapInteraction === 'static' ? 0 : 40 }}>
           <ProgressBar aria-label={t('error.map.loadingLayers')!} />
         </Box>
       )}

--- a/packages/geoview-core/src/core/components/map/map.tsx
+++ b/packages/geoview-core/src/core/components/map/map.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useMemo } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -32,6 +32,9 @@ type MapProps = {
   viewer: MapViewer;
 };
 
+/** Sx class definitions for the map component (static - no theme dependency). */
+const sxClasses = getSxClasses();
+
 /**
  * Creates the map component.
  *
@@ -46,10 +49,6 @@ export function Map(props: MapProps): JSX.Element {
   const { t } = useTranslation();
 
   const defaultTheme = useTheme();
-  const memoSxClasses = useMemo(() => {
-    logger.logTraceUseMemo('MAP - memoSxClasses');
-    return getSxClasses();
-  }, []);
 
   // internal state - get ref to div element
   const mapElement = useRef<HTMLElement | undefined>();
@@ -84,7 +83,7 @@ export function Map(props: MapProps): JSX.Element {
 
   return (
     // ? the map is focusable and needs to be tabbable for keyboard navigation (only when interaction is dynamic)
-    <Box id={`mapTargetElement-${mapId}`} ref={mapElement} sx={memoSxClasses.mapContainer} tabIndex={mapInteraction === 'static' ? -1 : 0}>
+    <Box id={`mapTargetElement-${mapId}`} ref={mapElement} sx={sxClasses.mapContainer} tabIndex={mapInteraction === 'static' ? -1 : 0}>
       {mapLoaded && (
         <>
           {northArrow && <NorthArrow />}
@@ -96,7 +95,7 @@ export function Map(props: MapProps): JSX.Element {
         </>
       )}
       {layersAreLoading && (
-        <Box sx={{ ...memoSxClasses.progressBar, bottom: mapInteraction === 'static' ? 0 : 40 }}>
+        <Box sx={{ ...sxClasses.progressBar, bottom: mapInteraction === 'static' ? 0 : 40 }}>
           <ProgressBar aria-label={t('error.map.loadingLayers')!} />
         </Box>
       )}

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/basemap-select.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/basemap-select.tsx
@@ -58,8 +58,8 @@ export default function BasemapSelect(): JSX.Element {
 
       // If the Geoview basemap layer is present, toggle visibility based on selection. We hide it on nogeom.
       if (hasGeoviewBasemapLayer) {
-        if (basemapChoice === 'default') layerController.setVisibilityOfGeoviewBasemapLayers(true);
-        else layerController.setVisibilityOfGeoviewBasemapLayers(false);
+        if (basemapChoice === 'default') layerController.setAllLayersVisibilityBasemapsOnly(true);
+        else layerController.setAllLayersVisibilityBasemapsOnly(false);
       }
 
       mapController

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/fullscreen.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/fullscreen.tsx
@@ -65,8 +65,7 @@ export default function Fullscreen(): JSX.Element {
       document.removeEventListener('mozfullscreenchange', handleExit);
       document.removeEventListener('MSFullscreenChange', handleExit);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [uiController]);
 
   return (
     <IconButton

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/map-rotation.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/map-rotation.tsx
@@ -6,7 +6,6 @@ import {
   useStoreMapFixNorth,
   useStoreMapNorthArrow,
   useStoreMapCurrentProjectionEPSG,
-  setStoreMapFixNorth,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
 import NavbarPanelButton from '@/core/components/nav-bar/nav-bar-panel-button';
@@ -17,7 +16,6 @@ import { useManageArrow } from '@/core/components/north-arrow/hooks/useManageArr
 import type { TypePanelProps } from '@/ui/panel/panel-types';
 import type { IconButtonPropsExtend } from '@/ui/icon-button/icon-button';
 import { IconButton } from '@/ui/icon-button/icon-button';
-import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { useMapController } from '@/core/controllers/use-controllers';
 
 /**
@@ -32,7 +30,6 @@ export default function MapRotation(): JSX.Element {
   const { t } = useTranslation<string>();
 
   // Get values from store
-  const mapId = useStoreGeoViewMapId();
   const mapRotation = useStoreMapRotation();
   const isFixNorth = useStoreMapFixNorth();
   const isNorthEnable = useStoreMapNorthArrow();
@@ -114,14 +111,14 @@ export default function MapRotation(): JSX.Element {
   const handleFixNorth = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>): void => {
       const isChecked = event.target.checked;
-      setStoreMapFixNorth(mapId, isChecked);
+      mapController.setFixNorth(isChecked);
 
       if (!isChecked) {
         mapController.rotate(0);
         setSliderRotationDegrees(0);
       }
     },
-    [mapId, mapController]
+    [mapController]
   );
 
   /**

--- a/packages/geoview-core/src/core/components/nav-bar/nav-bar-api.ts
+++ b/packages/geoview-core/src/core/components/nav-bar/nav-bar-api.ts
@@ -1,8 +1,7 @@
 import type { TypeButtonGroupConfig, TypeButtonPanel, TypePanelProps } from '@/ui/panel/panel-types';
 import type { IconButtonPropsExtend } from '@/ui/icon-button/icon-button';
 
-import type { EventDelegateBase } from '@/api/events/event-helper';
-import EventHelper from '@/api/events/event-helper';
+import type { UIController } from '@/core/controllers/ui-controller';
 import { generateId } from '@/core/utils/utilities';
 
 /**
@@ -15,77 +14,17 @@ export class NavBarApi {
   /** Configuration for button groups. */
   groupConfigs: Record<string, TypeButtonGroupConfig> = {};
 
-  /** Callback handlers for the NavBar created event. */
-  #onNavBarCreatedHandlers: NavBarCreatedDelegate[] = [];
-
-  /** Callback handlers for the NavBar removed event. */
-  #onNavBarRemovedHandlers: NavBarRemovedDelegate[] = [];
+  /** The UI controller instance for accessing the map id. */
+  #uiController: UIController;
 
   /**
    * Instantiates a NavBarApi class.
+   *
+   * @param uiController - The UI controller instance
    */
-  constructor() {
+  constructor(uiController: UIController) {
+    this.#uiController = uiController;
     this.#createDefaultButtonPanels();
-  }
-
-  /**
-   * Emits an event to all registered NavBar created event handlers.
-   *
-   * @param event - The event to emit
-   */
-  #emitNavbarCreated(event: NavBarCreatedEvent): void {
-    // Emit the NavBar created event
-    EventHelper.emitEvent(this, this.#onNavBarCreatedHandlers, event);
-  }
-
-  /**
-   * Registers an event handler for NavBar created events.
-   *
-   * @param callback - The callback to be executed whenever the event is emitted
-   */
-  onNavbarCreated(callback: NavBarCreatedDelegate): void {
-    // Register the NavBar created event callback
-    EventHelper.onEvent(this.#onNavBarCreatedHandlers, callback);
-  }
-
-  /**
-   * Unregisters an event handler for NavBar created events.
-   *
-   * @param callback - The callback to stop being called whenever the event is emitted
-   */
-  offNavbarCreated(callback: NavBarCreatedDelegate): void {
-    // Unregister the NavBar created event callback
-    EventHelper.offEvent(this.#onNavBarCreatedHandlers, callback);
-  }
-
-  /**
-   * Emits an event to all registered NavBar removed event handlers.
-   *
-   * @param event - The event to emit
-   */
-  #emitNavbarRemoved(event: NavBarRemovedEvent): void {
-    // Emit the NavBar removed event
-    EventHelper.emitEvent(this, this.#onNavBarRemovedHandlers, event);
-  }
-
-  /**
-   * Registers an event handler for NavBar removed events.
-   *
-   * @param callback - The callback to be executed whenever the event is emitted
-   */
-  onNavbarRemoved(callback: NavBarRemovedDelegate): void {
-    // Register the NavBar removed event callback
-    EventHelper.onEvent(this.#onNavBarRemovedHandlers, callback);
-  }
-
-  /**
-   * Unregisters an event handler for NavBar removed events.
-   *
-   * @param callback - The callback to stop being called whenever the event is emitted
-   */
-  offNavbarRemoved(callback: NavBarRemovedDelegate): void {
-    // Unregister the NavBar removed event callback
-    EventHelper.offEvent(this.#onNavBarRemovedHandlers, callback);
   }
 
   /**
@@ -137,8 +76,8 @@ export class NavBarApi {
       // add the new button panel to the correct group
       if (group !== '__proto__' && buttonPanelId !== '__proto__') this.buttons[group][buttonPanelId] = buttonPanel;
 
-      // trigger an event that a new button or button panel has been created to update the state and re-render
-      this.#emitNavbarCreated({ buttonPanelId, group, buttonPanel });
+      // Bump the store version to trigger a re-render in the nav-bar component
+      this.#uiController.bumpNavBarButtonPanelVersion();
 
       return buttonPanel;
     }
@@ -206,11 +145,11 @@ export class NavBarApi {
       if (group[buttonPanelId]) {
         // delete the button or panel from the group
         delete group[buttonPanelId];
-
-        // trigger an event that a button or panel has been removed to update the state and re-render
-        this.#emitNavbarRemoved({ buttonPanelId, group: groupName });
       }
     });
+
+    // Bump the store version to trigger a re-render in the nav-bar component
+    this.#uiController.bumpNavBarButtonPanelVersion();
   }
 
   /**
@@ -237,27 +176,3 @@ export class NavBarApi {
     return this.groupConfigs[groupName] || { groupName, accordionThreshold: 10 };
   }
 }
-
-/** Event payload when a nav-bar button panel is created. */
-export type NavBarCreatedEvent = {
-  /** The button panel identifier. */
-  buttonPanelId: string;
-  /** The group the button panel belongs to. */
-  group: string;
-  /** The created button panel. */
-  buttonPanel: TypeButtonPanel;
-};
-
-/** Delegate type for NavBar created event handlers. */
-type NavBarCreatedDelegate = EventDelegateBase<NavBarApi, NavBarCreatedEvent, void>;
-
-/** Event payload when a nav-bar button panel is removed. */
-export type NavBarRemovedEvent = {
-  /** The button panel identifier. */
-  buttonPanelId: string;
-  /** The group the button panel belonged to. */
-  group: string;
-};
-
-/** Delegate type for NavBar removed event handlers. */
-type NavBarRemovedDelegate = EventDelegateBase<NavBarApi, NavBarRemovedEvent, void>;

--- a/packages/geoview-core/src/core/components/nav-bar/nav-bar.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/nav-bar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, Fragment, useMemo, isValidElement } from 'react';
+import { useRef, useState, useEffect, Fragment, useMemo, isValidElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@mui/material/styles';
 
@@ -15,12 +15,10 @@ import { ButtonGroup, Box, IconButton } from '@/ui';
 import { ExpandLessIcon, ExpandMoreIcon } from '@/ui/icons';
 import type { TypeButtonPanel } from '@/ui/panel/panel-types';
 import { getSxClasses } from './nav-bar-style';
-import type { NavBarApi, NavBarCreatedEvent, NavBarRemovedEvent } from '@/core/components';
-import type { TypeValidNavBarProps } from '@/api/types/map-schema-types';
-import { useStoreUINavbarComponents } from '@/core/stores/store-interface-and-intial-values/ui-state';
+import type { NavBarApi } from '@/core/components';
+import { useStoreUINavbarComponents, useStoreUINavBarButtonPanelVersion } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { logger } from '@/core/utils/logger';
 import NavbarPanelButton from './nav-bar-panel-button';
-import { usePluginController } from '@/core/controllers/use-controllers';
 
 /** The properties for the nav-bar component. */
 type NavBarProps = {
@@ -76,23 +74,23 @@ export function NavBar(props: NavBarProps): JSX.Element {
 
   // Store
   const navBarComponents = useStoreUINavbarComponents();
-  const pluginController = usePluginController();
+  const navBarButtonPanelVersion = useStoreUINavBarButtonPanelVersion();
 
   // Ref
   const navBarRef = useRef<HTMLDivElement>(null);
 
   // State
-  const [buttonPanelGroups, setButtonPanelGroups] = useState<NavButtonGroups>({});
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [maxButtonsPerColumn, setMaxButtonsPerColumn] = useState<number>(10);
 
   /**
-   * Builds the initial button panel groups from the navbar component configuration.
+   * Derives button panel groups from config and the NavBar API registry.
    */
-  useEffect(() => {
+  const memoButtonPanelGroups = useMemo<NavButtonGroups>((): NavButtonGroups => {
     // Log
-    logger.logTraceUseEffect('navBarComponents store value changed');
+    logger.logTraceUseMemo('NAV-BAR - memoButtonPanelGroups', navBarComponents, navBarButtonPanelVersion);
 
+    // Build built-in button groups from config
     let zoomRotateButtons: NavbarButtonGroup = {};
     if (navBarComponents.includes('zoom')) {
       zoomRotateButtons = { ...zoomRotateButtons, zoomIn: 'zoomIn', zoomOut: 'zoomOut' };
@@ -105,106 +103,38 @@ export function NavBar(props: NavBarProps): JSX.Element {
     if (navBarComponents.includes('fullscreen')) {
       displayButtons = { ...displayButtons, fullScreen: 'fullScreen' };
     }
-
     if (navBarComponents.includes('location')) {
       displayButtons = { ...displayButtons, location: 'location' };
     }
-
     if (navBarComponents.includes('home')) {
       displayButtons = { ...displayButtons, home: 'home' };
     }
-
     if (navBarComponents.includes('basemap-select')) {
       displayButtons = { ...displayButtons, basemapSelect: 'basemapSelect' };
     }
-
     if (navBarComponents.includes('measurement')) {
       displayButtons = { ...displayButtons, measurement: 'measurement' };
     }
-
     if (navBarComponents.includes('projection')) {
       displayButtons = { ...displayButtons, projection: 'projection' };
     }
 
-    setButtonPanelGroups((prevState) => ({
+    // Start with built-in groups
+    const groups: NavButtonGroups = {
       ...(Object.keys(zoomRotateButtons).length > 0 && { zoom: zoomRotateButtons }),
       ...(Object.keys(displayButtons).length > 0 && { display: displayButtons }),
-      ...prevState,
-    }));
-    // If buttonPanelGroups is in the dependencies, it triggers endless rerenders
-  }, [navBarComponents]);
+    };
 
-  /**
-   * Handles when a button panel is added via the NavBar API.
-   */
-  const handleNavApiAddButtonPanel = useCallback((sender: NavBarApi, event: NavBarCreatedEvent): void => {
-    setButtonPanelGroups((prevState) => {
-      const existingGroup = prevState?.[event.group] || {};
-
-      return {
-        ...prevState,
-        [event.group]: {
-          ...existingGroup, // Spread existing buttons first
-          [event.buttonPanelId]: event.buttonPanel,
-        },
-      };
-    });
-  }, []);
-
-  /**
-   * Handles when a button panel is removed via the NavBar API.
-   */
-  const handleNavApiRemoveButtonPanel = useCallback(
-    (sender: NavBarApi, event: NavBarRemovedEvent): void => {
-      setButtonPanelGroups((prevState) => {
-        const state = { ...prevState };
-        const group = state[event.group];
-        delete group[event.buttonPanelId];
-        return state;
-      });
-    },
-    [setButtonPanelGroups]
-  );
-
-  /**
-   * Loads and adds navbar plugins from the configuration.
-   */
-  useEffect(() => {
-    // Log
-    logger.logTraceUseEffect('NAV-BAR - navBarComponents');
-
-    const processPlugin = (pluginName: TypeValidNavBarProps): void => {
-      // Check if the plugin is in navBarComponents but not in corePackages
-      if (navBarComponents.includes(pluginName)) {
-        // Load and add the plugin
-        pluginController.loadAndAddPlugin(pluginName).catch((error: unknown) => {
-          // Log
-          logger.logPromiseFailed('loadAndAddPlugin(time-slider) in processPlugin in nav-bar', error);
-        });
+    // Merge plugin button panels from the NavBar API registry
+    Object.entries(navBarApi.buttons).forEach(([groupName, groupButtons]) => {
+      if (Object.keys(groupButtons).length > 0) {
+        groups[groupName] = { ...groups[groupName], ...groupButtons };
       }
-    };
+    });
 
-    // Process drawer plugin if it's in the navBar
-    processPlugin('drawer');
-  }, [navBarComponents, pluginController]);
-
-  /**
-   * Registers NavBar API event listeners on mount and cleans up on unmount.
-   */
-  useEffect(() => {
-    // Log
-    logger.logTraceUseEffect('NAV-BAR API - mount');
-
-    // Register NavBar created/removed handlers
-    navBarApi.onNavbarCreated(handleNavApiAddButtonPanel);
-    navBarApi.onNavbarRemoved(handleNavApiRemoveButtonPanel);
-
-    return () => {
-      // Unregister events
-      navBarApi.offNavbarCreated(handleNavApiAddButtonPanel);
-      navBarApi.offNavbarRemoved(handleNavApiRemoveButtonPanel);
-    };
-  }, [navBarApi, handleNavApiAddButtonPanel, handleNavApiRemoveButtonPanel]);
+    return groups;
+    // navBarButtonPanelVersion triggers re-computation when plugins add/remove button panels
+  }, [navBarComponents, navBarButtonPanelVersion, navBarApi.buttons]);
 
   /**
    * Calculates and updates the maximum buttons per column based on available height.
@@ -375,7 +305,7 @@ export function NavBar(props: NavBarProps): JSX.Element {
 
   return (
     <Box ref={navBarRef} sx={sxClasses.navBarRef}>
-      {[...Object.keys(buttonPanelGroups)].map((key) => renderButtonPanelGroup(buttonPanelGroups[key], key))}
+      {[...Object.keys(memoButtonPanelGroups)].map((key) => renderButtonPanelGroup(memoButtonPanelGroups[key], key))}
     </Box>
   );
 }

--- a/packages/geoview-core/src/core/components/nav-bar/nav-bar.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/nav-bar.tsx
@@ -70,7 +70,7 @@ export function NavBar(props: NavBarProps): JSX.Element {
   // Hooks
   const { t } = useTranslation();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
   // Store
   const navBarComponents = useStoreUINavbarComponents();
@@ -214,7 +214,7 @@ export function NavBar(props: NavBarProps): JSX.Element {
             aria-label={buttonPanel.button['aria-label']}
             tooltip={buttonPanel.button.tooltip}
             tooltipPlacement={buttonPanel.button.tooltipPlacement}
-            sx={sxClasses.navButton}
+            sx={memoSxClasses.navButton}
             onClick={buttonPanel.button.onClick}
           >
             {buttonPanel.button.children}
@@ -270,14 +270,14 @@ export function NavBar(props: NavBarProps): JSX.Element {
     };
 
     return (
-      <Box key={groupName} sx={sxClasses.navBtnGroupColumns}>
+      <Box key={groupName} sx={memoSxClasses.navBtnGroupColumns}>
         {columns.map((columnKeys, columnIndex) => (
           <ButtonGroup
             // eslint-disable-next-line react/no-array-index-key
             key={`${groupName}-column-${columnIndex}`}
             aria-label={t('mapnav.arianavbar')!}
             variant="contained"
-            sx={sxClasses.navBtnGroup}
+            sx={memoSxClasses.navBtnGroup}
             orientation="vertical"
           >
             {columnKeys.map((buttonPanelKey) => {
@@ -291,7 +291,7 @@ export function NavBar(props: NavBarProps): JSX.Element {
                 key={`expand-${groupName}`}
                 aria-label={isExpanded ? t('general.close') : t('general.open')}
                 tooltipPlacement="left"
-                sx={sxClasses.navButton}
+                sx={memoSxClasses.navButton}
                 onClick={toggleExpansion}
               >
                 {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
@@ -304,7 +304,7 @@ export function NavBar(props: NavBarProps): JSX.Element {
   }
 
   return (
-    <Box ref={navBarRef} sx={sxClasses.navBarRef}>
+    <Box ref={navBarRef} sx={memoSxClasses.navBarRef}>
       {[...Object.keys(memoButtonPanelGroups)].map((key) => renderButtonPanelGroup(memoButtonPanelGroups[key], key))}
     </Box>
   );

--- a/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
+++ b/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Projection } from '@/geo/utils/projection';
-import { NORTH_POLE_POSITION } from '@/core/utils/constant';
+import { NORTH_POLE_POSITION_LONLAT } from '@/core/utils/constant';
 import {
   useStoreMapCenterCoordinates,
   useStoreMapFixNorth,
@@ -139,7 +139,7 @@ export const useManageArrow = (): ArrowReturn => {
 
       // Calculate offset
       let newOffset = offsetX;
-      const northPolePosition = mapController.getPixelFromCoordinate(NORTH_POLE_POSITION);
+      const northPolePosition = mapController.getPixelFromCoordinate(NORTH_POLE_POSITION_LONLAT);
 
       if (!fixNorth && northPolePosition !== null) {
         const screenNorthPoint = northPolePosition;

--- a/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
+++ b/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
@@ -45,14 +45,11 @@ export const useManageArrow = (): ArrowReturn => {
   const mapSize = useStoreMapSize();
   const mapController = useMapController();
 
-  /**
-   * Whether the map projection is Lambert Conformal Conic.
-   */
-  const memoIsLCCProjection = useMemo(() => mapProjectionEPSG === Projection.PROJECTION_NAMES.LCC, [mapProjectionEPSG]);
-  /**
-   * Whether the map projection is Web Mercator.
-   */
-  const memoIsWebMercator = useMemo(() => mapProjectionEPSG === Projection.PROJECTION_NAMES.WM, [mapProjectionEPSG]);
+  /** Whether the map projection is Lambert Conformal Conic. */
+  const isLCCProjection = mapProjectionEPSG === Projection.PROJECTION_NAMES.LCC;
+
+  /** Whether the map projection is Web Mercator. */
+  const isWebMercator = mapProjectionEPSG === Projection.PROJECTION_NAMES.WM;
 
   const prevRotationRef = useRef(0);
   const equalCountRef = useRef(0);
@@ -75,12 +72,12 @@ export const useManageArrow = (): ArrowReturn => {
     }
 
     // Early return if unsupported projection
-    if (!memoIsLCCProjection && !memoIsWebMercator) {
+    if (!isLCCProjection && !isWebMercator) {
       return { memoCalculatedRotation: { angle: 0 }, memoCalculatedOffset: 0 };
     }
 
     // Handle Web Mercator Projection first - north is always up, only map rotation matters
-    if (memoIsWebMercator) {
+    if (isWebMercator) {
       return {
         memoCalculatedRotation: { angle: mapRotation * (180 / Math.PI) },
         memoCalculatedOffset: offsetX,
@@ -99,7 +96,7 @@ export const useManageArrow = (): ArrowReturn => {
     }
 
     // Handle LCC Projection
-    if (memoIsLCCProjection) {
+    if (isLCCProjection) {
       const arrowAngle = parseFloat(northArrowElement.degreeRotation);
       const angleDegrees = 270 - arrowAngle;
 
@@ -172,7 +169,7 @@ export const useManageArrow = (): ArrowReturn => {
 
     // Should never goes here but failover to default values
     return { memoCalculatedRotation: { angle: 0 }, memoCalculatedOffset: 0 };
-  }, [mapSize, northArrowElement, memoIsLCCProjection, memoIsWebMercator, mapCenterCoord, mapZoom, mapRotation, fixNorth, mapController]);
+  }, [mapSize, northArrowElement, isLCCProjection, isWebMercator, mapCenterCoord, mapZoom, mapRotation, fixNorth, mapController]);
 
   /**
    * Updates local state with the calculated rotation and offset values.

--- a/packages/geoview-core/src/core/components/north-arrow/north-arrow.tsx
+++ b/packages/geoview-core/src/core/components/north-arrow/north-arrow.tsx
@@ -41,13 +41,10 @@ export const NorthArrow = memo(function NorthArrow(): JSX.Element {
   /**
    * Checks whether the map projection supports a north arrow.
    */
-  const memoIsValidProjection = useMemo(
-    () => {
-      logger.logTraceUseMemo('NORTH-ARROW - memoIsValidProjection', mapProjectionEPSG);
-      return mapProjectionEPSG === Projection.PROJECTION_NAMES.LCC || mapProjectionEPSG === Projection.PROJECTION_NAMES.WM;
-    },
-    [mapProjectionEPSG]
-  );
+  const memoIsValidProjection = useMemo(() => {
+    logger.logTraceUseMemo('NORTH-ARROW - memoIsValidProjection', mapProjectionEPSG);
+    return mapProjectionEPSG === Projection.PROJECTION_NAMES.LCC || mapProjectionEPSG === Projection.PROJECTION_NAMES.WM;
+  }, [mapProjectionEPSG]);
 
   if (!memoIsValidProjection) return <Box />;
 

--- a/packages/geoview-core/src/core/components/north-arrow/north-arrow.tsx
+++ b/packages/geoview-core/src/core/components/north-arrow/north-arrow.tsx
@@ -25,7 +25,10 @@ export const NorthArrow = memo(function NorthArrow(): JSX.Element {
 
   // Hooks
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('NORTH-ARROW - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // State (no useState for item used inside function only without rendering... use useRef)
   const northArrowRef = useRef<HTMLDivElement>(null);
@@ -39,7 +42,10 @@ export const NorthArrow = memo(function NorthArrow(): JSX.Element {
    * Checks whether the map projection supports a north arrow.
    */
   const memoIsValidProjection = useMemo(
-    () => mapProjectionEPSG === Projection.PROJECTION_NAMES.LCC || mapProjectionEPSG === Projection.PROJECTION_NAMES.WM,
+    () => {
+      logger.logTraceUseMemo('NORTH-ARROW - memoIsValidProjection', mapProjectionEPSG);
+      return mapProjectionEPSG === Projection.PROJECTION_NAMES.LCC || mapProjectionEPSG === Projection.PROJECTION_NAMES.WM;
+    },
     [mapProjectionEPSG]
   );
 
@@ -48,7 +54,7 @@ export const NorthArrow = memo(function NorthArrow(): JSX.Element {
   return (
     <Box
       ref={northArrowRef}
-      sx={sxClasses.northArrowContainer}
+      sx={memoSxClasses.northArrowContainer}
       style={{
         transition: theme.transitions.create(['all', 'transform'], {
           duration: theme.transitions.duration.standard,
@@ -59,7 +65,7 @@ export const NorthArrow = memo(function NorthArrow(): JSX.Element {
         left: northOffset,
       }}
     >
-      <NorthArrowIcon width={sxClasses.northArrow.width || 30} height={sxClasses.northArrow.height || 30} />
+      <NorthArrowIcon width={memoSxClasses.northArrow.width || 30} height={memoSxClasses.northArrow.height || 30} />
     </Box>
   );
 });
@@ -85,6 +91,7 @@ export const NorthPoleFlag = memo(function NorthPoleFlag(): JSX.Element {
    * Registers the north pole marker overlay ref on mount.
    */
   useEffect(() => {
+    logger.logTraceUseEffect('NORTH-ARROW - register north pole marker overlay ref', mapController);
     mapController.setNorthPoleMarkerOverlayRef(northPoleRef.current!);
   }, [mapController]);
 

--- a/packages/geoview-core/src/core/components/north-arrow/north-arrow.tsx
+++ b/packages/geoview-core/src/core/components/north-arrow/north-arrow.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useRef } from 'react';
+import { memo, useEffect, useMemo, useRef } from 'react';
 
 import { useTheme } from '@mui/material/styles';
 
@@ -6,16 +6,12 @@ import { Box } from '@/ui';
 import { Projection } from '@/geo/utils/projection';
 import { NorthArrowIcon, NorthPoleIcon } from './north-arrow-icon';
 import { getSxClasses } from './north-arrow-style';
-import {
-  setStoreMapOverlayNorthMarkerRef,
-  useStoreMapNorthArrowElement,
-  useStoreMapCurrentProjectionEPSG,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapNorthArrowElement, useStoreMapCurrentProjectionEPSG } from '@/core/stores/store-interface-and-intial-values/map-state';
 
 import { useManageArrow } from './hooks/useManageArrow';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
-import { TIMEOUT } from '@/core/utils/constant';
+import { useMapController } from '@/core/controllers/use-controllers';
 
 /**
  * Creates a north arrow component.
@@ -81,14 +77,19 @@ export const NorthPoleFlag = memo(function NorthPoleFlag(): JSX.Element {
 
   // Store
   const mapId = useStoreGeoViewMapId();
-  const northPoleId = `${mapId}-northpole`;
   const mapProjectionEPSG = useStoreMapCurrentProjectionEPSG();
-  setTimeout(() => setStoreMapOverlayNorthMarkerRef(mapId, northPoleRef.current as HTMLElement), TIMEOUT.deferExecution); // set marker reference
-
   const isVisible = mapProjectionEPSG === Projection.PROJECTION_NAMES.LCC;
+  const mapController = useMapController();
+
+  /**
+   * Registers the north pole marker overlay ref on mount.
+   */
+  useEffect(() => {
+    mapController.setNorthPoleMarkerOverlayRef(northPoleRef.current!);
+  }, [mapController]);
 
   return (
-    <Box ref={northPoleRef} id={northPoleId} style={{ visibility: isVisible ? 'visible' : 'hidden' }}>
+    <Box ref={northPoleRef} id={`${mapId}-northpole`} style={{ visibility: isVisible ? 'visible' : 'hidden' }}>
       <NorthPoleIcon />
     </Box>
   );

--- a/packages/geoview-core/src/core/components/notifications/notifications.tsx
+++ b/packages/geoview-core/src/core/components/notifications/notifications.tsx
@@ -215,7 +215,10 @@ export default memo(function Notifications(): JSX.Element {
   // Hooks
   const { t } = useTranslation();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('NOTIFICATIONS - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // State
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
@@ -341,12 +344,12 @@ export default memo(function Notifications(): JSX.Element {
         key={notification.key}
         notification={notification}
         onRemove={handleRemoveNotification}
-        sxClasses={sxClasses}
+        sxClasses={memoSxClasses}
         t={t}
         closeButtonId={closeButtonId}
       />
     ));
-  }, [notifications, handleRemoveNotification, sxClasses, t, closeButtonId]);
+  }, [notifications, handleRemoveNotification, memoSxClasses, t, closeButtonId]);
 
   return (
     <ClickAwayListener mouseEvent="onMouseDown" touchEvent="onTouchStart" onClickAway={handleClickAway}>
@@ -400,17 +403,17 @@ export default memo(function Notifications(): JSX.Element {
           }}
           handleKeyDown={(key, callBackFn) => handleEscapeKey(key, '', false, callBackFn)}
         >
-          <Paper component="section" sx={sxClasses.notificationPanel}>
+          <Paper component="section" sx={memoSxClasses.notificationPanel}>
             <NotificationHeader
               onClose={handleClickAway}
               onRemoveAll={handleRemoveAllNotifications}
               hasNotifications={notifications.length > 0}
               t={t}
-              sxClasses={sxClasses}
+              sxClasses={memoSxClasses}
               titleId={titleId}
               closeButtonId={closeButtonId}
             />
-            <List sx={sxClasses.notificationsList} aria-live="polite" aria-relevant="all">
+            <List sx={memoSxClasses.notificationsList} aria-live="polite" aria-relevant="all">
               {notifications.length > 0 ? (
                 memoNotificationsList
               ) : (

--- a/packages/geoview-core/src/core/components/notifications/notifications.tsx
+++ b/packages/geoview-core/src/core/components/notifications/notifications.tsx
@@ -226,6 +226,10 @@ export default memo(function Notifications(): JSX.Element {
   const [notificationsCount, setNotificationsCount] = useState(0);
   const [open, setOpen] = useState(false);
 
+  // Ref to read the latest notificationsCount inside the notifications effect without making it a dep
+  const notificationsCountRef = useRef(notificationsCount);
+  notificationsCountRef.current = notificationsCount;
+
   // Store
   const notifications = useStoreAppNotifications();
   const interaction = useStoreMapInteraction();
@@ -311,7 +315,7 @@ export default memo(function Notifications(): JSX.Element {
     logger.logTraceUseEffect('Notifications - notifications list changed', notificationsCount, notifications);
 
     const curNotificationCount = notifications.reduce((sum, n) => sum + n.count, 0);
-    if (curNotificationCount > notificationsCount) {
+    if (curNotificationCount > notificationsCountRef.current) {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
@@ -330,7 +334,6 @@ export default memo(function Notifications(): JSX.Element {
         clearTimeout(timerRef.current);
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [notifications]); // Only depend on notifications changes
 
   /**

--- a/packages/geoview-core/src/core/components/notifications/notifications.tsx
+++ b/packages/geoview-core/src/core/components/notifications/notifications.tsx
@@ -312,7 +312,7 @@ export default memo(function Notifications(): JSX.Element {
    * Triggers the shake animation when new notifications arrive.
    */
   useEffect(() => {
-    logger.logTraceUseEffect('Notifications - notifications list changed', notificationsCount, notifications);
+    logger.logTraceUseEffect('Notifications - notifications list changed', notifications);
 
     const curNotificationCount = notifications.reduce((sum, n) => sum + n.count, 0);
     if (curNotificationCount > notificationsCountRef.current) {
@@ -334,7 +334,7 @@ export default memo(function Notifications(): JSX.Element {
         clearTimeout(timerRef.current);
       }
     };
-  }, [notifications]); // Only depend on notifications changes
+  }, [notifications]);
 
   /**
    * Builds the rendered list of notification items.

--- a/packages/geoview-core/src/core/components/overview-map/overview-map.tsx
+++ b/packages/geoview-core/src/core/components/overview-map/overview-map.tsx
@@ -45,17 +45,20 @@ export function OverviewMap(props: OverviewMapProps): JSX.Element {
 
   // Values
   // TODO: CHECK - Alternative approach, the determination of 'if the overview-map should be visible' could probably be handled elsewhere and the component only listen to a visibility flag from the store?
-  const shouldBeVisibile = isInitialized && (hideOnZoom === 0 || zoomLevel > hideOnZoom);
+  let shouldBeVisible: boolean | undefined = undefined;
+  if (isInitialized) {
+    shouldBeVisible = hideOnZoom === 0 || zoomLevel > hideOnZoom;
+  }
 
   /**
    * Updates visibility based on zoom level changes.
    */
   useEffect(() => {
-    logger.logTraceUseEffect('OVERVIEW-MAP - zoom level changed');
+    logger.logTraceUseEffect('OVERVIEW-MAP - shouldBeVisible', shouldBeVisible);
 
     // Tweak the visibility
-    mapController.setOverviewMapVisibility(shouldBeVisibile);
-  }, [mapController, shouldBeVisibile]);
+    mapController.setOverviewMapVisibility(!!shouldBeVisible);
+  }, [mapController, shouldBeVisible]);
 
   /**
    * Initializes the overview map control and renders the toggle button on mount.

--- a/packages/geoview-core/src/core/components/overview-map/overview-map.tsx
+++ b/packages/geoview-core/src/core/components/overview-map/overview-map.tsx
@@ -31,16 +31,21 @@ export function OverviewMap(props: OverviewMapProps): JSX.Element {
   // Log
   logger.logTraceRender('components/overview-map/overview-map');
 
+  // Props
+  const { i18n } = props;
+
   // Store
   const zoomLevel = useStoreMapZoom();
   const hideOnZoom = useStoreMapOverviewMapHideZoom();
   const displayLanguage = useStoreAppDisplayLanguage();
-  const { i18n } = props;
   const mapController = useMapController();
 
   // State
-  const [visibility, setVisibility] = useState<boolean>(!(zoomLevel > hideOnZoom));
   const [isInitialized, setIsInitialized] = useState(false);
+
+  // Values
+  // TODO: CHECK - Alternative approach, the determination of 'if the overview-map should be visible' could probably be handled elsewhere and the component only listen to a visibility flag from the store?
+  const shouldBeVisibile = isInitialized && (hideOnZoom === 0 || zoomLevel > hideOnZoom);
 
   /**
    * Updates visibility based on zoom level changes.
@@ -48,15 +53,9 @@ export function OverviewMap(props: OverviewMapProps): JSX.Element {
   useEffect(() => {
     logger.logTraceUseEffect('OVERVIEW-MAP - zoom level changed');
 
-    // Don't set the visibility until after the component is initialized
-    if (!isInitialized) return;
-
-    const shouldBeVisibile = zoomLevel > hideOnZoom;
-    if (shouldBeVisibile !== visibility) {
-      setVisibility(shouldBeVisibile);
-      mapController.setOverviewMapVisibility(shouldBeVisibile);
-    }
-  }, [mapController, hideOnZoom, zoomLevel, visibility, isInitialized]);
+    // Tweak the visibility
+    mapController.setOverviewMapVisibility(shouldBeVisibile);
+  }, [mapController, shouldBeVisibile]);
 
   /**
    * Initializes the overview map control and renders the toggle button on mount.

--- a/packages/geoview-core/src/core/components/toggle-all/toggle-all.tsx
+++ b/packages/geoview-core/src/core/components/toggle-all/toggle-all.tsx
@@ -67,7 +67,7 @@ export function ToggleAll({ source, containerType }: ToggleAllProps): JSX.Elemen
    * Handles when the user toggles the collapse switch.
    */
   const handleCollapseToggle = useCallback((): void => {
-    layerController.setAllMapLayerCollapsed(!allLayersCollapsed);
+    layerController.setAllLayerCollapsed(!allLayersCollapsed);
   }, [allLayersCollapsed, layerController]);
 
   // TODO Hide this component until all layers have loaded the first time.

--- a/packages/geoview-core/src/core/components/toggle-all/toggle-all.tsx
+++ b/packages/geoview-core/src/core/components/toggle-all/toggle-all.tsx
@@ -3,12 +3,12 @@ import { useTheme, useMediaQuery } from '@mui/material';
 import { useCallback } from 'react';
 import { Box, Switch, Tooltip } from '@/ui';
 import {
-  setStoreMapAllMapLayerCollapsed,
-  useStoreMapAllLayersCollapsedToggle,
-  useStoreMapAllLayersVisibleToggle,
-  useStoreMapHasCollapsibleLayersToggle,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
-import { useStoreLayerDisplayState, useStoreLayerAreLayersLoading } from '@/core/stores/store-interface-and-intial-values/layer-state';
+  useStoreLayerDisplayState,
+  useStoreLayerAllLayersVisibleToggle,
+  useStoreLayerAllLayersCollapsedToggle,
+  useStoreLayerAreLayersLoading,
+  useStoreLayerHasCollapsibleLayersToggle,
+} from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { logger } from '@/core/utils/logger';
 
@@ -50,25 +50,25 @@ export function ToggleAll({ source, containerType }: ToggleAllProps): JSX.Elemen
   // Store
   const mapId = useStoreGeoViewMapId();
   const displayState = useStoreLayerDisplayState();
-  const allLayersVisible = useStoreMapAllLayersVisibleToggle();
-  const allLayersCollapsed = useStoreMapAllLayersCollapsedToggle();
+  const allLayersVisible = useStoreLayerAllLayersVisibleToggle();
+  const allLayersCollapsed = useStoreLayerAllLayersCollapsedToggle();
   const layersAreLoading = useStoreLayerAreLayersLoading();
-  const hasCollapsibleLayers = useStoreMapHasCollapsibleLayersToggle();
+  const hasCollapsibleLayers = useStoreLayerHasCollapsibleLayersToggle();
   const layerController = useLayerController();
 
   /**
    * Handles when the user toggles the visibility switch.
    */
   const handleVisibilityToggle = useCallback((): void => {
-    layerController.setAllMapLayerVisibility(!allLayersVisible);
+    layerController.setAllLayersVisibilityExceptBasemaps(!allLayersVisible);
   }, [allLayersVisible, layerController]);
 
   /**
    * Handles when the user toggles the collapse switch.
    */
   const handleCollapseToggle = useCallback((): void => {
-    setStoreMapAllMapLayerCollapsed(mapId, !allLayersCollapsed);
-  }, [allLayersCollapsed, mapId]);
+    layerController.setAllMapLayerCollapsed(!allLayersCollapsed);
+  }, [allLayersCollapsed, layerController]);
 
   // TODO Hide this component until all layers have loaded the first time.
   // TO.DO May require something external as a useRef for the first time the !layerAreLoading didn't work

--- a/packages/geoview-core/src/core/controllers/base/abstract-map-viewer-controller.ts
+++ b/packages/geoview-core/src/core/controllers/base/abstract-map-viewer-controller.ts
@@ -1,10 +1,8 @@
-import { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
 import { ConfigBaseClass } from '@/api/config/validation-classes/config-base-class';
 import type { TypeGeoviewLayerConfig, TypeLayerEntryConfig } from '@/api/types/layer-schema-types';
-import type { TypeOrderedLayerInfo } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { AbstractController } from './abstract-controller';
-import type { MapViewer } from '@/geo/map/map-viewer';
 import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
+import type { MapViewer } from '@/geo/map/map-viewer';
 import type { GeometryApi } from '@/geo/layer/geometry/geometry';
 import type { BasemapApi } from '@/geo/layer/basemap/basemap';
 
@@ -19,14 +17,19 @@ export class AbstractMapViewerController extends AbstractController {
   /** The map viewer instance associated with this controller */
   #mapViewer: MapViewer;
 
+  /** The controller registry associated with this controller */
+  #controllerRegistry: ControllerRegistry;
+
   /**
    * Creates an instance of AbstractMapViewerController.
    *
    * @param mapViewer - The map viewer instance to associate with this controller
+   * @param controllerRegistry - The controller registry for accessing sibling controllers
    */
-  constructor(mapViewer: MapViewer) {
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
     super();
     this.#mapViewer = mapViewer;
+    this.#controllerRegistry = controllerRegistry;
   }
 
   /**
@@ -53,7 +56,7 @@ export class AbstractMapViewerController extends AbstractController {
    * @returns The controller registry owned by the map viewer
    */
   getControllersRegistry(): ControllerRegistry {
-    return this.getMapViewer().controllers;
+    return this.#controllerRegistry;
   }
 
   /**
@@ -77,31 +80,18 @@ export class AbstractMapViewerController extends AbstractController {
   // #region STATIC METHODS
 
   /**
-   * Generates an array of layer info for the orderedLayerList.
+   * Generates an array of layer paths for the ordered layer list.
    *
    * @param geoviewLayerConfig - The config to get the info from
-   * @returns The array of ordered layer info
+   * @returns The array of ordered layer paths
    */
-  static generateArrayOfLayerOrderInfo(geoviewLayerConfig: TypeGeoviewLayerConfig | ConfigBaseClass): TypeOrderedLayerInfo[] {
-    const newOrderedLayerInfos: TypeOrderedLayerInfo[] = [];
+  static generateOrderedLayerPaths(geoviewLayerConfig: TypeGeoviewLayerConfig | ConfigBaseClass): string[] {
+    const layerPaths: string[] = [];
 
     const addSubLayerPathToLayerOrder = (layerEntryConfig: TypeLayerEntryConfig, layerPath: string): void => {
       const subLayerPath = layerPath.endsWith(`/${layerEntryConfig.layerId}`) ? layerPath : `${layerPath}/${layerEntryConfig.layerId}`;
 
-      const settings = ConfigBaseClass.getClassOrTypeInitialSettings(layerEntryConfig);
-      const featureInfo = AbstractBaseLayerEntryConfig.getClassOrTypeFeatureInfo(layerEntryConfig);
-
-      const layerInfo: TypeOrderedLayerInfo = {
-        layerPath: subLayerPath,
-        visible: settings?.states?.visible ?? true, // default: true
-        queryableSource: featureInfo?.queryable ?? true, // default: true
-        queryableState: settings?.states?.queryable ?? true, // default: true
-        hoverable: settings?.states?.hoverable ?? true, // default: true
-        legendCollapsed: settings?.states?.legendCollapsed ?? false, // default: false
-        inVisibleRange: true,
-      };
-
-      newOrderedLayerInfos.push(layerInfo);
+      layerPaths.push(subLayerPath);
       if (layerEntryConfig.listOfLayerEntryConfig?.length) {
         layerEntryConfig.listOfLayerEntryConfig?.forEach((subLayerEntryConfig) => {
           addSubLayerPathToLayerOrder(subLayerEntryConfig, subLayerPath);
@@ -121,17 +111,8 @@ export class AbstractMapViewerController extends AbstractController {
     if (!(geoviewLayerConfig instanceof ConfigBaseClass)) {
       if (geoviewLayerConfig.listOfLayerEntryConfig?.length > 1) {
         const layerPath = `${geoviewLayerConfig.geoviewLayerId}/base-group`;
-        // Using as any, because even a TypeGeoviewLayerConfig can have initialSettings? To confirm...
-        const settingsGVLC = ConfigBaseClass.getClassOrTypeInitialSettings(geoviewLayerConfig)?.states;
 
-        const layerInfo: TypeOrderedLayerInfo = {
-          layerPath,
-          legendCollapsed: settingsGVLC?.legendCollapsed ?? false, // default: false
-          visible: settingsGVLC?.visible ?? true, // default: true
-          inVisibleRange: true,
-        };
-
-        newOrderedLayerInfos.push(layerInfo);
+        layerPaths.push(layerPath);
         geoviewLayerConfig.listOfLayerEntryConfig.forEach((layerEntryConfig) => {
           addSubLayerPathToLayerOrder(layerEntryConfig, layerPath);
         });
@@ -143,7 +124,7 @@ export class AbstractMapViewerController extends AbstractController {
       addSubLayerPathToLayerOrder(geoviewLayerConfig as TypeLayerEntryConfig, geoviewLayerConfig.layerPath);
     }
 
-    return newOrderedLayerInfos;
+    return layerPaths;
   }
 
   // #endregion STATIC METHODS

--- a/packages/geoview-core/src/core/controllers/base/controller-registry.ts
+++ b/packages/geoview-core/src/core/controllers/base/controller-registry.ts
@@ -5,15 +5,16 @@ import { LayerController } from '@/core/controllers/layer-controller';
 import { LayerCreatorController } from '@/core/controllers/layer-creator-controller';
 import { LayerSetController } from '@/core/controllers/layer-set-controller';
 import { DrawerController } from '@/core/controllers/drawer-controller';
+import { DetailsController } from '@/core/controllers/details-controller';
 import { DataTableController } from '@/core/controllers/data-table-controller';
 import { PluginController } from '@/core/controllers/plugin-controller';
 import { TimeSliderController } from '@/core/controllers/time-slider-controller';
+import { SwiperController } from '@/core/controllers/swiper-controller';
+import { GeoChartController } from '@/core/controllers/geochart-controller';
 import type { UIDomain } from '@/core/domains/ui-domain';
 import type { LayerDomain } from '@/core/domains/layer-domain';
-import { getGeoViewStore, hasDrawerPlugin, hasTimeSliderPlugin } from '@/core/stores/stores-managers';
+import { getGeoViewStore, hasDrawerPlugin, hasGeoChartPlugin, hasSwiperPlugin, hasTimeSliderPlugin } from '@/core/stores/stores-managers';
 import type { MapViewer } from '@/geo/map/map-viewer';
-import type { GeometryApi } from '@/geo/layer/geometry/geometry';
-import type { FeatureHighlight } from '@/geo/map/feature-highlight';
 
 /**
  * Central registry that owns and provides access to all framework-level controllers.
@@ -35,20 +36,29 @@ export class ControllerRegistry {
   /** The layer creator controller used to create layers */
   readonly layerCreatorController: LayerCreatorController;
 
-  /** The layer set controller used to manage the layer sets. */
-  readonly layerSetController: LayerSetController;
-
   /** The plugin controller used to interact with plugins. */
   readonly pluginController: PluginController;
 
+  /** The details controller used to interact with the details panel. */
+  readonly detailsController: DetailsController;
+
   /** The data table controller used to interact with the data table. */
   readonly dataTableController: DataTableController;
+
+  /** The swiper controller used to interact with the swiper functionality. Only present when the swiper plugin is configured. */
+  readonly swiperController?: SwiperController;
 
   /** The drawer controller used to interact with the drawer. Only present when the drawer plugin is configured. */
   readonly drawerController?: DrawerController;
 
   /** The time slider controller used to interact with the time slider. Only present when the time slider plugin is configured. */
   readonly timeSliderController?: TimeSliderController;
+
+  /** The geo chart controller used to interact with the geo chart panel. Only present when the geo chart plugin is configured. */
+  readonly geoChartController?: GeoChartController;
+
+  /** The layer set controller used to manage the layer sets. */
+  readonly layerSetController: LayerSetController;
 
   /** All controllers registered in this registry. */
   readonly allControllers: AbstractController[] = [];
@@ -61,46 +71,55 @@ export class ControllerRegistry {
    * @param mapViewer - The map viewer instance
    * @param uiDomain - The UI domain instance
    * @param layerDomain - The layer domain instance
-   * @param geometryApi - The geometry API instance
    */
-  constructor(
-    mapViewer: MapViewer,
-    uiDomain: UIDomain,
-    layerDomain: LayerDomain,
-    geometryApi: GeometryApi,
-    featureHighlight: FeatureHighlight
-  ) {
-    this.uiController = new UIController(mapViewer, uiDomain);
-    this.mapController = new MapController(mapViewer, featureHighlight);
-    this.layerController = new LayerController(mapViewer, layerDomain);
-    this.layerCreatorController = new LayerCreatorController(mapViewer, layerDomain);
-    this.layerSetController = new LayerSetController(mapViewer, layerDomain);
-    this.pluginController = new PluginController(mapViewer);
-    this.dataTableController = new DataTableController(mapViewer);
+  constructor(mapViewer: MapViewer, uiDomain: UIDomain, layerDomain: LayerDomain) {
+    this.uiController = new UIController(mapViewer, this, uiDomain);
+    this.mapController = new MapController(mapViewer, this);
+    this.layerController = new LayerController(mapViewer, this, layerDomain);
+    this.layerCreatorController = new LayerCreatorController(mapViewer, this, layerDomain);
+    this.pluginController = new PluginController(mapViewer, this);
+    this.detailsController = new DetailsController(mapViewer, this);
+    this.dataTableController = new DataTableController(mapViewer, this);
+    this.layerSetController = new LayerSetController(mapViewer, this, layerDomain);
+
+    // If the swiper plugin is present (we know via the store)
+    if (hasSwiperPlugin(getGeoViewStore(mapViewer.mapId))) {
+      // Create the swiper controller only if the swiper plugin is present, as it relies on the swiper state which is part of that plugin
+      this.swiperController = new SwiperController(mapViewer, this);
+    }
 
     // If the drawer plugin is preset (we know via the store)
     if (hasDrawerPlugin(getGeoViewStore(mapViewer.mapId))) {
       // Create the drawer controller only if the drawer plugin is present, as it relies on the drawer state which is part of that plugin
-      this.drawerController = new DrawerController(mapViewer, uiDomain, geometryApi);
+      this.drawerController = new DrawerController(mapViewer, this, uiDomain);
     }
 
     // If the time slider plugin is present (we know via the store)
     if (hasTimeSliderPlugin(getGeoViewStore(mapViewer.mapId))) {
       // Create the time slider controller only if the time slider plugin is present, as it relies on the time slider state which is part of that plugin
-      this.timeSliderController = new TimeSliderController(mapViewer);
+      this.timeSliderController = new TimeSliderController(mapViewer, this);
+    }
+
+    // If the geo chart plugin is present (we know via the store)
+    if (hasGeoChartPlugin(getGeoViewStore(mapViewer.mapId))) {
+      // Create the geo chart controller only if the geo chart plugin is present, as it relies on the geo chart state which is part of that plugin
+      this.geoChartController = new GeoChartController(mapViewer, this);
     }
 
     // Add all controllers to the registry
     this.allControllers.push(
       this.uiController,
       this.mapController,
+      this.detailsController,
       this.layerController,
       this.layerCreatorController,
       this.layerSetController,
       this.pluginController
     );
+    if (this.swiperController) this.allControllers.push(this.swiperController);
     if (this.drawerController) this.allControllers.push(this.drawerController);
     if (this.timeSliderController) this.allControllers.push(this.timeSliderController);
+    if (this.geoChartController) this.allControllers.push(this.geoChartController);
   }
 
   /**

--- a/packages/geoview-core/src/core/controllers/data-table-controller.ts
+++ b/packages/geoview-core/src/core/controllers/data-table-controller.ts
@@ -8,12 +8,12 @@ import {
   setStoreDataTableColumnFiltersEntry,
   setStoreDataTableColumnsFiltersVisibility,
   setStoreDataTableColumnFilterModesEntry,
+  setStoreDataTableFilterDataToExtent,
   setStoreDataTableFilteredEntry,
   setStoreDataTableGlobalFilteredEntry,
   setStoreDataTableRowsFilteredEntry,
   setStoreDataTableSelectedFeature,
   setStoreDataTableSelectedLayerPath,
-  setStoreDataTableToolbarRowSelectedMessageEntry,
   type TypeColumnFiltersState,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import type { MapViewer } from '@/geo/map/map-viewer';
@@ -143,15 +143,14 @@ export class DataTableController extends AbstractMapViewerController {
   }
 
   /**
-   * Sets the toolbar message for the selected row in a specific layer in the data table, which determines the
-   * message displayed in the toolbar for the selected row.
+   * Sets whether to filter data to the map extent for a specific layer in the data table, which determines whether the data table is filtered based on the current map extent for that layer.
    *
    * @param layerPath - The path of the layer to update
-   * @param message - The message to set for the selected row in the toolbar
+   * @param filterDataToExtent - A boolean indicating whether to filter data to the map extent for the layer
    */
-  setToolbarRowSelectedMessageEntry(layerPath: string, message: string): void {
+  setFilterDataToExtent(layerPath: string, filterDataToExtent: boolean): void {
     // Save in the store
-    setStoreDataTableToolbarRowSelectedMessageEntry(this.getMapId(), message, layerPath);
+    setStoreDataTableFilterDataToExtent(this.getMapId(), filterDataToExtent, layerPath);
   }
 
   // #endregion PUBLIC METHODS

--- a/packages/geoview-core/src/core/controllers/data-table-controller.ts
+++ b/packages/geoview-core/src/core/controllers/data-table-controller.ts
@@ -1,8 +1,20 @@
+import type { TypeFeatureInfoEntry } from '@/api/types/map-schema-types';
 import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
 import {
-  addOrUpdateStoreTableFilter,
+  addOrUpdateStoreDataTableFilter,
   getStoreDataTableSelectedLayerPath,
-  getStoreMapFilteredRecord,
+  getStoreDataTableFilteredRecord,
+  setStoreDataTableColumnFiltersEntry,
+  setStoreDataTableColumnsFiltersVisibility,
+  setStoreDataTableColumnFilterModesEntry,
+  setStoreDataTableFilteredEntry,
+  setStoreDataTableGlobalFilteredEntry,
+  setStoreDataTableRowsFilteredEntry,
+  setStoreDataTableSelectedFeature,
+  setStoreDataTableSelectedLayerPath,
+  setStoreDataTableToolbarRowSelectedMessageEntry,
+  type TypeColumnFiltersState,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import type { MapViewer } from '@/geo/map/map-viewer';
 
@@ -14,11 +26,12 @@ export class DataTableController extends AbstractMapViewerController {
    * Creates an instance of DataTableController.
    *
    * @param mapViewer - The map viewer instance to associate with this controller
+   * @param controllerRegistry - The controller registry for accessing sibling controllers
    */
   // GV Leave the constructor here, because we'll likely need it soon to inject dependencies.
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-  constructor(mapViewer: MapViewer) {
-    super(mapViewer);
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(mapViewer, controllerRegistry);
   }
 
   // #region OVERRIDES
@@ -37,9 +50,108 @@ export class DataTableController extends AbstractMapViewerController {
    */
   applyMapFilters(filterStrings: string): void {
     const layerPath = getStoreDataTableSelectedLayerPath(this.getMapId());
-    const filter = getStoreMapFilteredRecord(this.getMapId(), layerPath) ? filterStrings : '';
-    addOrUpdateStoreTableFilter(this.getMapId(), layerPath, filter);
+    const filter = getStoreDataTableFilteredRecord(this.getMapId(), layerPath) ? filterStrings : '';
+    addOrUpdateStoreDataTableFilter(this.getMapId(), layerPath, filter);
     this.getControllersRegistry().layerController.applyLayerFilters(layerPath);
+  }
+
+  /**
+   * Sets the selected layer path in the store, which determines which layer's data is displayed in the data table.
+   *
+   * @param layerPath - The path of the layer to select
+   */
+  setSelectedLayerPath(layerPath: string): void {
+    // Save in the store
+    setStoreDataTableSelectedLayerPath(this.getMapId(), layerPath);
+  }
+
+  /**
+   * Sets the filtered entry state for a specific layer in the data table, which determines whether map filters are applied to that layer.
+   *
+   * @param layerPath - The path of the layer to update
+   * @param mapFiltered - A boolean indicating whether the layer should be filtered based on the data table filters
+   */
+  setFilteredEntry(layerPath: string, mapFiltered: boolean): void {
+    // Save in the store
+    setStoreDataTableFilteredEntry(this.getMapId(), mapFiltered, layerPath);
+  }
+
+  /**
+   * Sets the global filter value for a specific layer in the data table, which determines the global filter applied to that layer.
+   *
+   * @param layerPath - The path of the layer to update
+   * @param globalFilterValue - The global filter value to set for the layer
+   */
+  setGlobalFilteredEntry(layerPath: string, globalFilterValue: string): void {
+    // Save in the store
+    setStoreDataTableGlobalFilteredEntry(this.getMapId(), globalFilterValue, layerPath);
+  }
+
+  /**
+   * Sets the column filters state for a specific layer in the data table, which determines the filters applied to individual columns for that layer.
+   *
+   * @param layerPath - The path of the layer to update
+   * @param columnFilters - The column filters state to set for the layer
+   */
+  setColumnFiltersEntry(layerPath: string, columnFilters: TypeColumnFiltersState): void {
+    // Save in the store
+    setStoreDataTableColumnFiltersEntry(this.getMapId(), columnFilters, layerPath);
+  }
+
+  /**
+   * Sets the column filter modes for a specific layer in the data table, which determines how filters are applied to individual columns for that layer.
+   *
+   * @param layerPath - The path of the layer to update
+   * @param columnFilterModes - The column filter modes to set for the layer
+   */
+  setColumnFilterModesEntry(layerPath: string, columnFilterModes: Record<string, string>): void {
+    // Save in the store
+    setStoreDataTableColumnFilterModesEntry(this.getMapId(), columnFilterModes, layerPath);
+  }
+
+  /**
+   * Sets the visibility of column filters for a specific layer in the data table, which determines whether the column filter UI is shown for that layer.
+   *
+   * @param layerPath - The path of the layer to update
+   * @param visible - A boolean indicating whether the column filter UI should be visible for the layer
+   */
+  setColumnsFiltersVisibility(layerPath: string, visible: boolean): void {
+    // Save in the store
+    setStoreDataTableColumnsFiltersVisibility(this.getMapId(), visible, layerPath);
+  }
+
+  /**
+   * Sets the selected feature in the data table, which determines which feature's details are displayed.
+   *
+   * @param feature - The feature to select
+   */
+  setSelectedFeature(feature: TypeFeatureInfoEntry): void {
+    // Save in the store
+    setStoreDataTableSelectedFeature(this.getMapId(), feature);
+  }
+
+  /**
+   * Sets the number of rows filtered for a specific layer in the data table, which determines how many rows are
+   * currently filtered for that layer.
+   *
+   * @param layerPath - The path of the layer to update
+   * @param rows - The number of rows filtered for the layer
+   */
+  setRowsFilteredEntry(layerPath: string, rows: number): void {
+    // Save in the store
+    setStoreDataTableRowsFilteredEntry(this.getMapId(), rows, layerPath);
+  }
+
+  /**
+   * Sets the toolbar message for the selected row in a specific layer in the data table, which determines the
+   * message displayed in the toolbar for the selected row.
+   *
+   * @param layerPath - The path of the layer to update
+   * @param message - The message to set for the selected row in the toolbar
+   */
+  setToolbarRowSelectedMessageEntry(layerPath: string, message: string): void {
+    // Save in the store
+    setStoreDataTableToolbarRowSelectedMessageEntry(this.getMapId(), message, layerPath);
   }
 
   // #endregion PUBLIC METHODS

--- a/packages/geoview-core/src/core/controllers/data-table-controller.ts
+++ b/packages/geoview-core/src/core/controllers/data-table-controller.ts
@@ -4,12 +4,12 @@ import type { ControllerRegistry } from '@/core/controllers/base/controller-regi
 import {
   addOrUpdateStoreDataTableFilter,
   getStoreDataTableSelectedLayerPath,
-  getStoreDataTableFilteredRecord,
+  getStoreDataTableMapFilteredRecord,
   setStoreDataTableColumnFiltersEntry,
   setStoreDataTableColumnsFiltersVisibility,
   setStoreDataTableColumnFilterModesEntry,
   setStoreDataTableFilterDataToExtent,
-  setStoreDataTableFilteredEntry,
+  setStoreDataTableMapFilteredRecord,
   setStoreDataTableGlobalFilteredEntry,
   setStoreDataTableRowsFilteredEntry,
   setStoreDataTableSelectedFeature,
@@ -50,7 +50,7 @@ export class DataTableController extends AbstractMapViewerController {
    */
   applyMapFilters(filterStrings: string): void {
     const layerPath = getStoreDataTableSelectedLayerPath(this.getMapId());
-    const filter = getStoreDataTableFilteredRecord(this.getMapId(), layerPath) ? filterStrings : '';
+    const filter = getStoreDataTableMapFilteredRecord(this.getMapId(), layerPath) ? filterStrings : '';
     addOrUpdateStoreDataTableFilter(this.getMapId(), layerPath, filter);
     this.getControllersRegistry().layerController.applyLayerFilters(layerPath);
   }
@@ -71,9 +71,9 @@ export class DataTableController extends AbstractMapViewerController {
    * @param layerPath - The path of the layer to update
    * @param mapFiltered - A boolean indicating whether the layer should be filtered based on the data table filters
    */
-  setFilteredEntry(layerPath: string, mapFiltered: boolean): void {
+  setMapFilteredRecord(layerPath: string, mapFiltered: boolean): void {
     // Save in the store
-    setStoreDataTableFilteredEntry(this.getMapId(), mapFiltered, layerPath);
+    setStoreDataTableMapFilteredRecord(this.getMapId(), mapFiltered, layerPath);
   }
 
   /**

--- a/packages/geoview-core/src/core/controllers/data-table-controller.ts
+++ b/packages/geoview-core/src/core/controllers/data-table-controller.ts
@@ -5,13 +5,14 @@ import {
   addOrUpdateStoreDataTableFilter,
   getStoreDataTableSelectedLayerPath,
   getStoreDataTableMapFilteredRecord,
-  setStoreDataTableColumnFiltersEntry,
+  setStoreDataTableColumnFiltersRecord,
+  setStoreDataTableColumnVisibilityRecord,
   setStoreDataTableColumnsFiltersVisibility,
-  setStoreDataTableColumnFilterModesEntry,
+  setStoreDataTableColumnFilterModesRecord,
   setStoreDataTableFilterDataToExtent,
   setStoreDataTableMapFilteredRecord,
-  setStoreDataTableGlobalFilteredEntry,
-  setStoreDataTableRowsFilteredEntry,
+  setStoreDataTableGlobalFilterRecord,
+  setStoreDataTableRowsFilteredRecord,
   setStoreDataTableSelectedFeature,
   setStoreDataTableSelectedLayerPath,
   type TypeColumnFiltersState,
@@ -82,9 +83,9 @@ export class DataTableController extends AbstractMapViewerController {
    * @param layerPath - The path of the layer to update
    * @param globalFilterValue - The global filter value to set for the layer
    */
-  setGlobalFilteredEntry(layerPath: string, globalFilterValue: string): void {
+  setGlobalFilterRecord(layerPath: string, globalFilterValue: string): void {
     // Save in the store
-    setStoreDataTableGlobalFilteredEntry(this.getMapId(), globalFilterValue, layerPath);
+    setStoreDataTableGlobalFilterRecord(this.getMapId(), globalFilterValue, layerPath);
   }
 
   /**
@@ -93,9 +94,20 @@ export class DataTableController extends AbstractMapViewerController {
    * @param layerPath - The path of the layer to update
    * @param columnFilters - The column filters state to set for the layer
    */
-  setColumnFiltersEntry(layerPath: string, columnFilters: TypeColumnFiltersState): void {
+  setColumnFiltersRecord(layerPath: string, columnFilters: TypeColumnFiltersState): void {
     // Save in the store
-    setStoreDataTableColumnFiltersEntry(this.getMapId(), columnFilters, layerPath);
+    setStoreDataTableColumnFiltersRecord(this.getMapId(), columnFilters, layerPath);
+  }
+
+  /**
+   * Sets the column visibility state for a specific layer in the data table.
+   *
+   * @param layerPath - The path of the layer to update
+   * @param columnVisibility - A record mapping column ids to their visibility state
+   */
+  setColumnVisibilityRecord(layerPath: string, columnVisibility: Record<string, boolean>): void {
+    // Save in the store
+    setStoreDataTableColumnVisibilityRecord(this.getMapId(), columnVisibility, layerPath);
   }
 
   /**
@@ -104,9 +116,9 @@ export class DataTableController extends AbstractMapViewerController {
    * @param layerPath - The path of the layer to update
    * @param columnFilterModes - The column filter modes to set for the layer
    */
-  setColumnFilterModesEntry(layerPath: string, columnFilterModes: Record<string, string>): void {
+  setColumnFilterModesRecord(layerPath: string, columnFilterModes: Record<string, string>): void {
     // Save in the store
-    setStoreDataTableColumnFilterModesEntry(this.getMapId(), columnFilterModes, layerPath);
+    setStoreDataTableColumnFilterModesRecord(this.getMapId(), columnFilterModes, layerPath);
   }
 
   /**
@@ -137,9 +149,9 @@ export class DataTableController extends AbstractMapViewerController {
    * @param layerPath - The path of the layer to update
    * @param rows - The number of rows filtered for the layer
    */
-  setRowsFilteredEntry(layerPath: string, rows: number): void {
+  setRowsFilteredRecord(layerPath: string, rows: number): void {
     // Save in the store
-    setStoreDataTableRowsFilteredEntry(this.getMapId(), rows, layerPath);
+    setStoreDataTableRowsFilteredRecord(this.getMapId(), rows, layerPath);
   }
 
   /**

--- a/packages/geoview-core/src/core/controllers/details-controller.ts
+++ b/packages/geoview-core/src/core/controllers/details-controller.ts
@@ -1,0 +1,91 @@
+import type { TypeFeatureInfoEntry } from '@/api/types/map-schema-types';
+import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
+import type { MapViewer } from '@/geo/map/map-viewer';
+import {
+  addStoreDetailsCheckedFeature,
+  deleteStoreDetailsFeatureInfo,
+  propagateStoreFeatureInfoDetails,
+  removeStoreDetailsCheckedFeature,
+  setStoreDetailsLayerDataArrayBatchLayerPathBypass,
+  setStoreDetailsSelectedLayerPath,
+  type TypeFeatureInfoResultSetEntry,
+} from '@/core/stores/store-interface-and-intial-values/feature-info-state';
+
+/**
+ * Controller responsible for details interactions and
+ * bridging the details state with the UI domain.
+ */
+export class DetailsController extends AbstractMapViewerController {
+  /**
+   * Creates an instance of DetailsController.
+   *
+   * @param mapViewer - The map viewer instance to associate with this controller
+   * @param controllerRegistry - The controller registry for accessing sibling controllers
+   */
+  // GV Leave the constructor here, because we'll likely need it soon to inject dependencies.
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(mapViewer, controllerRegistry);
+  }
+
+  /**
+   * Sets the selected layer path in the details panel.
+   *
+   * @param layerPath - The layer path to select
+   */
+  setSelectedLayerPath(layerPath: string): void {
+    // Save in the store
+    setStoreDetailsSelectedLayerPath(this.getMapId(), layerPath);
+  }
+
+  /**
+   * Sets the layer data array batch layer path bypass in the details panel.
+   *
+   * @param layerPath - The layer path to set
+   */
+  setLayerDataArrayBatchLayerPathBypass(layerPath: string): void {
+    // Save in the store
+    setStoreDetailsLayerDataArrayBatchLayerPathBypass(this.getMapId(), layerPath);
+  }
+
+  /**
+   * Adds a checked feature to the details panel.
+   *
+   * @param feature - The feature information entry to add as checked
+   */
+  addCheckedFeature(feature: TypeFeatureInfoEntry): void {
+    // Save in the store
+    addStoreDetailsCheckedFeature(this.getMapId(), feature);
+  }
+
+  /**
+   * Removes a checked feature from the details panel.
+   *
+   * @param feature - The feature information entry to remove as checked, or 'all' to remove all checked features
+   */
+  removeCheckedFeature(feature: TypeFeatureInfoEntry | 'all'): void {
+    // Save in the store
+    removeStoreDetailsCheckedFeature(this.getMapId(), feature);
+  }
+
+  /**
+   * Propagates feature information to the details panel.
+   *
+   * @param resultSetEntry - The feature information result set entry to propagate
+   */
+  propagateFeatureInfo(resultSetEntry: TypeFeatureInfoResultSetEntry): void {
+    // Save in the store
+    propagateStoreFeatureInfoDetails(this.getMapId(), resultSetEntry);
+  }
+
+  /**
+   * Deletes feature information from the details panel for a specific layer path.
+   *
+   * @param layerPath - The layer path for which to delete feature information
+   */
+  deleteFeatureInfo(layerPath: string): void {
+    // Save in the store
+    deleteStoreDetailsFeatureInfo(this.getMapId(), layerPath);
+  }
+}

--- a/packages/geoview-core/src/core/controllers/drawer-controller.ts
+++ b/packages/geoview-core/src/core/controllers/drawer-controller.ts
@@ -632,7 +632,8 @@ export class DrawerController extends AbstractMapViewerController {
     // Save to the store
     setStoreDrawerIconSrc(this.getMapId(), iconSrc);
 
-    // Update the feature style at large? Wasn't doing it before, leaving it like this with comment in case we should uncomment
+    // GV There's only the one point icon and there's no way currently to change it, so no need to update the feature style here
+    // GV If we were to add a way to select different icons, then this would need to be uncommented.
     // this.updateFeatureStyle();
   }
 

--- a/packages/geoview-core/src/core/controllers/drawer-controller.ts
+++ b/packages/geoview-core/src/core/controllers/drawer-controller.ts
@@ -13,24 +13,11 @@ import { getArea, getLength } from 'ol/sphere';
 import { Text, Fill, Icon as OLIcon, Stroke, Style } from 'ol/style';
 import type { StyleLike } from 'ol/style/Style';
 
-import type { MapViewer } from '@/geo/map/map-viewer';
-import type {
-  Transform,
-  TransformDeleteFeatureEvent,
-  TransformEvent,
-  TransformSelectionEvent,
-} from '@/geo/interaction/transform/transform';
-import type { Draw } from '@/geo/interaction/draw';
-import type { Snap } from '@/geo/interaction/snap';
-import type { GeometryApi } from '@/geo/layer/geometry/geometry';
-import { Projection } from '@/geo/utils/projection';
-import { GeoUtilities } from '@/geo/utils/utilities';
-
+import type { TypeDisplayLanguage } from '@/api/types/map-schema-types';
 import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
-import { getGeoViewStore } from '@/core/stores/stores-managers';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
 import {
   DEFAULT_TEXT_VALUES,
-  isStoreDrawerInitialized,
   getStoreDrawerActiveGeom,
   getStoreDrawerHideMeasurements,
   getStoreDrawerIconSrc,
@@ -38,8 +25,11 @@ import {
   getStoreDrawerIsEditing,
   getStoreDrawerIsSnapping,
   getStoreDrawerStyle,
+  isStoreDrawerInitialized,
+  updateStoreStateStyle,
   setStoreActiveGeom,
   setStoreDrawerIconSize,
+  setStoreDrawerIconSrc,
   setStoreFillColor,
   setStoreHideMeasurements,
   setStoreRedoDisabled,
@@ -56,19 +46,25 @@ import {
   setStoreTextSize,
   setStoreTextValue,
   setStoreUndoDisabled,
-  updateStoreStateStyle,
-  type StyleProps,
   setStoreIsDrawing,
   setStoreIsEditing,
   setStoreIsSnapping,
+  type StyleProps,
 } from '@/core/stores/store-interface-and-intial-values/drawer-state';
 import type { DomainLanguageChangedDelegate, DomainLanguageChangedEvent, UIDomain } from '@/core/domains/ui-domain';
+import type { MapProjectionChangedDelegate, MapProjectionChangedEvent, MapViewer } from '@/geo/map/map-viewer';
+import type {
+  Transform,
+  TransformDeleteFeatureEvent,
+  TransformEvent,
+  TransformSelectionEvent,
+} from '@/geo/interaction/transform/transform';
+import type { Draw } from '@/geo/interaction/draw';
+import type { Snap } from '@/geo/interaction/snap';
 import { formatArea, formatLength, generateId } from '@/core/utils/utilities';
+import { GeoUtilities } from '@/geo/utils/utilities';
 import { getStoreAppDisplayLanguage } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { getStoreMapCurrentProjection } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
-
-import type { TypeDisplayLanguage, TypeValidMapProjectionCodes } from '@/api/types/map-schema-types';
 
 /**
  * Controller responsible for drawer interactions, keyboard shortcuts, and
@@ -122,30 +118,24 @@ export class DrawerController extends AbstractMapViewerController {
   /** The UI Domain instance associated with this controller. */
   #uiDomain: UIDomain;
 
-  /** The Geometry Api used by this controller. */
-  #geometryApi: GeometryApi;
-
   /** The language changed event hook. */
   #hookLanguageChanged?: DomainLanguageChangedDelegate;
 
-  /** The store subscription callback to unsubscribe from projection changes. */
-  #hookProjectionSubscription?: () => void;
+  /** The map projection changed event subscription reference. */
+  #hookMapProjectionChanged?: MapProjectionChangedDelegate;
 
   /**
    * Creates an instance of DrawerController.
    *
    * @param mapViewer - The map viewer instance to associate with this controller
+   * @param controllerRegistry - The controller registry for accessing sibling controllers
    * @param uiDomain - The UI domain instance to associate with this controller
-   * @param geometryApi - The geometry API instance to associate with this controller
    */
-  constructor(mapViewer: MapViewer, uiDomain: UIDomain, geometryApi: GeometryApi) {
-    super(mapViewer);
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry, uiDomain: UIDomain) {
+    super(mapViewer, controllerRegistry);
 
     // Keep a reference on the UI domain
     this.#uiDomain = uiDomain;
-
-    // Keep a reference on the geometry api
-    this.#geometryApi = geometryApi;
   }
 
   // #region OVERRIDES
@@ -157,17 +147,11 @@ export class DrawerController extends AbstractMapViewerController {
     // Setup the keyboard handlers for undo/redo
     this.#hookKeyboardHandlers();
 
-    // Listens when the language is changed in the UI domain and process actions accordingly
+    // Listen when the language is changed in the UI domain
     this.#hookLanguageChanged = this.#uiDomain.onLanguageChanged(this.#handleDisplayLanguageChanged.bind(this));
 
-    // Subscribe to projection changes
-    // TODO: REFACTOR - Change this to listen on the domain event instead of the store state, because we are doing application-domain work with this subscribe.
-    this.#hookProjectionSubscription = getGeoViewStore(this.getMapId()).subscribe(
-      (state) => state.mapState.currentProjection,
-      (currentProjection, previousProjection) => {
-        this.#handleMapReprojection(currentProjection, previousProjection, this.getMapViewer().getDisplayLanguage());
-      }
-    );
+    // Listen when the map projection changes on the MapViewer
+    this.#hookMapProjectionChanged = this.getMapViewer().onMapProjectionChanged(this.#handleMapReprojection.bind(this));
   }
 
   /**
@@ -181,9 +165,9 @@ export class DrawerController extends AbstractMapViewerController {
     }
 
     // Unsubscribe from projection changes
-    if (this.#hookProjectionSubscription) {
-      this.#hookProjectionSubscription();
-      this.#hookProjectionSubscription = undefined;
+    if (this.#hookMapProjectionChanged) {
+      this.getMapViewer().offMapProjectionChanged(this.#hookMapProjectionChanged);
+      this.#hookMapProjectionChanged = undefined;
     }
 
     // Remove keyboard handler
@@ -593,11 +577,8 @@ export class DrawerController extends AbstractMapViewerController {
    * @param geomType - The geometry type to set as active
    */
   setActiveGeom(geomType: string): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreActiveGeom(mapId, geomType);
+    setStoreActiveGeom(this.getMapId(), geomType);
 
     // Refresh
     this.refreshInteractionInstances();
@@ -609,11 +590,8 @@ export class DrawerController extends AbstractMapViewerController {
    * @param fillColor - The fill color value
    */
   setFillColor(fillColor: string): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreFillColor(mapId, fillColor);
+    setStoreFillColor(this.getMapId(), fillColor);
 
     // Update the feature style at large
     this.updateFeatureStyle();
@@ -625,11 +603,8 @@ export class DrawerController extends AbstractMapViewerController {
    * @param strokeColor - The stroke color value
    */
   setStrokeColor(strokeColor: string): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreStrokeColor(mapId, strokeColor);
+    setStoreStrokeColor(this.getMapId(), strokeColor);
 
     // Update the feature style at large
     this.updateFeatureStyle();
@@ -641,14 +616,24 @@ export class DrawerController extends AbstractMapViewerController {
    * @param strokeWidth - The stroke width value
    */
   setStrokeWidth(strokeWidth: number): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreStrokeWidth(mapId, strokeWidth);
+    setStoreStrokeWidth(this.getMapId(), strokeWidth);
 
     // Update the feature style at large
     this.updateFeatureStyle();
+  }
+
+  /**
+   * Sets the drawer icon source in the store.
+   *
+   * @param iconSrc - The icon source value
+   */
+  setDrawerIconSrc(iconSrc: string): void {
+    // Save to the store
+    setStoreDrawerIconSrc(this.getMapId(), iconSrc);
+
+    // Update the feature style at large? Wasn't doing it before, leaving it like this with comment in case we should uncomment
+    // this.updateFeatureStyle();
   }
 
   /**
@@ -657,11 +642,8 @@ export class DrawerController extends AbstractMapViewerController {
    * @param iconSize - The icon size value
    */
   setDrawerIconSize(iconSize: number): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreDrawerIconSize(mapId, iconSize);
+    setStoreDrawerIconSize(this.getMapId(), iconSize);
 
     // Update the feature style at large
     this.updateFeatureStyle();
@@ -673,11 +655,8 @@ export class DrawerController extends AbstractMapViewerController {
    * @param text - The text content
    */
   setTextValue(text: string | string[]): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreTextValue(mapId, text);
+    setStoreTextValue(this.getMapId(), text);
 
     // Update the feature style at large
     this.updateFeatureStyle();
@@ -689,11 +668,8 @@ export class DrawerController extends AbstractMapViewerController {
    * @param size - The text size in pixels
    */
   setTextSize(size: number): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreTextSize(mapId, size);
+    setStoreTextSize(this.getMapId(), size);
 
     // Update the feature style at large
     this.updateFeatureStyle();
@@ -705,11 +681,8 @@ export class DrawerController extends AbstractMapViewerController {
    * @param font - The font family name
    */
   setTextFont(font: string): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreTextFont(mapId, font);
+    setStoreTextFont(this.getMapId(), font);
 
     // Update the feature style at large
     this.updateFeatureStyle();
@@ -721,11 +694,8 @@ export class DrawerController extends AbstractMapViewerController {
    * @param color - The text color value
    */
   setTextColor(color: string): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreTextColor(mapId, color);
+    setStoreTextColor(this.getMapId(), color);
 
     // Update the feature style at large
     this.updateFeatureStyle();
@@ -737,11 +707,8 @@ export class DrawerController extends AbstractMapViewerController {
    * @param color - The halo color value
    */
   setTextHaloColor(color: string): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreTextHaloColor(mapId, color);
+    setStoreTextHaloColor(this.getMapId(), color);
 
     // Update the feature style at large
     this.updateFeatureStyle();
@@ -753,11 +720,8 @@ export class DrawerController extends AbstractMapViewerController {
    * @param width - The halo width value
    */
   setTextHaloWidth(width: number): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreTextHaloWidth(mapId, width);
+    setStoreTextHaloWidth(this.getMapId(), width);
 
     // Update the feature style at large
     this.updateFeatureStyle();
@@ -769,11 +733,8 @@ export class DrawerController extends AbstractMapViewerController {
    * @param bold - Whether the text should be bold
    */
   setTextBold(bold: boolean): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreTextBold(mapId, bold);
+    setStoreTextBold(this.getMapId(), bold);
 
     // Update the feature style at large
     this.updateFeatureStyle();
@@ -785,11 +746,8 @@ export class DrawerController extends AbstractMapViewerController {
    * @param italic - Whether the text should be italic
    */
   setTextItalic(italic: boolean): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreTextItalic(mapId, italic);
+    setStoreTextItalic(this.getMapId(), italic);
 
     // Update the feature style at large
     this.updateFeatureStyle();
@@ -801,11 +759,8 @@ export class DrawerController extends AbstractMapViewerController {
    * @param rotation - The rotation angle
    */
   setTextRotation(rotation: number): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     // Save to the store
-    setStoreTextRotation(mapId, rotation);
+    setStoreTextRotation(this.getMapId(), rotation);
 
     // Update the feature style at large
     this.updateFeatureStyle();
@@ -1084,14 +1039,11 @@ export class DrawerController extends AbstractMapViewerController {
    *
    */
   downloadDrawings(): void {
-    // Get the map id
-    const mapId = this.getMapId();
-
     const features = this.#getDrawingFeatures();
     if (features.length === 0) return;
 
     // Get current map projection
-    const mapProjection = Projection.PROJECTIONS[getStoreMapCurrentProjection(mapId)];
+    const mapProjection = this.getMapViewer().getProjection();
 
     // Convert to GeoJSON with style properties
     const geojson = {
@@ -1151,7 +1103,7 @@ export class DrawerController extends AbstractMapViewerController {
         const viewer = this.getMapViewer();
 
         // Get current map projection
-        const mapProjection = Projection.PROJECTIONS[getStoreMapCurrentProjection(mapId)];
+        const mapProjection = this.getMapViewer().getProjection();
 
         const newFeatures: Feature[] = [];
         geojson.features.forEach((geoFeature: GeoJsonFeature) => {
@@ -1310,7 +1262,7 @@ export class DrawerController extends AbstractMapViewerController {
     if (!isStoreDrawerInitialized(mapId)) return [];
 
     // Get features from drawing group
-    const geometryGroup = this.#geometryApi.getGeometryGroup(DrawerController.DRAW_GROUP_KEY);
+    const geometryGroup = this.getGeometryApi().getGeometryGroup(DrawerController.DRAW_GROUP_KEY);
     const features = geometryGroup?.vectorSource.getFeatures();
     if (!features) {
       return [];
@@ -1640,31 +1592,23 @@ export class DrawerController extends AbstractMapViewerController {
   /**
    * Handles map projection changes to reproject the drawings.
    *
-   * @param currentProjection - The current projection code
-   * @param previousProjection - The previous projection code
-   * @param displayLanguage - The current display language for updating measurement tooltips after reprojection
+   * @param sender - The map viewer that sent the event
+   * @param event - The map projection change event containing the previous and current projections
    */
-  #handleMapReprojection(
-    currentProjection: TypeValidMapProjectionCodes,
-    previousProjection: TypeValidMapProjectionCodes,
-    displayLanguage: TypeDisplayLanguage
-  ): void {
-    if (previousProjection) {
+  #handleMapReprojection(sender: MapViewer, event: MapProjectionChangedEvent): void {
+    if (event.previousProjection) {
       this.#stopAllInteractions();
-
-      const fromProjection = Projection.PROJECTIONS[previousProjection];
-      const toProjection = Projection.PROJECTIONS[currentProjection];
 
       const features = this.#getDrawingFeatures();
       features.forEach((feature) => {
         const geometry = feature.getGeometry();
         if (!geometry) return;
 
-        geometry.transform(fromProjection, toProjection);
+        geometry.transform(event.previousProjection, event.projection);
       });
 
       // Update tooltips once
-      this.#updateMeasurementTooltips(displayLanguage);
+      this.#updateMeasurementTooltips(sender.getDisplayLanguage());
 
       // Reproject all geometries in the history
       if (this.#drawerHistory) {
@@ -1673,18 +1617,18 @@ export class DrawerController extends AbstractMapViewerController {
           action.features.forEach((feature) => {
             const geometry = feature.getGeometry();
             if (geometry) {
-              geometry.transform(fromProjection, toProjection);
+              geometry.transform(event.previousProjection, event.projection);
             }
           });
 
           // Reproject original geometries (for modify actions)
           action.originalGeometries?.forEach((geometry) => {
-            geometry.transform(fromProjection, toProjection);
+            geometry.transform(event.previousProjection, event.projection);
           });
 
           // Reproject modified geometries (for modify actions)
           action.modifiedGeometries?.forEach((geometry) => {
-            geometry.transform(fromProjection, toProjection);
+            geometry.transform(event.previousProjection, event.projection);
           });
         });
       }

--- a/packages/geoview-core/src/core/controllers/drawer-controller.ts
+++ b/packages/geoview-core/src/core/controllers/drawer-controller.ts
@@ -632,9 +632,10 @@ export class DrawerController extends AbstractMapViewerController {
     // Save to the store
     setStoreDrawerIconSrc(this.getMapId(), iconSrc);
 
-    // GV There's only the one point icon and there's no way currently to change it, so no need to update the feature style here
-    // GV If we were to add a way to select different icons, then this would need to be uncommented.
-    // this.updateFeatureStyle();
+    // TODO: DRAWER - Drawing icon issue when you click on a different point icon, it will have it's style overwritten by the current style
+
+    // Update the feature style at large
+    this.updateFeatureStyle();
   }
 
   /**

--- a/packages/geoview-core/src/core/controllers/geochart-controller.ts
+++ b/packages/geoview-core/src/core/controllers/geochart-controller.ts
@@ -1,0 +1,81 @@
+import type { GeoViewGeoChartConfig } from '@/api/config/reader/uuid-config-reader';
+import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
+import type { MapViewer } from '@/geo/map/map-viewer';
+import {
+  addStoreGeochartChart,
+  initStoreGeochartCharts,
+  removeStoreGeochartChart,
+  setStoreGeochartLayerDataArrayBatchLayerPathBypass,
+  setStoreGeochartSelectedLayerPath,
+} from '@/core/stores/store-interface-and-intial-values/geochart-state';
+
+/**
+ * Controller responsible for geochart interactions and
+ * bridging the geochart state with the UI domain.
+ */
+export class GeoChartController extends AbstractMapViewerController {
+  /**
+   * Creates an instance of GeoChartController.
+   *
+   * @param mapViewer - The map viewer instance to associate with this controller
+   * @param controllerRegistry - The controller registry for accessing sibling controllers
+   */
+  // GV Leave the constructor here, because we'll likely need it soon to inject dependencies.
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(mapViewer, controllerRegistry);
+  }
+
+  /**
+   * Sets the selected layer path in the geochart panel.
+   *
+   * @param layerPath - The layer path to select
+   */
+  setSelectedLayerPath(layerPath: string): void {
+    // Save in the store
+    setStoreGeochartSelectedLayerPath(this.getMapId(), layerPath);
+  }
+
+  /**
+   * Sets the layer data array batch layer path bypass in the geochart panel.
+   *
+   * @param layerPath - The layer path to set
+   */
+  setLayerDataArrayBatchLayerPathBypass(layerPath: string): void {
+    // Save in the store
+    setStoreGeochartLayerDataArrayBatchLayerPathBypass(this.getMapId(), layerPath);
+  }
+
+  /**
+   * Initializes the geochart panel with a list of charts.
+   *
+   * @param charts - An array of chart configurations to initialize the geochart panel with
+   */
+  initCharts(charts: GeoViewGeoChartConfig[]): void {
+    // Save in the store
+    initStoreGeochartCharts(this.getMapId(), charts);
+  }
+
+  /**
+   * Adds a chart to the geochart panel.
+   *
+   * @param layerPath - The layer path of the chart to add
+   * @param chartConfig - The configuration of the chart to add
+   */
+  addChart(layerPath: string, chartConfig: GeoViewGeoChartConfig): void {
+    // Save in the store
+    addStoreGeochartChart(this.getMapId(), layerPath, chartConfig);
+  }
+
+  /**
+   * Removes a chart from the geochart panel.
+   *
+   * @param layerPath - The layer path of the chart to remove
+   * @param callbackWhenEmpty - A callback function to execute when the chart panel is empty
+   */
+  removeChart(layerPath: string, callbackWhenEmpty: () => void): void {
+    // Save in the store
+    removeStoreGeochartChart(this.getMapId(), layerPath, callbackWhenEmpty);
+  }
+}

--- a/packages/geoview-core/src/core/controllers/layer-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-controller.ts
@@ -17,6 +17,7 @@ import type { ConfigBaseClass } from '@/api/config/validation-classes/config-bas
 import type { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
 import type { GroupLayerEntryConfig } from '@/api/config/validation-classes/group-layer-entry-config';
 import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
 import { LayerNotEsriDynamicError, LayerNotGeoJsonError, LayerWrongTypeError } from '@/core/exceptions/layer-exceptions';
 import {
   getStoreLayerBounds,
@@ -24,12 +25,15 @@ import {
   getStoreLayerHighlightedLayer,
   getStoreLayerLegendLayerByPath,
   getStoreLayerLegendLayers,
-  setStoreHighlightedLayer,
+  getStoreLayerOrderedLayerIndexByPath,
+  getStoreLayerOrderedLayerPaths,
+  setStoreLayerAllMapLayerCollapsed,
   setStoreLayerBoundsForLayerAndParentsAndForget,
   setStoreLayerDateTemporal,
   setStoreLayerDeletionStartTime,
   setStoreLayerDisplayDateFormat,
   setStoreLayerDisplayDateFormatShort,
+  setStoreLayerHighlightedLayer,
   setStoreLayerHoverable,
   setStoreLayerItemVisibility,
   setStoreLayerMosaicRule,
@@ -39,49 +43,51 @@ import {
   setStoreLayersAreLoading,
   setStoreLayerTextVisibility,
   setStoreLayerWmsStyle,
-  setStoreLegendLayersDirectly,
-  setStoreOpacity,
-} from '@/core/stores/store-interface-and-intial-values/layer-state';
-import {
-  getStoreMapConfigCorePackagesConfig,
-  getStoreMapOrderedLayerIndexByPath,
-  getStoreMapOrderedLayerInfo,
+  setStoreLayerOpacity,
+  setStoreLayerDisplayState,
   setStoreLayerInVisibleRange,
-  setStoreMapLayerHoverable,
-  setStoreMapLayerQueryable,
-  setStoreMapLayerVisibility,
-  setStoreMapOrderedLayerDirectly,
-  utilFindMapLayerAndChildrenFromOrderedInfo,
-  type TypeOrderedLayerInfo,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
-import { getStoreShowLayerHighlightLayerBbox } from '@/core/stores/store-interface-and-intial-values/app-state';
+  setStoreLayerVisibility,
+  setStoreLayerLegendCollapsed,
+  setStoreLayerOrderedLayers,
+  setStoreLayerSelectedLayersTabLayer,
+  setStoreLegendLayersDirectly,
+  utilFindLayerAndChildrenPaths,
+} from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { getStoreMapConfigCorePackagesConfig } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { getStoreAppShowLayerHighlightLayerBbox } from '@/core/stores/store-interface-and-intial-values/app-state';
 import {
   getStoreTimeSliderFilter,
   isStoreTimeSliderInitialized,
   type TypeTimeSliderProps,
 } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
-import { getStoreTableFilter } from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { getStoreDataTableFilter } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import type {
   DomainLayerHoverableChangedDelegate,
   DomainLayerHoverableChangedEvent,
   DomainLayerBaseDelegate,
   DomainLayerBaseEvent,
+  DomainLayerItemVisibilityChangedDelegate,
+  DomainLayerItemVisibilityChangedEvent,
+  DomainLayerMosaicRuleChangedDelegate,
+  DomainLayerMosaicRuleChangedEvent,
   DomainLayerNameChangedDelegate,
   DomainLayerNameChangedEvent,
   DomainLayerOpacityChangedDelegate,
   DomainLayerOpacityChangedEvent,
   DomainLayerQueryableChangedDelegate,
   DomainLayerQueryableChangedEvent,
+  DomainLayerRasterFunctionChangedDelegate,
+  DomainLayerRasterFunctionChangedEvent,
+  DomainLayerRegisteredDelegate,
+  DomainLayerRegisteredEvent,
   DomainLayerStatusChangedDelegate,
   DomainLayerStatusChangedEvent,
   DomainLayerVisibleChangedDelegate,
   DomainLayerVisibleChangedEvent,
-  DomainLayerItemVisibilityChangedDelegate,
-  DomainLayerItemVisibilityChangedEvent,
-  DomainLayerRegisteredDelegate,
-  DomainLayerRegisteredEvent,
   DomainLayerWMSImageLoadRescueEvent,
   DomainLayerWMSImageLoadRescueDelegate,
+  DomainLayerWMSStyleChangedDelegate,
+  DomainLayerWMSStyleChangedEvent,
   DomainLayerGroupChildrenUpdatedEvent,
   DomainLayerGroupChildrenUpdatedDelegate,
   DomainLayerMessageDelegate,
@@ -90,7 +96,7 @@ import type {
 } from '@/core/domains/layer-domain';
 import { doTimeout, isValidUUID, type DelayJob } from '@/core/utils/utilities';
 import type { TemporalMode, TypeDisplayDateFormat } from '@/core/utils/date-mgt';
-import type { TypeLegendItem } from '@/core/components/layers/types';
+import type { TypeLayersViewDisplayState, TypeLegendItem } from '@/core/components/layers/types';
 import { logger } from '@/core/utils/logger';
 import { NoBoundsError } from '@/core/exceptions/geoview-exceptions';
 import { OL_ZOOM_DURATION, OL_ZOOM_PADDING } from '@/core/utils/constant';
@@ -181,6 +187,15 @@ export class LayerController extends AbstractMapViewerController {
   /** The bounded reference to the handle WMS Layer Image Load Callbacks */
   #boundedHandleDomainLayerWMSImageLoadRescue: DomainLayerWMSImageLoadRescueDelegate;
 
+  /** The bounded reference to the handle WMS style changed */
+  #boundedHandleDomainLayerWMSStyleChanged: DomainLayerWMSStyleChangedDelegate;
+
+  /** The bounded reference to the handle raster function changed */
+  #boundedHandleDomainLayerRasterFunctionChanged: DomainLayerRasterFunctionChangedDelegate;
+
+  /** The bounded reference to the handle mosaic rule changed */
+  #boundedHandleDomainLayerMosaicRuleChanged: DomainLayerMosaicRuleChangedDelegate;
+
   /** Callback delegates for the layer item visibility toggled event */
   #onLayerItemVisibilityToggledHandlers: ControllerLayerItemVisibilityChangedDelegate[] = [];
 
@@ -188,10 +203,11 @@ export class LayerController extends AbstractMapViewerController {
    * Creates an instance of LayerController.
    *
    * @param mapViewer - The map viewer instance to associate with this controller
+   * @param controllerRegistry - The controller registry for accessing sibling controllers
    * @param layerDomain - The layer domain instance to associate with this controller
    */
-  constructor(mapViewer: MapViewer, layerDomain: LayerDomain) {
-    super(mapViewer);
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry, layerDomain: LayerDomain) {
+    super(mapViewer, controllerRegistry);
 
     // Keep the domain internally
     this.#layerDomain = layerDomain;
@@ -249,6 +265,15 @@ export class LayerController extends AbstractMapViewerController {
 
     // Keep a bounded reference to the handle WMS Layer Image Load Callbacks
     this.#boundedHandleDomainLayerWMSImageLoadRescue = this.#handleDomainLayerWMSImageLoadRescue.bind(this);
+
+    // Keep a bounded reference to the handle WMS style changed
+    this.#boundedHandleDomainLayerWMSStyleChanged = this.#handleDomainLayerWMSStyleChanged.bind(this);
+
+    // Keep a bounded reference to the handle layer raster function changed
+    this.#boundedHandleDomainLayerRasterFunctionChanged = this.#handleDomainLayerRasterFunctionChanged.bind(this);
+
+    // Keep a bounded reference to the handle layer mosaic rule changed
+    this.#boundedHandleDomainLayerMosaicRuleChanged = this.#handleDomainLayerMosaicRuleChanged.bind(this);
   }
 
   // #region OVERRIDES
@@ -310,12 +335,30 @@ export class LayerController extends AbstractMapViewerController {
 
     // Listens when a WMS image load rescue event occurs
     this.#layerDomain.onLayerWMSImageLoadRescue(this.#boundedHandleDomainLayerWMSImageLoadRescue);
+
+    // Listens when a WMS style is changed in the Layer domain
+    this.#layerDomain.onLayerWmsStyleChanged(this.#boundedHandleDomainLayerWMSStyleChanged);
+
+    // Listens when a layer raster function is changed in the Layer domain
+    this.#layerDomain.onLayerRasterFunctionChanged(this.#boundedHandleDomainLayerRasterFunctionChanged);
+
+    // Listens when a layer mosaic rule is changed in the Layer domain
+    this.#layerDomain.onLayerMosaicRuleChanged(this.#boundedHandleDomainLayerMosaicRuleChanged);
   }
 
   /**
    * Unhooks the controller from the action.
    */
   protected override onUnhook(): void {
+    // Unhooks when a layer mosaic rule is changed in the Layer domain
+    this.#layerDomain.offLayerMosaicRuleChanged(this.#boundedHandleDomainLayerMosaicRuleChanged);
+
+    // Unhooks when a layer raster function is changed in the Layer domain
+    this.#layerDomain.offLayerRasterFunctionChanged(this.#boundedHandleDomainLayerRasterFunctionChanged);
+
+    // Unhooks when a WMS style is changed in the Layer domain
+    this.#layerDomain.offLayerWmsStyleChanged(this.#boundedHandleDomainLayerWMSStyleChanged);
+
     // Unhooks when a WMS image load rescue event occurs
     this.#layerDomain.offLayerWMSImageLoadRescue(this.#boundedHandleDomainLayerWMSImageLoadRescue);
 
@@ -577,6 +620,30 @@ export class LayerController extends AbstractMapViewerController {
 
   // #endregion PUBLIC METHODS - DOMAIN SIMPLE GETTERS
 
+  // #region PUBLIC METHODS - UI RELATED
+
+  /**
+   * Sets the layer panel display state.
+   *
+   * @param displayState - The new display state for the layers view
+   */
+  setLayerDisplayState(displayState: TypeLayersViewDisplayState): void {
+    // Save in the store
+    setStoreLayerDisplayState(this.getMapId(), displayState);
+  }
+
+  /**
+   * Sets the selected layer path in the layers tab.
+   *
+   * @param layerPath - The layer path to select
+   */
+  setSelectedLayerPath(layerPath: string): void {
+    // Save in the store
+    setStoreLayerSelectedLayersTabLayer(this.getMapId(), layerPath);
+  }
+
+  // #endregion PUBLIC METHODS - UI RELATED
+
   // #region PUBLIC METHODS
 
   /**
@@ -756,27 +823,6 @@ export class LayerController extends AbstractMapViewerController {
   }
 
   /**
-   * Sets or toggles the visibility of a specific layer within a map.
-   *
-   * If the layer exists at the provided layer path for the given map, the method delegates
-   * the visibility change to the map viewer's layer API. If `newValue` is provided, the layer
-   * visibility is explicitly set to that value; otherwise, the visibility is toggled.
-   *
-   * @param layerPath - The path of the layer whose visibility is being changed
-   * @param newValue - Optional. The new visibility value. If omitted, the visibility is toggled
-   * @returns The resulting visibility state of the layer after the operation, or `false`
-   * if the layer does not exist at the given path.
-   */
-  setOrToggleMapLayerVisibility(layerPath: string, newValue?: boolean): boolean {
-    // If the GV layer exists at the layer path
-    if (this.getGeoviewLayerIfExists(layerPath)) {
-      // Redirect to set or toggle the layer visibility and return the resulting visibility
-      return this.setOrToggleLayerVisibility(layerPath, newValue);
-    }
-    return false;
-  }
-
-  /**
    * Sets or toggles the visibility of a layer within the current map.
    *
    * Retrieves the current visibility of the layer, determines the resulting visibility
@@ -807,65 +853,78 @@ export class LayerController extends AbstractMapViewerController {
   }
 
   /**
-   * Sets the visibility of all geoview layers on the map.
+   * Sets or toggles the visibility of a specific layer within a map.
    *
-   * @param newValue - The new visibility
+   * If the layer exists at the provided layer path for the given map, the method delegates
+   * the visibility change to the map viewer's layer API. If `newValue` is provided, the layer
+   * visibility is explicitly set to that value; otherwise, the visibility is toggled.
+   *
+   * @param layerPath - The path of the layer whose visibility is being changed
+   * @param newValue - Optional. The new visibility value. If omitted, the visibility is toggled
+   * @returns The resulting visibility state of the layer after the operation, or `false`
+   * if the layer does not exist at the given path.
+   */
+  setOrToggleLayerVisibilityIfExists(layerPath: string, newValue?: boolean): boolean {
+    // TODO: CHECK - Validate that when this function is called it wouldn't simply be better to
+    // TO.DOCONT: call the 'setOrToggleLayerVisibility' function instead and let it throw an exception?
+    // If the GV layer exists at the layer path
+    if (this.getGeoviewLayerIfExists(layerPath)) {
+      // Redirect to set or toggle the layer visibility and return the resulting visibility
+      return this.setOrToggleLayerVisibility(layerPath, newValue);
+    }
+    return false;
+  }
+
+  /**
+   * Sets the visibility of all GeoView layers on the map, including basemaps.
+   *
+   * Iterates through every registered GeoView layer and applies the provided
+   * visibility value unconditionally via `setOrToggleLayerVisibility`.
+   *
+   * @param newValue - The visibility state to apply to all layers (`true` to show, `false` to hide)
    */
   setAllLayersVisibility(newValue: boolean): void {
-    // For each layer entries
-    this.getLayerEntryLayerPaths().forEach((layerPath) => {
-      // If the layer path has a corresponding Geoview layer (it's possible that there's a layer entry config without necessarily a GV layer)
-      if (this.getGeoviewLayerIfExists(layerPath)) {
-        // There is a geoview layer at this layer path
-        this.setOrToggleLayerVisibility(layerPath, newValue);
-      }
+    // For each layer
+    this.getGeoviewLayers().forEach((layer) => {
+      // There is a geoview layer at this layer path
+      this.setOrToggleLayerVisibility(layer.getLayerPath(), newValue);
     });
   }
 
   /**
-   * Sets the visibility of the Geoview basemap layer.
+   * Sets the visibility of basemap layers only.
    *
-   * @param newVisibility - The visibility state to apply to the basemap layer (`true` to show, `false` to hide)
+   * Iterates through all GeoView layers and applies the provided visibility
+   * value only to layers marked as basemaps (`useAsBasemap === true`). Layers
+   * whose visibility already matches the desired state are skipped.
+   *
+   * @param newVisibility - The visibility state to apply to basemap layers (`true` to show, `false` to hide)
    */
-  setVisibilityOfGeoviewBasemapLayers(newVisibility: boolean): void {
-    // For each layer entries
+  setAllLayersVisibilityBasemapsOnly(newVisibility: boolean): void {
+    // For each layer
     this.getGeoviewLayers().forEach((layer) => {
-      if (layer.getLayerConfig().getGeoviewLayerConfig().useAsBasemap === true && layer.getVisible() !== newVisibility) {
+      if (layer.getLayerConfig().getGeoviewLayerConfig().useAsBasemap && layer.getVisible() !== newVisibility) {
         this.setOrToggleLayerVisibility(layer.getLayerPath(), newVisibility);
       }
     });
   }
 
   /**
-   * Sets the visibility of **all layers** in a given map.
+   * Sets the visibility of all non-basemap layers.
    *
-   * Iterates through all GeoView layers associated with the specified map ID and
-   * applies the provided visibility value. Only layers whose current visibility
-   * differs from the desired state will be updated.
+   * Iterates through all GeoView layers and applies the provided visibility
+   * value only to layers that are not marked as basemaps (`useAsBasemap !== true`).
+   * Layers whose visibility already matches the desired state are skipped.
    *
-   * @param newVisibility - The visibility state to apply to all layers (`true` to show, `false` to hide)
+   * @param newVisibility - The visibility state to apply to non-basemap layers (`true` to show, `false` to hide)
    */
-  setAllMapLayerVisibility(newVisibility: boolean): void {
-    // For each layer entries
+  setAllLayersVisibilityExceptBasemaps(newVisibility: boolean): void {
+    // For each layer
     this.getGeoviewLayers().forEach((layer) => {
       if (layer.getLayerConfig().getGeoviewLayerConfig().useAsBasemap !== true && layer.getVisible() !== newVisibility) {
         this.setOrToggleLayerVisibility(layer.getLayerPath(), newVisibility);
       }
     });
-  }
-
-  /**
-   * Sets the visibility of a layer in the store ordered layer info.
-   *
-   * @param layerPath - The layer path of the layer to change
-   * @param visibility - The visibility to set
-   */
-  setMapLayerVisibility(layerPath: string, visibility: boolean): void {
-    // Save to the store
-    setStoreMapLayerVisibility(this.getMapId(), layerPath, visibility);
-
-    // Update the z indices
-    this.setLayerZIndices();
   }
 
   /**
@@ -934,100 +993,135 @@ export class LayerController extends AbstractMapViewerController {
    * Sets Z index for layers.
    */
   setLayerZIndices(): void {
-    const reversedLayers = [...getStoreMapOrderedLayerInfo(this.getMapId())].reverse();
-    reversedLayers.forEach((orderedLayerInfo, index) => {
-      const gvLayer = this.getGeoviewLayerIfExists(orderedLayerInfo.layerPath);
+    const reversedLayers = [...getStoreLayerOrderedLayerPaths(this.getMapId())].reverse();
+    reversedLayers.forEach((layerPath, index) => {
+      const gvLayer = this.getGeoviewLayerIfExists(layerPath);
       gvLayer?.setZIndex(index + 10);
     });
   }
 
   /**
-   * Replaces a layer in the orderedLayerInfo array.
+   * Toggles the legend collapsed state for a layer in the store.
+   *
+   * @param layerPath - The path of the layer to toggle the legend collapsed state for
+   */
+  toggleLegendCollapsed(layerPath: string): void {
+    // Get the current state
+    const legendCollapsed = getStoreLayerLegendLayerByPath(this.getMapId(), layerPath)?.legendCollapsed ?? false;
+
+    // Redirect
+    this.setLegendCollapsed(layerPath, !legendCollapsed);
+  }
+
+  /**
+   * Sets the legend collapsed state for a layer in the store.
+   *
+   * @param layerPath - The path of the layer to set the legend collapsed state for
+   * @param legendCollapsed - The new collapsed state of the legend
+   */
+  setLegendCollapsed(layerPath: string, legendCollapsed: boolean): void {
+    // Save in the store
+    setStoreLayerLegendCollapsed(this.getMapId(), layerPath, legendCollapsed);
+  }
+
+  /**
+   * Sets the legend collapsed state for all layers in the store.
+   *
+   * @param newCollapsed - The new collapsed state of the legends
+   */
+  setAllMapLayerCollapsed(newCollapsed: boolean): void {
+    // Save in the store
+    setStoreLayerAllMapLayerCollapsed(this.getMapId(), newCollapsed);
+  }
+
+  /**
+   * Replaces a layer's paths in the ordered layers array.
    *
    * @param layerConfig - The config of the layer to add
-   * @param layerPathToReplace - The layerPath of the info to replace
+   * @param layerPathToReplace - The layerPath of the entry to replace
    */
-  replaceOrderedLayerInfo(layerConfig: ConfigBaseClass, layerPathToReplace?: string): void {
-    const orderedLayerInfo = getStoreMapOrderedLayerInfo(this.getMapId());
+  replaceOrderedLayerPaths(layerConfig: ConfigBaseClass, layerPathToReplace?: string): void {
+    const orderedLayers = [...getStoreLayerOrderedLayerPaths(this.getMapId())];
     const layerPath = layerConfig.getGeoviewLayerId() ? `${layerConfig.getGeoviewLayerId()}/base-group` : layerConfig.layerPath;
     const pathToSearch = layerPathToReplace || layerPath;
-    const index = getStoreMapOrderedLayerIndexByPath(this.getMapId(), pathToSearch);
-    const replacedLayers = utilFindMapLayerAndChildrenFromOrderedInfo(pathToSearch, orderedLayerInfo);
+    const index = getStoreLayerOrderedLayerIndexByPath(this.getMapId(), pathToSearch);
+    const replacedLayers = utilFindLayerAndChildrenPaths(pathToSearch, orderedLayers);
 
-    const newOrderedLayerInfo = AbstractMapViewerController.generateArrayOfLayerOrderInfo(layerConfig);
-    orderedLayerInfo.splice(index, replacedLayers.length, ...newOrderedLayerInfo);
+    const newLayerPaths = AbstractMapViewerController.generateOrderedLayerPaths(layerConfig);
+    orderedLayers.splice(index, replacedLayers.length, ...newLayerPaths);
 
     // Save in the store
-    setStoreMapOrderedLayerDirectly(this.getMapId(), orderedLayerInfo);
+    setStoreLayerOrderedLayers(this.getMapId(), orderedLayers);
 
     // Update the z indices
     this.setLayerZIndices();
   }
 
   /**
-   * Adds a new layer to the orderedLayerInfo array using a layer config.
+   * Adds a new layer to the ordered layers array using a layer config.
    *
    * @param geoviewLayerConfig - The config of the layer to add
+   * @param index - Optional position to insert at
    */
-  addOrderedLayerInfoByConfig(geoviewLayerConfig: TypeGeoviewLayerConfig | TypeLayerEntryConfig, index?: number): void {
-    const orderedLayerInfo = getStoreMapOrderedLayerInfo(this.getMapId());
+  addOrderedLayerPathsByConfig(geoviewLayerConfig: TypeGeoviewLayerConfig | TypeLayerEntryConfig, index?: number): void {
+    const orderedLayers = [...getStoreLayerOrderedLayerPaths(this.getMapId())];
 
-    const newOrderedLayerInfo = AbstractMapViewerController.generateArrayOfLayerOrderInfo(geoviewLayerConfig);
-    if (!index) orderedLayerInfo.unshift(...newOrderedLayerInfo);
-    else orderedLayerInfo.splice(index, 0, ...newOrderedLayerInfo);
+    const newLayerPaths = AbstractMapViewerController.generateOrderedLayerPaths(geoviewLayerConfig);
+    if (!index) orderedLayers.unshift(...newLayerPaths);
+    else orderedLayers.splice(index, 0, ...newLayerPaths);
 
     // Save in the store
-    setStoreMapOrderedLayerDirectly(this.getMapId(), orderedLayerInfo);
+    setStoreLayerOrderedLayers(this.getMapId(), orderedLayers);
 
     // Update the z indices
     this.setLayerZIndices();
   }
 
   /**
-   * Adds new layer info to the orderedLayerInfo array.
+   * Adds a new layer path to the ordered layers array.
    *
-   * @param layerInfo - The ordered layer info to add
+   * @param layerPath - The layer path to add
+   * @param index - Optional position to insert at
    */
-  addOrderedLayerInfo(layerInfo: TypeOrderedLayerInfo, index?: number): void {
-    const orderedLayerInfo = getStoreMapOrderedLayerInfo(this.getMapId());
-    if (!index) orderedLayerInfo.unshift(layerInfo);
-    else orderedLayerInfo.splice(index, 0, layerInfo);
+  addOrderedLayerPath(layerPath: string, index?: number): void {
+    const orderedLayers = [...getStoreLayerOrderedLayerPaths(this.getMapId())];
+    if (!index) orderedLayers.unshift(layerPath);
+    else orderedLayers.splice(index, 0, layerPath);
 
     // Save in store
-    setStoreMapOrderedLayerDirectly(this.getMapId(), orderedLayerInfo);
+    setStoreLayerOrderedLayers(this.getMapId(), orderedLayers);
 
     // Update the z indices
     this.setLayerZIndices();
   }
 
   /**
-   * Removes a layer from the orderedLayerInfo array.
+   * Removes a layer from the ordered layers array.
    *
    * @param layerPath - The path of the layer to remove
    * @param removeSublayers - Should sublayers be removed
    */
-  removeOrderedLayerInfo(layerPath: string, removeSublayers: boolean = true): void {
-    const orderedLayerInfo = getStoreMapOrderedLayerInfo(this.getMapId());
-    const newOrderedLayerInfo = removeSublayers
-      ? orderedLayerInfo.filter((layerInfo) => !layerInfo.layerPath.startsWith(`${layerPath}/`) && !(layerInfo.layerPath === layerPath))
-      : orderedLayerInfo.filter((layerInfo) => !(layerInfo.layerPath === layerPath));
+  removeOrderedLayerPath(layerPath: string, removeSublayers: boolean = true): void {
+    const orderedLayers = getStoreLayerOrderedLayerPaths(this.getMapId());
+    const newOrderedLayers = removeSublayers
+      ? orderedLayers.filter((path) => !path.startsWith(`${layerPath}/`) && path !== layerPath)
+      : orderedLayers.filter((path) => path !== layerPath);
 
     // Save in store
-    setStoreMapOrderedLayerDirectly(this.getMapId(), newOrderedLayerInfo);
+    setStoreLayerOrderedLayers(this.getMapId(), newOrderedLayers);
 
     // Update the z indices
     this.setLayerZIndices();
   }
 
   /**
-   * Updates the ordered layer info in the store and recalculates layer Z indices.
+   * Updates the ordered layers in the store and recalculates layer Z indices.
    *
-   * @param orderedLayerInfo - The new ordered layer info array
-   * @deprecated This function shouldn't exist as it breaks the separation of concern between the controller and the store implementation.
+   * @param orderedLayers - The new ordered layers array
    */
-  setMapOrderedLayerInfoDirectly(orderedLayerInfo: TypeOrderedLayerInfo[]): void {
+  setMapOrderedLayersDirectly(orderedLayers: string[]): void {
     // Save in store
-    setStoreMapOrderedLayerDirectly(this.getMapId(), orderedLayerInfo);
+    setStoreLayerOrderedLayers(this.getMapId(), orderedLayers);
 
     // Update the z indices
     this.setLayerZIndices();
@@ -1061,15 +1155,6 @@ export class LayerController extends AbstractMapViewerController {
 
     // Update the raster function
     layer.setRasterFunction(rasterFunctionId);
-
-    //TODO: REFACTOR - The function should stop here and an event should be raised by the domain to the controller to manage the store
-    //TO.DOCONT: Same pattern as setLayerName, setLayerOpacity, etc, etc
-
-    // Update the store
-    setStoreLayerRasterFunction(this.getMapId(), layerPath, rasterFunctionId);
-
-    // Trigger legend re-query through the layer set system (forced refresh)
-    this.getControllersRegistry().layerSetController.legendsLayerSet.queryLegend(layer, true);
   }
 
   /**
@@ -1108,22 +1193,17 @@ export class LayerController extends AbstractMapViewerController {
    * @param layerPath - The layer path
    * @param mosaicRule - The mosaic rule to apply or undefined to remove it
    * @throws {LayerNotFoundError} When the layer couldn't be found at the given layer path
+   * @throws {LayerWrongTypeError} When the layer is not an ESRI Image layer
    */
   setLayerMosaicRule(layerPath: string, mosaicRule: TypeMosaicRule | undefined): void {
+    // Get the layer
     const layer = this.getGeoviewLayer(layerPath);
-    if (!(layer instanceof GVEsriImage)) return;
+
+    // Check if it's the right type
+    if (!(layer instanceof GVEsriImage)) throw new LayerWrongTypeError(layerPath, layer.getLayerName());
 
     // Update the mosaic rule
     layer.setMosaicRule(mosaicRule);
-
-    //TODO: REFACTOR - The function should stop here and an event should be raised by the domain to the controller to manage the store
-    //TO.DOCONT: Same pattern as setLayerName, setLayerOpacity, etc, etc
-
-    // Update the store
-    setStoreLayerMosaicRule(this.getMapId(), layerPath, mosaicRule);
-
-    // Trigger legend re-query through the layer set system
-    this.getControllersRegistry().layerSetController.legendsLayerSet.queryLegend(layer, true);
   }
 
   /**
@@ -1171,7 +1251,7 @@ export class LayerController extends AbstractMapViewerController {
     const classFilter = layer.getFilterFromStyle();
 
     // The data table filter if any
-    const dataFilter = getStoreTableFilter(this.getMapId(), layerPath);
+    const dataFilter = getStoreDataTableFilter(this.getMapId(), layerPath);
 
     // If the TimeSlider is initialized
     let timeFilter: string | undefined;
@@ -1254,7 +1334,7 @@ export class LayerController extends AbstractMapViewerController {
     const opacity = layerConfig.getInitialSettings()?.states?.opacity ?? 1; // default: 1
     const visibility = layerConfig.getInitialSettings()?.states?.visible ?? true; // default: true
     this.setLayerOpacity(layerPath, opacity);
-    this.setOrToggleMapLayerVisibility(layerPath, visibility);
+    this.setOrToggleLayerVisibility(layerPath, visibility);
 
     if (visibility) {
       // Return the promise that all items visibility will be renderered if layer is set to visible
@@ -1284,12 +1364,9 @@ export class LayerController extends AbstractMapViewerController {
    * @throws {LayerNotFoundError} When the layer couldn't be found at the given layer path
    * @throws {LayerWrongTypeError} When the layer was of wrong type
    */
-  async setItemVisibility(layerPath: string, item: TypeLegendItem, visible: boolean, waitForRender: boolean): Promise<void> {
-    // Get registered layer config
-    const layer = this.getGeoviewLayerRegular(layerPath);
-
-    // Set it
-    await layer.setStyleItemVisibility(item, visible, waitForRender);
+  setItemVisibility(layerPath: string, item: TypeLegendItem, visible: boolean, waitForRender: boolean): Promise<void> {
+    // Get registered layer and set visibility
+    return this.getGeoviewLayerRegular(layerPath).setStyleItemVisibility(item, visible, waitForRender);
   }
 
   /**
@@ -1304,7 +1381,7 @@ export class LayerController extends AbstractMapViewerController {
    * @returns A promise that resolves once the visibility change has been applied
    */
   toggleItemVisibility(layerPath: string, item: TypeLegendItem, waitForRender: boolean): Promise<void> {
-    // Redirect to layer API
+    // Redirect to controller
     return this.setItemVisibility(layerPath, item, !item.isVisible, waitForRender);
   }
 
@@ -1435,7 +1512,7 @@ export class LayerController extends AbstractMapViewerController {
     const highlightedLayerpath = this.changeOrRemoveLayerHighlight(layerPath, currentHighlight);
 
     // Save to the store
-    setStoreHighlightedLayer(this.getMapId(), highlightedLayerpath);
+    setStoreLayerHighlightedLayer(this.getMapId(), highlightedLayerpath);
   }
 
   /**
@@ -1494,7 +1571,7 @@ export class LayerController extends AbstractMapViewerController {
 
     // Get bounds and highlight a bounding box for the layer (if true in global settings)
     const bounds = getStoreLayerBounds(this.getMapId(), layerPath);
-    if (bounds && getStoreShowLayerHighlightLayerBbox(this.getMapId()))
+    if (bounds && getStoreAppShowLayerHighlightLayerBbox(this.getMapId()))
       this.getControllersRegistry().mapController.highlightBBox(bounds, true);
 
     return layerPath;
@@ -1686,25 +1763,21 @@ export class LayerController extends AbstractMapViewerController {
    * Sets the WMS style for a WMS layer.
    *
    * @param layerPath - The layer path
-   * @param wmsStyle - The WMS style to apply, if any
+   * @param wmsStyleName - The WMS style name to apply
+   * @throws {LayerNotFoundError} When the layer couldn't be found at the given layer path
+   * @throws {LayerWrongTypeError} When the layer is not a WMS layer
    */
   setLayerWmsStyle(layerPath: string, wmsStyleName: string | undefined): void {
     if (!wmsStyleName) return; // Skip if no style name to apply
 
+    // Get the layer
     const layer = this.getGeoviewLayer(layerPath);
-    if (!(layer instanceof GVWMS)) return;
+
+    // Check if it's the right type
+    if (!(layer instanceof GVWMS)) throw new LayerWrongTypeError(layerPath, layer.getLayerName());
 
     // Update the WMS style
     layer.setWmsStyle(wmsStyleName);
-
-    //TODO: REFACTOR - The function should stop here and an event should be raised by the domain to the controller to manage the store
-    //TO.DOCONT: Same pattern as setLayerName, setLayerOpacity, etc, etc
-
-    // Update the store
-    setStoreLayerWmsStyle(this.getMapId(), layerPath, wmsStyleName);
-
-    // Trigger legend re-query through the layer set system
-    this.getControllersRegistry().layerSetController.legendsLayerSet.queryLegend(layer, true);
   }
 
   /**
@@ -1948,8 +2021,11 @@ export class LayerController extends AbstractMapViewerController {
    * @param event - The event containing the opacity change
    */
   #handleDomainLayerVisibleChanged(sender: LayerDomain, event: DomainLayerVisibleChangedEvent): void {
-    // Redirect to the map controller
-    this.setMapLayerVisibility(event.layer.getLayerPath(), event.layerEvent.visible);
+    // Save to the store
+    setStoreLayerVisibility(this.getMapId(), event.layer.getLayerPath(), event.layerEvent.visible);
+
+    // Update the z indices
+    this.setLayerZIndices();
   }
 
   /**
@@ -1960,7 +2036,7 @@ export class LayerController extends AbstractMapViewerController {
    */
   #handleDomainLayerOpacityChanged(sender: LayerDomain, event: DomainLayerOpacityChangedEvent): void {
     // Update the store
-    setStoreOpacity(this.getMapId(), event.layer.getLayerPath(), event.layerEvent.opacity);
+    setStoreLayerOpacity(this.getMapId(), event.layer.getLayerPath(), event.layerEvent.opacity);
   }
 
   /**
@@ -2066,10 +2142,6 @@ export class LayerController extends AbstractMapViewerController {
    */
   #handleDomainLayerHoverableChanged(sender: LayerDomain, event: DomainLayerHoverableChangedEvent): void {
     // Save in store
-    // TODO: CHECK - Why 2 store locations to store the hoverable state? Centralize?
-    setStoreMapLayerHoverable(this.getMapId(), event.layer.getLayerPath(), event.layerEvent.hoverable);
-
-    // Save in store
     setStoreLayerHoverable(this.getMapId(), event.layer.getLayerPath(), event.layerEvent.hoverable);
 
     // If not hoverable
@@ -2091,10 +2163,6 @@ export class LayerController extends AbstractMapViewerController {
   #handleDomainLayerQueryableChanged(sender: LayerDomain, event: DomainLayerQueryableChangedEvent): void {
     // Save in store
     setStoreLayerQueryable(this.getMapId(), event.layer.getLayerPath(), event.layerEvent.queryable);
-
-    // Save in store
-    // TODO: CHECK - Why 2 store locations to store the queryable state? Centralize?
-    setStoreMapLayerQueryable(this.getMapId(), event.layer.getLayerPath(), event.layerEvent.queryable);
 
     // If not queryable
     if (!event.layerEvent.queryable) {
@@ -2168,7 +2236,7 @@ export class LayerController extends AbstractMapViewerController {
     // If any
     if (initialSettingsOpacity !== undefined) {
       // Update the store
-      setStoreOpacity(this.getMapId(), event.layer.getLayerPath(), initialSettingsOpacity);
+      setStoreLayerOpacity(this.getMapId(), event.layer.getLayerPath(), initialSettingsOpacity);
     }
   }
 
@@ -2260,18 +2328,60 @@ export class LayerController extends AbstractMapViewerController {
     return false;
   }
 
+  /**
+   * Handles when a layer's WMS style has changed in the domain.
+   *
+   * @param sender - The layer domain that emitted the event
+   * @param event - The WMS style changed event
+   */
+  #handleDomainLayerWMSStyleChanged(sender: LayerDomain, event: DomainLayerWMSStyleChangedEvent): void {
+    // Update the store
+    setStoreLayerWmsStyle(this.getMapId(), event.layer.getLayerPath(), event.layerEvent.wmsStyleName);
+
+    // Trigger legend re-query through the layer set system (forced refresh)
+    this.getControllersRegistry().layerSetController.legendsLayerSet.queryLegend(event.layer, true);
+  }
+
+  /**
+   * Handles when a layer's raster function has changed in the domain.
+   *
+   * @param sender - The layer domain that emitted the event
+   * @param event - The raster function changed event
+   */
+  #handleDomainLayerRasterFunctionChanged(sender: LayerDomain, event: DomainLayerRasterFunctionChangedEvent): void {
+    // Update the store
+    setStoreLayerRasterFunction(this.getMapId(), event.layer.getLayerPath(), event.layerEvent.functionId);
+
+    // Trigger legend re-query through the layer set system (forced refresh)
+    this.getControllersRegistry().layerSetController.legendsLayerSet.queryLegend(event.layer, true);
+  }
+
+  /**
+   * Handles when a layer's mosaic rule has changed in the domain.
+   *
+   * @param sender - The layer domain that emitted the event
+   * @param event - The mosaic rule changed event
+   */
+  #handleDomainLayerMosaicRuleChanged(sender: LayerDomain, event: DomainLayerMosaicRuleChangedEvent): void {
+    // Update the store
+    setStoreLayerMosaicRule(this.getMapId(), event.layer.getLayerPath(), event.layerEvent.mosaicRule);
+
+    // Trigger legend re-query through the layer set system (forced refresh)
+    this.getControllersRegistry().layerSetController.legendsLayerSet.queryLegend(event.layer, true);
+  }
+
   // #endregion DOMAIN HANDLERS
 
   // #region PRIVATE METHODS
 
   /**
-   * Registers layer information for the ordered layer info in the store.
+   * Registers layer information for the ordered layers in the store.
    *
    * @param layerConfig - The layer configuration to be reordered
    */
   #registerForOrderedLayerInfo(layerConfig: ConfigBaseClass): void {
     // If the map index for the given layer path hasn't been set yet
-    if (getStoreMapOrderedLayerIndexByPath(this.getMapId(), layerConfig.layerPath) === -1) {
+    if (getStoreLayerOrderedLayerIndexByPath(this.getMapId(), layerConfig.layerPath) === -1) {
       // Get the parent layer path
       const parentLayerPathArray = layerConfig.layerPath.split('/');
       parentLayerPathArray.pop();
@@ -2280,34 +2390,31 @@ export class LayerController extends AbstractMapViewerController {
       // Get the parent layer config, if any
       const parentLayerConfig = layerConfig.getParentLayerConfig();
 
-      // If the map index of a parent layer path has been set and it is a valid UUID, the ordered layer info is a place holder
+      // If the map index of a parent layer path has been set and it is a valid UUID, the ordered layer entry is a placeholder
       // registered while the geocore layer info was fetched
-      if (getStoreMapOrderedLayerIndexByPath(this.getMapId(), parentLayerPath) !== -1 && isValidUUID(parentLayerPath)) {
-        // Replace the placeholder ordered layer info
-        this.replaceOrderedLayerInfo(layerConfig, parentLayerPath);
+      if (getStoreLayerOrderedLayerIndexByPath(this.getMapId(), parentLayerPath) !== -1 && isValidUUID(parentLayerPath)) {
+        // Replace the placeholder ordered layer paths
+        this.replaceOrderedLayerPaths(layerConfig, parentLayerPath);
       } else if (parentLayerConfig) {
         // Here the map index of a sub layer path hasn't been set and there's a parent layer config for the current layer config
         // Get the map index of the parent layer path
-        const parentLayerIndex = getStoreMapOrderedLayerIndexByPath(this.getMapId(), parentLayerPath);
+        const parentLayerIndex = getStoreLayerOrderedLayerIndexByPath(this.getMapId(), parentLayerPath);
 
         // Get the number of layers
-        const numberOfLayers = utilFindMapLayerAndChildrenFromOrderedInfo(
-          parentLayerPath,
-          getStoreMapOrderedLayerInfo(this.getMapId())
-        ).length;
+        const numberOfLayers = utilFindLayerAndChildrenPaths(parentLayerPath, getStoreLayerOrderedLayerPaths(this.getMapId())).length;
 
         // If the map index of the parent has been set
         if (parentLayerIndex !== -1) {
-          // Add the ordered layer information for the sub layer path based on the parent index + the number of child layers
-          this.addOrderedLayerInfoByConfig(layerConfig as TypeLayerEntryConfig, parentLayerIndex + numberOfLayers);
+          // Add the ordered layer paths for the sub layer path based on the parent index + the number of child layers
+          this.addOrderedLayerPathsByConfig(layerConfig as TypeLayerEntryConfig, parentLayerIndex + numberOfLayers);
         } else {
           // If we get here, something went wrong and we have a sub layer being registered before the parent
           logger.logError(`Sub layer ${layerConfig.layerPath} registered in layer order before parent layer`);
-          this.addOrderedLayerInfoByConfig(parentLayerConfig);
+          this.addOrderedLayerPathsByConfig(parentLayerConfig);
         }
       } else {
-        // Add the orderedLayerInfo for layer that hasn't been set and has no parent layer or geocore placeholder
-        this.addOrderedLayerInfoByConfig(layerConfig as TypeLayerEntryConfig);
+        // Add the ordered layer paths for layer that hasn't been set and has no parent layer or geocore placeholder
+        this.addOrderedLayerPathsByConfig(layerConfig as TypeLayerEntryConfig);
       }
     }
   }

--- a/packages/geoview-core/src/core/controllers/layer-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-controller.ts
@@ -863,10 +863,9 @@ export class LayerController extends AbstractMapViewerController {
    * @param newValue - Optional. The new visibility value. If omitted, the visibility is toggled
    * @returns The resulting visibility state of the layer after the operation, or `false`
    * if the layer does not exist at the given path.
+   * @deprecated Seems not used anymore by codebase (2026-04-20) - remove the function?
    */
   setOrToggleLayerVisibilityIfExists(layerPath: string, newValue?: boolean): boolean {
-    // TODO: CHECK - Validate that when this function is called it wouldn't simply be better to
-    // TO.DOCONT: call the 'setOrToggleLayerVisibility' function instead and let it throw an exception?
     // If the GV layer exists at the layer path
     if (this.getGeoviewLayerIfExists(layerPath)) {
       // Redirect to set or toggle the layer visibility and return the resulting visibility
@@ -1029,7 +1028,7 @@ export class LayerController extends AbstractMapViewerController {
    *
    * @param newCollapsed - The new collapsed state of the legends
    */
-  setAllMapLayerCollapsed(newCollapsed: boolean): void {
+  setAllLayerCollapsed(newCollapsed: boolean): void {
     // Save in the store
     setStoreLayerAllMapLayerCollapsed(this.getMapId(), newCollapsed);
   }

--- a/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
@@ -16,6 +16,8 @@ import {
   type TypeGeoviewLayerConfig,
 } from '@/api/types/layer-schema-types';
 import type { TypeDisplayLanguage } from '@/api/types/map-schema-types';
+import type { GeoViewGeoChartConfig } from '@/api/config/reader/uuid-config-reader';
+import type { GroupLayerEntryConfig } from '@/api/config/validation-classes/group-layer-entry-config';
 import { EsriDynamicLayerEntryConfig } from '@/api/config/validation-classes/raster-validation-classes/esri-dynamic-layer-entry-config';
 import { CsvLayerEntryConfig } from '@/api/config/validation-classes/vector-validation-classes/csv-layer-entry-config';
 import { EsriFeatureLayerEntryConfig } from '@/api/config/validation-classes/vector-validation-classes/esri-feature-layer-entry-config';
@@ -32,6 +34,7 @@ import { OgcWmtsLayerEntryConfig } from '@/api/config/validation-classes/raster-
 import { XYZTilesLayerEntryConfig } from '@/api/config/validation-classes/raster-validation-classes/xyz-layer-entry-config';
 import { VectorTilesLayerEntryConfig } from '@/api/config/validation-classes/raster-validation-classes/vector-tiles-layer-entry-config';
 import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
 import type { DomainLayerBaseEvent, LayerDomain } from '@/core/domains/layer-domain';
 import { formatError, NotSupportedError } from '@/core/exceptions/core-exceptions';
 import { GeoViewError } from '@/core/exceptions/geoview-exceptions';
@@ -39,22 +42,14 @@ import { LayerEntryConfigError } from '@/core/exceptions/layer-entry-config-exce
 import { LayerCreatedTwiceError } from '@/core/exceptions/layer-exceptions';
 import { getStoreAppDisplayDateMode } from '@/core/stores/store-interface-and-intial-values/app-state';
 import {
+  getStoreLayerLegendLayers,
   getStoreLayerSelectedLayerPath,
   setStoreLayerSelectedLayersTabLayer,
+  getStoreLayerOrderedLayerPaths,
+  addStoreLayerInitialFilter,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
-import {
-  addStoreGeochartChart,
-  isStoreGeochartInitialized,
-  removeStoreGeochartChart,
-} from '@/core/stores/store-interface-and-intial-values/geochart-state';
-import {
-  addStoreMapInitialFilter,
-  getStoreMapOrderedLayerInfo,
-  getStoreMapOrderedLayerInfoByPath,
-  type TypeOrderedLayerInfo,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
-import { isStoreSwiperInitialized, removeStoreSwiperLayerPath } from '@/core/stores/store-interface-and-intial-values/swiper-state';
-import { deleteStoreDetailsFeatureInfo } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
+import { isStoreGeochartInitialized } from '@/core/stores/store-interface-and-intial-values/geochart-state';
+import { isStoreSwiperInitialized } from '@/core/stores/store-interface-and-intial-values/swiper-state';
 import {
   isStoreTimeSliderInitialized,
   removeStoreTimeSliderLayer,
@@ -88,7 +83,6 @@ import { ConfigValidation } from '@/api/config/config-validation';
 import { generateId, isValidUUID } from '@/core/utils/utilities';
 import { LayerGeoCoreError } from '@/core/exceptions/geocore-exceptions';
 import { GVGroupLayer } from '@/geo/layer/gv-layers/gv-group-layer';
-import type { GroupLayerEntryConfig } from '@/api/config/validation-classes/group-layer-entry-config';
 
 export class LayerCreatorController extends AbstractMapViewerController {
   /** Reference on the layer domain. */
@@ -112,10 +106,12 @@ export class LayerCreatorController extends AbstractMapViewerController {
   /**
    * Creates an instance of the LayerCreator class.
    *
+   * @param mapViewer - The map viewer instance to associate with this controller
+   * @param controllerRegistry - The controller registry for accessing sibling controllers
    * @param layerDomain - The layer domain to be used by the LayerCreator
    */
-  constructor(mapViewer: MapViewer, layerDomain: LayerDomain) {
-    super(mapViewer);
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry, layerDomain: LayerDomain) {
+    super(mapViewer, controllerRegistry);
     this.#layerDomain = layerDomain;
   }
 
@@ -134,6 +130,16 @@ export class LayerCreatorController extends AbstractMapViewerController {
       this.getControllersRegistry().layerController.getGeoviewLayerIds(),
       this.getMapViewer().getDisplayLanguage(),
       mapConfigLayerEntries,
+      (layerPath: string, geochartConfig: GeoViewGeoChartConfig) => {
+        // Add the chart to the store
+        this.getControllersRegistry().geoChartController?.addChart(layerPath, geochartConfig);
+
+        // Make sure geochart tab is shown
+        this.getControllersRegistry().uiController.showTabButton('geochart');
+
+        // Log
+        logger.logInfo('Added GeoChart configs for layer path:', layerPath);
+      },
       (mapConfigLayerEntry: MapConfigLayerEntry, error: unknown) => {
         // Show the error(s)
         this.showLayerError(error, mapConfigLayerEntry.geoviewLayerId);
@@ -141,14 +147,14 @@ export class LayerCreatorController extends AbstractMapViewerController {
     );
 
     // Wait for all promises (GeoCore ones) to process
-    // The reason for the Promise.allSettled is because of synch issues with the 'setMapOrderedLayerInfo' which happens below and the
-    // other setMapOrderedLayerInfos that happen in parallel via the ADD_LAYER events ping/pong'ing, making the setMapOrdered below fail
+    // The reason for the Promise.allSettled is because of synch issues with the 'setMapOrderedLayers' which happens below and the
+    // other setMapOrderedLayers that happen in parallel via the ADD_LAYER events ping/pong'ing, making the setMapOrdered below fail
     // if we don't stage the promises. If we don't stage the promises, sometimes I have 4 layers loaded in 'Details' and sometimes
     // I have 3 layers loaded in Details - for example.
     // To fix this, we'll have to synch the ADD_LAYER events and make sure those 'know' what order they should be in when they
-    // propagate the mapOrderedLayerInfo in their processes. For now at least, this is repeating the same behavior until the events are fixed.
-    const orderedLayerInfos: TypeOrderedLayerInfo[] = getStoreMapOrderedLayerInfo(this.getMapId()).length
-      ? getStoreMapOrderedLayerInfo(this.getMapId())
+    // propagate the mapOrderedLayers in their processes. For now at least, this is repeating the same behavior until the events are fixed.
+    const orderedLayers: string[] = getStoreLayerOrderedLayerPaths(this.getMapId()).length
+      ? [...getStoreLayerOrderedLayerPaths(this.getMapId())]
       : [];
     const promisedLayers = await Promise.allSettled(promisesOfGeoviewLayers);
 
@@ -160,10 +166,10 @@ export class LayerCreatorController extends AbstractMapViewerController {
         const geoviewLayerConfig = promise.value;
 
         try {
-          // Generate array of layer order information for non-basemap layers
+          // Generate array of layer paths for non-basemap layers
           if (geoviewLayerConfig.useAsBasemap !== true) {
-            const layerInfos = AbstractMapViewerController.generateArrayOfLayerOrderInfo(geoviewLayerConfig);
-            orderedLayerInfos.push(...layerInfos);
+            const layerPaths = AbstractMapViewerController.generateOrderedLayerPaths(geoviewLayerConfig);
+            orderedLayers.push(...layerPaths);
           }
 
           // Add it
@@ -204,8 +210,8 @@ export class LayerCreatorController extends AbstractMapViewerController {
     // Replace the array received in param
     mapConfigLayerEntries.splice(0, mapConfigLayerEntries.length, ...validGeoviewLayerConfigs);
 
-    // Init ordered layer info (?)
-    this.getControllersRegistry().layerController.setMapOrderedLayerInfoDirectly(orderedLayerInfos);
+    // Init ordered layers
+    this.getControllersRegistry().layerController.setMapOrderedLayersDirectly(orderedLayers);
   }
 
   /**
@@ -216,16 +222,6 @@ export class LayerCreatorController extends AbstractMapViewerController {
    * @returns A promise that resolves with the added layer result or undefined when an error occurs
    */
   async addGeoviewLayerByGeoCoreUUID(uuid: string, layerEntryConfig?: string): Promise<GeoViewLayerAddedResult | undefined> {
-    // Add a place holder to the ordered layer info array
-    const layerInfo: TypeOrderedLayerInfo = {
-      layerPath: uuid,
-      visible: true,
-      queryableState: true,
-      hoverable: true,
-      legendCollapsed: false,
-      inVisibleRange: true,
-    };
-
     // Get the current geoview layer ids
     const currentGeoviewLayerIds = this.getControllersRegistry().layerController.getGeoviewLayerIds();
 
@@ -237,7 +233,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
     try {
       // GV: This is here as a placeholder so that the layers will appear in the proper order,
       // GV: regardless of how quickly we get the response. It is removed, in the catch below, if the layer fails.
-      this.getControllersRegistry().layerController.addOrderedLayerInfo(layerInfo);
+      this.getControllersRegistry().layerController.addOrderedLayerPath(uuid);
 
       const parsedLayerEntryConfig = layerEntryConfig ? JSON.parse(layerEntryConfig) : undefined;
       if (parsedLayerEntryConfig && !parsedLayerEntryConfig[0].layerId) parsedLayerEntryConfig[0].layerId = 'base-group';
@@ -278,7 +274,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
         // For each geocharts configuration
         Object.entries(response.geocharts).forEach(([layerPath, geochartConfig]) => {
           // Add a GeoChart configuration on-the-fly
-          addStoreGeochartChart(this.getMapId(), layerPath, geochartConfig);
+          this.getControllersRegistry().geoChartController?.addChart(layerPath, geochartConfig);
 
           // Make sure geochart tab is shown
           this.getControllersRegistry().uiController.showTabButton('geochart');
@@ -286,8 +282,8 @@ export class LayerCreatorController extends AbstractMapViewerController {
       }
 
       if (geoviewLayerConfig.useAsBasemap === true) {
-        // If a basemap, remove the orderedLayerInfo placeholder as basemap are not part of the ordered layer info.
-        this.getControllersRegistry().layerController.removeOrderedLayerInfo(geoviewLayerConfig.geoviewLayerId, true);
+        // If a basemap, remove the ordered layer placeholder as basemap are not part of the ordered layers.
+        this.getControllersRegistry().layerController.removeOrderedLayerPath(geoviewLayerConfig.geoviewLayerId, true);
       }
 
       // Add the geoview layer
@@ -296,9 +292,8 @@ export class LayerCreatorController extends AbstractMapViewerController {
       // An error happening here likely means an issue with the UUID or a trivial config error.
       // The majority of typicaly errors happen in the addGeoviewLayer promise catcher, not here.
 
-      // Remove geoCore ordered layer info placeholder
-      const orderedInfo = getStoreMapOrderedLayerInfoByPath(this.getMapId(), uuid);
-      if (orderedInfo) this.getControllersRegistry().layerController.removeOrderedLayerInfo(uuid, false);
+      // Remove geoCore ordered layer placeholder
+      this.getControllersRegistry().layerController.removeOrderedLayerPath(uuid, false);
 
       // Show the error(s)
       this.showLayerError(error, uuid);
@@ -354,10 +349,11 @@ export class LayerCreatorController extends AbstractMapViewerController {
    */
   reloadGeocoreLayers(): void {
     const configs = this.getControllersRegistry().layerController.getLayerEntryConfigs();
-    const originalMapOrderedLayerInfo = getStoreMapOrderedLayerInfo(this.getMapId());
+    const originalOrderedLayers = [...getStoreLayerOrderedLayerPaths(this.getMapId())];
+    const originalLegendLayersInfo = getStoreLayerLegendLayers(this.getMapId());
     const parentPaths: string[] = [];
 
-    // Have to do the Promise allSettled so the new MapOrderedLayerInfo has all the children layerPaths
+    // Have to do the Promise allSettled so the new ordered layers have all the children layerPaths
     Promise.allSettled(
       configs
         .filter((config) => {
@@ -375,14 +371,12 @@ export class LayerCreatorController extends AbstractMapViewerController {
         })
     )
       .then(() => {
-        const originalLayerPaths = originalMapOrderedLayerInfo.map((info) => info.layerPath);
-
         // Prepare listeners for removing previously removed layers
         parentPaths.forEach((parentPath) => {
           function removeChildLayers(sender: LayerCreatorController): void {
             const childPaths = sender.#getAllChildPaths(parentPath);
             childPaths.forEach((childPath) => {
-              if (!originalLayerPaths.includes(childPath)) {
+              if (!originalOrderedLayers.includes(childPath)) {
                 sender.removeLayerUsingPath(childPath);
               }
             });
@@ -394,12 +388,12 @@ export class LayerCreatorController extends AbstractMapViewerController {
         });
 
         // Prepare listeners for changing the visibility
-        this.getControllersRegistry().layerController.setMapOrderedLayerInfoDirectly(originalMapOrderedLayerInfo);
-        originalMapOrderedLayerInfo.forEach((layerInfo) => {
+        this.getControllersRegistry().layerController.setMapOrderedLayersDirectly(originalOrderedLayers);
+        originalOrderedLayers.forEach((layerPath) => {
           function setLayerVisibility(sender: LayerDomain, event: DomainLayerBaseEvent): void {
-            const layerPath = event.layer.getLayerPath();
-            if (layerInfo.layerPath === layerPath) {
-              const { visible } = originalMapOrderedLayerInfo.filter((info) => info.layerPath === layerPath)[0];
+            const eventLayerPath = event.layer.getLayerPath();
+            if (layerPath === eventLayerPath) {
+              const { visible } = originalLegendLayersInfo.filter((info) => info.layerPath === eventLayerPath)[0];
               event.layer?.setVisible(visible);
               // TODO: MINOR - Bound this 'setLayerVisibility' function (like other ones) instead of creating a new handler on each 'forEach'
               sender.offLayerFirstLoaded(setLayerVisibility);
@@ -594,7 +588,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
       }
 
       // Redirect to feature info delete
-      deleteStoreDetailsFeatureInfo(this.getMapId(), layerPath);
+      this.getControllersRegistry().detailsController.deleteFeatureInfo(layerPath);
     }
   }
 
@@ -719,13 +713,13 @@ export class LayerCreatorController extends AbstractMapViewerController {
    * Unregisters the layer in the Domain to stop managing it.
    *
    * @param layerConfig - The layer entry config to unregister
-   * @param unregisterOrderedLayerInfo - Should it be unregistered from orderedLayerInfo
+   * @param unregisterOrderedLayer - Should it be unregistered from orderedLayers
    */
-  #unregisterLayerConfig(layerConfig: ConfigBaseClass, unregisterOrderedLayerInfo: boolean = true): void {
-    // Unregister from ordered layer info
-    if (unregisterOrderedLayerInfo) {
-      // Remove from ordered layer info
-      this.getControllersRegistry().layerController.removeOrderedLayerInfo(layerConfig.layerPath);
+  #unregisterLayerConfig(layerConfig: ConfigBaseClass, unregisterOrderedLayer: boolean = true): void {
+    // Unregister from ordered layers
+    if (unregisterOrderedLayer) {
+      // Remove from ordered layers
+      this.getControllersRegistry().layerController.removeOrderedLayerPath(layerConfig.layerPath);
     }
 
     // If the TimeSlider plugin is initialized
@@ -740,7 +734,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
     // If the geochart plugin is initialized
     if (isStoreGeochartInitialized(this.getMapId())) {
       // Remove from the GeoChart Charts
-      removeStoreGeochartChart(this.getMapId(), layerConfig.layerPath, () => {
+      this.getControllersRegistry().geoChartController?.removeChart(layerConfig.layerPath, () => {
         // Remove the tab
         this.getControllersRegistry().uiController.hideTabButton('geochart');
       });
@@ -749,7 +743,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
     // If the swiper plugin is initialized
     if (isStoreSwiperInitialized(this.getMapId())) {
       // Remove it from the Swiper
-      removeStoreSwiperLayerPath(this.getMapId(), layerConfig.layerPath);
+      this.getControllersRegistry().swiperController?.removeLayerPathIfExists(layerConfig.layerPath);
     }
 
     // Unregister from the domain
@@ -962,7 +956,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
       // If any layer filter
       if (layerFilter) {
         // Save to the store
-        addStoreMapInitialFilter(this.getMapId(), layerConfig.layerPath, layerFilter);
+        addStoreLayerInitialFilter(this.getMapId(), layerConfig.layerPath, layerFilter);
       }
     }
   }
@@ -984,11 +978,8 @@ export class LayerCreatorController extends AbstractMapViewerController {
           ) {
             this.#printDuplicateGeoviewLayerConfigError(geoviewLayerConfigToCreate);
 
-            // Remove geoCore ordered layer info placeholder
-            const orderedInfo = getStoreMapOrderedLayerInfoByPath(this.getMapId(), geoviewLayerConfigToCreate.geoviewLayerId);
-            if (orderedInfo) {
-              this.getControllersRegistry().layerController.removeOrderedLayerInfo(geoviewLayerConfigToCreate.geoviewLayerId, false);
-            }
+            // Remove geoCore ordered layer placeholder
+            this.getControllersRegistry().layerController.removeOrderedLayerPath(geoviewLayerConfigToCreate.geoviewLayerId, false);
 
             return false;
           }
@@ -1091,6 +1082,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
    * @param mapId - The unique identifier of the map instance this configuration applies to
    * @param language - The language setting used for layer labels and metadata
    * @param mapConfigLayerEntries - The array of layer entries to convert
+   * @param addGeoChartCallback - Callback invoked when a geochart configuration is initialized during layer processing
    * @param errorCallback - Callback invoked when an error occurs during layer processing
    * @returns An array of promises, each resolving to a TypeGeoviewLayerConfig object
    */
@@ -1099,12 +1091,13 @@ export class LayerCreatorController extends AbstractMapViewerController {
     currentLayerIds: string[],
     language: TypeDisplayLanguage,
     mapConfigLayerEntries: MapConfigLayerEntry[],
+    addGeoChartCallback: (layerPath: string, geochartConfig: GeoViewGeoChartConfig) => void,
     errorCallback: (mapConfigLayerEntry: MapConfigLayerEntry, error: unknown) => void
   ): Promise<TypeGeoviewLayerConfig>[] {
     // For each layer entry
     return mapConfigLayerEntries.map((entry) => {
       // Redirect
-      return this.convertMapConfigToGeoviewLayerConfig(mapId, currentLayerIds, language, entry, errorCallback);
+      return this.convertMapConfigToGeoviewLayerConfig(mapId, currentLayerIds, language, entry, addGeoChartCallback, errorCallback);
     });
   }
 
@@ -1118,6 +1111,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
    * @param mapId - The unique identifier of the map instance this configuration applies to
    * @param language - The language setting used for layer labels and metadata
    * @param entry - The array of layer entry to convert
+   * @param addGeoChartCallback - Callback invoked when a geochart configuration is initialized during layer processing
    * @param errorCallback - Callback invoked when an error occurs during layer processing
    * @returns A promise that resolves to a TypeGeoviewLayerConfig object
    */
@@ -1126,6 +1120,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
     currentLayerIds: string[],
     language: TypeDisplayLanguage,
     entry: MapConfigLayerEntry,
+    addGeoChartCallback: (layerPath: string, geochartConfig: GeoViewGeoChartConfig) => void,
     errorCallback: (mapConfigLayerEntry: MapConfigLayerEntry, error: unknown) => void
   ): Promise<TypeGeoviewLayerConfig> {
     // Depending on the map config layer entry type
@@ -1137,11 +1132,8 @@ export class LayerCreatorController extends AbstractMapViewerController {
         if (isStoreGeochartInitialized(mapId)) {
           // For each geocharts configuration
           Object.entries(response.geocharts).forEach(([layerPath, geochartConfig]) => {
-            // Add the chart to the store
-            addStoreGeochartChart(mapId, layerPath, geochartConfig);
-
-            // Log
-            logger.logInfo('Added GeoChart configs for layer path:', layerPath);
+            // Callback
+            addGeoChartCallback(layerPath, geochartConfig);
           });
         }
         return response.config;
@@ -1154,7 +1146,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
       promise = ShapefileReader.convertShapefileConfigToGeoJson(entry);
     } else if (mapConfigLayerEntryIsRCS(entry)) {
       // Working with a RCS (Geocore subset) layer
-      promise = GeoCore.createLayerConfigFromRCSUUID(entry.geoviewLayerId, language, mapId, entry);
+      promise = GeoCore.createLayerConfigFromRCSUUID(entry.geoviewLayerId, language, mapId);
     } else {
       // Working with a standard GeoView layer
       promise = Promise.resolve(entry);

--- a/packages/geoview-core/src/core/controllers/layer-set-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-set-controller.ts
@@ -4,10 +4,10 @@ import type { TypeFeatureInfoResult } from '@/api/types/map-schema-types';
 import { CONST_LAYER_TYPES, type TypeLayerControls, type TypeMosaicMethod } from '@/api/types/layer-schema-types';
 import type { ConfigBaseClass } from '@/api/config/validation-classes/config-base-class';
 import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
 import type { LayerDomain } from '@/core/domains/layer-domain';
 import {
   getStoreDetailsSelectedLayerPath,
-  propagateStoreFeatureInfoDetails,
   type TypeFeatureInfoResultSet,
 } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import {
@@ -15,12 +15,7 @@ import {
   getStoreUIAppBarComponents,
   getStoreUIFooterBarComponents,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
-import {
-  getStoreMapConfigGlobalSettings,
-  getStoreMapOrderedLayerIndexByPath,
-  setStoreMapClickMarkerIconHide,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
-import { setStoreSelectedLayerPath } from '@/core/stores/store-interface-and-intial-values/data-table-state';
+import { getStoreMapConfigGlobalSettings } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
 import { LayerNoLastQueryToPerformError } from '@/core/exceptions/geoview-exceptions';
 import { AllFeatureInfoLayerSet } from '@/geo/layer/layer-sets/all-feature-info-layer-set';
@@ -39,6 +34,7 @@ import { AbstractGVVector } from '@/geo/layer/gv-layers/vector/abstract-gv-vecto
 import type { TypeLegendItem, TypeLegendLayer, TypeLegendLayerItem } from '@/core/components/layers/types';
 import {
   getStoreLayerLegendLayers,
+  getStoreLayerOrderedLayerIndexByPath,
   setStoreLegendLayersDirectly,
   type TypeLegendResultSetEntry,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
@@ -82,16 +78,17 @@ export class LayerSetController extends AbstractMapViewerController {
    * Creates an instance of LayerSetController.
    *
    * @param mapViewer - The map viewer instance to associate with this controller
+   * @param controllerRegistry - The controller registry for accessing sibling controllers
    * @param layerDomain - The layer domain instance to associate with this controller
    */
-  constructor(mapViewer: MapViewer, layerDomain: LayerDomain) {
-    super(mapViewer);
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry, layerDomain: LayerDomain) {
+    super(mapViewer, controllerRegistry);
 
     // The layer sets
-    this.legendsLayerSet = new LegendsLayerSet(mapViewer, this, layerDomain);
-    this.hoverFeatureInfoLayerSet = new HoverFeatureInfoLayerSet(mapViewer, layerDomain);
-    this.allFeatureInfoLayerSet = new AllFeatureInfoLayerSet(mapViewer, layerDomain);
-    this.featureInfoLayerSet = new FeatureInfoLayerSet(mapViewer, layerDomain);
+    this.legendsLayerSet = new LegendsLayerSet(mapViewer, controllerRegistry, layerDomain);
+    this.hoverFeatureInfoLayerSet = new HoverFeatureInfoLayerSet(mapViewer, controllerRegistry, layerDomain);
+    this.allFeatureInfoLayerSet = new AllFeatureInfoLayerSet(mapViewer, controllerRegistry, layerDomain);
+    this.featureInfoLayerSet = new FeatureInfoLayerSet(mapViewer, controllerRegistry, layerDomain);
     this.allLayerSets = [this.legendsLayerSet, this.hoverFeatureInfoLayerSet, this.featureInfoLayerSet, this.allFeatureInfoLayerSet];
 
     // Keep bounded references to the handlers
@@ -158,7 +155,7 @@ export class LayerSetController extends AbstractMapViewerController {
     this.allFeatureInfoLayerSet.clearLayerFeatures(layerPath);
 
     // Update the layer data array in the store, all the time
-    setStoreSelectedLayerPath(this.getMapId(), '');
+    this.getControllersRegistry().dataTableController.setSelectedLayerPath('');
   }
 
   /**
@@ -175,13 +172,13 @@ export class LayerSetController extends AbstractMapViewerController {
 
     if (resultSet[layerPath]) {
       resultSet[layerPath].features = [];
-      propagateStoreFeatureInfoDetails(this.getMapId(), resultSet[layerPath]);
+      this.getControllersRegistry().detailsController.propagateFeatureInfo(resultSet[layerPath]);
     }
 
     // Remove highlighted features and marker if it is the selected layer path
     if (getStoreDetailsSelectedLayerPath(this.getMapId()) === layerPath) {
       this.getControllersRegistry().mapController.removeHighlightedFeature('all');
-      setStoreMapClickMarkerIconHide(this.getMapId());
+      this.getControllersRegistry().mapController.clickMarkerIconHide();
     }
   }
 
@@ -372,6 +369,9 @@ export class LayerSetController extends AbstractMapViewerController {
             entryType: 'group',
             canToggle: legendResultSetEntry.data?.type !== CONST_LAYER_TYPES.ESRI_IMAGE,
             opacity: layerConfig.getInitialSettings()?.states?.opacity ?? 1, // GV: This is call all the time, if set on OL use value, default to config or 1
+            visible: true,
+            inVisibleRange: true,
+            legendCollapsed: layerConfig.getInitialSettings()?.states?.legendCollapsed ?? false, // default: false
             icons: [] as TypeLegendLayerItem[],
             items: [] as TypeLegendItem[],
             children: [] as TypeLegendLayer[],
@@ -433,6 +433,9 @@ export class LayerSetController extends AbstractMapViewerController {
           opacityMaxFromParent: existingStoreEntry?.opacityMaxFromParent ?? 1, // Reassigning the value, because we try to not manage this property from within this function anymore
           hoverable: layerConfig.getInitialSettings()?.states?.hoverable, // default: true
           queryable: layerConfig.getInitialSettings()?.states?.queryable, // default: true
+          visible: layer?.getVisible() ?? true,
+          inVisibleRange: layer?.inVisibleRange(this.getMapViewer().getView().getZoom() ?? 0) ?? true,
+          legendCollapsed: layerConfig.getInitialSettings()?.states?.legendCollapsed ?? false, // default: false
           children: [] as TypeLegendLayer[],
           items,
           icons,
@@ -484,7 +487,8 @@ export class LayerSetController extends AbstractMapViewerController {
     // Reorder the array so legend tab is in synch
     const sortedLayers = layers.sort(
       (a, b) =>
-        getStoreMapOrderedLayerIndexByPath(this.getMapId(), a.layerPath) - getStoreMapOrderedLayerIndexByPath(this.getMapId(), b.layerPath)
+        getStoreLayerOrderedLayerIndexByPath(this.getMapId(), a.layerPath) -
+        getStoreLayerOrderedLayerIndexByPath(this.getMapId(), b.layerPath)
     );
     this.#sortLegendLayersChildren(sortedLayers);
 
@@ -556,8 +560,8 @@ export class LayerSetController extends AbstractMapViewerController {
       if (legendLayer.children.length)
         legendLayer.children.sort(
           (a, b) =>
-            getStoreMapOrderedLayerIndexByPath(this.getMapId(), a.layerPath) -
-            getStoreMapOrderedLayerIndexByPath(this.getMapId(), b.layerPath)
+            getStoreLayerOrderedLayerIndexByPath(this.getMapId(), a.layerPath) -
+            getStoreLayerOrderedLayerIndexByPath(this.getMapId(), b.layerPath)
         );
       this.#sortLegendLayersChildren(legendLayer.children);
     });

--- a/packages/geoview-core/src/core/controllers/layer-set-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-set-controller.ts
@@ -17,6 +17,7 @@ import {
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { getStoreMapConfigGlobalSettings } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { logger } from '@/core/utils/logger';
+import { whenThisThen } from '@/core/utils/utilities';
 import { LayerNoLastQueryToPerformError } from '@/core/exceptions/geoview-exceptions';
 import { AllFeatureInfoLayerSet } from '@/geo/layer/layer-sets/all-feature-info-layer-set';
 import { HoverFeatureInfoLayerSet } from '@/geo/layer/layer-sets/hover-feature-info-layer-set';
@@ -139,7 +140,14 @@ export class LayerSetController extends AbstractMapViewerController {
    * @param layerPath - The layer path to query the features from
    * @returns A promise that resolves with the feature info result
    */
-  triggerGetAllFeatureInfo(layerPath: string): Promise<TypeFeatureInfoResult> {
+  async triggerGetAllFeatureInfo(layerPath: string, waitForLayer: boolean = false): Promise<TypeFeatureInfoResult> {
+    // If the layer isn't in the domain yet, give it a chance to get registered
+    if (waitForLayer) {
+      // Wait for the layer to be available, this can happen if the trigger is called too soon (or between the layer config registration and the actual layer registration)
+      await whenThisThen(() => this.allFeatureInfoLayerSet.getRegisteredLayerPaths().includes(layerPath));
+    }
+
+    // Query the registered layer
     return this.allFeatureInfoLayerSet.queryLayer(layerPath);
   }
 

--- a/packages/geoview-core/src/core/controllers/layer-set-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-set-controller.ts
@@ -422,6 +422,9 @@ export class LayerSetController extends AbstractMapViewerController {
         // Get the schema tag
         const schemaTag = legendResultSetEntry.data?.type ?? layerConfig.getSchemaTag();
 
+        // Get the visibility flag, invisible if the layer doesn't exist yet (could be only the config exists)
+        const visible = layer?.getVisible() ?? false;
+
         const legendLayerEntry: TypeLegendLayer = {
           url: layerConfig.getMetadataAccessPath(),
           bounds: existingStoreEntry?.bounds, // Reassigning the value, because we try to not manage this property from within this function anymore
@@ -441,7 +444,7 @@ export class LayerSetController extends AbstractMapViewerController {
           opacityMaxFromParent: existingStoreEntry?.opacityMaxFromParent ?? 1, // Reassigning the value, because we try to not manage this property from within this function anymore
           hoverable: layerConfig.getInitialSettings()?.states?.hoverable, // default: true
           queryable: layerConfig.getInitialSettings()?.states?.queryable, // default: true
-          visible: layer?.getVisible() ?? true,
+          visible,
           inVisibleRange: layer?.inVisibleRange(this.getMapViewer().getView().getZoom() ?? 0) ?? true,
           legendCollapsed: layerConfig.getInitialSettings()?.states?.legendCollapsed ?? false, // default: false
           children: [] as TypeLegendLayer[],

--- a/packages/geoview-core/src/core/controllers/map-controller.ts
+++ b/packages/geoview-core/src/core/controllers/map-controller.ts
@@ -6,7 +6,7 @@ import type { OverviewMap as OLOverviewMap } from 'ol/control';
 
 import {
   MAP_EXTENTS,
-  MAX_EXTENTS_RESTRICTION,
+  VALID_PROJECTION_CODES,
   type Extent,
   type TypeAltitudeResponse,
   type TypeBasemapOptions,
@@ -34,6 +34,7 @@ import { GroupLayerEntryConfig } from '@/api/config/validation-classes/group-lay
 import type { TypeMapFeaturesConfig } from '@/core/types/global-types';
 import type { TypeLegendLayer } from '@/core/components/layers/types';
 import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
 import {
   getStoreMapClickCoordinates,
   getStoreMapConfigAppBar,
@@ -51,34 +52,34 @@ import {
   getStoreMapConfigServiceUrls,
   getStoreMapConfigViewSettings,
   getStoreMapCurrentBasemapOptions,
-  getStoreMapCurrentProjection,
-  getStoreMapCurrentProjectionEPSG,
   getStoreMapHighlightedFeatures,
   getStoreMapHighlightedFeaturesByUid,
   getStoreMapHomeView,
   getStoreMapInitialView,
   getStoreMapInteraction,
-  getStoreMapLayerPaths,
-  getStoreMapOrderedLayerInfoByPath,
   getStoreMapPointMarkers,
   getStoreMapRotation,
   isStoreMapConfigInitialized,
+  setStoreMapAttribution,
   setStoreMapClickCoordinates,
-  setStoreMapClickMarker,
+  setStoreMapClickMarkerIconHide,
   setStoreMapCurrentBasemapOptions,
+  setStoreMapFixNorth,
   setStoreMapGeolocatorSearchArea,
   setStoreMapHighlightedFeatures,
   setStoreMapPointMarkers,
   setStoreMapProjection,
   setStoreMapSize,
-  type TypeOrderedLayerInfo,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { getStoreDataTableSelectedLayerPath } from '@/core/stores/store-interface-and-intial-values/data-table-state';
 import { getStoreUIActiveAppBarTab, getStoreUIActiveFooterBarTab } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import { getStoreAppDisplayTheme, getStoreAppIsCrosshairsActive } from '@/core/stores/store-interface-and-intial-values/app-state';
 import {
   getStoreLayerHighlightedLayer,
+  getStoreLayerHoverable,
   getStoreLayerLegendLayerByPath,
+  getStoreLayerOrderedLayerPaths,
+  getStoreLayerQueryable,
   getStoreLayerSelectedLayerPath,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import {
@@ -91,7 +92,6 @@ import {
   updateStoreCoordinateInfoLayer,
   getStoreDetailsCoordinateInfoEnabled,
   setStoreDetailsCoordinateInfoEnabled,
-  deleteStoreDetailsFeatureInfo,
   LAYER_PATH_COORDINATE_INFO,
 } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import { DEFAULT_OL_FITOPTIONS, OL_ZOOM_DURATION, OL_ZOOM_PADDING, TIMEOUT } from '@/core/utils/constant';
@@ -99,7 +99,7 @@ import { DateMgt, type TimeDimension } from '@/core/utils/date-mgt';
 import { delay, doTimeout, isValidUUID } from '@/core/utils/utilities';
 import { Fetch } from '@/core/utils/fetch-helper';
 import { logger } from '@/core/utils/logger';
-import type { MapViewer } from '@/geo/map/map-viewer';
+import type { MapProjectionChangedDelegate, MapProjectionChangedEvent, MapViewer } from '@/geo/map/map-viewer';
 import { Projection } from '@/geo/utils/projection';
 import { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
 import { VectorLayerEntryConfig } from '@/api/config/validation-classes/vector-layer-entry-config';
@@ -111,7 +111,6 @@ import type { FitOptions } from 'ol/View';
 import { GeoUtilities } from '@/geo/utils/utilities';
 import { InvalidExtentError } from '@/core/exceptions/geoview-exceptions';
 import { AbstractGVVectorTile } from '@/geo/layer/gv-layers/vector/abstract-gv-vector-tile';
-import type { FeatureHighlight } from '@/geo/map/feature-highlight';
 
 /**
  * Controller responsible for Map interactions.
@@ -120,21 +119,57 @@ export class MapController extends AbstractMapViewerController {
   /** The minimal delay in ms to wait after a zoom animation to ensure it has completed. */
   static readonly ZOOM_MIN_DELAY = 500;
 
-  /** The feature highlight instance associated with this controller */
-  #featureHighlight: FeatureHighlight;
+  /** The bounded reference to the handle map projection changed method */
+  #boundedHandleMapProjectionChangeStarted: MapProjectionChangedDelegate;
+
+  /** The bounded reference to the handle map projection changed method */
+  #boundedHandleMapProjectionChanged: MapProjectionChangedDelegate;
+
+  /** Resolve callback for the pending projection change promise. */
+  #projectionChangeResolve: (() => void) | undefined;
+
+  /** Indicates if the overview map visibility state before the map projection happened */
+  #projectionChangingOverviewMapVisibility: boolean = false;
 
   /**
    * Creates an instance of MapController.
    *
    * @param mapViewer - The map viewer instance to associate with this controller
-   * @param featureHighlight - The feature highlight instance to associate with this controller
+   * @param controllerRegistry - The controller registry for accessing sibling controllers
    */
-  constructor(mapViewer: MapViewer, featureHighlight: FeatureHighlight) {
-    super(mapViewer);
-    this.#featureHighlight = featureHighlight;
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(mapViewer, controllerRegistry);
+
+    // Keep a bounded reference to the handle map projection changed method
+    this.#boundedHandleMapProjectionChangeStarted = this.#handleMapProjectionChangeStarted.bind(this);
+
+    // Keep a bounded reference to the handle map projection changed method
+    this.#boundedHandleMapProjectionChanged = this.#handleMapProjectionChanged.bind(this);
   }
 
   // #region OVERRIDES
+
+  /**
+   * Subscribes to the map projection changed event on the MapViewer.
+   */
+  protected override onHook(): void {
+    // Listens when a map projection change start occurs
+    this.getMapViewer().onMapProjectionChangeStarted(this.#boundedHandleMapProjectionChangeStarted);
+
+    // Listens when a map projection change occurs
+    this.getMapViewer().onMapProjectionChanged(this.#boundedHandleMapProjectionChanged);
+  }
+
+  /**
+   * Unsubscribes from the map projection changed event on the MapViewer.
+   */
+  protected override onUnhook(): void {
+    // Unhooks when a map projection change occurs
+    this.getMapViewer().offMapProjectionChanged(this.#boundedHandleMapProjectionChanged);
+
+    // Listens when a map projection change start occurs
+    this.getMapViewer().offMapProjectionChangeStarted(this.#boundedHandleMapProjectionChangeStarted);
+  }
 
   // #endregion OVERRIDES
 
@@ -153,7 +188,7 @@ export class MapController extends AbstractMapViewerController {
     const mergedOptions: FitOptions = { ...DEFAULT_OL_FITOPTIONS, ...options };
 
     // Validate the extent coordinates - need to make sure we aren't excluding zero with !number or using invalid extents
-    const validatedExtent = GeoUtilities.validateExtent(extent, getStoreMapCurrentProjectionEPSG(this.getMapId()));
+    const validatedExtent = GeoUtilities.validateExtent(extent, this.getMapViewer().getProjectionEPSG());
     if (
       !extent.some((number) => {
         return (!number && number !== 0) || Number.isNaN(number);
@@ -181,7 +216,7 @@ export class MapController extends AbstractMapViewerController {
     // Get the map id
     const mapId = this.getMapId();
 
-    const currProjection = getStoreMapCurrentProjection(mapId);
+    const currProjection = this.getMapViewer().getProjectionNumber();
     let extent: Extent | undefined = MAP_EXTENTS[currProjection];
     const options: FitOptions = { padding: OL_ZOOM_PADDING, duration: OL_ZOOM_DURATION };
     const homeView = getStoreMapHomeView(mapId) || getStoreMapInitialView(mapId);
@@ -236,7 +271,7 @@ export class MapController extends AbstractMapViewerController {
     const projectedCoords = Projection.transformPoints(
       [coord],
       Projection.PROJECTION_NAMES.LONLAT,
-      getStoreMapCurrentProjectionEPSG(this.getMapId())
+      this.getMapViewer().getProjectionEPSG()
     );
 
     const extent: Extent = [...projectedCoords[0], ...projectedCoords[0]];
@@ -303,15 +338,18 @@ export class MapController extends AbstractMapViewerController {
       (indicatorBox[i] as HTMLElement).style.display = 'none';
     }
 
-    const projectionConfig = Projection.PROJECTIONS[getStoreMapCurrentProjection(mapId)];
     if (bbox) {
       // GV There were issues with fromLonLat in rare cases in LCC projections, transformExtentFromProj seems to solve them.
       // GV fromLonLat and transformExtentFromProj give differing results in many cases, fromLonLat had issues with the first
       // GV three results from a geolocator search for "vancouver river"
-      const convertedExtent = Projection.transformExtentFromProj(bbox, Projection.getProjectionLonLat(), projectionConfig);
+      const convertedExtent = Projection.transformExtentFromProj(
+        bbox,
+        Projection.getProjectionLonLat(),
+        this.getMapViewer().getProjection()
+      );
 
       // Highlight
-      this.#featureHighlight.highlightGeolocatorBBox(convertedExtent);
+      this.getMapViewer().featureHighlight.highlightGeolocatorBBox(convertedExtent);
 
       // Zoom to extent and await
       await this.zoomToExtent(convertedExtent, {
@@ -329,7 +367,7 @@ export class MapController extends AbstractMapViewerController {
       const projectedCoords = Projection.transformPoints(
         [coords],
         Projection.PROJECTION_NAMES.LONLAT,
-        getStoreMapCurrentProjectionEPSG(mapId)
+        this.getMapViewer().getProjectionEPSG()
       );
 
       const extent: Extent = [...projectedCoords[0], ...projectedCoords[0]];
@@ -358,7 +396,7 @@ export class MapController extends AbstractMapViewerController {
    */
   addHighlightedFeature(feature: TypeFeatureInfoEntry): void {
     if (feature.geoviewLayerType !== CONST_LAYER_TYPES.WMS) {
-      this.#featureHighlight.highlightFeature(feature);
+      this.getMapViewer().featureHighlight.highlightFeature(feature);
 
       // Save in store
       // TODO: CHECK - What is this doing? Just refreshing the highlighted features with the same list?
@@ -374,7 +412,7 @@ export class MapController extends AbstractMapViewerController {
    */
   highlightBBox(extent: Extent, isLayerHighlight?: boolean): void {
     // Perform a highlight bbox
-    this.#featureHighlight.highlightGeolocatorBBox(extent, isLayerHighlight);
+    this.getMapViewer().featureHighlight.highlightGeolocatorBBox(extent, isLayerHighlight);
   }
 
   /**
@@ -382,7 +420,7 @@ export class MapController extends AbstractMapViewerController {
    */
   removeBBoxHighlight(): void {
     // Remove the highlight bbox
-    this.#featureHighlight.removeBBoxHighlight();
+    this.getMapViewer().featureHighlight.removeBBoxHighlight();
   }
 
   /**
@@ -397,9 +435,9 @@ export class MapController extends AbstractMapViewerController {
       // Filter what we want to keep as highlighted features
       let highlightedFeatures: TypeFeatureInfoEntry[] = [];
       if (feature === 'all') {
-        this.#featureHighlight.removeHighlight(feature);
+        this.getMapViewer().featureHighlight.removeHighlight(feature);
       } else {
-        this.#featureHighlight.removeHighlight(feature.uid!);
+        this.getMapViewer().featureHighlight.removeHighlight(feature.uid!);
 
         // Get highlighted features from the store
         // TODO: CHECK - Why are we getting the features to resave them right after? Just to trigger a store update?
@@ -436,7 +474,7 @@ export class MapController extends AbstractMapViewerController {
     // Set the group markers, and update on the map
     curMarkers[group] = groupMarkers;
     setStoreMapPointMarkers(this.getMapId(), curMarkers);
-    this.#featureHighlight.pointMarkers?.updatePointMarkers(curMarkers);
+    this.getMapViewer().featureHighlight.pointMarkers?.updatePointMarkers(curMarkers);
   }
 
   /**
@@ -466,7 +504,7 @@ export class MapController extends AbstractMapViewerController {
 
     // Set the pointMarkers and update on map
     setStoreMapPointMarkers(this.getMapId(), curMarkers);
-    this.#featureHighlight.pointMarkers?.updatePointMarkers(curMarkers);
+    this.getMapViewer().featureHighlight.pointMarkers?.updatePointMarkers(curMarkers);
   }
 
   // #endregion PUBLIC METHODS - HIGHLIGHT FEATURES
@@ -479,103 +517,44 @@ export class MapController extends AbstractMapViewerController {
    * Reprojects the view, reloads basemaps, refreshes layers, removes incompatible vector tile layers,
    * and repeats the last feature query. Shows a circular progress indicator during the transition.
    *
-   * @param projectionCode - The target projection code
+   * @param projectionNumber - The target projection code
    * @returns A promise that resolves when the projection change is complete
    */
-  async setProjection(projectionCode: TypeValidMapProjectionCodes): Promise<void> {
-    try {
-      // Set circular progress to hide basemap switching
-      this.getControllersRegistry().uiController.setCircularProgress(true);
+  setProjection(projectionNumber: TypeValidMapProjectionCodes): Promise<void> {
+    // If invalid, return
+    if (!VALID_PROJECTION_CODES.includes(Number(projectionNumber))) return Promise.resolve();
 
-      // get view status (center and projection) to calculate new center
-      const currentView = this.getMapViewer().map.getView();
-      const currentCenter = currentView.getCenter();
-      const currentProjection = currentView.getProjection().getCode();
-      const centerLatLng = Projection.transformPoints([currentCenter!], currentProjection, Projection.PROJECTION_NAMES.LONLAT)[0] as [
-        number,
-        number,
-      ];
-      const newProjection = projectionCode;
-
-      // If maxExtent was provided and in the native projection, apply
-      // GV The extent is different between LCC and WM and switching from one to the other may introduce weird constraint.
-      // GV We may have to keep extent as array for configuration file but, technically, user does not change projection often.
-      // GV A wider LCC extent like [-125, 30, -60, 89] (minus -125) will introduce distortion on larger screen...
-      // GV It is why we apply the max extent only on native projection, otherwise we apply default
-      const viewSettings = getStoreMapConfigViewSettings(this.getMapId());
-      const mapMaxExtent =
-        viewSettings && viewSettings.maxExtent && Number(newProjection) === Number(viewSettings.projection)
-          ? viewSettings?.maxExtent
-          : MAX_EXTENTS_RESTRICTION[newProjection];
-
-      // create new view settings
-      const newView: TypeViewSettings = {
-        initialView: { zoomAndCenter: [currentView.getZoom() as number, centerLatLng] },
-        minZoom: currentView.getMinZoom(),
-        maxZoom: currentView.getMaxZoom(),
-        maxExtent: mapMaxExtent,
-        projection: newProjection,
-      };
-
-      // use store action to set projection value in store and apply new view to the map
-      setStoreMapProjection(this.getMapId(), projectionCode);
-
-      // Clear the WMS layers that had an override CRS
-      this.getControllersRegistry().layerController.clearWMSLayersWithOverrideCRS();
-
-      // Clear any loaded vector features in the data table
-      this.getControllersRegistry().layerSetController.clearVectorFeaturesFromAllFeatureInfoLayerSet();
-
-      // Before changing the view, clear the basemaps right away to prevent a moment where a
-      // vector tile basemap might, momentarily, be in different projection than the view.
-      // Note: It seems that since OpenLayers 10.5 OpenLayers throws an exception about this. So this line was added.
-      this.getMapViewer().basemap.clearBasemaps();
-
-      // Set overview map visibility to false when reproject to remove it from the map as it is vector tile
-      this.setOverviewMapVisibility(false);
-
-      // Remove all vector tiles from the map, because they don't allow on-the-fly reprojection (OpenLayers 10.5 exception issue)
-      // GV Experimental code, to test further... not problematic to keep it for now
-      this.getControllersRegistry()
-        .layerController.getGeoviewLayers()
-        .filter((layer) => layer instanceof AbstractGVVectorTile)
-        .forEach((layer) => {
-          // Remove the layer through the controller
-          this.getControllersRegistry().layerCreatorController.removeLayerUsingPath(layer.getLayerPath());
-
-          // Log
-          this.getMapViewer().notifications.showWarning('warning.layer.vectorTileRemoved', [layer.getLayerName()], true);
-        });
-
-      // set new view
-      this.getMapViewer().setView(newView);
-
-      // reload the basemap from new projection
-      await this.resetBasemap();
-
-      // refresh layers so new projection is render properly
-      this.getControllersRegistry().layerController.refreshLayers();
-
-      // Remove layer highlight if present to avoid bad reprojection
-      const highlightName = getStoreLayerHighlightedLayer(this.getMapId());
-      if (highlightName !== '') {
-        this.getControllersRegistry().layerController.changeOrRemoveLayerHighlight(highlightName, highlightName);
-      }
-
-      // Reset the map object of overview map control
-      this.setOverviewMapVisibility(true);
-
-      // Repeat last query for layer features after a delay to allow projection change to propagate
-      this.getMapViewer()
-        .controllers.layerSetController.repeatLastQueryIfAny()
-        .catch((error: unknown) => {
-          // Log
-          logger.logPromiseFailed('in repeatLastQueryIfAny in mapController.setProjection', error);
-        });
-    } finally {
-      // Remove circular progress as refresh is done
-      this.getControllersRegistry().uiController.setCircularProgress(false);
+    // Get the max extent
+    // GV The extent is different between LCC and WM and switching from one to the other may introduce weird constraint.
+    // GV We may have to keep extent as array for configuration file but, technically, user does not change projection often.
+    // GV A wider LCC extent like [-125, 30, -60, 89] (minus -125) will introduce distortion on larger screen...
+    // GV It is why we apply the max extent only on native projection, otherwise we send undefined so that it applies default
+    const viewSettings = getStoreMapConfigViewSettings(this.getMapId());
+    let maxMapExtent;
+    if (
+      viewSettings &&
+      viewSettings.maxExtent &&
+      Projection.readEPSGNumber(this.getMapViewer().getProjection()) === Number(viewSettings.projection)
+    ) {
+      maxMapExtent = viewSettings.maxExtent;
     }
+
+    // Create a promise that will be resolved by the projection changed event handler
+    const promise = new Promise<void>((resolve) => {
+      this.#projectionChangeResolve = resolve;
+    });
+
+    // Set the projection on the MapViewer (fires the MapProjectionChangedEvent)
+    const changed = this.getMapViewer().setProjection(projectionNumber, maxMapExtent);
+
+    // If the projection was not changed (unsupported), resolve immediately
+    if (!changed) {
+      this.#projectionChangeResolve = undefined;
+      return Promise.resolve();
+    }
+
+    // Return the promise that the projection will happen
+    return promise;
   }
 
   /**
@@ -632,25 +611,51 @@ export class MapController extends AbstractMapViewerController {
   }
 
   /**
-   * Shows the click marker icon at the given marker position.
+   * Sets the reference to the click marker overlay element in the MapViewer.
    *
-   * Projects the marker's lon/lat coordinates to the current map projection before placing it.
+   * This allows the MapViewer to control the display and positioning of the click marker on the map.
+   *
+   * @param clickMarkerRef - The HTMLDivElement reference for the click marker overlay
+   */
+  setClickMarkerOverlayRef(clickMarkerRef: HTMLDivElement): void {
+    this.getMapViewer().getClickMarkerOverlay().setElement(clickMarkerRef);
+  }
+
+  /**
+   * Sets the reference to the north pole marker overlay element in the MapViewer.
+   *
+   * @param northPoleMarkerRef - The HTMLDivElement reference for the north pole marker overlay
+   */
+  setNorthPoleMarkerOverlayRef(northPoleMarkerRef: HTMLDivElement): void {
+    this.getMapViewer().getNorthPoleMarkerOverlay().setElement(northPoleMarkerRef);
+  }
+
+  /**
+   * Shows the click marker icon at the given marker position.
    *
    * @param marker - The click marker containing lon/lat coordinates
    */
   clickMarkerIconShow(marker: TypeClickMarker): void {
-    // Project coords
-    const projectedCoords = Projection.transformPoints(
-      [marker.lonlat],
-      Projection.PROJECTION_NAMES.LONLAT,
-      getStoreMapCurrentProjectionEPSG(this.getMapId())
-    );
+    // Redirect to the map viewer
+    this.getMapViewer().clickMarkerIconShow(marker);
+  }
 
-    // Set it on the MapViewer
-    this.getMapViewer().map.getOverlayById(`${this.getMapId()}-clickmarker`)!.setPosition(projectedCoords[0]);
+  /**
+   * Hides the click marker icon and clears the click marker from the store.
+   */
+  clickMarkerIconHide(): void {
+    // Save to the store
+    setStoreMapClickMarkerIconHide(this.getMapId());
+  }
 
-    // Save in store
-    setStoreMapClickMarker(this.getMapId(), projectedCoords[0]);
+  /**
+   * Sets the fix north state.
+   *
+   * @param fixNorth - The new fix north state
+   */
+  setFixNorth(fixNorth: boolean): void {
+    // Save to the store
+    setStoreMapFixNorth(this.getMapId(), fixNorth);
   }
 
   /**
@@ -758,7 +763,7 @@ export class MapController extends AbstractMapViewerController {
     // If toggling it off
     if (!newCoordinateInfoEnabledState) {
       // Remove coordinate info layer when disabled
-      deleteStoreDetailsFeatureInfo(this.getMapId(), LAYER_PATH_COORDINATE_INFO);
+      this.getControllersRegistry().detailsController.deleteFeatureInfo(LAYER_PATH_COORDINATE_INFO);
     }
   }
 
@@ -888,6 +893,16 @@ export class MapController extends AbstractMapViewerController {
   // #region PUBLIC METHODS - BASEMAP API
 
   /**
+   * Sets the attribution text for the map.
+   *
+   * @param attribution - An array of attribution strings to display on the map
+   */
+  setAttribution(attribution: string[]): void {
+    // Save in the store
+    setStoreMapAttribution(this.getMapId(), attribution);
+  }
+
+  /**
    * Gets the OpenLayers overview map control for the given map.
    *
    * @param div - The HTML div element to host the overview map
@@ -896,6 +911,15 @@ export class MapController extends AbstractMapViewerController {
   initOverviewMapControl(div: HTMLDivElement): OLOverviewMap {
     const olMap = this.getMapViewer().map;
     return this.getMapViewer().basemap.initOverviewMapControl(olMap, div);
+  }
+
+  /**
+   * Gets the visibility state of the overview map control.
+   *
+   * @returns True if the overview map control is visible, false otherwise
+   */
+  getOverviewMapVisibility(): boolean {
+    return this.getMapViewer().basemap.getOverviewMapControlVisibility();
   }
 
   /**
@@ -916,7 +940,7 @@ export class MapController extends AbstractMapViewerController {
   resetBasemap(): Promise<void> {
     // reset basemap will use the current display language and projection and recreate the basemap
     const language = this.getMapViewer().getDisplayLanguage();
-    const projection = getStoreMapCurrentProjection(this.getMapId());
+    const projection = this.getMapViewer().getProjectionNumber();
     return this.getMapViewer().basemap.loadDefaultBasemaps(projection, language);
   }
 
@@ -929,7 +953,7 @@ export class MapController extends AbstractMapViewerController {
   async setBasemap(basemapOptions: TypeBasemapOptions): Promise<void> {
     // Set basemap will use the current display language and projection and recreate the basemap
     const language = this.getMapViewer().getDisplayLanguage();
-    const projection = getStoreMapCurrentProjection(this.getMapId());
+    const projection = this.getMapViewer().getProjectionNumber();
 
     // Create the core basemap
     const basemap = await this.getMapViewer().basemap.createCoreBasemap(basemapOptions, projection, language);
@@ -960,7 +984,7 @@ export class MapController extends AbstractMapViewerController {
 
     if (isStoreMapConfigInitialized(mapId)) {
       // Get paths of top level layers
-      const layerOrder = getStoreMapLayerPaths(mapId).filter(
+      const layerOrder = getStoreLayerOrderedLayerPaths(mapId).filter(
         (layerPath) => !this.getControllersRegistry().layerController.getLayerEntryConfigIfExists(layerPath)?.getParentLayerConfig()
       );
 
@@ -970,7 +994,7 @@ export class MapController extends AbstractMapViewerController {
         .filter((mapLayerEntry) => !!mapLayerEntry);
 
       // Get info for view
-      const projection = getStoreMapCurrentProjection(mapId);
+      const projection = mapViewer.getProjectionNumber();
       const currentView = mapViewer.map.getView();
       const currentCenter = currentView.getCenter();
       const currentProjection = currentView.getProjection().getCode();
@@ -1160,8 +1184,97 @@ export class MapController extends AbstractMapViewerController {
   // #endregion PUBLIC METHODS - GEOMETRY API FOR DRAWING TOOLS
 
   // #region DOMAIN HANDLERS
-  // GV Eventually, these should be moved to a store adaptor or similar construct that directly connects the domain to the store without going through the controller
-  // GV.CONT but for now this allows us to keep domain-store interactions in one place and call application-level processes as needed during migration.
+
+  /**
+   * Handles the pre-projection-change cleanup before the map view applies the new projection.
+   *
+   * Shows a loading indicator, clears stale WMS override CRS layers and vector feature data,
+   * hides the overview map, removes layer highlights, and strips incompatible vector tile layers.
+   *
+   * @param mapViewer - The MapViewer instance that emitted the event
+   * @param event - The projection changed event containing the new and previous projections
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  #handleMapProjectionChangeStarted(mapViewer: MapViewer, event: MapProjectionChangedEvent): void {
+    // Show loading indicator while the projection change is being processed
+    this.getControllersRegistry().uiController.setCircularProgress(true);
+
+    // Clear the WMS layers that had an override CRS
+    this.getControllersRegistry().layerController.clearWMSLayersWithOverrideCRS();
+
+    // Clear any loaded vector features in the data table, we'll need to refetch those on the new projection
+    this.getControllersRegistry().layerSetController.clearVectorFeaturesFromAllFeatureInfoLayerSet();
+
+    // Set overview map visibility to false when reproject to remove it from the map as it is vector tile
+    this.#projectionChangingOverviewMapVisibility = this.getOverviewMapVisibility();
+    this.setOverviewMapVisibility(false);
+
+    // Remove layer highlight if present to avoid bad reprojection
+    const highlightName = getStoreLayerHighlightedLayer(this.getMapId());
+    if (highlightName !== '') {
+      this.getControllersRegistry().layerController.changeOrRemoveLayerHighlight(highlightName, highlightName);
+    }
+
+    // Remove all vector tiles from the map, because they don't allow on-the-fly reprojection (OpenLayers 10.5 exception issue)
+    // GV Experimental code, to test further... not problematic to keep it for now
+    this.getControllersRegistry()
+      .layerController.getGeoviewLayers()
+      .filter((layer) => layer instanceof AbstractGVVectorTile)
+      .forEach((layer) => {
+        // Remove the layer through the controller
+        this.getControllersRegistry().layerCreatorController.removeLayerUsingPath(layer.getLayerPath());
+
+        // Log
+        this.getMapViewer().notifications.showWarning('warning.layer.vectorTileRemoved', [layer.getLayerName()], true);
+      });
+  }
+
+  /**
+   * Handles the post-projection-change work after the map view has applied the new projection.
+   *
+   * Updates the store projection, reloads the basemap, refreshes remaining layers,
+   * restores the overview map, repeats the last feature query, and resolves the
+   * pending projection change promise.
+   *
+   * @param mapViewer - The MapViewer instance that emitted the event
+   * @param event - The projection changed event containing the new and previous projections
+   */
+  #handleMapProjectionChanged(mapViewer: MapViewer, event: MapProjectionChangedEvent): void {
+    // Save in the store
+    setStoreMapProjection(this.getMapId(), Projection.readEPSGNumber(event.projection) as TypeValidMapProjectionCodes);
+
+    // Reload the basemap from new projection
+    this.resetBasemap()
+      .then(() => {
+        // Remove circular progress as basemap is reset, rest is interesting to see
+        this.getControllersRegistry().uiController.setCircularProgress(false);
+
+        // Refresh layers so new projection is render properly
+        this.getControllersRegistry().layerController.refreshLayers();
+
+        // Reset the overview map visiblity to what it was before changing the map projection
+        this.setOverviewMapVisibility(this.#projectionChangingOverviewMapVisibility);
+
+        // Repeat last query for layer features
+        this.getControllersRegistry()
+          .layerSetController.repeatLastQueryIfAny()
+          .catch((error: unknown) => {
+            // Log
+            logger.logPromiseFailed('in repeatLastQueryIfAny in mapController.setProjection', error);
+          });
+      })
+      .catch((error: unknown) => {
+        // Log
+        logger.logPromiseFailed('in resetBasemap in mapController.handleMapProjectionChanged', error);
+      })
+      .finally(() => {
+        // Resolve the pending projection change promise
+        if (this.#projectionChangeResolve) {
+          this.#projectionChangeResolve();
+          this.#projectionChangeResolve = undefined;
+        }
+      });
+  }
 
   // #endregion DOMAIN HANDLERS
 
@@ -1191,7 +1304,6 @@ export class MapController extends AbstractMapViewerController {
     }
 
     // Get info
-    const orderedLayerInfo = getStoreMapOrderedLayerInfoByPath(mapId, layerPath)!; // Should always find one, so use a '!', otherwise let it break (was like this before)
     const legendLayerInfo = getStoreLayerLegendLayerByPath(mapId, layerPath);
 
     // Check if the layer is a geocore layers
@@ -1204,7 +1316,7 @@ export class MapController extends AbstractMapViewerController {
     }
 
     // Check for sublayers
-    const sublayerPaths = getStoreMapLayerPaths(mapId).filter(
+    const sublayerPaths = getStoreLayerOrderedLayerPaths(mapId).filter(
       // We only want the immediate child layers, group sublayers will handle their own sublayers
       (entryLayerPath) => layerEntryLayerPaths.includes(entryLayerPath)
     );
@@ -1218,7 +1330,7 @@ export class MapController extends AbstractMapViewerController {
     else listOfLayerEntryConfig.push(this.#createLayerEntryConfig(layerPath, isGeocore, overrideGeocoreServiceNames));
 
     // Get initial settings
-    const initialSettings = MapController.#getInitialSettings(layerEntryConfig, orderedLayerInfo, legendLayerInfo);
+    const initialSettings = MapController.#getInitialSettings(mapId, layerEntryConfig, legendLayerInfo!);
 
     // Construct geoview layer config
     const newGeoviewLayerConfig: MapConfigLayerEntry =
@@ -1265,7 +1377,6 @@ export class MapController extends AbstractMapViewerController {
     const mapId = this.getMapId();
 
     const layerEntryConfig = this.getControllersRegistry().layerController.getLayerEntryConfig(layerPath);
-    const orderedLayerInfo = getStoreMapOrderedLayerInfoByPath(mapId, layerPath)!; // Should always find one, so use a '!', otherwise let it break (was like this before)
     const legendLayerInfo = getStoreLayerLegendLayerByPath(mapId, layerPath);
 
     // Get original layerEntryConfig from map config
@@ -1292,7 +1403,7 @@ export class MapController extends AbstractMapViewerController {
     // Create list of sublayer entry configs if it is a group layer
     const listOfLayerEntryConfig: TypeLayerEntryConfig[] = [];
     if (layerEntryConfig.getEntryTypeIsGroup()) {
-      const sublayerPaths = getStoreMapLayerPaths(mapId).filter(
+      const sublayerPaths = getStoreLayerOrderedLayerPaths(mapId).filter(
         (entryLayerPath) =>
           entryLayerPath.startsWith(`${layerPath}/`) && entryLayerPath.split('/').length === layerPath.split('/').length + 1
       );
@@ -1302,7 +1413,7 @@ export class MapController extends AbstractMapViewerController {
     }
 
     // Get initial settings
-    const initialSettings = MapController.#getInitialSettings(layerEntryConfig, orderedLayerInfo, legendLayerInfo);
+    const initialSettings = MapController.#getInitialSettings(mapId, layerEntryConfig, legendLayerInfo!);
 
     // Clone the source object
     let source;
@@ -1422,23 +1533,19 @@ export class MapController extends AbstractMapViewerController {
   /**
    * Creates layer initial settings according to provided configs.
    *
+   * @param mapId - The map identifier
    * @param layerEntryConfig - Layer entry config for the layer
-   * @param orderedLayerInfo - Ordered layer info for the layer
    * @param legendLayerInfo - Legend layer info for the layer
    * @returns Initial settings object
    */
-  static #getInitialSettings(
-    layerEntryConfig: ConfigBaseClass,
-    orderedLayerInfo: TypeOrderedLayerInfo,
-    legendLayerInfo: TypeLegendLayer | undefined
-  ): TypeLayerInitialSettings {
+  static #getInitialSettings(mapId: string, layerEntryConfig: ConfigBaseClass, legendLayerInfo: TypeLegendLayer): TypeLayerInitialSettings {
     return {
       states: {
-        visible: orderedLayerInfo.visible,
+        visible: legendLayerInfo.visible,
         opacity: legendLayerInfo?.opacity ?? 1,
-        legendCollapsed: orderedLayerInfo.legendCollapsed,
-        queryable: orderedLayerInfo.queryableState,
-        hoverable: orderedLayerInfo.hoverable,
+        legendCollapsed: legendLayerInfo.legendCollapsed,
+        queryable: getStoreLayerQueryable(mapId, layerEntryConfig.layerPath),
+        hoverable: getStoreLayerHoverable(mapId, layerEntryConfig.layerPath),
       },
       controls: layerEntryConfig.getInitialSettings()?.controls,
       bounds: layerEntryConfig.getInitialSettingsBounds(),

--- a/packages/geoview-core/src/core/controllers/map-controller.ts
+++ b/packages/geoview-core/src/core/controllers/map-controller.ts
@@ -524,28 +524,13 @@ export class MapController extends AbstractMapViewerController {
     // If invalid, return
     if (!VALID_PROJECTION_CODES.includes(Number(projectionNumber))) return Promise.resolve();
 
-    // Get the max extent
-    // GV The extent is different between LCC and WM and switching from one to the other may introduce weird constraint.
-    // GV We may have to keep extent as array for configuration file but, technically, user does not change projection often.
-    // GV A wider LCC extent like [-125, 30, -60, 89] (minus -125) will introduce distortion on larger screen...
-    // GV It is why we apply the max extent only on native projection, otherwise we send undefined so that it applies default
-    const viewSettings = getStoreMapConfigViewSettings(this.getMapId());
-    let maxMapExtent;
-    if (
-      viewSettings &&
-      viewSettings.maxExtent &&
-      Projection.readEPSGNumber(this.getMapViewer().getProjection()) === Number(viewSettings.projection)
-    ) {
-      maxMapExtent = viewSettings.maxExtent;
-    }
-
     // Create a promise that will be resolved by the projection changed event handler
     const promise = new Promise<void>((resolve) => {
       this.#projectionChangeResolve = resolve;
     });
 
     // Set the projection on the MapViewer (fires the MapProjectionChangedEvent)
-    const changed = this.getMapViewer().setProjection(projectionNumber, maxMapExtent);
+    const changed = this.getMapViewer().setProjection(projectionNumber);
 
     // If the projection was not changed (unsupported), resolve immediately
     if (!changed) {

--- a/packages/geoview-core/src/core/controllers/plugin-controller.ts
+++ b/packages/geoview-core/src/core/controllers/plugin-controller.ts
@@ -1,6 +1,9 @@
 import type { AbstractPlugin } from '@/api/plugin/abstract-plugin';
 import type { PluginsContainer } from '@/api/plugin/plugin-types';
+import { DEFAULT_APPBAR_CORE, DEFAULT_FOOTERBAR_CORE, DEFAULT_NAVBAR_CORE } from '@/api/types/map-schema-types';
+import type { TypeValidAppBarCoreProps } from '@/api/types/map-schema-types';
 import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
 import { getScriptAndAssetURL, whenThisThen } from '@/core/utils/utilities';
 import { formatError } from '@/core/exceptions/core-exceptions';
 import type { MapViewer } from '@/geo/map/map-viewer';
@@ -18,11 +21,12 @@ export class PluginController extends AbstractMapViewerController {
    * Creates an instance of PluginController.
    *
    * @param mapViewer - The map viewer instance to associate with this controller
+   * @param controllerRegistry - The controller registry for accessing sibling controllers
    */
   // GV Leave the constructor here, because we'll likely need it soon to inject dependencies.
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-  constructor(mapViewer: MapViewer) {
-    super(mapViewer);
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(mapViewer, controllerRegistry);
   }
 
   // #region OVERRIDES
@@ -60,6 +64,43 @@ export class PluginController extends AbstractMapViewerController {
 
     // Not found
     return undefined;
+  }
+
+  /**
+   * Loads plugins referenced in the footer-bar, app-bar, and nav-bar configuration.
+   *
+   * Collects tab/component names from all three configs, filters out built-in core components,
+   * deduplicates the remaining plugin names, and loads each one.
+   *
+   * @returns A promise that resolves when all configured plugins are loaded
+   */
+  loadConfiguredPlugins(): Promise<void[]> {
+    // Get the map configuration
+    const config = this.getMapViewer().mapFeaturesConfig;
+
+    // Build sets of built-in names that are NOT plugins (they are rendered by core components)
+    const builtInAppBar = new Set<string>(Object.values(DEFAULT_APPBAR_CORE) as string[]);
+    const builtInFooterBar = new Set<string>(Object.values(DEFAULT_FOOTERBAR_CORE));
+    const builtInNavBar = new Set<string>(Object.values(DEFAULT_NAVBAR_CORE));
+
+    // Collect plugin names from footer-bar config (e.g. 'time-slider', 'geochart')
+    const footerPlugins = (config?.footerBar?.tabs?.core ?? []).filter((name: string) => !builtInFooterBar.has(name));
+
+    // Collect plugin names from app-bar config (e.g. 'about-panel', 'aoi-panel')
+    const appBarPlugins = (config?.appBar?.tabs?.core ?? []).filter((name: TypeValidAppBarCoreProps) => !builtInAppBar.has(name));
+
+    // Collect plugin names from nav-bar config (e.g. 'drawer')
+    const navBarPlugins = (config?.navBar ?? []).filter((name: string) => !builtInNavBar.has(name));
+
+    // Deduplicate across all bars and load each plugin
+    const uniquePlugins = [...new Set([...footerPlugins, ...appBarPlugins, ...navBarPlugins])];
+    const promises = uniquePlugins.map((pluginName) =>
+      this.loadAndAddPlugin(pluginName).catch((error: unknown) => {
+        logger.logError(`Failed to load configured plugin: ${pluginName}`, error);
+      })
+    );
+
+    return Promise.all(promises);
   }
 
   /**
@@ -122,7 +163,7 @@ export class PluginController extends AbstractMapViewerController {
     // in order to cancel the "'new' expression, whose target lacks a construct signature" error message
     // ? unknown type cannot be use, need to escape
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const plugin: AbstractPlugin = new (constructor as any)(pluginId, mapViewer, props);
+    const plugin: AbstractPlugin = new (constructor as any)(pluginId, mapViewer, this.getControllersRegistry(), props);
 
     // Attach to the map plugins object
     mapViewer.plugins[pluginId] = plugin;

--- a/packages/geoview-core/src/core/controllers/swiper-controller.ts
+++ b/packages/geoview-core/src/core/controllers/swiper-controller.ts
@@ -1,0 +1,95 @@
+import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
+import type { MapViewer } from '@/geo/map/map-viewer';
+import {
+  addStoreSwiperLayerPath,
+  removeAllStoreSwipers,
+  removeStoreSwiperLayerPath,
+  setStoreSwiperLayerPaths,
+  setStoreSwiperOrientation,
+  type SwipeOrientation,
+} from '@/core/stores/store-interface-and-intial-values/swiper-state';
+
+/**
+ * Controller responsible for time swiper interactions and
+ * bridging the swiper state with the UI domain.
+ */
+export class SwiperController extends AbstractMapViewerController {
+  /**
+   * Creates an instance of SwiperController.
+   *
+   * @param mapViewer - The map viewer instance to associate with this controller
+   * @param controllerRegistry - The controller registry for accessing sibling controllers
+   */
+  // GV Leave the constructor here, because we'll likely need it soon to inject dependencies.
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(mapViewer, controllerRegistry);
+  }
+
+  /**
+   * Sets the layer paths for the swiper, which determines which layers are included in the swipe comparison.
+   *
+   * @param layerPaths - The array of layer paths to set for the swiper
+   */
+  setLayerPaths(layerPaths: string[]): void {
+    // Save in the store
+    setStoreSwiperLayerPaths(this.getMapId(), layerPaths);
+  }
+
+  /**
+   * Sets the swiper orientation, which determines the direction of the swipe comparison (e.g., vertical or horizontal).
+   *
+   * @param orientation - The swipe orientation to set
+   */
+  setOrientation(orientation: SwipeOrientation): void {
+    // Save in the store
+    setStoreSwiperOrientation(this.getMapId(), orientation);
+  }
+
+  /**
+   * Adds a layer path to the swiper.
+   *
+   * @param layerPath - The layer path to add for the swiper
+   * @throws {LayerNotFoundError} When the layer couldn't be found at the given layer path
+   */
+  addLayerPath(layerPath: string): void {
+    // Check if the layer exists on the map, this call throws when it doesn't exist
+    this.getControllersRegistry().layerController.getGeoviewLayer(layerPath);
+
+    // Save in the store
+    addStoreSwiperLayerPath(this.getMapId(), layerPath);
+  }
+
+  /**
+   * Removes a layer path from the swiper.
+   *
+   * @param layerPath - The layer path to remove from the swiper
+   * @throws {LayerNotFoundError} When the layer couldn't be found at the given layer path
+   */
+  removeLayerPath(layerPath: string): void {
+    // Check if the layer exists on the map, this call throws when it doesn't exist
+    this.getControllersRegistry().layerController.getGeoviewLayer(layerPath);
+
+    // Remove from the store
+    removeStoreSwiperLayerPath(this.getMapId(), layerPath);
+  }
+
+  /**
+   * Removes a layer path from the swiper if it exists.
+   *
+   * @param layerPath - The layer path to remove from the swiper
+   */
+  removeLayerPathIfExists(layerPath: string): void {
+    // Remove from the store
+    removeStoreSwiperLayerPath(this.getMapId(), layerPath);
+  }
+
+  /**
+   * Removes all layer paths from the swiper, effectively deactivating the swiper for all layers.
+   */
+  removeAllLayerPaths(): void {
+    // Remove all layers from the store
+    removeAllStoreSwipers(this.getMapId());
+  }
+}

--- a/packages/geoview-core/src/core/controllers/time-slider-controller.ts
+++ b/packages/geoview-core/src/core/controllers/time-slider-controller.ts
@@ -1,17 +1,26 @@
 import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
 import {
   addOrUpdateStoreTimeSliderFilter,
   addStoreTimeSliderLayer,
   getStoreTimeSliderLayer,
   isStoreTimeSliderInitialized,
+  setStoreTimeSliderDelay,
+  setStoreTimeSliderDisplayDateFormat,
+  setStoreTimeSliderDisplayDateFormatShort,
+  setStoreTimeSliderDisplayDateTimezone,
   setStoreTimeSliderFiltering,
+  setStoreTimeSliderLocked,
+  setStoreTimeSliderReversed,
+  setStoreTimeSliderSelectedLayerPath,
+  setStoreTimeSliderStep,
   setStoreTimeSliderValues,
   type TypeTimeSliderProps,
   type TypeTimeSliderValues,
 } from '@/core/stores/store-interface-and-intial-values/time-slider-state';
 import type { MapViewer } from '@/geo/map/map-viewer';
 import type { AbstractGVLayer } from '@/geo/layer/gv-layers/abstract-gv-layer';
-import { DateMgt, type TimeDimension } from '@/core/utils/date-mgt';
+import { DateMgt, type TimeDimension, type TypeDisplayDateFormat } from '@/core/utils/date-mgt';
 import type { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
 import { GVWMS } from '@/geo/layer/gv-layers/raster/gv-wms';
 import { GVEsriImage } from '@/geo/layer/gv-layers/raster/gv-esri-image';
@@ -25,11 +34,12 @@ export class TimeSliderController extends AbstractMapViewerController {
    * Creates an instance of TimeSliderController.
    *
    * @param mapViewer - The map viewer instance to associate with this controller
+   * @param controllerRegistry - The controller registry for accessing sibling controllers
    */
   // GV Leave the constructor here, because we'll likely need it soon to inject dependencies.
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-  constructor(mapViewer: MapViewer) {
-    super(mapViewer);
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(mapViewer, controllerRegistry);
   }
 
   // #region OVERRIDES
@@ -37,6 +47,16 @@ export class TimeSliderController extends AbstractMapViewerController {
   // #endregion OVERRIDES
 
   // #region PUBLIC METHODS
+
+  /**
+   * Sets the selected layer path in the time-slider panel.
+   *
+   * @param layerPath - The layer path to select
+   */
+  setSelectedLayerPathTimeSlider(layerPath: string): void {
+    // Save in the store
+    setStoreTimeSliderSelectedLayerPath(this.getMapId(), layerPath);
+  }
 
   /**
    * Checks if the layer has time slider values. If there are, adds the time slider layer and applies filters.
@@ -104,6 +124,84 @@ export class TimeSliderController extends AbstractMapViewerController {
 
     // Update the filters on the layer in question and potential additional ones
     this.#updateAndApplyTimeFiltersForAll(layer, timeSliderValues, filtering, timeSliderValues.values);
+  }
+
+  /**
+   * Sets the step value for a layer path in the time-slider panel.
+   *
+   * @param layerPath - The layer path
+   * @param step - The step value
+   */
+  setStep(layerPath: string, step: number): void {
+    // Save in the store
+    setStoreTimeSliderStep(this.getMapId(), layerPath, step);
+  }
+
+  /**
+   * Sets the delay value for a layer path in the time-slider panel.
+   *
+   * @param layerPath - The layer path
+   * @param delay - The delay value
+   */
+  setDelay(layerPath: string, delay: number): void {
+    // Save in the store
+    setStoreTimeSliderDelay(this.getMapId(), layerPath, delay);
+  }
+
+  /**
+   * Sets the locked state for a layer path in the time-slider panel.
+   *
+   * @param layerPath - The layer path
+   * @param locked - The locked state
+   */
+  setLocked(layerPath: string, locked: boolean): void {
+    // Save in the store
+    setStoreTimeSliderLocked(this.getMapId(), layerPath, locked);
+  }
+
+  /**
+   * Sets the reversed state for a layer path in the time-slider panel.
+   *
+   * @param layerPath - The layer path
+   * @param reversed - The reversed state
+   */
+
+  setReversed(layerPath: string, reversed: boolean): void {
+    // Save in the store
+    setStoreTimeSliderReversed(this.getMapId(), layerPath, reversed);
+  }
+
+  /**
+   * Sets the display date format for a layer path in the time-slider panel.
+   *
+   * @param layerPath - The layer path
+   * @param displayDateFormat - The display date format
+   */
+  setDisplayDateFormat(layerPath: string, displayDateFormat: TypeDisplayDateFormat): void {
+    // Save in the store
+    setStoreTimeSliderDisplayDateFormat(this.getMapId(), layerPath, displayDateFormat);
+  }
+
+  /**
+   * Sets the short display date format for a layer path in the time-slider panel.
+   *
+   * @param layerPath - The layer path
+   * @param displayDateFormat - The short display date format
+   */
+  setDisplayDateFormatShort(layerPath: string, displayDateFormat: TypeDisplayDateFormat): void {
+    // Save in the store
+    setStoreTimeSliderDisplayDateFormatShort(this.getMapId(), layerPath, displayDateFormat);
+  }
+
+  /**
+   * Sets the display date timezone for a layer path in the time-slider panel.
+   *
+   * @param layerPath - The layer path
+   * @param displayDateTimezone - The display date timezone
+   */
+  setDisplayDateTimezone(layerPath: string, displayDateTimezone: string): void {
+    // Save in the store
+    setStoreTimeSliderDisplayDateTimezone(this.getMapId(), layerPath, displayDateTimezone);
   }
 
   // #endregion PUBLIC METHODS

--- a/packages/geoview-core/src/core/controllers/ui-controller.ts
+++ b/packages/geoview-core/src/core/controllers/ui-controller.ts
@@ -1,29 +1,36 @@
 import type { TypeDisplayLanguage, TypeDisplayTheme } from '@/api/types/map-schema-types';
 import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
 import {
-  disableStoreFocusTrap,
-  enableStoreFocusTrap,
-  hideStoreTabButton,
-  setStoreActiveAppBarTab,
-  setStoreActiveFooterBarTab,
-  setStoreActiveTrapGeoView,
-  setStoreFooterBarIsOpen,
-  setStoreFooterPanelResizeValue,
-  showStoreTabButton,
+  addStoreUIAppBarPanelId,
+  addStoreUIFooterTab,
+  bumpStoreUINavBarButtonPanelVersion,
+  disableStoreUIFocusTrap,
+  enableStoreUIFocusTrap,
+  hideStoreUITabButton,
+  removeStoreUIAppBarPanelId,
+  removeStoreUIFooterTab,
+  setStoreUIActiveAppBarTab,
+  setStoreUIActiveFooterBarTab,
+  setStoreUIActiveTrapGeoView,
+  setStoreUIFooterBarIsOpen,
+  setStoreUIFooterPanelResizeValue,
+  showStoreUITabButton,
   type FocusItemProps,
+  type TypeFooterTabEntry,
 } from '@/core/stores/store-interface-and-intial-values/ui-state';
 import {
-  addStoreNotification,
+  addStoreAppNotification,
   getStoreAppGeoviewAssetsURL,
-  removeStoreAllNotifications,
-  removeStoreNotification,
-  setStoreCircularProgress,
-  setStoreCrosshairActive,
-  setStoreDisplayDateTimezone,
-  setStoreDisplayLanguage,
-  setStoreDisplayTheme,
-  setStoreFullScreenActive,
-  setStoreGuide,
+  removeStoreAppAllNotifications,
+  removeStoreAppNotification,
+  setStoreAppCircularProgress,
+  setStoreAppCrosshairActive,
+  setStoreAppDisplayDateTimezone,
+  setStoreAppDisplayLanguage,
+  setStoreAppDisplayTheme,
+  setStoreAppFullScreenActive,
+  setStoreAppGuide,
 } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { DateMgt, type TimeIANA } from '@/core/utils/date-mgt';
 import type { TypeHTMLElement } from '@/core/types/global-types';
@@ -53,10 +60,11 @@ export class UIController extends AbstractMapViewerController {
    * Creates an instance of UIController.
    *
    * @param mapViewer - The map viewer instance
+   * @param controllerRegistry - The controller registry for accessing sibling controllers
    * @param uiDomain - The UI domain instance
    */
-  constructor(mapViewer: MapViewer, uiDomain: UIDomain) {
-    super(mapViewer);
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry, uiDomain: UIDomain) {
+    super(mapViewer, controllerRegistry);
 
     // Keep the domain internally
     this.#uiDomain = uiDomain;
@@ -93,6 +101,7 @@ export class UIController extends AbstractMapViewerController {
    * @returns The current display language
    */
   getDisplayLanguage(): TypeDisplayLanguage {
+    // Get the language from the domain
     return this.#uiDomain.getLanguage();
   }
 
@@ -102,8 +111,8 @@ export class UIController extends AbstractMapViewerController {
    * @param tab - The tab identifier to show
    */
   showTabButton(tab: string): void {
-    // Save in store
-    showStoreTabButton(this.getMapId(), tab);
+    // Save in the store
+    showStoreUITabButton(this.getMapId(), tab);
   }
 
   /**
@@ -112,8 +121,28 @@ export class UIController extends AbstractMapViewerController {
    * @param tab - The tab identifier to hide
    */
   hideTabButton(tab: string): void {
-    // Save in store
-    hideStoreTabButton(this.getMapId(), tab);
+    // Save in the store
+    hideStoreUITabButton(this.getMapId(), tab);
+  }
+
+  /**
+   * Adds a tab to the footer bar with the given properties.
+   *
+   * @param tab - The properties of the tab to add
+   */
+  addFooterTab(tab: TypeFooterTabEntry): void {
+    // Save in the store
+    addStoreUIFooterTab(this.getMapId(), tab);
+  }
+
+  /**
+   * Removes a tab from the footer bar by its identifier.
+   *
+   * @param id - The identifier of the tab to remove
+   */
+  removeFooterTab(id: string): void {
+    // Save in the store
+    removeStoreUIFooterTab(this.getMapId(), id);
   }
 
   /**
@@ -122,8 +151,28 @@ export class UIController extends AbstractMapViewerController {
    * @param tab - The tab identifier to activate, or undefined to deactivate
    */
   setActiveFooterBarTab(tab: string | undefined): void {
-    // Save in store
-    setStoreActiveFooterBarTab(this.getMapId(), tab);
+    // Save in the store
+    setStoreUIActiveFooterBarTab(this.getMapId(), tab);
+  }
+
+  /**
+   * Adds an app-bar panel id to the store, which will make the app-bar show the corresponding panel.
+   *
+   * @param id - The id of the panel to be added and shown in the app-bar
+   */
+  addAppBarPanelId(id: string): void {
+    // Save in the store
+    addStoreUIAppBarPanelId(this.getMapId(), id);
+  }
+
+  /**
+   * Removes an app-bar panel id from the store, which will make the app-bar hide the corresponding panel.
+   *
+   * @param id - The id of the panel to be removed and hidden in the app-bar
+   */
+  removeAppBarPanelId(id: string): void {
+    // Save in the store
+    removeStoreUIAppBarPanelId(this.getMapId(), id);
   }
 
   /**
@@ -134,8 +183,8 @@ export class UIController extends AbstractMapViewerController {
    * @param isFocusTrapped - Whether focus should be trapped in the panel
    */
   setActiveAppBarTab(tab: string | undefined, isOpen: boolean, isFocusTrapped: boolean): void {
-    // Save in store
-    setStoreActiveAppBarTab(this.getMapId(), tab, isOpen, isFocusTrapped);
+    // Save in the store
+    setStoreUIActiveAppBarTab(this.getMapId(), tab, isOpen, isFocusTrapped);
   }
 
   /**
@@ -145,7 +194,19 @@ export class UIController extends AbstractMapViewerController {
    */
   setFooterBarIsOpen(isOpen: boolean): void {
     // Save in store
-    setStoreFooterBarIsOpen(this.getMapId(), isOpen);
+    setStoreUIFooterBarIsOpen(this.getMapId(), isOpen);
+  }
+
+  /**
+   * Bumps the nav-bar button panel version to trigger a re-render in the nav-bar component when button panels are
+   * added or removed without necessarily adding or removing a panel id (ex: when all buttons are removed from a panel
+   * but the panel itself is not removed from the store to avoid losing its state).
+   * This is a workaround and eventually the store structure should be refactored to better accommodate button panel
+   * state and avoid this type of workaround.
+   */
+  bumpNavBarButtonPanelVersion(): void {
+    // Save in the store
+    bumpStoreUINavBarButtonPanelVersion(this.getMapId());
   }
 
   /**
@@ -155,7 +216,7 @@ export class UIController extends AbstractMapViewerController {
    */
   enableFocusTrap(uiFocus: FocusItemProps): void {
     // Save in store
-    enableStoreFocusTrap(this.getMapId(), uiFocus);
+    enableStoreUIFocusTrap(this.getMapId(), uiFocus);
   }
 
   /**
@@ -165,7 +226,7 @@ export class UIController extends AbstractMapViewerController {
    */
   disableFocusTrap(callbackElementId?: string): void {
     // Save in store
-    disableStoreFocusTrap(this.getMapId(), callbackElementId);
+    disableStoreUIFocusTrap(this.getMapId(), callbackElementId);
   }
 
   /**
@@ -175,7 +236,7 @@ export class UIController extends AbstractMapViewerController {
    */
   setActiveTrapGeoView(active: boolean): void {
     // Save in store
-    setStoreActiveTrapGeoView(this.getMapId(), active);
+    setStoreUIActiveTrapGeoView(this.getMapId(), active);
   }
 
   /**
@@ -185,7 +246,7 @@ export class UIController extends AbstractMapViewerController {
    */
   setFooterPanelResizeValue(value: number): void {
     // Save in store
-    setStoreFooterPanelResizeValue(this.getMapId(), value);
+    setStoreUIFooterPanelResizeValue(this.getMapId(), value);
   }
 
   /**
@@ -195,7 +256,7 @@ export class UIController extends AbstractMapViewerController {
    */
   setCircularProgress(active: boolean): void {
     // Save in store
-    setStoreCircularProgress(this.getMapId(), active);
+    setStoreAppCircularProgress(this.getMapId(), active);
   }
 
   /**
@@ -223,7 +284,7 @@ export class UIController extends AbstractMapViewerController {
       const promiseSetGuide = this.createGuide();
 
       // Remove all previous notifications to ensure there is no mix en and fr
-      removeStoreAllNotifications(mapId);
+      removeStoreAppAllNotifications(mapId);
 
       // When all promises are done
       Promise.all([promiseChangeLanguage, promiseResetBasemap, promiseSetGuide])
@@ -245,7 +306,7 @@ export class UIController extends AbstractMapViewerController {
    */
   setDisplayTheme(theme: TypeDisplayTheme): void {
     // Save in store
-    setStoreDisplayTheme(this.getMapId(), theme);
+    setStoreAppDisplayTheme(this.getMapId(), theme);
   }
 
   /**
@@ -258,7 +319,7 @@ export class UIController extends AbstractMapViewerController {
     DateMgt.validateTimezone(displayDateTimezone);
 
     // Save in store
-    setStoreDisplayDateTimezone(this.getMapId(), displayDateTimezone);
+    setStoreAppDisplayDateTimezone(this.getMapId(), displayDateTimezone);
   }
 
   /**
@@ -268,7 +329,7 @@ export class UIController extends AbstractMapViewerController {
    */
   setCrosshairActive(active: boolean): void {
     // Save in store
-    setStoreCrosshairActive(this.getMapId(), active);
+    setStoreAppCrosshairActive(this.getMapId(), active);
 
     // Because the map is focused/blured, we need to enable/disable the map interaction for WCAG
     this.setActiveMapInteractionWCAG(active);
@@ -346,7 +407,7 @@ export class UIController extends AbstractMapViewerController {
     }
 
     // Save in store
-    setStoreFullScreenActive(this.getMapId(), status);
+    setStoreAppFullScreenActive(this.getMapId(), status);
   }
 
   /**
@@ -383,7 +444,7 @@ export class UIController extends AbstractMapViewerController {
    */
   addNotification(notification: NotificationDetailsType): void {
     // Save in store
-    addStoreNotification(this.getMapId(), notification).catch((error: unknown) => {
+    addStoreAppNotification(this.getMapId(), notification).catch((error: unknown) => {
       // Log
       logger.logPromiseFailed('uiController.addNotification in uiController', error);
     });
@@ -396,7 +457,7 @@ export class UIController extends AbstractMapViewerController {
    */
   removeNotification(key: string): void {
     // Save in store
-    removeStoreNotification(this.getMapId(), key).catch((error: unknown) => {
+    removeStoreAppNotification(this.getMapId(), key).catch((error: unknown) => {
       // Log
       logger.logPromiseFailed('uiController.removeNotification in uiController', error);
     });
@@ -405,7 +466,7 @@ export class UIController extends AbstractMapViewerController {
   /** Removes all notifications from the notification center. */
   removeAllNotifications(): void {
     // Save in store
-    removeStoreAllNotifications(this.getMapId());
+    removeStoreAppAllNotifications(this.getMapId());
   }
 
   /**
@@ -425,7 +486,7 @@ export class UIController extends AbstractMapViewerController {
       const guide = await createGuideObject(language, getStoreAppGeoviewAssetsURL(mapId));
 
       // Save in store
-      setStoreGuide(mapId, guide);
+      setStoreAppGuide(mapId, guide);
 
       // Check guide loading tracker
       logger.logMarkerCheck('map-guide', 'for guide to be loaded');
@@ -448,7 +509,7 @@ export class UIController extends AbstractMapViewerController {
    * @param event - The language changed event containing the new language
    */
   #handleDisplayLanguageChanged(sender: UIDomain, event: DomainLanguageChangedEvent): void {
-    setStoreDisplayLanguage(this.getMapId(), event.language);
+    setStoreAppDisplayLanguage(this.getMapId(), event.language);
   }
 
   // #endregion DOMAIN HANDLERS

--- a/packages/geoview-core/src/core/controllers/use-controllers.ts
+++ b/packages/geoview-core/src/core/controllers/use-controllers.ts
@@ -8,9 +8,11 @@ import type { LayerCreatorController } from '@/core/controllers/layer-creator-co
 import type { LayerSetController } from '@/core/controllers/layer-set-controller';
 import type { UIController } from '@/core/controllers/ui-controller';
 import type { DataTableController } from '@/core/controllers/data-table-controller';
+import type { DetailsController } from '@/core/controllers/details-controller';
 import type { DrawerController } from '@/core/controllers/drawer-controller';
 import type { PluginController } from '@/core/controllers/plugin-controller';
 import type { TimeSliderController } from '@/core/controllers/time-slider-controller';
+import type { GeoChartController } from '@/core/controllers/geochart-controller';
 import { useControllers } from '@/core/controllers/base/controller-manager';
 
 /**
@@ -74,6 +76,16 @@ export function useUIController(): UIController {
 }
 
 /**
+ * Hook to access the DetailsController from the controller context.
+ *
+ * @returns The details controller instance
+ * @throws {Error} When used outside of a ControllerContext.Provider
+ */
+export function useDetailsController(): DetailsController {
+  return useControllers().detailsController;
+}
+
+/**
  * Hook to access the DataTableController from the controller context.
  *
  * @returns The data table controller instance
@@ -107,4 +119,45 @@ export function useTimeSliderController(): TimeSliderController {
   const controller = useControllers().timeSliderController;
   if (!controller) throw new Error('useTimeSliderController must be used with an initialized time slider plugin state');
   return controller;
+}
+
+/**
+ * Hook to optionally access the TimeSliderController from the controller context.
+ *
+ * Unlike `useTimeSliderController`, this hook does not throw when the TimeSlider
+ * plugin is not configured. Use this in shared components that may or may not
+ * have the time slider plugin active.
+ *
+ * @returns The time slider controller instance, or undefined if the plugin is not configured
+ * @throws {Error} When used outside of a ControllerContext.Provider
+ */
+export function useTimeSliderControllerIfExists(): TimeSliderController | undefined {
+  return useControllers().timeSliderController;
+}
+
+/**
+ * Hook to access the GeoChartController from the controller context.
+ *
+ * @returns The geo chart controller instance
+ * @throws {Error} When used outside of a ControllerContext.Provider
+ * @throws {Error} When the GeoChart plugin is not configured
+ */
+export function useGeoChartController(): GeoChartController {
+  const controller = useControllers().geoChartController;
+  if (!controller) throw new Error('useGeoChartController must be used with an initialized geo chart plugin state');
+  return controller;
+}
+
+/**
+ * Hook to optionally access the GeoChartController from the controller context.
+ *
+ * Unlike `useGeoChartController`, this hook does not throw when the GeoChart
+ * plugin is not configured. Use this in shared components that may or may not
+ * have the geo chart plugin active.
+ *
+ * @returns The geo chart controller instance, or undefined if the plugin is not configured
+ * @throws {Error} When used outside of a ControllerContext.Provider
+ */
+export function useGeoChartControllerIfExists(): GeoChartController | undefined {
+  return useControllers().geoChartController;
 }

--- a/packages/geoview-core/src/core/domains/layer-domain.ts
+++ b/packages/geoview-core/src/core/domains/layer-domain.ts
@@ -43,7 +43,20 @@ import type {
   LayerQueryableChangedEvent,
 } from '@/geo/layer/gv-layers/abstract-gv-layer';
 import { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
-import { GVWMS, type ImageLoadRescueDelegate, type ImageLoadRescueEvent } from '@/geo/layer/gv-layers/raster/gv-wms';
+import {
+  GVWMS,
+  type ImageLoadRescueDelegate,
+  type ImageLoadRescueEvent,
+  type WMSStyleChangedDelegate,
+  type WMSStyleChangedEvent,
+} from '@/geo/layer/gv-layers/raster/gv-wms';
+import {
+  GVEsriImage,
+  type RasterFunctionChangedEvent,
+  type RasterFunctionChangedDelegate,
+  type MosaicRuleChangedEvent,
+  type MosaicRuleChangedDelegate,
+} from '@/geo/layer/gv-layers/raster/gv-esri-image';
 import { GeoUtilities } from '@/geo/utils/utilities';
 
 /**
@@ -109,65 +122,83 @@ export class LayerDomain {
   /** Keep a bounded reference to the handle WMS Layer Image Load Callbacks */
   #boundedHandleLayerWMSImageLoadRescue: ImageLoadRescueDelegate;
 
-  /** Keep all callback delegate references */
+  /** Keep a bounded reference to the handle WMS style changed */
+  #boundedHandleLayerWMSStyleChanged: WMSStyleChangedDelegate;
+
+  /** Keep a bounded reference to the handle layer raster function changed */
+  #boundedHandleLayerRasterFunctionChanged: RasterFunctionChangedDelegate;
+
+  /** Keep a bounded reference to the handle layer mosaic rule changed */
+  #boundedHandleLayerMosaicRuleChanged: MosaicRuleChangedDelegate;
+
+  /** Callback delegates for the layer entry config registered event. */
   #onLayerEntryConfigRegisteredHandlers: DomainLayerStatusChangedDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer entry config unregistered event. */
   #onLayerEntryConfigUnregisteredHandlers: DomainLayerStatusChangedDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer status changed event. */
   #onLayerStatusChangedHandlers: DomainLayerStatusChangedDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer registered event. */
   #onLayerRegisteredHandlers: DomainLayerRegisteredDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer unregistered event. */
   #onLayerUnregisteredHandlers: DomainLayerRegisteredDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the all layers loaded event. */
   #onLayerAllLoadedHandlers: DomainLayerStatusChangedDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer name changed event. */
   #onLayerNameChangedHandlers: DomainLayerNameChangedDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer visible changed event. */
   #onLayerVisibleChangedHandlers: DomainLayerVisibleChangedDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer opacity changed event. */
   #onLayerOpacityChangedHandlers: DomainLayerOpacityChangedDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer loading event. */
   #onLayerLoadingHandlers: DomainLayerBaseDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer first loaded event. */
   #onLayerFirstLoadedHandlers: DomainLayerBaseDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer loaded event. */
   #onLayerLoadedHandlers: DomainLayerBaseDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer error event. */
   #onLayerErrorHandlers: DomainLayerErrorDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer message event. */
   #onLayerMessageHandlers: DomainLayerMessageDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer hoverable changed event. */
   #onLayerHoverableChangedHandlers: DomainLayerHoverableChangedDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer queryable changed event. */
   #onLayerQueryableChangedHandlers: DomainLayerQueryableChangedDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the layer item visibility changed event. */
   #onLayerItemVisibilityChangedHandlers: DomainLayerItemVisibilityChangedDelegate[] = [];
 
-  /** Keep all callback delegate references */
-  #onLayerWMSImageLoadRescueHandlers: DomainLayerWMSImageLoadRescueDelegate[] = [];
-
-  /** Keep all callback delegate references */
+  /** Callback delegates for the group layer added event. */
   #onLayerGroupLayerAddedHandlers: DomainLayerGroupChildrenUpdatedDelegate[] = [];
 
-  /** Keep all callback delegate references */
+  /** Callback delegates for the group layer removed event. */
   #onLayerGroupLayerRemovedHandlers: DomainLayerGroupChildrenUpdatedDelegate[] = [];
+
+  /** Callback delegates for the WMS image load rescue event. */
+  #onLayerWMSImageLoadRescueHandlers: DomainLayerWMSImageLoadRescueDelegate[] = [];
+
+  /** Callback delegates for the WMS style changed event. */
+  #onLayerWMSStyleChangedHandlers: DomainLayerWMSStyleChangedDelegate[] = [];
+
+  /** Callback delegates for the layer raster function changed event. */
+  #onLayerRasterFunctionChangedHandlers: DomainLayerRasterFunctionChangedDelegate[] = [];
+
+  /** Callback delegates for the layer mosaic rule changed event. */
+  #onLayerMosaicRuleChangedHandlers: DomainLayerMosaicRuleChangedDelegate[] = [];
 
   /**
    * Constructor for the LayerDomain class.
@@ -189,6 +220,9 @@ export class LayerDomain {
     this.#boundedHandleLayerGroupLayerAdded = this.#handleLayerGroupLayerAdded.bind(this);
     this.#boundedHandleLayerGroupLayerRemoved = this.#handleLayerGroupLayerRemoved.bind(this);
     this.#boundedHandleLayerWMSImageLoadRescue = this.#handleLayerWMSImageLoadRescue.bind(this);
+    this.#boundedHandleLayerWMSStyleChanged = this.#handleLayerWmsStyleChanged.bind(this);
+    this.#boundedHandleLayerRasterFunctionChanged = this.#handleLayerRasterFunctionChanged.bind(this);
+    this.#boundedHandleLayerMosaicRuleChanged = this.#handleLayerMosaicRuleChanged.bind(this);
   }
 
   // #region PUBLIC LAYER GETTERS
@@ -529,6 +563,15 @@ export class LayerDomain {
       // For a WMS, register a hook when the image fails to load so that we can try to rescue it
       if (gvLayer instanceof GVWMS) gvLayer.onImageLoadRescue(this.#boundedHandleLayerWMSImageLoadRescue);
 
+      // For a WMS, register a hook when the WMS style is changed so that we can update the layer accordingly
+      if (gvLayer instanceof GVWMS) gvLayer.onWmsStyleChanged(this.#boundedHandleLayerWMSStyleChanged);
+
+      // For an Esri Image, register a hook when the raster function is changed so that we can update the layer accordingly
+      if (gvLayer instanceof GVEsriImage) gvLayer.onRasterFunctionChanged(this.#boundedHandleLayerRasterFunctionChanged);
+
+      // For an Esri Image, register a hook when the mosaic rule is changed so that we can update the layer accordingly
+      if (gvLayer instanceof GVEsriImage) gvLayer.onMosaicRuleChanged(this.#boundedHandleLayerMosaicRuleChanged);
+
       // Initialize it, attaching OpenLayers event on it
       gvLayer.init();
     } else if (gvLayer instanceof GVGroupLayer) {
@@ -560,6 +603,15 @@ export class LayerDomain {
 
     // If deleting a regular layer
     if (gvLayer instanceof AbstractGVLayer) {
+      // For an Esri Image, unregister the hook when the mosaic rule is changed
+      if (gvLayer instanceof GVEsriImage) gvLayer.offMosaicRuleChanged(this.#boundedHandleLayerMosaicRuleChanged);
+
+      // For an Esri Image, unregister the hook when the raster function is changed
+      if (gvLayer instanceof GVEsriImage) gvLayer.offRasterFunctionChanged(this.#boundedHandleLayerRasterFunctionChanged);
+
+      // For a WMS, unregister the hook when the WMS style is changed
+      if (gvLayer instanceof GVWMS) gvLayer.offWmsStyleChanged(this.#boundedHandleLayerWMSStyleChanged);
+
       // For a WMS, unregister the hook when the image fails to load
       if (gvLayer instanceof GVWMS) gvLayer.offImageLoadRescue(this.#boundedHandleLayerWMSImageLoadRescue);
 
@@ -892,6 +944,45 @@ export class LayerDomain {
   #handleLayerWMSImageLoadRescue(layer: GVWMS, event: ImageLoadRescueEvent): boolean {
     // Emit about it
     return this.#emitLayerWMSImageLoadRescue({ layer, layerEvent: event })?.[0];
+  }
+
+  /**
+   * Handles layer raster function changed events from registered layers.
+   *
+   * Forwards the event to domain listeners via emitLayerRasterFunctionChanged.
+   *
+   * @param layer - The layer whose raster function changed
+   * @param event - The raster function changed event
+   */
+  #handleLayerRasterFunctionChanged(layer: GVEsriImage, event: RasterFunctionChangedEvent): void {
+    // Emit about it
+    this.#emitLayerRasterFunctionChanged({ layer, layerEvent: event });
+  }
+
+  /**
+   * Handles layer mosaic rule changed events from registered layers.
+   *
+   * Forwards the event to domain listeners via emitLayerMosaicRuleChanged.
+   *
+   * @param layer - The layer whose mosaic rule changed
+   * @param event - The mosaic rule changed event
+   */
+  #handleLayerMosaicRuleChanged(layer: GVEsriImage, event: MosaicRuleChangedEvent): void {
+    // Emit about it
+    this.#emitLayerMosaicRuleChanged({ layer, layerEvent: event });
+  }
+
+  /**
+   * Handles layer WMS style changed events from registered layers.
+   *
+   * Forwards the event to domain listeners via emitLayerWmsStyleChanged.
+   *
+   * @param layer - The layer whose WMS style changed
+   * @param event - The WMS style changed event
+   */
+  #handleLayerWmsStyleChanged(layer: GVWMS, event: WMSStyleChangedEvent): void {
+    // Emit about it
+    this.#emitLayerWmsStyleChanged({ layer, layerEvent: event });
   }
 
   // #endregion PRIVATE LAYER HANDLERS
@@ -1461,6 +1552,99 @@ export class LayerDomain {
   }
 
   /**
+   * Emits layer raster function changed event.
+   *
+   * @param event - The event to emit
+   */
+  #emitLayerRasterFunctionChanged(event: DomainLayerRasterFunctionChangedEvent): void {
+    // Emit the event for all handlers
+    EventHelper.emitEvent(this, this.#onLayerRasterFunctionChangedHandlers, event);
+  }
+
+  /**
+   * Registers a layer raster function changed event handler.
+   *
+   * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback registered, for chaining or unregistration purposes
+   */
+  onLayerRasterFunctionChanged(callback: DomainLayerRasterFunctionChangedDelegate): DomainLayerRasterFunctionChangedDelegate {
+    // Register the event handler
+    return EventHelper.onEvent(this.#onLayerRasterFunctionChangedHandlers, callback);
+  }
+
+  /**
+   * Unregisters a layer raster function changed event handler.
+   *
+   * @param callback - The callback to stop being called whenever the event is emitted
+   */
+  offLayerRasterFunctionChanged(callback: DomainLayerRasterFunctionChangedDelegate | undefined): void {
+    // Unregister the event handler
+    EventHelper.offEvent(this.#onLayerRasterFunctionChangedHandlers, callback);
+  }
+
+  /**
+   * Emits layer mosaic rule changed event.
+   *
+   * @param event - The event to emit
+   */
+  #emitLayerMosaicRuleChanged(event: DomainLayerMosaicRuleChangedEvent): void {
+    // Emit the event for all handlers
+    EventHelper.emitEvent(this, this.#onLayerMosaicRuleChangedHandlers, event);
+  }
+
+  /**
+   * Registers a layer mosaic rule changed event handler.
+   *
+   * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback registered, for chaining or unregistration purposes
+   */
+  onLayerMosaicRuleChanged(callback: DomainLayerMosaicRuleChangedDelegate): DomainLayerMosaicRuleChangedDelegate {
+    // Register the event handler
+    return EventHelper.onEvent(this.#onLayerMosaicRuleChangedHandlers, callback);
+  }
+
+  /**
+   * Unregisters a layer mosaic rule changed event handler.
+   *
+   * @param callback - The callback to stop being called whenever the event is emitted
+   */
+  offLayerMosaicRuleChanged(callback: DomainLayerMosaicRuleChangedDelegate | undefined): void {
+    // Unregister the event handler
+    EventHelper.offEvent(this.#onLayerMosaicRuleChangedHandlers, callback);
+  }
+
+  /**
+   * Emits layer WMS style changed event.
+   *
+   * @param event - The event to emit
+   */
+  #emitLayerWmsStyleChanged(event: DomainLayerWMSStyleChangedEvent): void {
+    // Emit the event for all handlers
+    EventHelper.emitEvent(this, this.#onLayerWMSStyleChangedHandlers, event);
+  }
+
+  /**
+   * Registers a layer WMS style changed event handler.
+   *
+   * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback registered, for chaining or unregistration purposes
+   */
+  onLayerWmsStyleChanged(callback: DomainLayerWMSStyleChangedDelegate): DomainLayerWMSStyleChangedDelegate {
+    // Register the event handler
+    return EventHelper.onEvent(this.#onLayerWMSStyleChangedHandlers, callback);
+  }
+
+  /**
+   * Unregisters a layer WMS style changed event handler.
+   *
+   * @param callback - The callback to stop being called whenever the event is emitted
+   */
+  offLayerWmsStyleChanged(callback: DomainLayerWMSStyleChangedDelegate | undefined): void {
+    // Unregister the event handler
+    EventHelper.offEvent(this.#onLayerWMSStyleChangedHandlers, callback);
+  }
+
+  /**
    * Emits layer group layer added event.
    *
    * @param event - The event to emit
@@ -1525,8 +1709,9 @@ export class LayerDomain {
   // #endregion EVENTS - GV LAYERS
 }
 
+/** Define a base event for layer entry events. */
 export interface DomainLayerEntryBaseEvent<T extends ConfigBaseClass = ConfigBaseClass> {
-  // The layer entry config
+  /** The layer entry configuration. */
   config: T;
 }
 
@@ -1534,7 +1719,7 @@ export interface DomainLayerEntryBaseEvent<T extends ConfigBaseClass = ConfigBas
  * Define an event for the delegate
  */
 export interface DomainLayerStatusChangedEvent extends DomainLayerEntryBaseEvent {
-  // The new layer status
+  /** The new layer status. */
   status: TypeLayerStatus;
 }
 
@@ -1547,6 +1732,7 @@ export type DomainLayerStatusChangedDelegate = EventDelegateBase<LayerDomain, Do
  * Define an event for the delegate
  */
 export interface DomainLayerRegisteredEvent {
+  /** The registered layer. */
   layer: AbstractBaseGVLayer;
 }
 
@@ -1559,10 +1745,10 @@ export type DomainLayerRegisteredDelegate = EventDelegateBase<LayerDomain, Domai
  * Define an event for the delegate
  */
 export interface DomainLayerBaseEvent<T extends AbstractBaseGVLayer = AbstractBaseGVLayer, U extends LayerBaseEvent = LayerBaseEvent> {
-  // The layer included in the event payload
+  /** The layer included in the event payload. */
   layer: T;
 
-  // The layer event itself being redirected
+  /** The layer event itself being redirected. */
   layerEvent: U;
 }
 
@@ -1642,6 +1828,36 @@ export interface DomainLayerWMSImageLoadRescueEvent extends DomainLayerBaseEvent
  * Define a delegate for the event handler function signature
  */
 export type DomainLayerWMSImageLoadRescueDelegate = EventDelegateBase<LayerDomain, DomainLayerWMSImageLoadRescueEvent, boolean>;
+
+/**
+ * Define an event for the delegate
+ */
+export interface DomainLayerWMSStyleChangedEvent extends DomainLayerBaseEvent<GVWMS, WMSStyleChangedEvent> {}
+
+/**
+ * Define a delegate for the event handler function signature
+ */
+export type DomainLayerWMSStyleChangedDelegate = EventDelegateBase<LayerDomain, DomainLayerWMSStyleChangedEvent, void>;
+
+/**
+ * Define an event for the delegate
+ */
+export interface DomainLayerRasterFunctionChangedEvent extends DomainLayerBaseEvent<AbstractGVLayer, RasterFunctionChangedEvent> {}
+
+/**
+ * Define a delegate for the event handler function signature
+ */
+export type DomainLayerRasterFunctionChangedDelegate = EventDelegateBase<LayerDomain, DomainLayerRasterFunctionChangedEvent, void>;
+
+/**
+ * Define an event for the delegate
+ */
+export interface DomainLayerMosaicRuleChangedEvent extends DomainLayerBaseEvent<GVEsriImage, MosaicRuleChangedEvent> {}
+
+/**
+ * Define a delegate for the event handler function signature
+ */
+export type DomainLayerMosaicRuleChangedDelegate = EventDelegateBase<LayerDomain, DomainLayerMosaicRuleChangedEvent, void>;
 
 /**
  * Define an event for the delegate

--- a/packages/geoview-core/src/core/exceptions/geocore-exceptions.ts
+++ b/packages/geoview-core/src/core/exceptions/geocore-exceptions.ts
@@ -33,23 +33,23 @@ export class LayerGeoCoreError extends GeoViewError {
 }
 
 /**
- * Error thrown when one or more layer UUIDs are not found when queried.
+ * Error thrown when the Geocore service fails to respond.
  */
-export class LayerGeoCoreUUIDNotFoundError extends LayerGeoCoreError {
+export class LayerGeoCoreServiceFailError extends LayerGeoCoreError {
   /**
-   * Constructs a new UUID-not-found error for a given map and list of UUIDs.
+   * Constructs a new geocore service fail error for a given UUIDs.
    *
    * @param uuids - The list of UUIDs that could not be found
    * @param cause - The original error that caused this one
    */
   constructor(uuids: string[], cause: Error) {
-    super(uuids, 'error.geocore.uuidNotFound', uuids, { cause });
+    super(uuids, 'error.geocore.serviceFail', uuids, { cause });
 
     // Set a custom name for the error type to differentiate it from other error types
-    this.name = 'LayerGeoCoreUUIDNotFoundError';
+    this.name = 'LayerGeoCoreServiceFailError';
 
     // Ensure correct inheritance (important for transpilation targets)
-    Object.setPrototypeOf(this, LayerGeoCoreUUIDNotFoundError.prototype);
+    Object.setPrototypeOf(this, LayerGeoCoreServiceFailError.prototype);
   }
 }
 
@@ -61,9 +61,9 @@ export class LayerGeoCoreInvalidResponseError extends LayerGeoCoreError {
    * Constructs a new LayerGeoCoreInvalidResponseError for a given map and UUIDs.
    *
    * @param uuids - The list of UUIDs that caused an invalid response by GeoCore
-   * @param errorMessage - The error message from the invalid response
+   * @param errorMessage - The error message explaining the invalid response
    */
-  constructor(uuids: string[], errorMessage: unknown) {
+  constructor(uuids: string[], errorMessage: string) {
     super(uuids, 'error.geocore.invalidResponse', [errorMessage, uuids.toString()]);
 
     // Set a custom name for the error type to differentiate it from other error types

--- a/packages/geoview-core/src/core/stores/state-api.ts
+++ b/packages/geoview-core/src/core/stores/state-api.ts
@@ -6,17 +6,15 @@ import {
   type GeoChartStoreByLayerPath,
   type TypeGeochartResultSetEntry,
 } from './store-interface-and-intial-values/geochart-state';
-import {
-  type TypeOrderedLayerInfo,
-  getStoreMapLegendCollapsedByPath,
-  getStoreMapOrderedLayerInfo,
-  setStoreMapLegendCollapsed,
-  utilFindMapLayerAndChildrenFromOrderedInfo,
-} from './store-interface-and-intial-values/map-state';
 import type { TimeSliderLayerSet } from './store-interface-and-intial-values/time-slider-state';
 import { getStoreTimeSliderLayers } from './store-interface-and-intial-values/time-slider-state';
 import { getStoreSwiperLayerPaths } from './store-interface-and-intial-values/swiper-state';
-import { setStoreLayerSelectedLayersTabLayer, setStoreReorderLegendLayers } from './store-interface-and-intial-values/layer-state';
+import {
+  getStoreLayerLegendCollapsed,
+  getStoreLayerOrderedLayerPaths,
+  setStoreReorderLegendLayers,
+  utilFindLayerAndChildrenPaths,
+} from './store-interface-and-intial-values/layer-state';
 import { logger } from '@/core/utils/logger';
 import type { EventDelegateBase } from '@/api/events/event-helper';
 import EventHelper from '@/api/events/event-helper';
@@ -48,7 +46,7 @@ export class StateApi {
    */
   getLegendCollapsedState(layerPath: string): boolean {
     // Get from store
-    return getStoreMapLegendCollapsedByPath(this.#layerController.getMapId(), layerPath);
+    return getStoreLayerLegendCollapsed(this.#layerController.getMapId(), layerPath);
   }
 
   /**
@@ -99,8 +97,8 @@ export class StateApi {
    * @returns If the legend is collapsed.
    */
   setLegendCollapsedState(layerPath: string, collapsed: boolean): void {
-    // Save to the store
-    setStoreMapLegendCollapsed(this.#layerController.getMapId(), layerPath, collapsed);
+    // Redirect to controller
+    this.#layerController.setLegendCollapsed(layerPath, collapsed);
   }
 
   /**
@@ -108,16 +106,26 @@ export class StateApi {
    * @param layerPath - The path of the layer to set
    */
   setSelectedLayersTabLayer(layerPath: string): void {
-    setStoreLayerSelectedLayersTabLayer(this.#layerController.getMapId(), layerPath);
+    // Redirect to controller
+    this.#layerController.setSelectedLayerPath(layerPath);
   }
 
+  /**
+   * Reorders a layer and its children within the ordered layers list by a given number of positions.
+   *
+   * The layer (along with any child paths) is extracted from its current position and re-inserted
+   * at the target index, skipping only siblings at the same depth. Updates the store, reorders the
+   * legend layers, and emits a layers reordered event.
+   *
+   * @param layerPath - The path of the layer to move
+   * @param move - The number of sibling positions to move (negative = toward index 0, positive = toward end)
+   */
   reorderLayers(layerPath: string, move: number): void {
     // Apply some ordering logic
     const direction = move < 0 ? -1 : 1;
     let absoluteMoves = Math.abs(move);
-    const orderedLayers = [...getStoreMapOrderedLayerInfo(this.#layerController.getMapId())];
-    let startingIndex = -1;
-    for (let i = 0; i < orderedLayers.length; i++) if (orderedLayers[i].layerPath === layerPath) startingIndex = i;
+    const orderedLayers = [...getStoreLayerOrderedLayerPaths(this.#layerController.getMapId())];
+    const startingIndex = orderedLayers.indexOf(layerPath);
 
     // If layer not found, exit early
     if (startingIndex === -1) {
@@ -125,23 +133,22 @@ export class StateApi {
       return;
     }
 
-    const layerInfo = orderedLayers[startingIndex];
-    const movedLayers = utilFindMapLayerAndChildrenFromOrderedInfo(layerPath, orderedLayers);
+    const movedLayers = utilFindLayerAndChildrenPaths(layerPath, orderedLayers);
     orderedLayers.splice(startingIndex, movedLayers.length);
     let nextIndex = startingIndex;
-    const pathLength = layerInfo.layerPath.split('/').length;
+    const pathLength = layerPath.split('/').length;
     while (absoluteMoves > 0) {
       nextIndex += direction;
       if (nextIndex === orderedLayers.length || nextIndex === 0) {
         absoluteMoves = 0;
-      } else if (orderedLayers[nextIndex].layerPath.split('/').length === pathLength) absoluteMoves--;
+      } else if (orderedLayers[nextIndex].split('/').length === pathLength) absoluteMoves--;
     }
     orderedLayers.splice(nextIndex, 0, ...movedLayers);
 
     // Redirect
-    this.#layerController.setMapOrderedLayerInfoDirectly(orderedLayers);
+    this.#layerController.setMapOrderedLayersDirectly(orderedLayers);
 
-    // Reorder the legend layers, because the order layer info has changed
+    // Reorder the legend layers, because the ordered layers have changed
     setStoreReorderLegendLayers(this.#layerController.getMapId());
 
     // Emit event
@@ -191,8 +198,8 @@ type LayersReorderedDelegate = EventDelegateBase<StateApi, LayersReorderedEvent,
  * Define an event for the delegate
  */
 export type LayersReorderedEvent = {
-  // The layer path of the affected layer
-  orderedLayers: TypeOrderedLayerInfo[];
+  // The layer paths in the new order
+  orderedLayers: string[];
 };
 
 // #endregion EVENTS & DELEGATES

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/app-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/app-state.ts
@@ -400,10 +400,10 @@ export const useStoreAppDisplayDateMode = (): DisplayDateMode => useStore(useGeo
  * @param mapId - The map identifier.
  * @returns The IANA timezone string.
  */
-export const getStoreDisplayDateTimezone = (mapId: string): TimeIANA => getStoreAppState(mapId).displayDateTimezone;
+export const getStoreAppDisplayDateTimezone = (mapId: string): TimeIANA => getStoreAppState(mapId).displayDateTimezone;
 
 /** Hook that returns the current display date timezone. */
-export const useStoreDisplayDateTimezone = (): TimeIANA => useStore(useGeoViewStore(), (state) => state.appState.displayDateTimezone);
+export const useStoreAppDisplayDateTimezone = (): TimeIANA => useStore(useGeoViewStore(), (state) => state.appState.displayDateTimezone);
 
 /**
  * Gets whether fullscreen mode is active for the given map.
@@ -531,7 +531,7 @@ export const useStoreAppShellContainer = (): HTMLElement => {
  * @param mapId - The map identifier.
  * @returns True if layer highlight bboxes should be shown.
  */
-export const getStoreShowLayerHighlightLayerBbox = (mapId: string): boolean => getStoreAppState(mapId).showLayerHighlightLayerBbox;
+export const getStoreAppShowLayerHighlightLayerBbox = (mapId: string): boolean => getStoreAppState(mapId).showLayerHighlightLayerBbox;
 
 /**
  * Gets the default date format settings derived from the current display date mode.
@@ -539,7 +539,7 @@ export const getStoreShowLayerHighlightLayerBbox = (mapId: string): boolean => g
  * @param mapId - The map identifier.
  * @returns The default date display settings.
  */
-export const getStoreDisplayDateFormatDefault = (mapId: string): TypeDisplayDateDefaults =>
+export const getStoreAppDisplayDateFormatDefault = (mapId: string): TypeDisplayDateDefaults =>
   DateMgt.getDisplayDateDefaults(getStoreAppDisplayDateMode(mapId));
 
 // #endregion STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
@@ -553,7 +553,7 @@ export const getStoreDisplayDateFormatDefault = (mapId: string): TypeDisplayDate
  * @param mapId - The map identifier
  * @param active - Whether the circular progress is active
  */
-export const setStoreCircularProgress = (mapId: string, active: boolean): void => {
+export const setStoreAppCircularProgress = (mapId: string, active: boolean): void => {
   getStoreAppState(mapId).actions.setCircularProgress(active);
 };
 
@@ -563,7 +563,7 @@ export const setStoreCircularProgress = (mapId: string, active: boolean): void =
  * @param mapId - The map identifier
  * @param lang - The language code (e.g. 'en' or 'fr')
  */
-export const setStoreDisplayLanguage = (mapId: string, lang: TypeDisplayLanguage): void => {
+export const setStoreAppDisplayLanguage = (mapId: string, lang: TypeDisplayLanguage): void => {
   getStoreAppState(mapId).actions.setDisplayLanguage(lang);
 };
 
@@ -573,7 +573,7 @@ export const setStoreDisplayLanguage = (mapId: string, lang: TypeDisplayLanguage
  * @param mapId - The map identifier
  * @param theme - The theme identifier
  */
-export const setStoreDisplayTheme = (mapId: string, theme: TypeDisplayTheme): void => {
+export const setStoreAppDisplayTheme = (mapId: string, theme: TypeDisplayTheme): void => {
   getStoreAppState(mapId).actions.setDisplayTheme(theme);
 };
 
@@ -583,7 +583,7 @@ export const setStoreDisplayTheme = (mapId: string, theme: TypeDisplayTheme): vo
  * @param mapId - The map identifier
  * @param displayDateTimezone - The IANA timezone identifier
  */
-export const setStoreDisplayDateTimezone = (mapId: string, displayDateTimezone: TimeIANA): void => {
+export const setStoreAppDisplayDateTimezone = (mapId: string, displayDateTimezone: TimeIANA): void => {
   getStoreAppState(mapId).actions.setDisplayDateTimezone(displayDateTimezone);
 };
 
@@ -593,7 +593,7 @@ export const setStoreDisplayDateTimezone = (mapId: string, displayDateTimezone: 
  * @param mapId - The map identifier
  * @param active - Whether the crosshairs are active
  */
-export const setStoreCrosshairActive = (mapId: string, active: boolean): void => {
+export const setStoreAppCrosshairActive = (mapId: string, active: boolean): void => {
   getStoreAppState(mapId).actions.setCrosshairActive(active);
 };
 
@@ -603,7 +603,7 @@ export const setStoreCrosshairActive = (mapId: string, active: boolean): void =>
  * @param mapId - The map identifier
  * @param active - Whether fullscreen mode is active
  */
-export const setStoreFullScreenActive = (mapId: string, active: boolean): void => {
+export const setStoreAppFullScreenActive = (mapId: string, active: boolean): void => {
   getStoreAppState(mapId).actions.setFullScreenActive(active);
 };
 
@@ -616,7 +616,7 @@ export const setStoreFullScreenActive = (mapId: string, active: boolean): void =
  * @param notification - The notification details to add
  * @returns A promise that resolves when the notification has been added
  */
-export const addStoreNotification = async (mapId: string, notification: NotificationDetailsType): Promise<void> => {
+export const addStoreAppNotification = async (mapId: string, notification: NotificationDetailsType): Promise<void> => {
   // Because notification is called before map is created, we use the async
   // version of getAppStateAsync
   const appState = await getGeoViewStoreAsync(mapId).then((store) => store.getState().appState);
@@ -650,7 +650,7 @@ export const addStoreNotification = async (mapId: string, notification: Notifica
  * @param key - The unique key of the notification to remove
  * @returns A promise that resolves when the notification has been removed
  */
-export const removeStoreNotification = async (mapId: string, key: string): Promise<void> => {
+export const removeStoreAppNotification = async (mapId: string, key: string): Promise<void> => {
   // Because notification is called before map is created, we use the async
   // version of getAppStateAsync
   const appState = await getGeoViewStoreAsync(mapId).then((store) => store.getState().appState);
@@ -665,7 +665,7 @@ export const removeStoreNotification = async (mapId: string, key: string): Promi
  *
  * @param mapId - The map identifier
  */
-export const removeStoreAllNotifications = (mapId: string): void => {
+export const removeStoreAppAllNotifications = (mapId: string): void => {
   getStoreAppState(mapId).actions.setNotifications([]);
 };
 
@@ -675,7 +675,7 @@ export const removeStoreAllNotifications = (mapId: string): void => {
  * @param mapId - The map identifier
  * @param guide - The guide object to display
  */
-export const setStoreGuide = (mapId: string, guide: TypeGuideObject): void => {
+export const setStoreAppGuide = (mapId: string, guide: TypeGuideObject): void => {
   getStoreAppState(mapId).actions.setGuide(guide);
 };
 

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
@@ -49,7 +49,7 @@ export interface IDataTableState {
     setColumnsFiltersVisibility: (visible: boolean, layerPath: string) => void;
     setInitiallayerDataTableSetting: (layerPath: string) => void;
     setGlobalFilteredEntry: (globalFilterValue: string, layerPath: string) => void;
-    setMapFilteredEntry: (mapFiltered: boolean, layerPath: string) => void;
+    setMapFilteredRecord: (mapFiltered: boolean, layerPath: string) => void;
     setFilterDataToExtent: (filterDataToExtent: boolean, layerPath: string) => void;
     setRowsFilteredEntry: (rows: number, layerPath: string) => void;
     setSelectedFeature: (feature: TypeFeatureInfoEntry) => void;
@@ -138,12 +138,14 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
        */
       setColumnFiltersEntry: (filtered: TypeColumnFiltersState, layerPath: string): void => {
         const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
-        layerSettings.columnFiltersRecord = filtered;
 
         set({
           dataTableState: {
             ...get().dataTableState,
-            layersDataTableSetting: { ...get().dataTableState.layersDataTableSetting, [layerPath]: layerSettings },
+            layersDataTableSetting: {
+              ...get().dataTableState.layersDataTableSetting,
+              [layerPath]: { ...layerSettings, columnFiltersRecord: filtered },
+            },
           },
         });
       },
@@ -156,12 +158,14 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
        */
       setColumnFilterModesEntry: (filterModes: Record<string, string>, layerPath: string): void => {
         const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
-        layerSettings.columnFilterModesRecord = filterModes;
 
         set({
           dataTableState: {
             ...get().dataTableState,
-            layersDataTableSetting: { ...get().dataTableState.layersDataTableSetting, [layerPath]: layerSettings },
+            layersDataTableSetting: {
+              ...get().dataTableState.layersDataTableSetting,
+              [layerPath]: { ...layerSettings, columnFilterModesRecord: filterModes },
+            },
           },
         });
       },
@@ -174,12 +178,14 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
        */
       setColumnsFiltersVisibility: (visible: boolean, layerPath: string): void => {
         const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
-        layerSettings.columnsFiltersVisibility = visible;
 
         set({
           dataTableState: {
             ...get().dataTableState,
-            layersDataTableSetting: { ...get().dataTableState.layersDataTableSetting, [layerPath]: layerSettings },
+            layersDataTableSetting: {
+              ...get().dataTableState.layersDataTableSetting,
+              [layerPath]: { ...layerSettings, columnsFiltersVisibility: visible },
+            },
           },
         });
       },
@@ -190,14 +196,16 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
        * @param mapFiltered - Whether map extent filtering is enabled.
        * @param layerPath - The target layer path.
        */
-      setMapFilteredEntry: (mapFiltered: boolean, layerPath: string): void => {
+      setMapFilteredRecord: (mapFiltered: boolean, layerPath: string): void => {
         const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
-        layerSettings.mapFilteredRecord = mapFiltered;
 
         set({
           dataTableState: {
             ...get().dataTableState,
-            layersDataTableSetting: { ...get().dataTableState.layersDataTableSetting, [layerPath]: layerSettings },
+            layersDataTableSetting: {
+              ...get().dataTableState.layersDataTableSetting,
+              [layerPath]: { ...layerSettings, mapFilteredRecord: mapFiltered },
+            },
           },
         });
       },
@@ -210,12 +218,14 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
        */
       setRowsFilteredEntry: (rows: number, layerPath: string): void => {
         const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
-        layerSettings.rowsFilteredRecord = rows;
 
         set({
           dataTableState: {
             ...get().dataTableState,
-            layersDataTableSetting: { ...get().dataTableState.layersDataTableSetting, [layerPath]: layerSettings },
+            layersDataTableSetting: {
+              ...get().dataTableState.layersDataTableSetting,
+              [layerPath]: { ...layerSettings, rowsFilteredRecord: rows },
+            },
           },
         });
       },
@@ -256,24 +266,28 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
        */
       setGlobalFilteredEntry: (globalFilterValue: string, layerPath: string): void => {
         const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
-        layerSettings.globalFilterRecord = globalFilterValue;
 
         set({
           dataTableState: {
             ...get().dataTableState,
-            layersDataTableSetting: { ...get().dataTableState.layersDataTableSetting, [layerPath]: layerSettings },
+            layersDataTableSetting: {
+              ...get().dataTableState.layersDataTableSetting,
+              [layerPath]: { ...layerSettings, globalFilterRecord: globalFilterValue },
+            },
           },
         });
       },
 
-      setFilterDataToExtent: (filterDataToExtent: boolean, layerPath: string) => {
+      setFilterDataToExtent: (filterDataToExtent: boolean, layerPath: string): void => {
         const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
-        layerSettings.filterDataToExtent = filterDataToExtent;
 
         set({
           dataTableState: {
             ...get().dataTableState,
-            layersDataTableSetting: { ...get().dataTableState.layersDataTableSetting, [layerPath]: layerSettings },
+            layersDataTableSetting: {
+              ...get().dataTableState.layersDataTableSetting,
+              [layerPath]: { ...layerSettings, filterDataToExtent },
+            },
           },
         });
       },
@@ -397,7 +411,7 @@ export const getStoreDataTableFeaturesByPath = (mapId: string, layerPath: string
  * @param layerPath - The layer path to check.
  * @returns True if map extent filtering is enabled, or undefined if the layer has no settings.
  */
-export const getStoreDataTableFilteredRecord = (mapId: string, layerPath: string): boolean | undefined => {
+export const getStoreDataTableMapFilteredRecord = (mapId: string, layerPath: string): boolean | undefined => {
   return getStoreDataTableState(mapId)?.layersDataTableSetting?.[layerPath]?.mapFilteredRecord;
 };
 
@@ -507,8 +521,8 @@ export const setStoreDataTableGlobalFilteredEntry = (mapId: string, globalFilter
  * @param mapFiltered - Whether map extent filtering is enabled.
  * @param layerPath - The target layer path.
  */
-export const setStoreDataTableFilteredEntry = (mapId: string, mapFiltered: boolean, layerPath: string): void => {
-  getStoreDataTableState(mapId).actions.setMapFilteredEntry(mapFiltered, layerPath);
+export const setStoreDataTableMapFilteredRecord = (mapId: string, mapFiltered: boolean, layerPath: string): void => {
+  getStoreDataTableState(mapId).actions.setMapFilteredRecord(mapFiltered, layerPath);
 };
 
 /**

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
@@ -44,14 +44,15 @@ export interface IDataTableState {
   /** Store actions callable from adaptors. */
   actions: {
     setAllFeaturesDataArray: (allFeaturesDataArray: TypeAllFeatureInfoResultSetEntry[]) => void;
-    setColumnFiltersEntry: (filtered: TypeColumnFiltersState, layerPath: string) => void;
-    setColumnFilterModesEntry: (filterModes: Record<string, string>, layerPath: string) => void;
+    setColumnFiltersRecord: (filtered: TypeColumnFiltersState, layerPath: string) => void;
+    setColumnFilterModesRecord: (filterModes: Record<string, string>, layerPath: string) => void;
     setColumnsFiltersVisibility: (visible: boolean, layerPath: string) => void;
     setInitiallayerDataTableSetting: (layerPath: string) => void;
-    setGlobalFilteredEntry: (globalFilterValue: string, layerPath: string) => void;
+    setColumnVisibilityRecord: (columnVisibility: Record<string, boolean>, layerPath: string) => void;
+    setGlobalFilterRecord: (globalFilterValue: string, layerPath: string) => void;
     setMapFilteredRecord: (mapFiltered: boolean, layerPath: string) => void;
     setFilterDataToExtent: (filterDataToExtent: boolean, layerPath: string) => void;
-    setRowsFilteredEntry: (rows: number, layerPath: string) => void;
+    setRowsFilteredRecord: (rows: number, layerPath: string) => void;
     setSelectedFeature: (feature: TypeFeatureInfoEntry) => void;
     setSelectedLayerPath: (layerPath: string) => void;
     setTableFilters(newTableFilters: Record<string, string>): void;
@@ -120,6 +121,7 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
           filterDataToExtent: false,
           rowsFilteredRecord: 0,
           globalFilterRecord: '',
+          columnVisibilityRecord: { geoviewID: false },
         };
 
         set({
@@ -136,7 +138,7 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
        * @param filtered - The column filter state to apply.
        * @param layerPath - The target layer path.
        */
-      setColumnFiltersEntry: (filtered: TypeColumnFiltersState, layerPath: string): void => {
+      setColumnFiltersRecord: (filtered: TypeColumnFiltersState, layerPath: string): void => {
         const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
 
         set({
@@ -156,7 +158,7 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
        * @param filterModes - A record mapping column ids to their filter mode.
        * @param layerPath - The target layer path.
        */
-      setColumnFilterModesEntry: (filterModes: Record<string, string>, layerPath: string): void => {
+      setColumnFilterModesRecord: (filterModes: Record<string, string>, layerPath: string): void => {
         const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
 
         set({
@@ -191,6 +193,26 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
       },
 
       /**
+       * Updates the column visibility for the specified layer in the store.
+       *
+       * @param columnVisibility - A record mapping column ids to their visibility state.
+       * @param layerPath - The target layer path.
+       */
+      setColumnVisibilityRecord: (columnVisibility: Record<string, boolean>, layerPath: string): void => {
+        const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
+
+        set({
+          dataTableState: {
+            ...get().dataTableState,
+            layersDataTableSetting: {
+              ...get().dataTableState.layersDataTableSetting,
+              [layerPath]: { ...layerSettings, columnVisibilityRecord: columnVisibility },
+            },
+          },
+        });
+      },
+
+      /**
        * Sets whether the data table is filtered to the current map extent for the specified layer.
        *
        * @param mapFiltered - Whether map extent filtering is enabled.
@@ -216,7 +238,7 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
        * @param rows - The filtered row count.
        * @param layerPath - The target layer path.
        */
-      setRowsFilteredEntry: (rows: number, layerPath: string): void => {
+      setRowsFilteredRecord: (rows: number, layerPath: string): void => {
         const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
 
         set({
@@ -264,7 +286,7 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
        * @param globalFilterValue - The global filter string.
        * @param layerPath - The target layer path.
        */
-      setGlobalFilteredEntry: (globalFilterValue: string, layerPath: string): void => {
+      setGlobalFilterRecord: (globalFilterValue: string, layerPath: string): void => {
         const layerSettings = get().dataTableState.layersDataTableSetting[layerPath];
 
         set({
@@ -477,8 +499,23 @@ export const setStoreDataTableSelectedFeature = (mapId: string, feature: TypeFea
  * @param filtered - The column filter state to apply.
  * @param layerPath - The target layer path.
  */
-export const setStoreDataTableColumnFiltersEntry = (mapId: string, filtered: TypeColumnFiltersState, layerPath: string): void => {
-  getStoreDataTableState(mapId).actions.setColumnFiltersEntry(filtered, layerPath);
+export const setStoreDataTableColumnFiltersRecord = (mapId: string, filtered: TypeColumnFiltersState, layerPath: string): void => {
+  getStoreDataTableState(mapId).actions.setColumnFiltersRecord(filtered, layerPath);
+};
+
+/**
+ * Sets the column visibility for a specific layer in the store.
+ *
+ * @param mapId - The map identifier.
+ * @param columnVisibility - A record mapping column ids to their visibility state.
+ * @param layerPath - The target layer path.
+ */
+export const setStoreDataTableColumnVisibilityRecord = (
+  mapId: string,
+  columnVisibility: Record<string, boolean>,
+  layerPath: string
+): void => {
+  getStoreDataTableState(mapId).actions.setColumnVisibilityRecord(columnVisibility, layerPath);
 };
 
 /**
@@ -488,8 +525,8 @@ export const setStoreDataTableColumnFiltersEntry = (mapId: string, filtered: Typ
  * @param filterModes - A record mapping column ids to their filter mode.
  * @param layerPath - The target layer path.
  */
-export const setStoreDataTableColumnFilterModesEntry = (mapId: string, filterModes: Record<string, string>, layerPath: string): void => {
-  getStoreDataTableState(mapId).actions.setColumnFilterModesEntry(filterModes, layerPath);
+export const setStoreDataTableColumnFilterModesRecord = (mapId: string, filterModes: Record<string, string>, layerPath: string): void => {
+  getStoreDataTableState(mapId).actions.setColumnFilterModesRecord(filterModes, layerPath);
 };
 
 /**
@@ -510,8 +547,8 @@ export const setStoreDataTableColumnsFiltersVisibility = (mapId: string, visible
  * @param globalFilterValue - The global filter string.
  * @param layerPath - The target layer path.
  */
-export const setStoreDataTableGlobalFilteredEntry = (mapId: string, globalFilterValue: string, layerPath: string): void => {
-  getStoreDataTableState(mapId).actions.setGlobalFilteredEntry(globalFilterValue, layerPath);
+export const setStoreDataTableGlobalFilterRecord = (mapId: string, globalFilterValue: string, layerPath: string): void => {
+  getStoreDataTableState(mapId).actions.setGlobalFilterRecord(globalFilterValue, layerPath);
 };
 
 /**
@@ -543,8 +580,8 @@ export const setStoreDataTableFilterDataToExtent = (mapId: string, filterDataToE
  * @param rows - The filtered row count.
  * @param layerPath - The target layer path.
  */
-export const setStoreDataTableRowsFilteredEntry = (mapId: string, rows: number, layerPath: string): void => {
-  getStoreDataTableState(mapId).actions.setRowsFilteredEntry(rows, layerPath);
+export const setStoreDataTableRowsFilteredRecord = (mapId: string, rows: number, layerPath: string): void => {
+  getStoreDataTableState(mapId).actions.setRowsFilteredRecord(rows, layerPath);
 };
 
 /**
@@ -661,6 +698,9 @@ export interface IDataTableSettings {
 
   /** The current global filter string applied across all columns. */
   globalFilterRecord: string;
+
+  /** A record mapping column ids to their visibility state. */
+  columnVisibilityRecord: Record<string, boolean>;
 }
 
 /** A feature info result set entry that combines result set entry metadata with layer data. */

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
@@ -388,7 +388,7 @@ export const useStoreDataTableAllFeaturesDataArray = (): TypeAllFeatureInfoResul
  * @returns The feature info entries for the layer, or undefined if not found
  */
 export const getStoreDataTableFeaturesByPath = (mapId: string, layerPath: string): TypeFeatureInfoEntry[] | undefined => {
-  return getStoreDataTableState(mapId)?.allFeaturesDataArray.filter((data) => data.layerPath === layerPath)?.[0].features;
+  return getStoreDataTableState(mapId)?.allFeaturesDataArray.filter((data) => data.layerPath === layerPath)?.[0]?.features;
 };
 
 /**

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
@@ -119,7 +119,6 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
           mapFilteredRecord: true,
           filterDataToExtent: false,
           rowsFilteredRecord: 0,
-          toolbarRowSelectedMessageRecord: '',
           globalFilterRecord: '',
         };
 

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/data-table-state.ts
@@ -43,7 +43,6 @@ export interface IDataTableState {
 
   /** Store actions callable from adaptors. */
   actions: {
-    setActiveLayersData: (layers: TypeLayerData[]) => void;
     setAllFeaturesDataArray: (allFeaturesDataArray: TypeAllFeatureInfoResultSetEntry[]) => void;
     setColumnFiltersEntry: (filtered: TypeColumnFiltersState, layerPath: string) => void;
     setColumnFilterModesEntry: (filterModes: Record<string, string>, layerPath: string) => void;
@@ -89,20 +88,6 @@ export function initialDataTableState(set: TypeSetStore, get: TypeGetStore): IDa
     },
 
     actions: {
-      /**
-       * Sets the active layer data array in the store.
-       *
-       * @param activeLayerData - The layer data objects to set as active.
-       */
-      setActiveLayersData: (activeLayerData: TypeLayerData[]): void => {
-        set({
-          dataTableState: {
-            ...get().dataTableState,
-            activeLayerData,
-          },
-        });
-      },
-
       /**
        * Sets the aggregated feature info result set entries in the store.
        *
@@ -349,7 +334,7 @@ export const useStoreDataTableFilters = (): Record<string, string> =>
  * @param layerPath - The path of the layer
  * @returns The data table filter(s) for the layer
  */
-export const getStoreTableFilter = (mapId: string, layerPath: string): string | undefined => {
+export const getStoreDataTableFilter = (mapId: string, layerPath: string): string | undefined => {
   return getStoreDataTableState(mapId)?.tableFilters?.[layerPath];
 };
 
@@ -359,7 +344,7 @@ export const getStoreTableFilter = (mapId: string, layerPath: string): string | 
  * @param layerPath - The layer path to get the filter for.
  * @returns The filter string for the layer, or undefined if not set.
  */
-export const useStoreTableFilter = (layerPath: string): string | undefined => {
+export const useStoreDataTableFilter = (layerPath: string): string | undefined => {
   return useStore(useGeoViewStore(), (state) => state.dataTableState.tableFilters[layerPath]);
 };
 
@@ -396,13 +381,24 @@ export const useStoreDataTableAllFeaturesDataArray = (): TypeAllFeatureInfoResul
 // #region STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
 
 /**
+ * Gets the feature info entries for a specific layer from the data table store.
+ *
+ * @param mapId - The map identifier
+ * @param layerPath - The layer path to retrieve features for
+ * @returns The feature info entries for the layer, or undefined if not found
+ */
+export const getStoreDataTableFeaturesByPath = (mapId: string, layerPath: string): TypeFeatureInfoEntry[] | undefined => {
+  return getStoreDataTableState(mapId)?.allFeaturesDataArray.filter((data) => data.layerPath === layerPath)?.[0].features;
+};
+
+/**
  * Gets whether the data table is filtered to the current map extent for a specific layer.
  *
  * @param mapId - The map identifier.
  * @param layerPath - The layer path to check.
  * @returns True if map extent filtering is enabled, or undefined if the layer has no settings.
  */
-export const getStoreMapFilteredRecord = (mapId: string, layerPath: string): boolean | undefined => {
+export const getStoreDataTableFilteredRecord = (mapId: string, layerPath: string): boolean | undefined => {
   return getStoreDataTableState(mapId)?.layersDataTableSetting?.[layerPath]?.mapFilteredRecord;
 };
 
@@ -437,7 +433,7 @@ export const getStoreDataTableFilterDataToExtent = (mapId: string, layerPath: st
  * @param mapId - The map identifier.
  * @param layerPath - The layer path to initialize settings for.
  */
-export const setStoreInitialSettings = (mapId: string, layerPath: string): void => {
+export const setStoreDataTableInitialSettings = (mapId: string, layerPath: string): void => {
   getStoreDataTableState(mapId).actions.setInitiallayerDataTableSetting(layerPath);
 };
 
@@ -447,7 +443,7 @@ export const setStoreInitialSettings = (mapId: string, layerPath: string): void 
  * @param mapId - The map identifier.
  * @param layerPath - The layer path to select.
  */
-export const setStoreSelectedLayerPath = (mapId: string, layerPath: string): void => {
+export const setStoreDataTableSelectedLayerPath = (mapId: string, layerPath: string): void => {
   getStoreDataTableState(mapId).actions.setSelectedLayerPath(layerPath);
 };
 
@@ -457,18 +453,8 @@ export const setStoreSelectedLayerPath = (mapId: string, layerPath: string): voi
  * @param mapId - The map identifier.
  * @param feature - The feature entry to select.
  */
-export const setStoreSelectedFeature = (mapId: string, feature: TypeFeatureInfoEntry): void => {
+export const setStoreDataTableSelectedFeature = (mapId: string, feature: TypeFeatureInfoEntry): void => {
   getStoreDataTableState(mapId).actions.setSelectedFeature(feature);
-};
-
-/**
- * Sets the active layer data in the data table store.
- *
- * @param mapId - The map identifier.
- * @param activeLayerData - The layer data objects to set as active.
- */
-export const setStoreActiveLayersData = (mapId: string, activeLayerData: TypeLayerData[]): void => {
-  getStoreDataTableState(mapId).actions.setActiveLayersData(activeLayerData);
 };
 
 /**
@@ -478,7 +464,7 @@ export const setStoreActiveLayersData = (mapId: string, activeLayerData: TypeLay
  * @param filtered - The column filter state to apply.
  * @param layerPath - The target layer path.
  */
-export const setStoreColumnFiltersEntry = (mapId: string, filtered: TypeColumnFiltersState, layerPath: string): void => {
+export const setStoreDataTableColumnFiltersEntry = (mapId: string, filtered: TypeColumnFiltersState, layerPath: string): void => {
   getStoreDataTableState(mapId).actions.setColumnFiltersEntry(filtered, layerPath);
 };
 
@@ -489,7 +475,7 @@ export const setStoreColumnFiltersEntry = (mapId: string, filtered: TypeColumnFi
  * @param filterModes - A record mapping column ids to their filter mode.
  * @param layerPath - The target layer path.
  */
-export const setStoreColumnFilterModesEntry = (mapId: string, filterModes: Record<string, string>, layerPath: string): void => {
+export const setStoreDataTableColumnFilterModesEntry = (mapId: string, filterModes: Record<string, string>, layerPath: string): void => {
   getStoreDataTableState(mapId).actions.setColumnFilterModesEntry(filterModes, layerPath);
 };
 
@@ -500,7 +486,7 @@ export const setStoreColumnFilterModesEntry = (mapId: string, filterModes: Recor
  * @param visible - Whether column filters should be visible.
  * @param layerPath - The target layer path.
  */
-export const setStoreColumnsFiltersVisibility = (mapId: string, visible: boolean, layerPath: string): void => {
+export const setStoreDataTableColumnsFiltersVisibility = (mapId: string, visible: boolean, layerPath: string): void => {
   getStoreDataTableState(mapId).actions.setColumnsFiltersVisibility(visible, layerPath);
 };
 
@@ -511,7 +497,7 @@ export const setStoreColumnsFiltersVisibility = (mapId: string, visible: boolean
  * @param globalFilterValue - The global filter string.
  * @param layerPath - The target layer path.
  */
-export const setStoreGlobalFilteredEntry = (mapId: string, globalFilterValue: string, layerPath: string): void => {
+export const setStoreDataTableGlobalFilteredEntry = (mapId: string, globalFilterValue: string, layerPath: string): void => {
   getStoreDataTableState(mapId).actions.setGlobalFilteredEntry(globalFilterValue, layerPath);
 };
 
@@ -522,7 +508,7 @@ export const setStoreGlobalFilteredEntry = (mapId: string, globalFilterValue: st
  * @param mapFiltered - Whether map extent filtering is enabled.
  * @param layerPath - The target layer path.
  */
-export const setStoreMapFilteredEntry = (mapId: string, mapFiltered: boolean, layerPath: string): void => {
+export const setStoreDataTableFilteredEntry = (mapId: string, mapFiltered: boolean, layerPath: string): void => {
   getStoreDataTableState(mapId).actions.setMapFilteredEntry(mapFiltered, layerPath);
 };
 
@@ -533,7 +519,7 @@ export const setStoreMapFilteredEntry = (mapId: string, mapFiltered: boolean, la
  * @param filterDataToExtent - Whether filtering data to extent is enabled.
  * @param layerPath - The target layer path.
  */
-export const setStoreFilterDataToExtent = (mapId: string, filterDataToExtent: boolean, layerPath: string): void => {
+export const setStoreDataTableFilterDataToExtent = (mapId: string, filterDataToExtent: boolean, layerPath: string): void => {
   getStoreDataTableState(mapId).actions.setFilterDataToExtent(filterDataToExtent, layerPath);
 };
 
@@ -544,7 +530,7 @@ export const setStoreFilterDataToExtent = (mapId: string, filterDataToExtent: bo
  * @param rows - The filtered row count.
  * @param layerPath - The target layer path.
  */
-export const setStoreRowsFilteredEntry = (mapId: string, rows: number, layerPath: string): void => {
+export const setStoreDataTableRowsFilteredEntry = (mapId: string, rows: number, layerPath: string): void => {
   getStoreDataTableState(mapId).actions.setRowsFilteredEntry(rows, layerPath);
 };
 
@@ -558,7 +544,7 @@ export const setStoreRowsFilteredEntry = (mapId: string, rows: number, layerPath
  * @param layerPath - The layer path to set the filter for.
  * @param filter - The filter expression string.
  */
-export const addOrUpdateStoreTableFilter = (mapId: string, layerPath: string, filter: string): void => {
+export const addOrUpdateStoreDataTableFilter = (mapId: string, layerPath: string, filter: string): void => {
   const dataTableState = getStoreDataTableState(mapId);
   const curTableFilters = dataTableState?.tableFilters;
   dataTableState?.actions.setTableFilters({ ...curTableFilters, [layerPath]: filter });
@@ -597,7 +583,7 @@ export const propagateFeatureInfoDataTableToStore = (mapId: string, resultSetEnt
  * @param layerPath - The layer path whose feature info should be removed.
  * @param callbackWhenEmpty - Callback invoked when no layer data remains.
  */
-export const deleteStoreFeatureAllInfo = (mapId: string, layerPath: string, callbackWhenEmpty: () => void): void => {
+export const deleteStoreDataTableFeatureAllInfo = (mapId: string, layerPath: string, callbackWhenEmpty: () => void): void => {
   // Redirect to helper function
   helperDeleteFromArray(getStoreDataTableState(mapId).allFeaturesDataArray, layerPath, (layerArrayResult) => {
     // Update the layer data array in the store

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -21,8 +21,7 @@ import type {
 } from '@/api/types/layer-schema-types';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import type { TypeVectorLayerStyles } from '@/geo/utils/renderer/geoview-renderer';
-import { getStoreMapOrderedLayerIndexByPath } from './map-state';
-import { getStoreDisplayDateFormatDefault, getStoreDisplayDateTimezone } from './app-state';
+import { getStoreAppDisplayDateFormatDefault, getStoreAppDisplayDateTimezone } from './app-state';
 import { logger } from '@/core/utils/logger';
 import { Projection } from '@/geo/utils/projection';
 import type { AbstractBaseGVLayer } from '@/geo/layer/gv-layers/abstract-base-layer';
@@ -53,6 +52,12 @@ export interface ILayerState {
   /** Whether one or more layers are currently loading. */
   layersAreLoading: boolean;
 
+  /** The ordered layer paths controlling display and Z-index order. */
+  orderedLayers: string[];
+
+  /** The initial filter strings keyed by layer path. */
+  initialFilters: Record<string, string>;
+
   /**
    * Applies default configuration values from the map config to the layer store.
    *
@@ -68,6 +73,8 @@ export interface ILayerState {
     setSelectedLayerPath: (layerPath: string | undefined) => void;
     setLayersAreLoading: (areLoading: boolean) => void;
     setLayerDeletionStartTime: (layerPath: string, startTime: number | undefined) => void;
+    setOrderedLayers: (newOrder: string[]) => void;
+    setInitialFilters: (filters: Record<string, string>) => void;
     updateLayerByPath: (layerPath: string, updater: (layer: TypeLegendLayer) => TypeLegendLayer) => void;
   };
 }
@@ -75,6 +82,20 @@ export interface ILayerState {
 // #endregion INTERFACE DEFINITION
 
 // #region UTIL FUNCTIONS (PRIVATE)
+
+/**
+ * Finds a layer and all its children from the ordered layers array.
+ *
+ * Matches the exact layer path and any paths that start with the given path followed by a separator.
+ *
+ * @param layerPath - The layer path to search for
+ * @param orderedLayers - The ordered layer paths array to search in
+ * @returns The matching layer paths including the layer and its children
+ */
+// TODO: CHECK - Should likely not export this function if we have proper encapsulation (we didn't export the other similar functions in other states)
+export const utilFindLayerAndChildrenPaths = (layerPath: string, orderedLayers: string[]): string[] => {
+  return orderedLayers.filter((path) => path.startsWith(`${layerPath}/`) || path === layerPath);
+};
 
 /**
  * Recursively searches the legend layers tree for a layer matching the given path.
@@ -222,6 +243,88 @@ const utilHasDisabledVisibilityRec = (layer: TypeLegendLayer): boolean => {
 };
 
 /**
+ * Checks whether any parent layer of the given layer path is hidden (not visible).
+ *
+ * Traverses up the layer path hierarchy and returns true as soon as any ancestor is not visible.
+ *
+ * @param layerPath - The layer path to check parent visibility for
+ * @param legendLayers - The legend layers array to search in
+ * @returns True if any parent layer is hidden, false otherwise
+ */
+const utilGetParentLayerHiddenOnMap = (legendLayers: TypeLegendLayer[], layerPath: string): boolean => {
+  // For each parent
+  const parentLayerPathArray = layerPath.split('/');
+  parentLayerPathArray.pop();
+  let parentLayerPath = parentLayerPathArray.join('/');
+  let parentLayerInfo = utilLegendLayerByPathRec(legendLayers, parentLayerPath);
+
+  while (parentLayerInfo !== undefined) {
+    // Return true as soon as any parent is not visible
+    if (parentLayerInfo.visible === false) return true;
+
+    // Prepare for next parent
+    parentLayerPathArray.pop();
+    parentLayerPath = parentLayerPathArray.join('/');
+    parentLayerInfo = utilLegendLayerByPathRec(legendLayers, parentLayerPath);
+  }
+
+  return false;
+};
+
+/**
+ * Checks whether a layer is hidden on the map.
+ *
+ * A layer is considered hidden if any of its parent layers are hidden,
+ * it is not in the visible range, or it is not visible.
+ *
+ * @param layerPath - The layer path to check
+ * @param legendLayers - The legend layers array to search in
+ * @returns True if the layer is hidden on the map, false otherwise
+ */
+const utilGetLayerHiddenOnMap = (legendLayers: TypeLegendLayer[], layerPath: string): boolean => {
+  return (
+    utilGetParentLayerHiddenOnMap(legendLayers, layerPath) ||
+    !utilLegendLayerByPathRec(legendLayers, layerPath)?.inVisibleRange ||
+    !utilLegendLayerByPathRec(legendLayers, layerPath)?.visible
+  );
+};
+
+/**
+ * Returns all layers in the tree that have collapsible legends.
+ *
+ * A layer is considered collapsible if it has children, multiple legend items,
+ * or is a WMS layer with valid icon images.
+ *
+ * @param legendLayers - The legend layers tree to search
+ * @returns The layers with collapsible legends
+ */
+const utilGetLegendCollapsibleLayers = (legendLayers: TypeLegendLayer[]): TypeLegendLayer[] => {
+  return Object.values(utilFindAllLayers(legendLayers)).filter((layer) => {
+    if (layer.children?.length > 0) return true;
+    if (layer.items?.length > 1) return true;
+    if (layer.schemaTag === CONST_LAYER_TYPES.WMS && layer.icons?.some((icon) => icon.iconImage && icon.iconImage !== 'no data'))
+      return true;
+    return false;
+  });
+};
+
+/**
+ * Recursively creates new children with updated opacity and opacityMaxFromParent values.
+ *
+ * @param children - The children array to update.
+ * @param opacity - The opacity to set.
+ * @returns A new children array with updated opacity values.
+ */
+const utilSetOpacityRec = (children: TypeLegendLayer[], opacity: number): TypeLegendLayer[] => {
+  return children.map((child) => ({
+    ...child,
+    opacity,
+    opacityMaxFromParent: opacity,
+    ...(child.children?.length ? { children: utilSetOpacityRec(child.children, opacity) } : {}),
+  }));
+};
+
+/**
  * Generic hook that selects a single property from a legend layer by path.
  *
  * @param layerPath - The layer path to look up.
@@ -261,6 +364,9 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
     highlightedLayer: '',
     legendLayers: [] as TypeLegendLayer[],
     displayState: 'view',
+    layersAreLoading: false,
+    orderedLayers: [],
+    initialFilters: {},
 
     // Initialize default
     setDefaultConfigValues: (geoviewConfig: TypeMapFeaturesConfig): void => {
@@ -397,6 +503,34 @@ export function initializeLayerState(set: TypeSetStore, get: TypeGetStore): ILay
           },
         }));
       },
+
+      /**
+       * Sets the ordered layers of the map.
+       *
+       * @param orderedLayers - The ordered layers.
+       */
+      setOrderedLayers: (orderedLayers: string[]): void => {
+        set({
+          layerState: {
+            ...get().layerState,
+            orderedLayers,
+          },
+        });
+      },
+
+      /**
+       * Sets the initial filters of the layers.
+       *
+       * @param filters - The filters keyed by layer path.
+       */
+      setInitialFilters: (filters: Record<string, string>): void => {
+        set({
+          layerState: {
+            ...get().layerState,
+            initialFilters: filters,
+          },
+        });
+      },
     },
   } as ILayerState;
 }
@@ -436,18 +570,36 @@ export const getStoreLayerLegendLayers = (mapId: string): TypeLegendLayer[] => {
 // Don't do this, see note in the getter above.
 // export const useStoreLayerStateLegendLayers = ...
 
-/**
- * Gets the layer paths for the given map.
- *
- * @param mapId - The map identifier.
- * @returns The layer paths array.
- */
-export const getStoreLayerLayerPaths = (mapId: string): string[] => {
-  return getStoreLayerState(mapId).legendLayers.map((layer) => layer.layerPath);
+/** Returns all layer paths from the ordered layers. */
+export const getStoreLayerOrderedLayerPaths = (mapId: string): string[] => {
+  return getStoreLayerState(mapId).orderedLayers;
 };
 
+/** Selects the ordered layer paths from the store. */
+export const useStoreLayerOrderedLayerPaths = (): string[] => useStore(useGeoViewStore(), (state) => state.layerState.orderedLayers);
+
+/**
+ * Returns the index of a layer in the ordered layers array by its path.
+ *
+ * @param mapId - The map identifier
+ * @param layerPath - The layer path to search for
+ * @returns The zero-based index of the layer, or -1 if not found
+ */
+export const getStoreLayerOrderedLayerIndexByPath = (mapId: string, layerPath: string): number => {
+  return getStoreLayerOrderedLayerPaths(mapId).indexOf(layerPath);
+};
+
+/** Returns the initial filter string for a layer path, or undefined if none is set. */
+export const getStoreLayerInitialFilter = (mapId: string, layerPath: string): string | undefined => {
+  return getStoreLayerState(mapId).initialFilters[layerPath];
+};
+
+/** Selects the initial layer filters from the store. */
+export const useStoreLayerInitialFilters = (): Record<string, string> =>
+  useStore(useGeoViewStore(), (state) => state.layerState.initialFilters);
+
 /** Hook that returns only the top-level layer paths. Re-renders only when layers are added, removed, or reordered. */
-export const useStoreLayerLayerPaths = (): string[] =>
+export const useStoreLayerTopLevelLayerPaths = (): string[] =>
   useStableSelector(useGeoViewStore(), (state) => state.layerState.legendLayers.map((layer) => layer.layerPath));
 
 /**
@@ -564,6 +716,53 @@ export const getStoreLayerStatus = (mapId: string, layerPath: string): TypeLayer
 export const useStoreLayerStatus = createLayerSelectorHook('layerStatus');
 
 /**
+ * Gets the queryable state for a specific layer.
+ *
+ * @param mapId - The map identifier
+ * @param layerPath - The layer path to look up
+ * @returns The layer queryable state, defaults to true
+ */
+export const getStoreLayerQueryable = (mapId: string, layerPath: string): boolean => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.queryable ?? true;
+};
+
+/** Hook that returns the queryable state for a specific layer. */
+export const useStoreLayerQueryable = createLayerSelectorHook('queryable');
+
+/**
+ * Hooks on the queryable states for multiple layer paths.
+ *
+ * @param layerPaths - The layer paths to check queryable state for
+ * @returns A record mapping each layer path to its queryable state
+ */
+export const useStoreLayerQueryableByPaths = (layerPaths: string[]): Record<string, boolean> => {
+  // Hook
+  return useStableSelector(useGeoViewStore(), (state) => {
+    const result: Record<string, boolean> = {};
+
+    for (const layerPath of layerPaths) {
+      result[layerPath] = utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.queryable ?? true;
+    }
+
+    return result;
+  });
+};
+
+/**
+ * Gets the hoverable state for a specific layer.
+ *
+ * @param mapId - The map identifier
+ * @param layerPath - The layer path to look up
+ * @returns The layer hoverable state, defaults to true
+ */
+export const getStoreLayerHoverable = (mapId: string, layerPath: string): boolean => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.hoverable ?? true;
+};
+
+/** Hook that returns the hoverable state for a specific layer. */
+export const useStoreLayerHoverable = createLayerSelectorHook('hoverable');
+
+/**
  * Hook that returns a record of layer statuses for all layers.
  *
  * @returns A record of layer statuses keyed by layer path, defaulting to 'newInstance'.
@@ -584,6 +783,228 @@ export const useStoreLayerStatusSet = (): Record<string, TypeLayerStatus> => {
     }, {});
   });
 };
+
+/**
+ * Gets the visible state for a specific layer.
+ *
+ * @param mapId - The map identifier
+ * @param layerPath - The layer path to look up
+ * @returns The layer visible state, defaults to true
+ */
+export const getStoreLayerVisible = (mapId: string, layerPath: string): boolean => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.visible ?? true;
+};
+
+/**
+ * Selects whether a layer is within its visible zoom range.
+ *
+ * @param layerPath - The layer path to check
+ * @returns True if the layer is in visible range
+ */
+export const useStoreLayerVisible = createLayerSelectorHook('visible');
+
+/** Returns the layer paths of all layers currently visible. */
+export const getStoreLayerVisibleLayerPaths = (mapId: string): string[] => {
+  const allLayers = utilFindAllLayers(getStoreLayerState(mapId).legendLayers);
+  return Object.values(allLayers)
+    .filter((layer) => layer.visible ?? true)
+    .map((layer) => layer.layerPath);
+};
+
+/**
+ * Selects whether any of the given layer paths are visible.
+ *
+ * @param layerPaths - The layer paths to check visibility for
+ * @returns True if at least one layer is visible, false otherwise
+ */
+// TODO: CHECK - Sometimes the default is true and sometimes it's false, put them all to true when it's logical to do so?
+export const useStoreLayerArrayVisibility = (layerPaths: string[]): boolean => {
+  return useStore(useGeoViewStore(), (state) => {
+    // Return true if all layers are visible (or don't exist yet)
+    return layerPaths.some((layerPath) => {
+      return utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.visible || false;
+    });
+  });
+};
+
+/** Returns whether any parent of the given layer is hidden. */
+export const getStoreLayerParentHidden = (mapId: string, layerPath: string): boolean => {
+  return utilGetParentLayerHiddenOnMap(getStoreLayerState(mapId).legendLayers, layerPath);
+};
+
+/**
+ * Gets the InVisibleRange flag for a specific layer.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path to look up.
+ * @returns The InVisibleRange flag, or true if not defined.
+ */
+export const getStoreLayerInVisibleRange = (mapId: string, layerPath: string): boolean => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.inVisibleRange ?? true;
+};
+
+/**
+ * Selects whether a layer is within its visible zoom range.
+ *
+ * @param layerPath - The layer path to check
+ * @returns True if the layer is in visible range
+ */
+export const useStoreLayerInVisibleRange = createLayerSelectorHook('inVisibleRange');
+
+/** Returns the layer paths of all layers currently in their visible zoom range. */
+export const getStoreLayerInVisibleRangeLayerPaths = (mapId: string): string[] => {
+  const allLayers = utilFindAllLayers(getStoreLayerState(mapId).legendLayers);
+  return Object.values(allLayers)
+    .filter((layer) => layer.inVisibleRange ?? true)
+    .map((layer) => layer.layerPath);
+};
+
+/**
+ * Selects whether all layers are visible (excluding errored layers).
+ *
+ * @returns True if all non-errored layers are visible
+ */
+export const useStoreLayerAllLayersVisibleToggle = (): boolean =>
+  useStore(useGeoViewStore(), (state) =>
+    Object.values(utilFindAllLayers(state.layerState.legendLayers)).every((layer) => layer.visible || layer.layerStatus === 'error')
+  );
+
+/** Returns whether a layer is effectively hidden on the map (parent hidden, out of range, or not visible). */
+export const getStoreLayerIsHiddenOnMap = (mapId: string, layerPath: string): boolean => {
+  return utilGetLayerHiddenOnMap(getStoreLayerState(mapId).legendLayers, layerPath);
+};
+
+/**
+ * Selects whether a layer is effectively hidden on the map.
+ *
+ * A layer is hidden if any parent is hidden, or if it is out of visible range, or if it is not visible.
+ *
+ * @param layerPath - The layer path to check
+ * @returns True if the layer is hidden on the map
+ */
+export const useStoreLayerIsHiddenOnMap = (layerPath: string): boolean => {
+  return useStore(useGeoViewStore(), (state) => utilGetLayerHiddenOnMap(state.layerState.legendLayers, layerPath));
+};
+
+/**
+ * Selects the hidden-on-map state for all layers.
+ *
+ * @returns A record mapping each layer path to whether it is hidden on the map
+ */
+export const useStoreLayerIsHiddenOnMapSet = (): Record<string, boolean> => {
+  return useStableSelector(useGeoViewStore(), (state) => {
+    const allLayers = utilFindAllLayers(state.layerState.legendLayers);
+    return Object.values(allLayers).reduce<Record<string, boolean>>((acc, layer) => {
+      // eslint-disable-next-line no-param-reassign
+      acc[layer.layerPath] = utilGetLayerHiddenOnMap(state.layerState.legendLayers, layer.layerPath);
+      return acc;
+    }, {});
+  });
+};
+
+/**
+ * Selects whether any parent of the given layer is hidden.
+ *
+ * @param layerPath - The layer path to check parent visibility for
+ * @returns True if any parent layer is hidden
+ */
+export const useStoreLayerIsParentHiddenOnMap = (layerPath: string): boolean => {
+  return useStore(useGeoViewStore(), (state) => utilGetParentLayerHiddenOnMap(state.layerState.legendLayers, layerPath));
+};
+
+/**
+ * Selects the parent-hidden state for all layers.
+ *
+ * @returns A record mapping each layer path to whether any of its parents are hidden
+ */
+export const useStoreLayerIsParentHiddenOnMapSet = (): Record<string, boolean> => {
+  return useStableSelector(useGeoViewStore(), (state) => {
+    const allLayers = utilFindAllLayers(state.layerState.legendLayers);
+    return Object.values(allLayers).reduce<Record<string, boolean>>((acc, layer) => {
+      // eslint-disable-next-line no-param-reassign
+      acc[layer.layerPath] = utilGetParentLayerHiddenOnMap(state.layerState.legendLayers, layer.layerPath);
+      return acc;
+    }, {});
+  });
+};
+
+/** Selects the visible layer paths derived from legendLayers. */
+export const useStoreLayerVisibleLayers = (): string[] =>
+  useStableSelector(useGeoViewStore(), (state) => {
+    const allLayers = utilFindAllLayers(state.layerState.legendLayers);
+    return Object.values(allLayers)
+      .filter((layer) => layer.visible ?? true)
+      .map((layer) => layer.layerPath);
+  });
+
+/**
+ * Selects the layer paths that are either visible or in their visible zoom range.
+ *
+ * Used by data-table, details, geochart, and time-slider left panel components.
+ *
+ * @returns The deduplicated array of layer paths that are visible or in visible range
+ */
+export const useStoreLayerAllVisibleAndInRangeLayers = (): string[] =>
+  useStableSelector(useGeoViewStore(), (state) => {
+    const allLayers = utilFindAllLayers(state.layerState.legendLayers);
+    return Object.values(allLayers)
+      .filter((layer) => (layer.visible ?? true) || (layer.inVisibleRange ?? true))
+      .map((layer) => layer.layerPath);
+  });
+
+/** Returns the legend collapsed state for all layers, defaulting to false if not found. */
+export const getStoreLayerLegendCollapsedSet = (mapId: string): Record<string, boolean> => {
+  const allLayers = utilFindAllLayers(getStoreLayerLegendLayers(mapId));
+  return Object.values(allLayers).reduce<Record<string, boolean>>((acc, layer) => {
+    // eslint-disable-next-line no-param-reassign
+    acc[layer.layerPath] = layer.legendCollapsed ?? false;
+    return acc;
+  }, {});
+};
+
+/** Returns the ordered layer info entries that have collapsible legends. */
+export const getStoreLayerLegendCollapsibleLayers = (mapId: string): TypeLegendLayer[] => {
+  return utilGetLegendCollapsibleLayers(getStoreLayerLegendLayers(mapId));
+};
+
+/** Returns the legend collapsed state for a layer, defaulting to false if not found. */
+export const getStoreLayerLegendCollapsed = (mapId: string, layerPath: string): boolean => {
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.legendCollapsed ?? false;
+};
+
+/**
+ * Selects the legend collapsed state for a given layer.
+ *
+ * @param layerPath - The layer path to check
+ * @returns True if the layer legend is collapsed
+ */
+export const useStoreLayerLegendCollapsed = createLayerSelectorHook('legendCollapsed') ?? false;
+
+/**
+ * Selects whether all collapsible layer legends are collapsed.
+ *
+ * Non-collapsible leaf layers are considered inherently collapsed (nothing to expand),
+ * so they do not prevent this from returning true.
+ *
+ * @returns True if all collapsible legends are collapsed, or if there are no collapsible layers
+ */
+export const useStoreLayerAllLayersCollapsedToggle = (): boolean =>
+  useStore(useGeoViewStore(), (state) => {
+    // Get the legend collapsible layers
+    const collapsibleLayers = utilGetLegendCollapsibleLayers(state.layerState.legendLayers);
+
+    // If there are no collapsible layers, return true (leaf layers are inherently collapsed)
+    if (collapsibleLayers.length === 0) return true;
+    return collapsibleLayers.every((layer) => layer.legendCollapsed ?? false);
+  });
+
+/**
+ * Selects whether there are any layers with collapsible legends.
+ *
+ * @returns True if at least one layer has a collapsible legend
+ */
+export const useStoreLayerHasCollapsibleLayersToggle = (): boolean =>
+  useStore(useGeoViewStore(), (state) => utilGetLegendCollapsibleLayers(state.layerState.legendLayers).length > 0);
 
 /**
  * Gets the WMS style for a specific layer.
@@ -742,7 +1163,7 @@ export const useStoreLayerCanToggle = createLayerSelectorHook('canToggle');
 /**
  * Selects whether all sublayers of a layer are visible.
  *
- * Reads from both layerState (children tree) and mapState (visibleLayers).
+ * Reads from layerState children tree and each layer's visible property.
  *
  * @param layerPath - The layer path to check
  * @returns True if all children and descendants are visible
@@ -751,7 +1172,11 @@ export const useStoreLayerAllChildrenVisible = (layerPath: string): boolean => {
   return useStore(useGeoViewStore(), (state): boolean => {
     const layer = utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath);
     if (!layer || !layer.children.length) return true;
-    return utilAllChildrenVisible(layer, state.mapState.visibleLayers);
+    const allLayers = utilFindAllLayers(state.layerState.legendLayers);
+    const visiblePaths = Object.values(allLayers)
+      .filter((l) => l.visible ?? true)
+      .map((l) => l.layerPath);
+    return utilAllChildrenVisible(layer, visiblePaths);
   });
 };
 
@@ -830,12 +1255,6 @@ export const useStoreLayerOpacity = createLayerSelectorHook('opacity');
 
 /** Hook that returns the max opacity inherited from parent for a specific layer. */
 export const useStoreLayerOpacityMaxFromParent = createLayerSelectorHook('opacityMaxFromParent');
-
-/** Hook that returns the hoverable flag for a specific layer. */
-export const useStoreLayerHoverable = createLayerSelectorHook('hoverable');
-
-/** Hook that returns the queryable flag for a specific layer. */
-export const useStoreLayerQueryable = createLayerSelectorHook('queryable');
 
 /** Hook that returns the URL for a specific layer. */
 export const useStoreLayerUrl = createLayerSelectorHook('url');
@@ -952,7 +1371,7 @@ export const useStoreLayerDisplayDateFormat = (layerPath: string | undefined): T
   return useStore(useGeoViewStore(), (state) => {
     return (
       utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.displayDateFormat ??
-      getStoreDisplayDateFormatDefault(state.mapId).datetimeFormat
+      getStoreAppDisplayDateFormatDefault(state.mapId).datetimeFormat
     );
   });
 };
@@ -966,7 +1385,7 @@ export const useStoreLayerDisplayDateFormatSet = (): Record<string, TypeDisplayD
   // Hook
   return useStableSelector(useGeoViewStore(), (state) => {
     // Get the default format
-    const defaultFormat = getStoreDisplayDateFormatDefault(state.mapId).datetimeFormat;
+    const defaultFormat = getStoreAppDisplayDateFormatDefault(state.mapId).datetimeFormat;
 
     // Get all layers
     const allLayers = utilFindAllLayers(state.layerState.legendLayers);
@@ -1000,7 +1419,7 @@ export const useStoreLayerDisplayDateFormatShort = (layerPath: string | undefine
     return (
       utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.displayDateFormatShort ??
       utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.displayDateFormat ??
-      getStoreDisplayDateFormatDefault(state.mapId).dateFormat
+      getStoreAppDisplayDateFormatDefault(state.mapId).dateFormat
     );
   });
 };
@@ -1021,7 +1440,7 @@ export const useStoreLayerDisplayDateTimezone = (layerPath: string | undefined):
   // Hook
   return useStore(useGeoViewStore(), (state) => {
     return (
-      utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.displayDateTimezone ?? getStoreDisplayDateTimezone(state.mapId)
+      utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.displayDateTimezone ?? getStoreAppDisplayDateTimezone(state.mapId)
     );
   });
 };
@@ -1041,7 +1460,7 @@ export const useStoreLayerDisplayDateTimezoneSet = (): Record<string, TimeIANA> 
     return Object.values(allLayers).reduce<Record<string, TimeIANA>>((acc, layer) => {
       if (layer.layerPath) {
         // eslint-disable-next-line no-param-reassign
-        acc[layer.layerPath] = layer.displayDateTimezone ?? getStoreDisplayDateTimezone(state.mapId);
+        acc[layer.layerPath] = layer.displayDateTimezone ?? getStoreAppDisplayDateTimezone(state.mapId);
       }
       return acc;
     }, {});
@@ -1249,29 +1668,13 @@ export const setStoreLayerItemVisibility = (
 };
 
 /**
- * Recursively creates new children with updated opacity and opacityMaxFromParent values.
- *
- * @param children - The children array to update.
- * @param opacity - The opacity to set.
- * @returns A new children array with updated opacity values.
- */
-const utilSetOpacityRec = (children: TypeLegendLayer[], opacity: number): TypeLegendLayer[] => {
-  return children.map((child) => ({
-    ...child,
-    opacity,
-    opacityMaxFromParent: opacity,
-    ...(child.children?.length ? { children: utilSetOpacityRec(child.children, opacity) } : {}),
-  }));
-};
-
-/**
  * Sets the opacity for a specific layer and propagates it to children.
  *
  * @param mapId - The map identifier.
  * @param layerPath - The layer path to update.
  * @param opacity - The opacity value (0–1).
  */
-export const setStoreOpacity = (mapId: string, layerPath: string, opacity: number): void => {
+export const setStoreLayerOpacity = (mapId: string, layerPath: string, opacity: number): void => {
   getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({
     ...layer,
     opacity,
@@ -1285,9 +1688,46 @@ export const setStoreOpacity = (mapId: string, layerPath: string, opacity: numbe
  * @param mapId - The map identifier.
  * @param layerPath - The layer path to highlight.
  */
-export const setStoreHighlightedLayer = (mapId: string, layerPath: string): void => {
-  // Set in store
+export const setStoreLayerHighlightedLayer = (mapId: string, layerPath: string): void => {
   getStoreLayerState(mapId).actions.setHighlightLayer(layerPath);
+};
+
+/**
+ * Sets the visibility of a layer in the store.
+ *
+ * @param mapId - The ID of the map
+ * @param layerPath - The layer path of the layer to change
+ * @param visible - The visible state to set
+ */
+export const setStoreLayerVisibility = (mapId: string, layerPath: string, visible: boolean): void => {
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, visible }));
+};
+
+/**
+ * Sets the visibility range state for a specific layer in the store.
+ *
+ * @param mapId - The map identifier
+ * @param layerPath - The unique layer path identifier
+ * @param inVisibleRange - Whether the layer is within its visible zoom range
+ */
+export const setStoreLayerInVisibleRange = (mapId: string, layerPath: string, inVisibleRange: boolean): void => {
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, inVisibleRange }));
+};
+
+/** Sets the legend collapsed state for a layer in the store. */
+export const setStoreLayerLegendCollapsed = (mapId: string, layerPath: string, legendCollapsed: boolean): void => {
+  getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, legendCollapsed }));
+};
+
+/** Sets the legend collapsed state for all layers in the store. */
+export const setStoreLayerAllMapLayerCollapsed = (mapId: string, newCollapsed: boolean): void => {
+  // Set the collapsed state for all layers in the tree
+  const allLayers = utilFindAllLayers(getStoreLayerLegendLayers(mapId));
+  Object.values(allLayers).forEach((layer) => {
+    if (layer.legendCollapsed !== newCollapsed) {
+      setStoreLayerLegendCollapsed(mapId, layer.layerPath, newCollapsed);
+    }
+  });
 };
 
 /**
@@ -1386,7 +1826,7 @@ export const setStoreLayerSelectedLayersTabLayer = (mapId: string, layerPath: st
 export const setStoreReorderLegendLayers = (mapId: string): void => {
   // Create a sorted copy of the layers (toSorted produces a new array)
   const sortedLayers = [...getStoreLayerLegendLayers(mapId)].sort(
-    (a, b) => getStoreMapOrderedLayerIndexByPath(mapId, a.layerPath) - getStoreMapOrderedLayerIndexByPath(mapId, b.layerPath)
+    (a, b) => getStoreLayerOrderedLayerIndexByPath(mapId, a.layerPath) - getStoreLayerOrderedLayerIndexByPath(mapId, b.layerPath)
   );
 
   // Save in store
@@ -1467,6 +1907,17 @@ export const setStoreLayerDeletionStartTime = (mapId: string, layerPath: string,
 export const setStoreLegendLayersDirectly = (mapId: string, legendLayers: TypeLegendLayer[]): void => {
   // Set updated legend layers
   getStoreLayerState(mapId).actions.setLegendLayers(legendLayers);
+};
+
+/** Sets the ordered layers directly in the store. */
+export const setStoreLayerOrderedLayers = (mapId: string, layerPaths: string[]): void => {
+  getStoreLayerState(mapId).actions.setOrderedLayers(layerPaths);
+};
+
+/** Adds an initial filter for a layer path in the store. */
+export const addStoreLayerInitialFilter = (mapId: string, layerPath: string, filter: string): void => {
+  const curFilters = getStoreLayerState(mapId).initialFilters;
+  getStoreLayerState(mapId).actions.setInitialFilters({ ...curFilters, [layerPath]: filter });
 };
 
 // #endregion STATE ADAPTORS

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -570,12 +570,21 @@ export const getStoreLayerLegendLayers = (mapId: string): TypeLegendLayer[] => {
 // Don't do this, see note in the getter above.
 // export const useStoreLayerStateLegendLayers = ...
 
-/** Returns all layer paths from the ordered layers. */
+/**
+ * Returns all layer paths from the ordered layers.
+ *
+ * @param mapId - The map identifier
+ * @returns The ordered layer paths array
+ */
 export const getStoreLayerOrderedLayerPaths = (mapId: string): string[] => {
   return getStoreLayerState(mapId).orderedLayers;
 };
 
-/** Selects the ordered layer paths from the store. */
+/**
+ * Selects the ordered layer paths from the store.
+ *
+ * @returns The ordered layer paths array
+ */
 export const useStoreLayerOrderedLayerPaths = (): string[] => useStore(useGeoViewStore(), (state) => state.layerState.orderedLayers);
 
 /**
@@ -589,16 +598,30 @@ export const getStoreLayerOrderedLayerIndexByPath = (mapId: string, layerPath: s
   return getStoreLayerOrderedLayerPaths(mapId).indexOf(layerPath);
 };
 
-/** Returns the initial filter string for a layer path, or undefined if none is set. */
+/**
+ * Returns the initial filter string for a layer path, or undefined if none is set.
+ *
+ * @param mapId - The map identifier.
+ * @param layerPath - The layer path.
+ * @returns The initial filter string, or undefined if none is set.
+ */
 export const getStoreLayerInitialFilter = (mapId: string, layerPath: string): string | undefined => {
   return getStoreLayerState(mapId).initialFilters[layerPath];
 };
 
-/** Selects the initial layer filters from the store. */
+/**
+ * Selects the initial layer filters from the store.
+ *
+ * @returns A record of filter strings keyed by layer path
+ */
 export const useStoreLayerInitialFilters = (): Record<string, string> =>
   useStore(useGeoViewStore(), (state) => state.layerState.initialFilters);
 
-/** Hook that returns only the top-level layer paths. Re-renders only when layers are added, removed, or reordered. */
+/**
+ * Hook that returns only the top-level layer paths. Re-renders only when layers are added, removed, or reordered.
+ *
+ * @returns The top-level layer paths
+ */
 export const useStoreLayerTopLevelLayerPaths = (): string[] =>
   useStableSelector(useGeoViewStore(), (state) => state.layerState.legendLayers.map((layer) => layer.layerPath));
 
@@ -612,11 +635,19 @@ export const getStoreLayerSelectedLayerPath = (mapId: string): string | undefine
   return getStoreLayerState(mapId).selectedLayerPath;
 };
 
-/** Hook that returns the selected layer path. */
+/**
+ * Hook that returns the selected layer path.
+ *
+ * @returns The selected layer path, or null/undefined if none is selected
+ */
 export const useStoreLayerSelectedLayerPath = (): string | null | undefined =>
   useStore(useGeoViewStore(), (state) => state.layerState.selectedLayerPath);
 
-/** Hook that returns the layer name of the currently selected layer. Primitive string so Object.is prevents spurious re-renders. */
+/**
+ * Hook that returns the layer name of the currently selected layer. Primitive string so Object.is prevents spurious re-renders.
+ *
+ * @returns The selected layer name, or undefined if no layer is selected
+ */
 export const useStoreLayerSelectedLayerName = (): string | undefined =>
   useStore(
     useGeoViewStore(),
@@ -633,7 +664,11 @@ export const getStoreLayerHighlightedLayer = (mapId: string): string => {
   return getStoreLayerState(mapId).highlightedLayer;
 };
 
-/** Hook that returns the highlighted layer path. */
+/**
+ * Hook that returns the highlighted layer path.
+ *
+ * @returns The highlighted layer path
+ */
 export const useStoreLayerHighlightedLayer = (): string => useStore(useGeoViewStore(), (state) => state.layerState.highlightedLayer);
 
 /**
@@ -646,7 +681,11 @@ export const getStoreLayerDisplayState = (mapId: string): TypeLayersViewDisplayS
   return getStoreLayerState(mapId).displayState;
 };
 
-/** Hook that returns the current layers panel display state. */
+/**
+ * Hook that returns the current layers panel display state.
+ *
+ * @returns The current display state
+ */
 export const useStoreLayerDisplayState = (): TypeLayersViewDisplayState =>
   useStore(useGeoViewStore(), (state) => state.layerState.displayState);
 
@@ -660,7 +699,11 @@ export const getStoreLayerAreLayersLoading = (mapId: string): boolean => {
   return getStoreLayerState(mapId).layersAreLoading;
 };
 
-/** Hook that returns whether layers are currently loading. */
+/**
+ * Hook that returns whether layers are currently loading.
+ *
+ * @returns True if layers are loading
+ */
 export const useStoreLayerAreLayersLoading = (): boolean => useStore(useGeoViewStore(), (state) => state.layerState.layersAreLoading);
 
 /**
@@ -798,12 +841,16 @@ export const getStoreLayerVisible = (mapId: string, layerPath: string): boolean 
 /**
  * Selects whether a layer is within its visible zoom range.
  *
- * @param layerPath - The layer path to check
  * @returns True if the layer is in visible range
  */
 export const useStoreLayerVisible = createLayerSelectorHook('visible');
 
-/** Returns the layer paths of all layers currently visible. */
+/**
+ * Returns the layer paths of all layers currently visible.
+ *
+ * @param mapId - The map identifier.
+ * @returns An array of layer paths that are currently visible.
+ */
 export const getStoreLayerVisibleLayerPaths = (mapId: string): string[] => {
   const allLayers = utilFindAllLayers(getStoreLayerState(mapId).legendLayers);
   return Object.values(allLayers)
@@ -827,7 +874,13 @@ export const useStoreLayerArrayVisibility = (layerPaths: string[]): boolean => {
   });
 };
 
-/** Returns whether any parent of the given layer is hidden. */
+/**
+ * Returns whether any parent of the given layer is hidden.
+ *
+ * @param mapId - The map identifier
+ * @param layerPath - The layer path to check parent visibility for
+ * @returns True if any parent layer is hidden
+ */
 export const getStoreLayerParentHidden = (mapId: string, layerPath: string): boolean => {
   return utilGetParentLayerHiddenOnMap(getStoreLayerState(mapId).legendLayers, layerPath);
 };
@@ -851,7 +904,12 @@ export const getStoreLayerInVisibleRange = (mapId: string, layerPath: string): b
  */
 export const useStoreLayerInVisibleRange = createLayerSelectorHook('inVisibleRange');
 
-/** Returns the layer paths of all layers currently in their visible zoom range. */
+/**
+ * Returns the layer paths of all layers currently in their visible zoom range.
+ *
+ * @param mapId - The map identifier
+ * @returns An array of layer paths that are in their visible zoom range
+ */
 export const getStoreLayerInVisibleRangeLayerPaths = (mapId: string): string[] => {
   const allLayers = utilFindAllLayers(getStoreLayerState(mapId).legendLayers);
   return Object.values(allLayers)
@@ -869,7 +927,13 @@ export const useStoreLayerAllLayersVisibleToggle = (): boolean =>
     Object.values(utilFindAllLayers(state.layerState.legendLayers)).every((layer) => layer.visible || layer.layerStatus === 'error')
   );
 
-/** Returns whether a layer is effectively hidden on the map (parent hidden, out of range, or not visible). */
+/**
+ * Returns whether a layer is effectively hidden on the map (parent hidden, out of range, or not visible).
+ *
+ * @param mapId - The map identifier
+ * @param layerPath - The layer path to check
+ * @returns True if the layer is hidden on the map
+ */
 export const getStoreLayerIsHiddenOnMap = (mapId: string, layerPath: string): boolean => {
   return utilGetLayerHiddenOnMap(getStoreLayerState(mapId).legendLayers, layerPath);
 };
@@ -928,7 +992,10 @@ export const useStoreLayerIsParentHiddenOnMapSet = (): Record<string, boolean> =
   });
 };
 
-/** Selects the visible layer paths derived from legendLayers. */
+/** Selects the visible layer paths derived from legendLayers.
+ *
+ * @returns The array of visible layer paths
+ */
 export const useStoreLayerVisibleLayers = (): string[] =>
   useStableSelector(useGeoViewStore(), (state) => {
     const allLayers = utilFindAllLayers(state.layerState.legendLayers);
@@ -952,7 +1019,12 @@ export const useStoreLayerAllVisibleAndInRangeLayers = (): string[] =>
       .map((layer) => layer.layerPath);
   });
 
-/** Returns the legend collapsed state for all layers, defaulting to false if not found. */
+/**
+ * Returns the legend collapsed state for all layers, defaulting to false if not found.
+ *
+ * @param mapId - The map identifier
+ * @returns A record mapping each layer path to its collapsed state
+ */
 export const getStoreLayerLegendCollapsedSet = (mapId: string): Record<string, boolean> => {
   const allLayers = utilFindAllLayers(getStoreLayerLegendLayers(mapId));
   return Object.values(allLayers).reduce<Record<string, boolean>>((acc, layer) => {
@@ -962,12 +1034,23 @@ export const getStoreLayerLegendCollapsedSet = (mapId: string): Record<string, b
   }, {});
 };
 
-/** Returns the ordered layer info entries that have collapsible legends. */
+/**
+ * Returns the ordered layer info entries that have collapsible legends.
+ *
+ * @param mapId - The map identifier
+ * @returns The layers with collapsible legends
+ */
 export const getStoreLayerLegendCollapsibleLayers = (mapId: string): TypeLegendLayer[] => {
   return utilGetLegendCollapsibleLayers(getStoreLayerLegendLayers(mapId));
 };
 
-/** Returns the legend collapsed state for a layer, defaulting to false if not found. */
+/**
+ * Returns the legend collapsed state for a layer, defaulting to false if not found.
+ *
+ * @param mapId - The map identifier
+ * @param layerPath - The layer path to check
+ * @returns True if the layer legend is collapsed
+ */
 export const getStoreLayerLegendCollapsed = (mapId: string, layerPath: string): boolean => {
   return getStoreLayerLegendLayerByPath(mapId, layerPath)?.legendCollapsed ?? false;
 };
@@ -1526,9 +1609,10 @@ export const setStoreLayerStatus = (mapId: string, layerPath: string, layerStatu
 
 /**
  * Sets the layer name of the layer and its children in the store.
- * @param mapId - The ID of the map.
- * @param layerPath - The layer path of the layer to change.
- * @param layerName - The layer name to set.
+ *
+ * @param mapId - The ID of the map
+ * @param layerPath - The layer path of the layer to change
+ * @param layerName - The layer name to set
  */
 export const setStoreLayerName = (mapId: string, layerPath: string, layerName: string | undefined): void => {
   getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, layerName: layerName ?? '' }));
@@ -1714,12 +1798,23 @@ export const setStoreLayerInVisibleRange = (mapId: string, layerPath: string, in
   getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, inVisibleRange }));
 };
 
-/** Sets the legend collapsed state for a layer in the store. */
+/**
+ * Sets the legend collapsed state for a layer in the store.
+ *
+ * @param mapId - The map identifier
+ * @param layerPath - The layer path to update
+ * @param legendCollapsed - Whether the legend should be collapsed
+ */
 export const setStoreLayerLegendCollapsed = (mapId: string, layerPath: string, legendCollapsed: boolean): void => {
   getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({ ...layer, legendCollapsed }));
 };
 
-/** Sets the legend collapsed state for all layers in the store. */
+/**
+ * Sets the legend collapsed state for all layers in the store.
+ *
+ * @param mapId - The map identifier
+ * @param newCollapsed - Whether all legends should be collapsed
+ */
 export const setStoreLayerAllMapLayerCollapsed = (mapId: string, newCollapsed: boolean): void => {
   // Set the collapsed state for all layers in the tree
   const allLayers = utilFindAllLayers(getStoreLayerLegendLayers(mapId));
@@ -1898,23 +1993,35 @@ export const setStoreLayerDeletionStartTime = (mapId: string, layerPath: string,
 /**
  * Temporary method to set the legend layers directly in the store, used for the moment to set the
  * legend layers with the data from the query result of the legend.
+ *
  * This method should be used with caution and only in specific cases, as it bypasses the usual
  * state update patterns and may lead to unintended side effects if not used properly.
  *
- * @param mapId
- * @param legendLayers
+ * @param mapId - The map identifier
+ * @param legendLayers - The legend layers to set
  */
 export const setStoreLegendLayersDirectly = (mapId: string, legendLayers: TypeLegendLayer[]): void => {
   // Set updated legend layers
   getStoreLayerState(mapId).actions.setLegendLayers(legendLayers);
 };
 
-/** Sets the ordered layers directly in the store. */
+/**
+ * Sets the ordered layers directly in the store.
+ *
+ * @param mapId - The map identifier
+ * @param layerPaths - The ordered layer paths to set
+ */
 export const setStoreLayerOrderedLayers = (mapId: string, layerPaths: string[]): void => {
   getStoreLayerState(mapId).actions.setOrderedLayers(layerPaths);
 };
 
-/** Adds an initial filter for a layer path in the store. */
+/**
+ * Adds an initial filter for a layer path in the store.
+ *
+ * @param mapId - The map identifier
+ * @param layerPath - The layer path to set the filter for
+ * @param filter - The filter string to add
+ */
 export const addStoreLayerInitialFilter = (mapId: string, layerPath: string, filter: string): void => {
   const curFilters = getStoreLayerState(mapId).initialFilters;
   getStoreLayerState(mapId).actions.setInitialFilters({ ...curFilters, [layerPath]: filter });

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -992,7 +992,8 @@ export const useStoreLayerIsParentHiddenOnMapSet = (): Record<string, boolean> =
   });
 };
 
-/** Selects the visible layer paths derived from legendLayers.
+/**
+ * Selects the visible layer paths derived from legendLayers.
  *
  * @returns The array of visible layer paths
  */

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/layer-state.ts
@@ -832,10 +832,10 @@ export const useStoreLayerStatusSet = (): Record<string, TypeLayerStatus> => {
  *
  * @param mapId - The map identifier
  * @param layerPath - The layer path to look up
- * @returns The layer visible state, defaults to true
+ * @returns The layer visible state, defaults to false
  */
 export const getStoreLayerVisible = (mapId: string, layerPath: string): boolean => {
-  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.visible ?? true;
+  return getStoreLayerLegendLayerByPath(mapId, layerPath)?.visible ?? false;
 };
 
 /**
@@ -854,22 +854,23 @@ export const useStoreLayerVisible = createLayerSelectorHook('visible');
 export const getStoreLayerVisibleLayerPaths = (mapId: string): string[] => {
   const allLayers = utilFindAllLayers(getStoreLayerState(mapId).legendLayers);
   return Object.values(allLayers)
-    .filter((layer) => layer.visible ?? true)
+    .filter((layer) => layer.visible ?? false)
     .map((layer) => layer.layerPath);
 };
 
 /**
  * Selects whether any of the given layer paths are visible.
  *
+ * A group layer is considered visible when at least one child layer is visible.
+ *
  * @param layerPaths - The layer paths to check visibility for
  * @returns True if at least one layer is visible, false otherwise
  */
-// TODO: CHECK - Sometimes the default is true and sometimes it's false, put them all to true when it's logical to do so?
 export const useStoreLayerArrayVisibility = (layerPaths: string[]): boolean => {
   return useStore(useGeoViewStore(), (state) => {
-    // Return true if all layers are visible (or don't exist yet)
+    // Return true if any layer is visible
     return layerPaths.some((layerPath) => {
-      return utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.visible || false;
+      return utilLegendLayerByPathRec(state.layerState.legendLayers, layerPath)?.visible ?? false;
     });
   });
 };

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/map-state.ts
@@ -1,8 +1,6 @@
-import { useMemo } from 'react';
 import { useStore } from 'zustand';
 
 import type { Coordinate } from 'ol/coordinate';
-import type Overlay from 'ol/Overlay';
 import type { Extent } from 'ol/extent';
 import type { Size } from 'ol/size';
 
@@ -32,14 +30,11 @@ import type {
 } from '@/api/types/map-schema-types';
 import { DEFAULT_HIGHLIGHT_COLOR, MAP_CENTER, MAP_ZOOM_LEVEL } from '@/api/types/map-schema-types';
 import type { MapConfigLayerEntry } from '@/api/types/layer-schema-types';
-import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import { getGeoViewStore, useGeoViewStore } from '@/core/stores/stores-managers';
 import type { TypeSetStore, TypeGetStore } from '@/core/stores/geoview-store';
-import { useStableSelector } from '@/core/stores/geoview-store';
 import type { TypeMapFeaturesConfig } from '@/core/types/global-types';
 import type { TypeClickMarker } from '@/core/components/click-marker/click-marker';
 import type { TypeHoverFeatureInfo } from './feature-info-state';
-import { getStoreLayerStatus, getStoreLayerLegendLayerByPath } from './layer-state';
 import type { TypeMapStateForExportLayout } from '@/core/components/export/utilities';
 
 // #region INTERFACE DEFINITION
@@ -66,7 +61,6 @@ export interface IMapState {
   homeView: TypeMapViewSettings | undefined;
   hoverFeatureInfo: TypeHoverFeatureInfo | undefined | null;
   isMouseInsideMap: boolean;
-  initialFilters: Record<string, string>;
   initialView: TypeMapViewSettings;
   interaction: TypeInteraction;
   mapExtent: Extent | undefined;
@@ -74,10 +68,6 @@ export interface IMapState {
   mapDisplayed: boolean;
   northArrow: boolean;
   northArrowElement: TypeNorthArrow;
-  orderedLayerInfo: TypeOrderedLayerInfo[];
-  orderedLayers: string[];
-  overlayClickMarker?: Overlay;
-  overlayNorthMarker?: Overlay;
   overviewMap: boolean;
   overviewMapHideZoom: number;
   pointerPosition?: TypeMapMouseInfo;
@@ -85,8 +75,6 @@ export interface IMapState {
   rotation: number;
   scale: TypeScaleInfo;
   size: Size;
-  visibleLayers: string[];
-  visibleRangeLayers: string[];
   zoom: number;
 
   setDefaultConfigValues: (config: TypeMapFeaturesConfig) => void;
@@ -97,7 +85,6 @@ export interface IMapState {
     setMapLoaded: (mapLoaded: boolean) => void;
     setMapDisplayed: () => void;
     setAttribution: (attribution: string[]) => void;
-    setInitialFilters: (filters: Record<string, string>) => void;
     setInitialView: (view: TypeZoomAndCenter | Extent) => void;
     setGeolocatorSearchArea: (area: { searchItem: string; coords: Coordinate; bbox?: Extent } | undefined) => void;
     setHomeView: (view: TypeMapViewSettings) => void;
@@ -105,8 +92,6 @@ export interface IMapState {
     setIsMouseInsideMap: (isMouseInsideMap: boolean) => void;
     setZoom: (zoom: number) => void;
     setRotation: (rotation: number) => void;
-    setOverlayClickMarker: (overlay: Overlay) => void;
-    setOverlayNorthMarker: (overlay: Overlay) => void;
     setProjection: (projectionCode: TypeValidMapProjectionCodes) => void;
     setMapMoveEnd: (
       centerCoordinates: Coordinate,
@@ -122,146 +107,12 @@ export interface IMapState {
     setCurrentBasemapOptions: (basemapOptions: TypeBasemapOptions) => void;
     setFixNorth: (ifFix: boolean) => void;
     setHighlightedFeatures: (highlightedFeatures: TypeFeatureInfoEntry[]) => void;
-    setVisibleLayers: (newOrder: string[]) => void;
-    setVisibleRangeLayers: (newOrder: string[]) => void;
-    setOrderedLayerInfo: (newOrderedLayerInfo: TypeOrderedLayerInfo[]) => void;
-    setOrderedLayers: (newOrder: string[]) => void;
-    setHoverable: (layerPath: string, hoverable: boolean) => void;
-    setLegendCollapsed: (layerPath: string, newValue?: boolean) => void;
-    setQueryable: (layerPath: string, queryable: boolean) => void;
-    updateOrderedLayerInfoByPath: (layerPath: string, updates: Partial<TypeOrderedLayerInfo>) => void;
     setClickMarker: (coord: number[] | undefined) => void;
     setHoverFeatureInfo: (hoverFeatureInfo: TypeHoverFeatureInfo) => void;
   };
 }
 
 // #endregion INTERFACE DEFINITION
-
-/**
- * Finds a single ordered layer info entry matching the given layer path.
- *
- * @param layerPath - The layer path to search for
- * @param orderedLayerInfo - The ordered layer info array to search in
- * @returns The matching ordered layer info, or undefined if not found
- */
-const utilFindMapLayerFromOrderedInfo = (layerPath: string, orderedLayerInfo: TypeOrderedLayerInfo[]): TypeOrderedLayerInfo | undefined => {
-  return orderedLayerInfo.find((layer) => layer.layerPath === layerPath);
-};
-
-/**
- * Finds a layer and all its children from the ordered layer info array.
- *
- * Matches the exact layer path and any paths that start with the given path followed by a separator.
- *
- * @param layerPath - The layer path to search for
- * @param orderedLayerInfo - The ordered layer info array to search in
- * @returns The matching ordered layer info entries including the layer and its children
- */
-// TODO: CHECK - Should likely not export this function if we have proper encapsulation (we didn't export the other similar functions in other states)
-export const utilFindMapLayerAndChildrenFromOrderedInfo = (
-  layerPath: string,
-  orderedLayerInfo: TypeOrderedLayerInfo[]
-): TypeOrderedLayerInfo[] => {
-  return orderedLayerInfo.filter((layer) => layer.layerPath.startsWith(`${layerPath}/`) || layer.layerPath === layerPath);
-};
-
-/**
- * Checks whether any parent layer of the given layer path is hidden (not visible).
- *
- * Traverses up the layer path hierarchy and returns true as soon as any ancestor is not visible.
- *
- * @param layerPath - The layer path to check parent visibility for
- * @param orderedLayerInfo - The ordered layer info array to search in
- * @returns True if any parent layer is hidden, false otherwise
- */
-const utilGetParentLayerHiddenOnMap = (layerPath: string, orderedLayerInfo: TypeOrderedLayerInfo[]): boolean => {
-  // For each parent
-  const parentLayerPathArray = layerPath.split('/');
-  parentLayerPathArray.pop();
-  let parentLayerPath = parentLayerPathArray.join('/');
-  let parentLayerInfo = orderedLayerInfo.find((info: TypeOrderedLayerInfo) => info.layerPath === parentLayerPath);
-
-  while (parentLayerInfo !== undefined) {
-    // Return true as soon as any parent is not visible
-    if (parentLayerInfo.visible === false) return true;
-
-    // Prepare for next parent
-    parentLayerPathArray.pop();
-    parentLayerPath = parentLayerPathArray.join('/');
-    // eslint-disable-next-line no-loop-func
-    parentLayerInfo = orderedLayerInfo.find((info: TypeOrderedLayerInfo) => info.layerPath === parentLayerPath);
-  }
-
-  return false;
-};
-
-/**
- * Checks whether a layer is hidden on the map.
- *
- * A layer is considered hidden if any of its parent layers are hidden,
- * it is not in the visible range, or it is not visible.
- *
- * @param layerPath - The layer path to check
- * @param orderedLayerInfo - The ordered layer info array to search in
- * @returns True if the layer is hidden on the map, false otherwise
- */
-const utilGetLayerHiddenOnMap = (layerPath: string, orderedLayerInfo: TypeOrderedLayerInfo[]): boolean => {
-  return (
-    utilGetParentLayerHiddenOnMap(layerPath, orderedLayerInfo) ||
-    !utilFindMapLayerFromOrderedInfo(layerPath, orderedLayerInfo)?.inVisibleRange ||
-    !utilFindMapLayerFromOrderedInfo(layerPath, orderedLayerInfo)?.visible
-  );
-};
-
-/**
- * Returns the ordered layer info entries that have collapsible legends.
- *
- * A layer is considered collapsible if it has children, multiple legend items,
- * or is a WMS layer with valid icon images.
- *
- * @param mapId - The map identifier
- * @param orderedLayerInfo - The ordered layer info array to filter
- * @returns The ordered layer info entries with collapsible legends
- */
-const utilGetLegendCollapsibleLayers = (mapId: string, orderedLayerInfo: TypeOrderedLayerInfo[]): TypeOrderedLayerInfo[] => {
-  // TODO: CHECK - This store references another store by using getStoreLayerLegendLayerByPath below :/
-  return orderedLayerInfo.filter((layer) => {
-    const legendLayer = getStoreLayerLegendLayerByPath(mapId, layer.layerPath);
-    return (
-      (legendLayer?.children && legendLayer.children.length > 0) ||
-      (legendLayer?.items && legendLayer.items.length > 1) ||
-      (legendLayer?.schemaTag === CONST_LAYER_TYPES.WMS &&
-        legendLayer?.icons?.some((icon) => icon.iconImage && icon.iconImage !== 'no data'))
-    );
-  });
-};
-
-/**
- * Immutably updates a single entry in the ordered layer info array by layer path.
- *
- * Returns a new array where only the matching entry is replaced with a shallow-merged copy.
- * Non-matching entries keep their original object references.
- *
- * @param orderedLayerInfo - The current ordered layer info array
- * @param layerPath - The layer path to update
- * @param updates - Partial properties to merge into the matching entry
- * @returns A new array with the updated entry, or the same array if the path was not found
- */
-const utilUpdateOrderedLayerInfoByPath = (
-  orderedLayerInfo: TypeOrderedLayerInfo[],
-  layerPath: string,
-  updates: Partial<TypeOrderedLayerInfo>
-): TypeOrderedLayerInfo[] => {
-  let found = false;
-  const result = orderedLayerInfo.map((entry) => {
-    if (entry.layerPath === layerPath) {
-      found = true;
-      return { ...entry, ...updates };
-    }
-    return entry;
-  });
-  return found ? result : orderedLayerInfo;
-};
 
 // #region STATE INITIALIZATION
 
@@ -287,7 +138,6 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
     highlightedFeatures: [],
     homeView: undefined,
     hoverFeatureInfo: undefined,
-    initialFilters: {},
     initialView: {
       zoomAndCenter: [MAP_ZOOM_LEVEL[3857], MAP_CENTER[3857]],
     },
@@ -298,8 +148,6 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
     mapDisplayed: false,
     northArrow: false,
     northArrowElement: { degreeRotation: '180.0', isNorthVisible: true } as TypeNorthArrow,
-    orderedLayerInfo: [],
-    orderedLayers: [],
     overviewMap: false,
     overviewMapHideZoom: 0,
     pointerPosition: undefined,
@@ -313,8 +161,6 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
       labelNumeric: '',
     } as TypeScaleInfo,
     size: [0, 0] as Size,
-    visibleLayers: [],
-    visibleRangeLayers: [],
     zoom: 0,
 
     /**
@@ -432,20 +278,6 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
       },
 
       /**
-       * Sets the initial filters of the map layers.
-       *
-       * @param filters - The filters.
-       */
-      setInitialFilters: (filters: Record<string, string>): void => {
-        set({
-          mapState: {
-            ...get().mapState,
-            initialFilters: filters,
-          },
-        });
-      },
-
-      /**
        * Sets the initial view of the map.
        *
        * @param view - The view extent or zoom&center.
@@ -547,34 +379,6 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
           mapState: {
             ...get().mapState,
             rotation,
-          },
-        });
-      },
-
-      /**
-       * Sets the overlay click marker of the map.
-       *
-       * @param overlayClickMarker - The overlay click marker.
-       */
-      setOverlayClickMarker: (overlayClickMarker: Overlay): void => {
-        set({
-          mapState: {
-            ...get().mapState,
-            overlayClickMarker,
-          },
-        });
-      },
-
-      /**
-       * Sets the overlay north marker of the map.
-       *
-       * @param overlayNorthMarker - The overlay north marker.
-       */
-      setOverlayNorthMarker: (overlayNorthMarker: Overlay): void => {
-        set({
-          mapState: {
-            ...get().mapState,
-            overlayNorthMarker,
           },
         });
       },
@@ -704,134 +508,6 @@ export function initializeMapState(set: TypeSetStore, get: TypeGetStore): IMapSt
       },
 
       /**
-       * Sets the visible layers of the map.
-       *
-       * @param visibleLayers - The visible layers.
-       */
-      setVisibleLayers: (visibleLayers: string[]): void => {
-        set({
-          mapState: {
-            ...get().mapState,
-            visibleLayers,
-          },
-        });
-      },
-
-      /**
-       * Sets the layers of the map that are in visible range.
-       *
-       * @param visibleRangeLayers - The layers in their visible range
-       */
-      setVisibleRangeLayers: (visibleRangeLayers: string[]): void => {
-        set({
-          mapState: {
-            ...get().mapState,
-            visibleRangeLayers,
-          },
-        });
-      },
-
-      /**
-       * Sets the ordered layer information of the map.
-       *
-       * @param orderedLayerInfo - The ordered layer information.
-       */
-      setOrderedLayerInfo: (orderedLayerInfo: TypeOrderedLayerInfo[]): void => {
-        set({
-          mapState: {
-            ...get().mapState,
-            orderedLayerInfo,
-          },
-        });
-
-        // Get all layers as specified in the order layer info we're updating
-        const orderedLayers = orderedLayerInfo.map((layer) => layer.layerPath);
-
-        // Check if the order of the layers has changed
-        if (JSON.stringify(orderedLayers) !== JSON.stringify(get().mapState.orderedLayers)) {
-          // Set the readonly representation of ordered layers array according to the order the layers are
-          get().mapState.actions.setOrderedLayers(orderedLayers);
-        }
-
-        // Get all visible layers as specified in the order layer info we're updating
-        const visibleLayers = orderedLayerInfo.filter((layer) => layer.visible).map((layer) => layer.layerPath);
-
-        // Check if the order of the layers has changed
-        if (JSON.stringify(visibleLayers) !== JSON.stringify(get().mapState.visibleLayers)) {
-          // Set the readonly representation of visibile layers array according to the visibile layers
-          get().mapState.actions.setVisibleLayers(visibleLayers);
-        }
-
-        // Get all layers in visible range as specified in the order layer info we're updating
-        const inVisibleRange = orderedLayerInfo.filter((layer) => layer.inVisibleRange).map((layer) => layer.layerPath);
-
-        // Check if the order of the layers has changed
-        if (JSON.stringify(inVisibleRange) !== JSON.stringify(get().mapState.visibleRangeLayers)) {
-          // Set the readonly representation of visibile range layers array according to the visibile range layers
-          get().mapState.actions.setVisibleRangeLayers(inVisibleRange);
-        }
-      },
-
-      /**
-       * Sets the visible layers of the map.
-       *
-       * @param orderedLayers - The ordered layers.
-       */
-      setOrderedLayers: (orderedLayers: string[]): void => {
-        set({
-          mapState: {
-            ...get().mapState,
-            orderedLayers,
-          },
-        });
-      },
-
-      /**
-       * Sets whether a layer is hoverable.
-       *
-       * @param layerPath - The path of the layer.
-       * @param hoverable - Flag indicating if the layer should be hoverable.
-       */
-      setHoverable: (layerPath: string, hoverable: boolean): void => {
-        get().mapState.actions.updateOrderedLayerInfoByPath(layerPath, { hoverable });
-      },
-
-      /**
-       * Sets whether a layer legend is collapsed.
-       *
-       * @param layerPath - The path of the layer.
-       * @param collapsed - Flag indicating if the layer should be collapsed.
-       */
-      setLegendCollapsed: (layerPath: string, collapsed: boolean): void => {
-        get().mapState.actions.updateOrderedLayerInfoByPath(layerPath, { legendCollapsed: collapsed });
-      },
-
-      /**
-       * Sets whether a layer is queryable.
-       *
-       * @param layerPath - The path of the layer.
-       * @param queryable - Flag indicating if the layer should be queryable.
-       */
-      setQueryable: (layerPath: string, queryable: boolean): void => {
-        const updates: Partial<TypeOrderedLayerInfo> = { queryableState: queryable };
-        if (queryable) updates.hoverable = true;
-        get().mapState.actions.updateOrderedLayerInfoByPath(layerPath, updates);
-      },
-
-      /**
-       * Immutably updates a single entry in orderedLayerInfo and recalculates derived state.
-       *
-       * @param layerPath - The layer path to update.
-       * @param updates - Partial properties to merge into the matching entry.
-       */
-      updateOrderedLayerInfoByPath: (layerPath: string, updates: Partial<TypeOrderedLayerInfo>): void => {
-        const newOrderedLayerInfo = utilUpdateOrderedLayerInfoByPath(get().mapState.orderedLayerInfo, layerPath, updates);
-        if (newOrderedLayerInfo !== get().mapState.orderedLayerInfo) {
-          get().mapState.actions.setOrderedLayerInfo(newOrderedLayerInfo);
-        }
-      },
-
-      /**
        * Sets the click marker of the map.
        *
        * @param coord - The click marker coordinates.
@@ -924,236 +600,6 @@ export const getStoreMapStateForExportLayout = (mapId: string): TypeMapStateForE
     mapRotation: mapState.rotation,
     currentProjection: mapState.currentProjection,
   };
-};
-
-/** Returns the ordered layer info array for the given map. */
-export const getStoreMapOrderedLayerInfo = (mapId: string): TypeOrderedLayerInfo[] => {
-  return getStoreMapState(mapId).orderedLayerInfo;
-};
-
-/** Returns the ordered layer info for a specific layer path, or undefined if not found. */
-export const getStoreMapOrderedLayerInfoByPath = (mapId: string, layerPath: string): TypeOrderedLayerInfo | undefined => {
-  return utilFindMapLayerFromOrderedInfo(layerPath, getStoreMapOrderedLayerInfo(mapId));
-};
-
-/** Returns the legend collapsed state for all layers, defaulting to true if not found. */
-export const getStoreMapLegendCollapsedSet = (mapId: string): Record<string, boolean> => {
-  const collapsedSet: Record<string, boolean> = {};
-  getStoreMapOrderedLayerInfo(mapId).forEach((layer) => {
-    collapsedSet[layer.layerPath] = layer.legendCollapsed ?? true;
-  });
-  return collapsedSet;
-};
-
-/** Returns the legend collapsed state for a layer, defaulting to true if not found. */
-export const getStoreMapLegendCollapsedByPath = (mapId: string, layerPath: string): boolean => {
-  return getStoreMapOrderedLayerInfoByPath(mapId, layerPath)?.legendCollapsed ?? true;
-};
-
-/**
- * Selects the legend collapsed state for a given layer.
- *
- * @param layerPath - The layer path to check
- * @returns True if the layer legend is collapsed
- */
-export const useStoreMapLegendCollapsedByPath = (layerPath: string): boolean => {
-  // Hook
-  return useStore(
-    useGeoViewStore(),
-    (state) => utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.legendCollapsed || false
-  );
-};
-
-/**
- * Selects whether all collapsible layer legends are collapsed.
- *
- * @returns True if all collapsible legends are collapsed, or if there are no collapsible layers
- */
-export const useStoreMapAllLayersCollapsedToggle = (): boolean =>
-  useStore(useGeoViewStore(), (state) => {
-    // Get the legend collapsible layers
-    const collapsibleLayers = utilGetLegendCollapsibleLayers(state.mapId, state.mapState.orderedLayerInfo);
-
-    // If there are no collapsible layers, return true
-    if (collapsibleLayers.length === 0) return true;
-    return collapsibleLayers.every((layer) => layer.legendCollapsed);
-  });
-
-/**
- * Selects whether there are any layers with collapsible legends.
- *
- * @returns True if at least one layer has a collapsible legend
- */
-export const useStoreMapHasCollapsibleLayersToggle = (): boolean =>
-  useStore(useGeoViewStore(), (state) => utilGetLegendCollapsibleLayers(state.mapId, state.mapState.orderedLayerInfo).length > 0);
-
-/** Returns the visibility state of a layer, or undefined if the layer is not found. */
-export const getStoreMapVisibilityByPath = (mapId: string, layerPath: string): boolean | undefined => {
-  return getStoreMapOrderedLayerInfoByPath(mapId, layerPath)?.visible;
-};
-
-/** Returns whether any parent of the given layer is hidden. */
-export const getStoreMapLayerParentHidden = (mapId: string, layerPath: string): boolean => {
-  const orderedLayerInfo = getStoreMapOrderedLayerInfo(mapId);
-  return utilGetParentLayerHiddenOnMap(layerPath, orderedLayerInfo);
-};
-
-/** Returns whether the layer is within its visible zoom range, defaulting to true. */
-export const getStoreMapInVisibleRangeByPath = (mapId: string, layerPath: string): boolean => {
-  return getStoreMapOrderedLayerInfoByPath(mapId, layerPath)?.inVisibleRange ?? true;
-};
-
-/** Returns all layer paths from the ordered layer info. */
-export const getStoreMapLayerPaths = (mapId: string): string[] => {
-  return getStoreMapOrderedLayerInfo(mapId).map((orderedLayerInfo) => {
-    return orderedLayerInfo.layerPath;
-  });
-};
-
-/**
- * Returns the index of a layer in the ordered layer info array by its path.
- *
- * @param mapId - The map identifier
- * @param layerPath - The layer path to search for
- * @returns The zero-based index of the layer, or -1 if not found
- * @deprecated This function seems fragile, do not use
- */
-export const getStoreMapOrderedLayerIndexByPath = (mapId: string, layerPath: string): number => {
-  const info = getStoreMapOrderedLayerInfo(mapId);
-  for (let i = 0; i < info.length; i++) if (info[i].layerPath === layerPath) return i;
-  return -1;
-};
-
-/** Returns the initial filter string for a layer path, or undefined if none is set. */
-export const getStoreMapInitialFilter = (mapId: string, layerPath: string): string | undefined => {
-  return getStoreMapState(mapId).initialFilters[layerPath];
-};
-
-/** Selects the initial layer filters from the store. */
-export const useStoreMapInitialFilters = (): Record<string, string> =>
-  useStore(useGeoViewStore(), (state) => state.mapState.initialFilters);
-
-/** Returns the layer paths of all layers currently in their visible zoom range. */
-export const getStoreMapLayersInVisibleRange = (mapId: string): string[] => {
-  const { orderedLayerInfo } = getStoreMapState(mapId);
-  const layersInVisibleRange = orderedLayerInfo.filter((layer) => layer.inVisibleRange).map((layer) => layer.layerPath);
-  return layersInVisibleRange;
-};
-
-/**
- * Selects the visibility state of a single layer.
- *
- * @param layerPath - The layer path to check visibility for
- * @returns True if the layer is visible, false otherwise
- */
-export const useStoreMapLayerVisibility = (layerPath: string): boolean => {
-  // Hook
-  return useStore(
-    useGeoViewStore(),
-    (state) => utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.visible || false
-  );
-};
-
-/**
- * Selects whether any of the given layer paths are visible.
- *
- * @param layerPaths - The layer paths to check visibility for
- * @returns True if at least one layer is visible, false otherwise
- */
-export const useStoreMapLayerArrayVisibility = (layerPaths: string[]): boolean => {
-  return useStore(useGeoViewStore(), (state) => {
-    // Return true if all layers are visible (or don't exist yet)
-    return layerPaths.some((layerPath) => {
-      return utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.visible || false;
-    });
-  });
-};
-
-/**
- * Selects whether a layer is within its visible zoom range.
- *
- * @param layerPath - The layer path to check
- * @returns True if the layer is in visible range
- */
-export const useStoreMapLayerInVisibleRange = (layerPath: string): boolean => {
-  // Hook
-  return useStore(
-    useGeoViewStore(),
-    (state) => utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.inVisibleRange || false
-  );
-};
-
-/**
- * Selects whether all layers are visible (excluding errored layers).
- *
- * @returns True if all non-errored layers are visible
- */
-export const useStoreMapAllLayersVisibleToggle = (): boolean =>
-  // TODO: CHECK - Cross-stores, here we jump into the layer store :/
-  useStore(useGeoViewStore(), (state) =>
-    state.mapState.orderedLayerInfo.every((layer) => layer.visible || getStoreLayerStatus(state.mapId, layer.layerPath) === 'error')
-  );
-
-/** Returns whether a layer is effectively hidden on the map (parent hidden, out of range, or not visible). */
-export const getStoreMapIsLayerHiddenOnMap = (mapId: string, layerPath: string): boolean => {
-  const { orderedLayerInfo } = getStoreMapState(mapId);
-  return utilGetLayerHiddenOnMap(layerPath, orderedLayerInfo);
-};
-
-/**
- * Selects whether a layer is effectively hidden on the map.
- *
- * A layer is hidden if any parent is hidden, or if it is out of visible range, or if it is not visible.
- *
- * @param layerPath - The layer path to check
- * @returns True if the layer is hidden on the map
- */
-export const useStoreMapIsLayerHiddenOnMap = (layerPath: string): boolean => {
-  return useStore(useGeoViewStore(), (state) => utilGetLayerHiddenOnMap(layerPath, state.mapState.orderedLayerInfo));
-};
-
-/**
- * Selects the hidden-on-map state for all layers.
- *
- * @returns A record mapping each layer path to whether it is hidden on the map
- */
-export const useStoreMapIsLayerHiddenOnMapSet = (): Record<string, boolean> => {
-  return useStableSelector(useGeoViewStore(), (state) => {
-    return state.mapState.orderedLayerInfo.reduce<Record<string, boolean>>((acc, layer) => {
-      if (layer.layerPath) {
-        // eslint-disable-next-line no-param-reassign
-        acc[layer.layerPath] = utilGetLayerHiddenOnMap(layer.layerPath, state.mapState.orderedLayerInfo);
-      }
-      return acc;
-    }, {});
-  });
-};
-
-/**
- * Selects whether any parent of the given layer is hidden.
- *
- * @param layerPath - The layer path to check parent visibility for
- * @returns True if any parent layer is hidden
- */
-export const useStoreMapIsParentLayerHiddenOnMap = (layerPath: string): boolean => {
-  return useStore(useGeoViewStore(), (state) => utilGetParentLayerHiddenOnMap(layerPath, state.mapState.orderedLayerInfo));
-};
-
-/**
- * Selects the parent-hidden state for all layers.
- *
- * @returns A record mapping each layer path to whether any of its parents are hidden
- */
-export const useStoreMapIsParentLayerHiddenOnMapSet = (): Record<string, boolean> => {
-  return useStableSelector(useGeoViewStore(), (state) => {
-    return state.mapState.orderedLayerInfo.reduce<Record<string, boolean>>((acc, layer) => {
-      if (layer.layerPath) {
-        // eslint-disable-next-line no-param-reassign
-        acc[layer.layerPath] = utilGetParentLayerHiddenOnMap(layer.layerPath, state.mapState.orderedLayerInfo);
-      }
-      return acc;
-    }, {});
-  });
 };
 
 /** Returns the current map projection code. */
@@ -1273,11 +719,6 @@ export const getStoreMapHighlightedFeaturesByUid = (mapId: string, featureUid: s
   return getStoreMapState(mapId).highlightedFeatures.filter((feature) => feature.uid === featureUid);
 };
 
-/** Returns the ordered layer info entries that have collapsible legends. */
-export const getStoreMapLegendCollapsibleLayers = (mapId: string): TypeOrderedLayerInfo[] => {
-  return utilGetLegendCollapsibleLayers(mapId, getStoreMapOrderedLayerInfo(mapId));
-};
-
 // #endregion STATE GETTERS & HOOKS
 
 // #region STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
@@ -1325,48 +766,8 @@ export const useStoreMapScale = (): TypeScaleInfo => useStore(useGeoViewStore(),
 /** Selects the map size from the store. */
 export const useStoreMapSize = (): Size => useStore(useGeoViewStore(), (state) => state.mapState.size);
 
-/** Selects the ordered layer paths from the store. */
-export const useStoreMapOrderedLayers = (): string[] => useStore(useGeoViewStore(), (state) => state.mapState.orderedLayers);
-
-/** Selects the visible layer paths from the store. */
-export const useStoreMapVisibleLayers = (): string[] => useStore(useGeoViewStore(), (state) => state.mapState.visibleLayers);
-
-/**
- * Selects the union of visible and in-range layer paths.
- *
- * Used by data-table, details, geochart, and time-slider left panel components.
- *
- * @returns The deduplicated array of layer paths that are visible or in visible range
- */
-export const useStoreMapAllVisibleandInRangeLayers = (): string[] => {
-  const visibleLayers = useStore(useGeoViewStore(), (state) => state.mapState.visibleLayers);
-  const visibleRangeLayers = useStore(useGeoViewStore(), (state) => state.mapState.visibleRangeLayers);
-  return useMemo(() => {
-    return [...new Set([...visibleLayers, ...visibleRangeLayers])];
-  }, [visibleLayers, visibleRangeLayers]);
-};
-
 /** Selects the current zoom level from the store. */
 export const useStoreMapZoom = (): number => useStore(useGeoViewStore(), (state) => state.mapState.zoom);
-
-/**
- * Selects the queryable state for multiple layer paths.
- *
- * @param layerPaths - The layer paths to check queryable state for
- * @returns A record mapping each layer path to its queryable state
- */
-export const useStoreMapLayerQueryable = (layerPaths: string[]): Record<string, boolean> => {
-  // Hook
-  return useStableSelector(useGeoViewStore(), (state) => {
-    const result: Record<string, boolean> = {};
-
-    for (const layerPath of layerPaths) {
-      result[layerPath] = utilFindMapLayerFromOrderedInfo(layerPath, state.mapState.orderedLayerInfo)?.queryableState || false;
-    }
-
-    return result;
-  });
-};
 
 // #endregion STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)
 
@@ -1493,16 +894,6 @@ export const setStoreMapCurrentBasemapOptions = (mapId: string, basemapOptions: 
   getStoreMapState(mapId).actions.setCurrentBasemapOptions(basemapOptions);
 };
 
-/** Sets the overlay north marker in the store. */
-export const setStoreMapOverlayNorthMarker = (mapId: string, overlay: Overlay): void => {
-  getStoreMapState(mapId).actions.setOverlayNorthMarker(overlay);
-};
-
-/** Sets the overlay click marker in the store. */
-export const setStoreMapOverlayClickMarker = (mapId: string, overlay: Overlay): void => {
-  getStoreMapState(mapId).actions.setOverlayClickMarker(overlay);
-};
-
 /** Sets the click marker position in the store. */
 export const setStoreMapClickMarker = (mapId: string, projectedCoords: number[]): void => {
   getStoreMapState(mapId).actions.setClickMarker(projectedCoords);
@@ -1548,36 +939,9 @@ export const setStoreMapPointerPosition = (mapId: string, pointerPosition: TypeM
   getStoreMapState(mapId).actions.setPointerPosition(pointerPosition);
 };
 
-/** Sets the hoverable state for a layer in the store. */
-export const setStoreMapLayerHoverable = (mapId: string, layerPath: string, hoverable: boolean): void => {
-  getStoreMapState(mapId).actions.setHoverable(layerPath, hoverable);
-};
-
 /** Sets the hover feature info in the store. */
 export const setStoreMapHoverFeatureInfo = (mapId: string, hoverFeatureInfo: TypeHoverFeatureInfo): void => {
   getStoreMapState(mapId).actions.setHoverFeatureInfo(hoverFeatureInfo);
-};
-
-/**
- * Sets the visibility of a layer in the store ordered layer info.
- *
- * @param mapId - The ID of the map
- * @param layerPath - The layer path of the layer to change
- * @param visibility - The visibility to set
- */
-export const setStoreMapLayerVisibility = (mapId: string, layerPath: string, visibility: boolean): void => {
-  getStoreMapState(mapId).actions.updateOrderedLayerInfoByPath(layerPath, { visible: visibility });
-};
-
-/**
- * Sets the visibility range state for a specific layer in the store.
- *
- * @param mapId - The map identifier
- * @param layerPath - The unique layer path identifier
- * @param inVisibleRange - Whether the layer is within its visible zoom range
- */
-export const setStoreLayerInVisibleRange = (mapId: string, layerPath: string, inVisibleRange: boolean): void => {
-  getStoreMapState(mapId).actions.updateOrderedLayerInfoByPath(layerPath, { inVisibleRange });
 };
 
 /** Sets the map interaction mode in the store. */
@@ -1605,32 +969,9 @@ export const setStoreMapRotation = (mapId: string, rotation: number): void => {
   getStoreMapState(mapId).actions.setRotation(rotation);
 };
 
-/** Sets the queryable state for a layer in the store. */
-export const setStoreMapLayerQueryable = (mapId: string, layerPath: string, queryable: boolean): void => {
-  getStoreMapState(mapId).actions.setQueryable(layerPath, queryable);
-};
-
 /** Sets the highlighted features in the store. */
 export const setStoreMapHighlightedFeatures = (mapId: string, highlightedFeatures: TypeFeatureInfoEntry[]): void => {
   getStoreMapState(mapId).actions.setHighlightedFeatures(highlightedFeatures);
-};
-
-/** Sets the legend collapsed state for a layer in the store. */
-export const setStoreMapLegendCollapsed = (mapId: string, layerPath: string, collapsed: boolean): void => {
-  getStoreMapState(mapId).actions.setLegendCollapsed(layerPath, collapsed);
-};
-
-/** Toggles the legend collapsed state for a layer in the store. */
-export const setStoreMapToggleLegendCollapsed = (mapId: string, layerPath: string): void => {
-  const legendCollapsedRightNow: boolean =
-    utilFindMapLayerFromOrderedInfo(layerPath, getStoreMapOrderedLayerInfo(mapId))?.legendCollapsed || false;
-  getStoreMapState(mapId).actions.setLegendCollapsed(layerPath, !legendCollapsedRightNow);
-};
-
-/** Adds an initial filter for a layer path in the store. */
-export const addStoreMapInitialFilter = (mapId: string, layerPath: string, filter: string): void => {
-  const curFilters = getStoreMapState(mapId).initialFilters;
-  getStoreMapState(mapId).actions.setInitialFilters({ ...curFilters, [layerPath]: filter });
 };
 
 /** Updates the store with map move end properties including center, rotation, extent, and scale. */
@@ -1646,44 +987,9 @@ export const setStoreMapMoveEnd = (
   getStoreMapState(mapId).actions.setMapMoveEnd(centerCoordinates, pointerPosition, degreeRotation, isNorthVisible, mapExtent, scale);
 };
 
-/** Sets the legend collapsed state for all layers in the store. */
-export const setStoreMapAllMapLayerCollapsed = (mapId: string, newCollapsed: boolean): void => {
-  // Set the collapsed state for all layers
-  const orderedLayerInfo = getStoreMapOrderedLayerInfo(mapId);
-  orderedLayerInfo.forEach((layer) => {
-    if (layer.legendCollapsed !== newCollapsed) {
-      setStoreMapLegendCollapsed(mapId, layer.layerPath, newCollapsed);
-    }
-  });
-};
-
 /** Sets the fix north state in the store. */
 export const setStoreMapFixNorth = (mapId: string, fixNorth: boolean): void => {
   getStoreMapState(mapId).actions.setFixNorth(fixNorth);
-};
-
-/** Sets the HTML element reference for the overlay click marker. */
-export const setStoreMapOverlayClickMarkerRef = (mapId: string, htmlRef: HTMLElement): void => {
-  const overlay = getStoreMapState(mapId).overlayClickMarker;
-  if (overlay !== undefined) overlay.setElement(htmlRef);
-};
-
-/** Sets the HTML element reference for the overlay north marker. */
-export const setStoreMapOverlayNorthMarkerRef = (mapId: string, htmlRef: HTMLElement): void => {
-  const overlay = getStoreMapState(mapId).overlayNorthMarker;
-  if (overlay !== undefined) overlay.setElement(htmlRef);
-};
-
-/**
- * Temporary method to set the ordered layers directly in the store.
- * This method should be used with caution and only in specific cases, as it bypasses the usual
- * state update patterns and may lead to unintended side effects if not used properly.
- *
- * @param mapId - The map identifier
- * @param orderedLayerInfo - The ordered layer info array to set
- */
-export const setStoreMapOrderedLayerDirectly = (mapId: string, orderedLayerInfo: TypeOrderedLayerInfo[]): void => {
-  getStoreMapState(mapId).actions.setOrderedLayerInfo(orderedLayerInfo);
 };
 
 // #endregion STATE ADAPTORS
@@ -1713,28 +1019,4 @@ export interface TypeNorthArrow {
 
   /** Whether the north direction is currently visible on the map. */
   isNorthVisible: boolean;
-}
-
-/** Represents ordering and state information for a single layer. */
-export interface TypeOrderedLayerInfo {
-  /** The unique layer path identifier. */
-  layerPath: string;
-
-  /** Whether the layer responds to hover interactions. */
-  hoverable?: boolean;
-
-  /** Whether the layer source supports queries. */
-  queryableSource?: boolean;
-
-  /** The current queryable state of the layer. */
-  queryableState?: boolean;
-
-  /** Whether the layer is visible. */
-  visible: boolean;
-
-  /** Whether the layer is within its visible zoom range. */
-  inVisibleRange: boolean;
-
-  /** Whether the layer legend is collapsed. */
-  legendCollapsed: boolean;
 }

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
@@ -139,7 +139,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
     footerPanelResizeValue: 35,
 
     // initialize default stores section from config information when store receive configuration file
-    setDefaultConfigValues: (geoviewConfig: TypeMapFeaturesConfig) => {
+    setDefaultConfigValues: (geoviewConfig: TypeMapFeaturesConfig): void => {
       // App bar and footer bar state rules:
       // - selectedTab set → open
       // - selectedTab unset → close
@@ -181,7 +181,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
        *
        * @param uiFocus - The focus item properties
        */
-      enableFocusTrap: (uiFocus: FocusItemProps) => {
+      enableFocusTrap: (uiFocus: FocusItemProps): void => {
         set({
           uiState: {
             ...get().uiState,
@@ -199,7 +199,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
        *
        * @param callBackElementId - The element ID to restore focus to
        */
-      disableFocusTrap: (callBackElementId: string) => {
+      disableFocusTrap: (callBackElementId: string): void => {
         const id = callBackElementId ?? (get().uiState.focusItem.callbackElementId as string);
         requestAnimationFrame(() => {
           // Don't focus if 'no-focus' is passed
@@ -223,7 +223,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
        *
        * @param tabId - The tab ID to activate, or undefined to clear
        */
-      setActiveFooterBarTab: (tabId: string | undefined) => {
+      setActiveFooterBarTab: (tabId: string | undefined): void => {
         set({
           uiState: {
             ...get().uiState,
@@ -240,7 +240,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
        *
        * @param active - Whether the trap is active
        */
-      setActiveTrapGeoView: (active: boolean) => {
+      setActiveTrapGeoView: (active: boolean): void => {
         set({
           uiState: {
             ...get().uiState,
@@ -254,7 +254,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
        *
        * @param hiddenTabs - The array of tab IDs to hide
        */
-      setHiddenTabs: (hiddenTabs: string[]) => {
+      setHiddenTabs: (hiddenTabs: string[]): void => {
         set({
           uiState: {
             ...get().uiState,
@@ -268,7 +268,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
        *
        * @param value - The resize value
        */
-      setFooterPanelResizeValue: (value) => {
+      setFooterPanelResizeValue: (value): void => {
         set({
           uiState: {
             ...get().uiState,
@@ -283,7 +283,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
        *
        * @param open - Whether the footer bar should be open
        */
-      setFooterBarIsOpen: (open: boolean) => {
+      setFooterBarIsOpen: (open: boolean): void => {
         set({
           uiState: {
             ...get().uiState,
@@ -300,7 +300,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
        *
        * @param tab - The footer tab entry to add
        */
-      addFooterTab: (tab: TypeFooterTabEntry) => {
+      addFooterTab: (tab: TypeFooterTabEntry): void => {
         const existing = get().uiState.footerTabs;
         const index = existing.findIndex((t) => t.id === tab.id);
         if (index === -1) {
@@ -329,7 +329,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
        *
        * @param id - The tab id to remove
        */
-      removeFooterTab: (id: string) => {
+      removeFooterTab: (id: string): void => {
         set({
           uiState: {
             ...get().uiState,
@@ -343,7 +343,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
        *
        * @param id - The panel id to add
        */
-      addAppBarPanelId: (id: string) => {
+      addAppBarPanelId: (id: string): void => {
         const existing = get().uiState.appBarPanelIds;
         if (!existing.includes(id)) {
           set({
@@ -360,7 +360,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
        *
        * @param id - The panel id to remove
        */
-      removeAppBarPanelId: (id: string) => {
+      removeAppBarPanelId: (id: string): void => {
         set({
           uiState: {
             ...get().uiState,
@@ -372,7 +372,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
       /**
        * Increments the nav-bar button panel version to trigger a re-render.
        */
-      bumpNavBarButtonPanelVersion: () => {
+      bumpNavBarButtonPanelVersion: (): void => {
         set({
           uiState: {
             ...get().uiState,
@@ -388,7 +388,7 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
        * @param isOpen - Whether the app bar panel should be open
        * @param isFocusTrapped - Optional whether focus should be trapped in the panel
        */
-      setActiveAppBarTab: (tabId: string | undefined, isOpen: boolean, isFocusTrapped: boolean = false) => {
+      setActiveAppBarTab: (tabId: string | undefined, isOpen: boolean, isFocusTrapped: boolean = false): void => {
         // Gv Side effect with focus trap and side panel app bar open
         // We need to check if the viewer is in keyboard navigation mode. If not, we don't apply the focus trap.
         // Focus trap has side effect when a app bar panel is open. It does not let user use their mouse

--- a/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
+++ b/packages/geoview-core/src/core/stores/store-interface-and-intial-values/ui-state.ts
@@ -12,6 +12,14 @@ import type { TypeMapFeaturesConfig } from '@/core/types/global-types';
 
 // #region INTERFACE DEFINITION
 
+/** Serializable metadata for a footer tab entry (no JSX \u2014 content lives in the FooterBarApi registry). */
+export type TypeFooterTabEntry = {
+  /** The unique tab identifier. */
+  id: string;
+  /** The tab label (translation key or display string). */
+  label?: string;
+};
+
 /**
  * Represents the UI Zustand store slice.
  *
@@ -42,8 +50,17 @@ export interface IUIState {
   /** Tab identifiers that are hidden from the footer bar. */
   hiddenTabs: string[];
 
+  /** Footer tab entries registered via the FooterBarApi (serializable metadata only — no JSX). */
+  footerTabs: TypeFooterTabEntry[];
+
+  /** App-bar panel identifiers registered via the AppBarApi (full objects live in the AppBarApi registry). */
+  appBarPanelIds: string[];
+
   /** The list of nav-bar component identifiers. */
   navBarComponents: TypeValidNavBarProps[];
+
+  /** Version counter that increments when nav-bar button panels are added or removed (triggers re-render). */
+  navBarButtonPanelVersion: number;
 
   /** The current resize value (percentage) for the footer panel. */
   footerPanelResizeValue: number;
@@ -76,6 +93,21 @@ export interface IUIState {
 
     /** Sets the footer bar open state. */
     setFooterBarIsOpen: (open: boolean) => void;
+
+    /** Adds a footer tab entry. */
+    addFooterTab: (tab: TypeFooterTabEntry) => void;
+
+    /** Removes a footer tab entry by id. */
+    removeFooterTab: (id: string) => void;
+
+    /** Adds an app-bar panel id. */
+    addAppBarPanelId: (id: string) => void;
+
+    /** Removes an app-bar panel id. */
+    removeAppBarPanelId: (id: string) => void;
+
+    /** Increments the nav-bar button panel version to trigger a re-render. */
+    bumpNavBarButtonPanelVersion: () => void;
   };
 }
 
@@ -97,10 +129,13 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
     footerBarComponents: [],
     activeFooterBarTab: { tabId: '', isOpen: false, isFocusTrapped: false },
     navBarComponents: [],
+    navBarButtonPanelVersion: 0,
     activeTrapGeoView: false,
     corePackagesComponents: [],
     focusItem: { activeElementId: false, callbackElementId: false },
     hiddenTabs: ['data-table', 'time-slider', 'geochart'],
+    footerTabs: [],
+    appBarPanelIds: [],
     footerPanelResizeValue: 35,
 
     // initialize default stores section from config information when store receive configuration file
@@ -110,6 +145,13 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
       // - selectedTab unset → close
       const isAppBarOpen = !!geoviewConfig.appBar?.selectedTab;
       const isFooterBarOpen = !!geoviewConfig.footerBar?.selectedTab;
+
+      // Seed footer tabs from config so they are available on the very first render
+      const coreTabs = geoviewConfig.footerBar?.tabs?.core || [];
+      const footerTabEntries: TypeFooterTabEntry[] = coreTabs.map((id) => ({ id }));
+
+      // If no selectedTab in config, default to the first core tab so the tab content renders
+      const footerSelectedTab = geoviewConfig.footerBar?.selectedTab || coreTabs[0] || '';
 
       set({
         uiState: {
@@ -121,8 +163,9 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
             isFocusTrapped: false,
           },
           footerBarComponents: geoviewConfig.footerBar?.tabs.core || [],
+          footerTabs: footerTabEntries,
           activeFooterBarTab: {
-            tabId: geoviewConfig.footerBar?.selectedTab || '',
+            tabId: footerSelectedTab,
             isOpen: isFooterBarOpen,
             isFocusTrapped: false,
           },
@@ -253,6 +296,92 @@ export function initializeUIState(set: TypeSetStore, get: TypeGetStore): IUIStat
       },
 
       /**
+       * Adds a footer tab entry to the store.
+       *
+       * @param tab - The footer tab entry to add
+       */
+      addFooterTab: (tab: TypeFooterTabEntry) => {
+        const existing = get().uiState.footerTabs;
+        const index = existing.findIndex((t) => t.id === tab.id);
+        if (index === -1) {
+          // Add new entry
+          set({
+            uiState: {
+              ...get().uiState,
+              footerTabs: [...existing, tab],
+            },
+          });
+        } else {
+          // Upsert existing entry to trigger re-render (e.g. when plugin registers content after seeding)
+          const updated = [...existing];
+          updated[index] = tab;
+          set({
+            uiState: {
+              ...get().uiState,
+              footerTabs: updated,
+            },
+          });
+        }
+      },
+
+      /**
+       * Removes a footer tab entry from the store by id.
+       *
+       * @param id - The tab id to remove
+       */
+      removeFooterTab: (id: string) => {
+        set({
+          uiState: {
+            ...get().uiState,
+            footerTabs: get().uiState.footerTabs.filter((t) => t.id !== id),
+          },
+        });
+      },
+
+      /**
+       * Adds an app-bar panel id to the store.
+       *
+       * @param id - The panel id to add
+       */
+      addAppBarPanelId: (id: string) => {
+        const existing = get().uiState.appBarPanelIds;
+        if (!existing.includes(id)) {
+          set({
+            uiState: {
+              ...get().uiState,
+              appBarPanelIds: [...existing, id],
+            },
+          });
+        }
+      },
+
+      /**
+       * Removes an app-bar panel id from the store.
+       *
+       * @param id - The panel id to remove
+       */
+      removeAppBarPanelId: (id: string) => {
+        set({
+          uiState: {
+            ...get().uiState,
+            appBarPanelIds: get().uiState.appBarPanelIds.filter((panelId) => panelId !== id),
+          },
+        });
+      },
+
+      /**
+       * Increments the nav-bar button panel version to trigger a re-render.
+       */
+      bumpNavBarButtonPanelVersion: () => {
+        set({
+          uiState: {
+            ...get().uiState,
+            navBarButtonPanelVersion: get().uiState.navBarButtonPanelVersion + 1,
+          },
+        });
+      },
+
+      /**
        * Sets the active app bar tab.
        *
        * @param tabId - The tab ID to activate, or undefined to clear
@@ -374,6 +503,32 @@ export const getStoreUICorePackageComponents = (mapId: string): TypeValidMapCore
 export const useStoreUICorePackagesComponents = (): TypeValidMapCorePackageProps[] =>
   useStore(useGeoViewStore(), (state) => state.uiState.corePackagesComponents);
 
+/**
+ * Gets the footer tab entries from the store.
+ *
+ * @param mapId - The map identifier
+ * @returns The array of footer tab entries
+ */
+export const getStoreUIFooterTabs = (mapId: string): TypeFooterTabEntry[] => getStoreUIState(mapId).footerTabs;
+
+/** Hooks the footer tab entries registered via the FooterBarApi. */
+export const useStoreUIFooterTabs = (): TypeFooterTabEntry[] => useStore(useGeoViewStore(), (state) => state.uiState.footerTabs);
+
+/**
+ * Gets the app-bar panel ids from the store.
+ *
+ * @param mapId - The map identifier
+ * @returns The array of app-bar panel ids
+ */
+export const getStoreUIAppBarPanelIds = (mapId: string): string[] => getStoreUIState(mapId).appBarPanelIds;
+
+/** Hooks the app-bar panel ids registered via the AppBarApi. */
+export const useStoreUIAppBarPanelIds = (): string[] => useStore(useGeoViewStore(), (state) => state.uiState.appBarPanelIds);
+
+/** Hooks the nav-bar button panel version counter (triggers re-render on change). */
+export const useStoreUINavBarButtonPanelVersion = (): number =>
+  useStore(useGeoViewStore(), (state) => state.uiState.navBarButtonPanelVersion);
+
 /** Hooks the current focus-trap item from the UI state. */
 export const useStoreUIActiveFocusItem = (): FocusItemProps => useStore(useGeoViewStore(), (state) => state.uiState.focusItem);
 
@@ -397,7 +552,7 @@ export const useStoreUIHiddenTabs = (): string[] => useStore(useGeoViewStore(), 
  * @param mapId - The map identifier
  * @param tab - The tab identifier, or undefined to deactivate
  */
-export const setStoreActiveFooterBarTab = (mapId: string, tab: string | undefined): void => {
+export const setStoreUIActiveFooterBarTab = (mapId: string, tab: string | undefined): void => {
   getStoreUIState(mapId).actions.setActiveFooterBarTab(tab);
 };
 
@@ -409,7 +564,7 @@ export const setStoreActiveFooterBarTab = (mapId: string, tab: string | undefine
  * @param isOpen - Whether the tab is open
  * @param isFocusTrapped - Whether focus is trapped on the tab
  */
-export const setStoreActiveAppBarTab = (mapId: string, tab: string | undefined, isOpen: boolean, isFocusTrapped: boolean): void => {
+export const setStoreUIActiveAppBarTab = (mapId: string, tab: string | undefined, isOpen: boolean, isFocusTrapped: boolean): void => {
   getStoreUIState(mapId).actions.setActiveAppBarTab(tab, isOpen, isFocusTrapped);
 };
 
@@ -419,7 +574,7 @@ export const setStoreActiveAppBarTab = (mapId: string, tab: string | undefined, 
  * @param mapId - The map identifier
  * @param isOpen - Whether the footer bar is open
  */
-export const setStoreFooterBarIsOpen = (mapId: string, isOpen: boolean): void => {
+export const setStoreUIFooterBarIsOpen = (mapId: string, isOpen: boolean): void => {
   getStoreUIState(mapId).actions.setFooterBarIsOpen(isOpen);
 };
 
@@ -429,7 +584,7 @@ export const setStoreFooterBarIsOpen = (mapId: string, isOpen: boolean): void =>
  * @param mapId - The map identifier
  * @param uiFocus - The focus item containing active and callback element identifiers
  */
-export const enableStoreFocusTrap = (mapId: string, uiFocus: FocusItemProps): void => {
+export const enableStoreUIFocusTrap = (mapId: string, uiFocus: FocusItemProps): void => {
   getStoreUIState(mapId).actions.enableFocusTrap(uiFocus);
 };
 
@@ -441,7 +596,7 @@ export const enableStoreFocusTrap = (mapId: string, uiFocus: FocusItemProps): vo
  * @param mapId - The map identifier
  * @param callbackElementId - Optional element identifier to restore focus to. If 'no-focus' is passed, focus is not restored
  */
-export const disableStoreFocusTrap = (mapId: string, callbackElementId?: string): void => {
+export const disableStoreUIFocusTrap = (mapId: string, callbackElementId?: string): void => {
   getStoreUIState(mapId).actions.disableFocusTrap(callbackElementId);
 };
 
@@ -451,7 +606,7 @@ export const disableStoreFocusTrap = (mapId: string, callbackElementId?: string)
  * @param mapId - The map identifier
  * @param active - Whether the focus trap is active
  */
-export const setStoreActiveTrapGeoView = (mapId: string, active: boolean): void => {
+export const setStoreUIActiveTrapGeoView = (mapId: string, active: boolean): void => {
   getStoreUIState(mapId).actions.setActiveTrapGeoView(active);
 };
 
@@ -461,7 +616,7 @@ export const setStoreActiveTrapGeoView = (mapId: string, active: boolean): void 
  * @param mapId - The map identifier
  * @param value - The resize percentage value
  */
-export const setStoreFooterPanelResizeValue = (mapId: string, value: number): void => {
+export const setStoreUIFooterPanelResizeValue = (mapId: string, value: number): void => {
   getStoreUIState(mapId).actions.setFooterPanelResizeValue(value);
 };
 
@@ -471,7 +626,7 @@ export const setStoreFooterPanelResizeValue = (mapId: string, value: number): vo
  * @param mapId - The map identifier
  * @param tab - The tab identifier to show
  */
-export const showStoreTabButton = (mapId: string, tab: string): void => {
+export const showStoreUITabButton = (mapId: string, tab: string): void => {
   const uiState = getStoreUIState(mapId);
   const { hiddenTabs } = uiState;
 
@@ -489,7 +644,7 @@ export const showStoreTabButton = (mapId: string, tab: string): void => {
  * @param mapId - The map identifier
  * @param tab - The tab identifier to hide
  */
-export const hideStoreTabButton = (mapId: string, tab: string): void => {
+export const hideStoreUITabButton = (mapId: string, tab: string): void => {
   const uiState = getStoreUIState(mapId);
   const { hiddenTabs } = uiState;
 
@@ -497,6 +652,55 @@ export const hideStoreTabButton = (mapId: string, tab: string): void => {
   if (!hiddenTabs.includes(tab)) {
     uiState.actions.setHiddenTabs([...hiddenTabs, tab]);
   }
+};
+
+/**
+ * Adds a footer tab entry to the store.
+ *
+ * @param mapId - The map identifier
+ * @param tab - The footer tab entry to add
+ */
+export const addStoreUIFooterTab = (mapId: string, tab: TypeFooterTabEntry): void => {
+  getStoreUIState(mapId).actions.addFooterTab(tab);
+};
+
+/**
+ * Removes a footer tab entry from the store by id.
+ *
+ * @param mapId - The map identifier
+ * @param id - The tab id to remove
+ */
+export const removeStoreUIFooterTab = (mapId: string, id: string): void => {
+  getStoreUIState(mapId).actions.removeFooterTab(id);
+};
+
+/**
+ * Adds an app-bar panel id to the store.
+ *
+ * @param mapId - The map identifier
+ * @param id - The panel id to add
+ */
+export const addStoreUIAppBarPanelId = (mapId: string, id: string): void => {
+  getStoreUIState(mapId).actions.addAppBarPanelId(id);
+};
+
+/**
+ * Removes an app-bar panel id from the store.
+ *
+ * @param mapId - The map identifier
+ * @param id - The panel id to remove
+ */
+export const removeStoreUIAppBarPanelId = (mapId: string, id: string): void => {
+  getStoreUIState(mapId).actions.removeAppBarPanelId(id);
+};
+
+/**
+ * Bumps the nav-bar button panel version to trigger a re-render.
+ *
+ * @param mapId - The map identifier
+ */
+export const bumpStoreUINavBarButtonPanelVersion = (mapId: string): void => {
+  getStoreUIState(mapId).actions.bumpNavBarButtonPanelVersion();
 };
 
 // #endregion STATE ADAPTORS

--- a/packages/geoview-core/src/core/stores/stores-managers.ts
+++ b/packages/geoview-core/src/core/stores/stores-managers.ts
@@ -74,7 +74,7 @@ export function hasTimeSliderPlugin(store: GeoviewStoreType): boolean {
   return store.getState().mapConfig!.footerBar?.tabs.core.includes('time-slider') ?? false;
 }
 
-export function hasGeochartPlugin(store: GeoviewStoreType): boolean {
+export function hasGeoChartPlugin(store: GeoviewStoreType): boolean {
   return store.getState().mapConfig!.footerBar?.tabs.core.includes('geochart') ?? false;
 }
 
@@ -97,7 +97,7 @@ export const addGeoViewStore = (config: TypeMapFeaturesConfig): void => {
 
   // Initialize the store subscriptions
   initDetailsStateSubscriptions(geoviewStore);
-  if (hasGeochartPlugin(geoviewStore)) initGeochartStateSubscriptions(geoviewStore);
+  if (hasGeoChartPlugin(geoviewStore)) initGeochartStateSubscriptions(geoviewStore);
 
   useStoresManager.setState((state) => ({
     stores: {
@@ -112,7 +112,7 @@ export const addGeoViewStore = (config: TypeMapFeaturesConfig): void => {
 export const removeGeoviewStore = (id: string): void => {
   // Clear the store subscriptions
   clearDetailsStateSubscriptions(id);
-  if (hasGeochartPlugin(getGeoViewStore(id))) clearGeochartStateSubscriptions(id);
+  if (hasGeoChartPlugin(getGeoViewStore(id))) clearGeochartStateSubscriptions(id);
 
   delete useStoresManager.getState().stores[id];
 };

--- a/packages/geoview-core/src/core/utils/constant.ts
+++ b/packages/geoview-core/src/core/utils/constant.ts
@@ -24,7 +24,7 @@ export const DEFAULT_OL_FITOPTIONS: FitOptions = {
 
 /** The north pole position used for north arrow marker and rotation angle. */
 // NOTE: north value (set longitude to be half of Canada extent (142° W, 52° W)) - projection central meridian is -95
-export const NORTH_POLE_POSITION: [number, number] = [90, -95];
+export const NORTH_POLE_POSITION_LONLAT: [number, number] = [90, -95];
 
 /** Overview map widget dimensions. */
 export const OL_OVERVIEWMAP_SIZE = {

--- a/packages/geoview-core/src/geo/layer/basemap/basemap.ts
+++ b/packages/geoview-core/src/geo/layer/basemap/basemap.ts
@@ -21,11 +21,8 @@ import type {
   BasemapJsonResponse,
 } from '@/geo/layer/basemap/basemap-types';
 import { Projection } from '@/geo/utils/projection';
-import {
-  getStoreMapBasemapOptions,
-  getStoreMapCurrentProjection,
-  setStoreMapAttribution,
-} from '@/core/stores/store-interface-and-intial-values/map-state';
+import { getStoreMapBasemapOptions } from '@/core/stores/store-interface-and-intial-values/map-state';
+import type { MapController } from '@/core/controllers/map-controller';
 import { logger } from '@/core/utils/logger';
 import type { EventDelegateBase } from '@/api/events/event-helper';
 import EventHelper from '@/api/events/event-helper';
@@ -51,9 +48,6 @@ export class BasemapApi {
   /** Indicates if the basemap has been created successfully */
   created: boolean = false;
 
-  /** The map viewer */
-  mapViewer: MapViewer;
-
   /** The active basemap */
   activeBasemap?: TypeBasemapProps;
 
@@ -75,22 +69,31 @@ export class BasemapApi {
   /** The basemap options passed from the map config */
   basemapOptions: TypeBasemapOptions;
 
+  /** The map viewer */
+  #mapViewer: MapViewer;
+
+  /** The map controller */
+  #mapController: MapController;
+
   /**
    * Initializes the basemap API.
    *
    * @param mapViewer - The map viewer
+   * @param mapController - The map controller
    * @param basemapOptions - The basemap option properties, passed in from map config
    */
-  constructor(mapViewer: MapViewer, basemapOptions: TypeBasemapOptions) {
+  constructor(mapViewer: MapViewer, mapController: MapController, basemapOptions: TypeBasemapOptions) {
     // Keep the properties
-    this.mapViewer = mapViewer;
+    this.#mapViewer = mapViewer;
+    this.#mapController = mapController;
     this.basemapOptions = basemapOptions;
 
-    // Create the overview default basemap (no label, no shaded)
-    this.setOverviewMap().catch((error: unknown) => {
-      // Log
-      logger.logPromiseFailed('setOverviewMap in constructor of layer/basemap', error);
-    });
+    // TODO: CLEANUP - Remove commented code. Commenting this out doesn't seem necessary and was causing issue where the getView() wasn't ready yet (better performance causing this sync issue?)
+    // // Create the overview default basemap (no label, no shaded)
+    // this.setOverviewMap().catch((error: unknown) => {
+    //   // Log
+    //   logger.logPromiseFailed('setOverviewMap in constructor of layer/basemap', error);
+    // });
   }
 
   /** The basemap creation configuration list */
@@ -225,7 +228,7 @@ export class BasemapApi {
 
       if (tileLayer) {
         // add this layer to the basemap group
-        tileLayer.set(this.mapViewer.mapId, 'basemap');
+        tileLayer.set(this.#mapViewer.mapId, 'basemap');
         newLayers.push(tileLayer as BaseLayer);
       }
     });
@@ -239,7 +242,7 @@ export class BasemapApi {
    */
   async setOverviewMap(): Promise<void> {
     // Only create overview map for supported projections (3857 and 3978)
-    const projectionCode = getStoreMapCurrentProjection(this.mapViewer.mapId);
+    const projectionCode = this.#mapViewer.getProjectionNumber();
     if (projectionCode !== 3857 && projectionCode !== 3978) return;
 
     try {
@@ -255,6 +258,15 @@ export class BasemapApi {
       // switches to layers of the correct projection (important for vector tiles)
       this.overviewMapCtrl.getOverviewMap().setLayers(this.createOverviewMapLayers());
     }
+  }
+
+  /**
+   * Gets the visibility state of the overview map control.
+   *
+   * @returns True if the overview map control is visible, false otherwise
+   */
+  getOverviewMapControlVisibility(): boolean {
+    return !!this.overviewMapCtrl?.getMap();
   }
 
   /**
@@ -339,7 +351,7 @@ export class BasemapApi {
       if (basemapLayer.styleUrl) {
         const tileSize = [tileInfo.rows, tileInfo.cols];
         source = new VectorTile({
-          attributions: getLocalizedMessage(this.mapViewer.getDisplayLanguage(), 'mapctrl.attribution.defaultnrcan'),
+          attributions: getLocalizedMessage(this.#mapViewer.getDisplayLanguage(), 'mapctrl.attribution.defaultnrcan'),
           projection: Projection.PROJECTIONS[urlProj],
           url: basemapLayer.url,
           format: new MVT(),
@@ -352,7 +364,7 @@ export class BasemapApi {
         });
       } else {
         source = new XYZ({
-          attributions: getLocalizedMessage(this.mapViewer.getDisplayLanguage(), 'mapctrl.attribution.defaultnrcan'),
+          attributions: getLocalizedMessage(this.#mapViewer.getDisplayLanguage(), 'mapctrl.attribution.defaultnrcan'),
           projection: Projection.PROJECTIONS[urlProj],
           url: basemapLayer.url,
           crossOrigin: 'Anonymous',
@@ -431,10 +443,10 @@ export class BasemapApi {
     let maxZoom = 23;
 
     // Check if projection is provided for the basemap creation
-    const projectionCode = projection === undefined ? getStoreMapCurrentProjection(this.mapViewer.mapId) : projection;
+    const projectionCode = projection === undefined ? this.#mapViewer.getProjectionNumber() : projection;
 
     // Check if language is provided for the basemap creation
-    const languageCode = language === undefined ? this.mapViewer.getDisplayLanguage() : language;
+    const languageCode = language === undefined ? this.#mapViewer.getDisplayLanguage() : language;
 
     // Check if basemap options are provided for the basemap creation
     const coreBasemapOptions = basemapOptions === undefined ? this.basemapOptions : basemapOptions;
@@ -581,10 +593,10 @@ export class BasemapApi {
         basemapOptions: coreBasemapOptions,
         attribution:
           coreBasemapOptions.basemapId === 'osm'
-            ? ['© OpenStreetMap', getLocalizedMessage(this.mapViewer.getDisplayLanguage(), 'mapctrl.attribution.defaultnrcan')]
+            ? ['© OpenStreetMap', getLocalizedMessage(this.#mapViewer.getDisplayLanguage(), 'mapctrl.attribution.defaultnrcan')]
             : [
                 basemapLayers.find((layer) => coreBasemapOptions.basemapId === layer.basemapId)?.copyright || '',
-                getLocalizedMessage(this.mapViewer.getDisplayLanguage(), 'mapctrl.attribution.defaultnrcan'),
+                getLocalizedMessage(this.#mapViewer.getDisplayLanguage(), 'mapctrl.attribution.defaultnrcan'),
               ],
         zoomLevels: {
           min: minZoom,
@@ -621,7 +633,7 @@ export class BasemapApi {
    */
   async loadDefaultBasemaps(projection?: TypeValidMapProjectionCodes, language?: TypeDisplayLanguage): Promise<void> {
     // Create the core basemap
-    const basemap = await this.createCoreBasemap(getStoreMapBasemapOptions(this.mapViewer.mapId), projection, language);
+    const basemap = await this.createCoreBasemap(getStoreMapBasemapOptions(this.#mapViewer.mapId), projection, language);
 
     // Info used by create custom basemap
     this.defaultOrigin = basemap?.defaultOrigin;
@@ -637,7 +649,7 @@ export class BasemapApi {
    */
   clearBasemaps(): void {
     // Remove previous basemaps
-    const layers = this.mapViewer.map.getAllLayers();
+    const layers = this.#mapViewer.map.getAllLayers();
 
     // Loop through all layers on the map
     for (let layerIndex = 0; layerIndex < layers.length; layerIndex++) {
@@ -649,7 +661,7 @@ export class BasemapApi {
       // Check if the group id matches basemap
       if (layerId && layerId === 'basemap') {
         // Remove the basemap layer
-        this.mapViewer.map.removeLayer(layer);
+        this.#mapViewer.map.removeLayer(layer);
       }
     }
   }
@@ -664,7 +676,7 @@ export class BasemapApi {
     this.activeBasemap = basemap;
 
     // Set store attribution for the selected basemap or empty string if not provided
-    setStoreMapAttribution(this.mapViewer.mapId, basemap ? basemap.attribution : ['']);
+    this.#mapController.setAttribution(basemap ? basemap.attribution : ['']);
 
     // Update the basemap layers on the map
     if (basemap?.layers) {
@@ -704,7 +716,7 @@ export class BasemapApi {
         basemapLayer.set('mapId', 'basemap');
 
         // Add the basemap layer
-        this.mapViewer.map.getLayers().insertAt(index, basemapLayer);
+        this.#mapViewer.map.getLayers().insertAt(index, basemapLayer);
 
         // Render the layer
         basemapLayer.changed();

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-base-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-base-layer.ts
@@ -502,7 +502,7 @@ export abstract class AbstractBaseGVLayer {
   }
 
   /**
-   * Checks if layer is visible at the given zoo
+   * Checks if layer is visible at the given zoom level.
    *
    * @param zoom - Zoom level to be compared
    * @returns If the layer is visible at this zoom level
@@ -687,7 +687,7 @@ export abstract class AbstractBaseGVLayer {
     return undefined;
   }
 
-  // #endregion
+  // #endregion STATIC METHODS
 }
 
 /**
@@ -704,7 +704,7 @@ export type LayerBaseDelegate = EventDelegateBase<AbstractBaseGVLayer, LayerBase
  * Define an event for the delegate.
  */
 export interface LayerNameChangedEvent extends LayerBaseEvent {
-  // The new layer name.
+  /** The new layer name. */
   layerName?: string;
 }
 
@@ -717,6 +717,7 @@ export type LayerNameChangedDelegate = EventDelegateBase<AbstractBaseGVLayer, La
  * Define an event for the delegate
  */
 export interface LayerVisibleChangedEvent extends LayerBaseEvent {
+  /** The new visibility state. */
   visible: boolean;
 }
 
@@ -729,7 +730,7 @@ export type LayerVisibleChangedDelegate = EventDelegateBase<AbstractBaseGVLayer,
  * Define an event for the delegate
  */
 export interface LayerOpacityChangedEvent extends LayerBaseEvent {
-  // The filter
+  /** The new opacity value. */
   opacity: number;
 }
 
@@ -742,7 +743,7 @@ export type LayerOpacityChangedDelegate = EventDelegateBase<AbstractBaseGVLayer,
  * Define an event for the delegate
  */
 export interface LayerZIndexChangedEvent extends LayerBaseEvent {
-  // The new z-index
+  /** The new z-index value. */
   zIndex: number;
 }
 

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
@@ -8,6 +8,8 @@ import { Feature } from 'ol';
 import type { Projection as OLProjection } from 'ol/proj';
 import type { Map as OLMap } from 'ol';
 
+import type { EventDelegateBase } from '@/api/events/event-helper';
+import EventHelper from '@/api/events/event-helper';
 import { GeoUtilities } from '@/geo/utils/utilities';
 import { Projection } from '@/geo/utils/projection';
 import { logger } from '@/core/utils/logger';
@@ -28,6 +30,7 @@ import type { TypeLegend } from '@/core/stores/store-interface-and-intial-values
 import type { TemporalMode } from '@/core/utils/date-mgt';
 import type { GeometryJson } from '@/geo/layer/gv-layers/utils';
 import { GeoviewRenderer } from '@/geo/utils/renderer/geoview-renderer';
+import type { LayerBaseEvent } from '@/geo/layer/gv-layers/abstract-base-layer';
 import { AbstractGVRaster } from '@/geo/layer/gv-layers/raster/abstract-gv-raster';
 import { GVWMS } from '@/geo/layer/gv-layers/raster/gv-wms';
 import type { LayerFilters } from '@/geo/layer/gv-layers/layer-filters';
@@ -45,6 +48,12 @@ export class GVEsriImage extends AbstractGVRaster {
 
   /** The currently active mosaic rule */
   #mosaicRule?: TypeMosaicRule;
+
+  /** Callback delegates for the raster function changed event */
+  #onRasterFunctionChangedHandlers: RasterFunctionChangedDelegate[] = [];
+
+  /** Callback delegates for the mosaic rule changed event */
+  #onMosaicRuleChangedHandlers: MosaicRuleChangedDelegate[] = [];
 
   /**
    * Constructs a GVEsriImage layer to manage an OpenLayer layer.
@@ -565,6 +574,9 @@ export class GVEsriImage extends AbstractGVRaster {
 
     // Update the OpenLayers source
     this.getOLSource().updateParams(params);
+
+    // Emit about it
+    this.#emitRasterFunctionChanged({ functionId: rasterFunctionId });
   }
 
   /**
@@ -652,16 +664,86 @@ export class GVEsriImage extends AbstractGVRaster {
     }
     olSource.updateParams(params);
     olSource.changed();
+
+    // Emit about it
+    this.#emitMosaicRuleChanged({ mosaicRule });
   }
 
   // #endregion METHODS
+
+  // #region EVENTS
+
+  /**
+   * Emits a raster function changed event to all handlers.
+   *
+   * @param event - The event to emit
+   */
+  #emitRasterFunctionChanged(event: RasterFunctionChangedEvent): void {
+    // Emit the event for all handlers
+    EventHelper.emitEvent(this, this.#onRasterFunctionChangedHandlers, event);
+  }
+
+  /**
+   * Registers a raster function changed event handler.
+   *
+   * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The registered callback, which can be used to unregister the event handler later
+   */
+  onRasterFunctionChanged(callback: RasterFunctionChangedDelegate): RasterFunctionChangedDelegate {
+    // Register the event handler
+    return EventHelper.onEvent(this.#onRasterFunctionChangedHandlers, callback);
+  }
+
+  /**
+   * Unregisters a raster function changed event handler.
+   *
+   * @param callback - The callback to stop being called whenever the event is emitted
+   */
+  offRasterFunctionChanged(callback: RasterFunctionChangedDelegate | undefined): void {
+    // Unregister the event handler
+    EventHelper.offEvent(this.#onRasterFunctionChangedHandlers, callback);
+  }
+
+  /**
+   * Emits a mosaic rule changed event to all handlers.
+   *
+   * @param event - The event to emit
+   */
+  #emitMosaicRuleChanged(event: MosaicRuleChangedEvent): void {
+    // Emit the event for all handlers
+    EventHelper.emitEvent(this, this.#onMosaicRuleChangedHandlers, event);
+  }
+
+  /**
+   * Registers a mosaic rule changed event handler.
+   *
+   * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The registered callback, which can be used to unregister the event handler later
+   */
+  onMosaicRuleChanged(callback: MosaicRuleChangedDelegate): MosaicRuleChangedDelegate {
+    // Register the event handler
+    return EventHelper.onEvent(this.#onMosaicRuleChangedHandlers, callback);
+  }
+
+  /**
+   * Unregisters a mosaic rule changed event handler.
+   *
+   * @param callback - The callback to stop being called whenever the event is emitted
+   */
+  offMosaicRuleChanged(callback: MosaicRuleChangedDelegate | undefined): void {
+    // Unregister the event handler
+    EventHelper.offEvent(this.#onMosaicRuleChangedHandlers, callback);
+  }
+
+  // #endregion EVENTS
 }
 
-// Exported for use in ESRI Dynamic raster layers
+/** Legend structure returned by the ESRI Image layer legend endpoint. */
 export type TypeEsriImageLayerLegend = {
   layers: TypeEsriImageLayerLegendLayer[];
 };
 
+/** A single layer entry within an ESRI image legend response. */
 export type TypeEsriImageLayerLegendLayer = {
   layerId: number | string;
   layerName: string;
@@ -672,6 +754,7 @@ export type TypeEsriImageLayerLegendLayer = {
   legend: TypeEsriImageLayerLegendLayerLegend[];
 };
 
+/** A single legend entry (symbol) within an ESRI image legend layer. */
 export type TypeEsriImageLayerLegendLayerLegend = {
   label: string;
   url: string;
@@ -682,6 +765,7 @@ export type TypeEsriImageLayerLegendLayerLegend = {
   values: string[];
 };
 
+/** JSON response from the ESRI Image identify operation. */
 export type EsriImageIdentifyJsonResponse = {
   objectId: number;
   name: string;
@@ -711,3 +795,33 @@ export type EsriImageIdentifyJsonResponse = {
   };
   processedValues?: string[];
 };
+
+// #region EVENT DELEGATES
+
+/**
+ * Define an event for the delegate.
+ */
+export interface RasterFunctionChangedEvent extends LayerBaseEvent {
+  /** The raster function identifier, or undefined when removed. */
+  functionId: string | undefined;
+}
+
+/**
+ * Define a delegate for the event handler function signature
+ */
+export type RasterFunctionChangedDelegate = EventDelegateBase<GVEsriImage, RasterFunctionChangedEvent, void>;
+
+/**
+ * Define an event for the delegate.
+ */
+export interface MosaicRuleChangedEvent extends LayerBaseEvent {
+  /** The mosaic rule, or undefined when removed. */
+  mosaicRule: TypeMosaicRule | undefined;
+}
+
+/**
+ * Define a delegate for the event handler function signature.
+ */
+export type MosaicRuleChangedDelegate = EventDelegateBase<GVEsriImage, MosaicRuleChangedEvent, void>;
+
+// #endregion EVENT DELEGATES

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -9,6 +9,7 @@ import type { Map as OLMap } from 'ol';
 import { Polygon } from 'ol/geom';
 
 import EventHelper, { type EventDelegateBase } from '@/api/events/event-helper';
+import type { LayerBaseEvent } from '@/geo/layer/gv-layers/abstract-base-layer';
 import type { TypeLegend } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { Fetch } from '@/core/utils/fetch-helper';
 import { parseXMLToJson } from '@/core/utils/utilities';
@@ -59,6 +60,9 @@ export class GVWMS extends AbstractGVRaster {
 
   /** Callback delegates for the image load rescue event */
   #onImageLoadRescueHandlers: ImageLoadRescueDelegate[] = [];
+
+  /** Callback delegates for the WMS style changed event */
+  #onWmsStyleChangedHandlers: WMSStyleChangedDelegate[] = [];
 
   /** Indicates if the CRS is to be overridden, because the layer struggles loading on the map */
   #overrideCRS?: CRSOverride;
@@ -626,6 +630,9 @@ export class GVWMS extends AbstractGVRaster {
     this.#wmsStyle = wmsStyleId;
 
     this.getOLSource()?.updateParams({ STYLES: wmsStyleId });
+
+    // Emit about it
+    this.#emitWmsStyleChanged({ wmsStyleName: wmsStyleId });
   }
 
   /**
@@ -1574,7 +1581,7 @@ export class GVWMS extends AbstractGVRaster {
   // #region EVENTS
 
   /**
-   * Emits an event to all handlers when the layer's sent a message.
+   * Emits an event to all handlers when the layer's image failed to load.
    *
    * @param event - The event to emit
    * @returns An array of boolean values returned by each event handler, indicating whether the event was handled
@@ -1605,6 +1612,37 @@ export class GVWMS extends AbstractGVRaster {
     EventHelper.offEvent(this.#onImageLoadRescueHandlers, callback);
   }
 
+  /**
+   * Emits a WMS style changed event to all handlers.
+   *
+   * @param event - The event to emit
+   */
+  #emitWmsStyleChanged(event: WMSStyleChangedEvent): void {
+    // Emit the event for all handlers
+    EventHelper.emitEvent(this, this.#onWmsStyleChangedHandlers, event);
+  }
+
+  /**
+   * Registers a WMS style changed event handler.
+   *
+   * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The registered callback, which can be used to unregister the event handler later
+   */
+  onWmsStyleChanged(callback: WMSStyleChangedDelegate): WMSStyleChangedDelegate {
+    // Register the event handler
+    return EventHelper.onEvent(this.#onWmsStyleChangedHandlers, callback);
+  }
+
+  /**
+   * Unregisters a WMS style changed event handler.
+   *
+   * @param callback - The callback to stop being called whenever the event is emitted
+   */
+  offWmsStyleChanged(callback: WMSStyleChangedDelegate | undefined): void {
+    // Unregister the event handler
+    EventHelper.offEvent(this.#onWmsStyleChangedHandlers, callback);
+  }
+
   // #endregion EVENTS
 }
 
@@ -1619,3 +1657,16 @@ export type ImageLoadRescueEvent = { imageLoadErrorEvent: Error };
  * Define a delegate for the event handler function signature
  */
 export type ImageLoadRescueDelegate = EventDelegateBase<GVWMS, ImageLoadRescueEvent, boolean>;
+
+/**
+ * Define an event for the delegate.
+ */
+export interface WMSStyleChangedEvent extends LayerBaseEvent {
+  /** The WMS style name that was applied. */
+  wmsStyleName: string;
+}
+
+/**
+ * Define a delegate for the event handler function signature.
+ */
+export type WMSStyleChangedDelegate = EventDelegateBase<GVWMS, WMSStyleChangedEvent, void>;

--- a/packages/geoview-core/src/geo/layer/layer-sets/abstract-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/abstract-layer-set.ts
@@ -9,18 +9,19 @@ import type {
   TypeResultSetEntry,
 } from '@/api/types/map-schema-types';
 import { generateId, whenThisThen } from '@/core/utils/utilities';
+import { logger } from '@/core/utils/logger';
 import type { LayerDomain } from '@/core/domains/layer-domain';
 import type { ConfigBaseClass } from '@/api/config/validation-classes/config-base-class';
 import type { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
 import { OgcWmsLayerEntryConfig } from '@/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
+import type { MapViewer } from '@/geo/map/map-viewer';
 import type { AbstractGVLayer } from '@/geo/layer/gv-layers/abstract-gv-layer';
 import { GVEsriDynamic } from '@/geo/layer/gv-layers/raster/gv-esri-dynamic';
 import { GVEsriImage } from '@/geo/layer/gv-layers/raster/gv-esri-image';
 import { AbstractGVVector } from '@/geo/layer/gv-layers/vector/abstract-gv-vector';
 import { GVWMS } from '@/geo/layer/gv-layers/raster/gv-wms';
 import type { AbstractBaseGVLayer } from '@/geo/layer/gv-layers/abstract-base-layer';
-import type { MapViewer } from '@/geo/map/map-viewer';
-import { logger } from '@/core/utils/logger';
 
 /**
  * A class to hold a set of layers associated with a value of any type.
@@ -35,6 +36,9 @@ export abstract class AbstractLayerSet {
 
   /** The MapViewer to work with */
   protected mapViewer: MapViewer;
+
+  /** The controller registry to work with */
+  protected controllerRegistry: ControllerRegistry;
 
   /** An object containing the result sets indexed using the layer path */
   resultSet: TypeResultSet = {};
@@ -54,10 +58,12 @@ export abstract class AbstractLayerSet {
    * Constructs a new LayerSet instance.
    *
    * @param mapViewer - The MapViewer instance to work with
+   * @param controllerRegistry - The ControllerRegistry instance to work with
    * @param layerDomain - The LayerDomain instance to work with
    */
-  constructor(mapViewer: MapViewer, layerDomain: LayerDomain) {
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry, layerDomain: LayerDomain) {
     this.mapViewer = mapViewer;
+    this.controllerRegistry = controllerRegistry;
     this.layerDomain = layerDomain;
   }
 

--- a/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
@@ -5,9 +5,9 @@ import type { AbstractBaseGVLayer } from '@/geo/layer/gv-layers/abstract-base-la
 import type { PropagationType } from '@/geo/layer/layer-sets/abstract-layer-set';
 import { AbstractLayerSet } from '@/geo/layer/layer-sets/abstract-layer-set';
 import {
-  deleteStoreFeatureAllInfo,
+  deleteStoreDataTableFeatureAllInfo,
   propagateFeatureInfoDataTableToStore,
-  setStoreInitialSettings,
+  setStoreDataTableInitialSettings,
   type TypeAllFeatureInfoResultSet,
   type TypeAllFeatureInfoResultSetEntry,
 } from '@/core/stores/store-interface-and-intial-values/data-table-state';
@@ -50,7 +50,7 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
     }
 
     if (isQueryable) {
-      this.mapViewer.controllers.uiController.showTabButton('data-table');
+      this.controllerRegistry.uiController.showTabButton('data-table');
     }
 
     // Return
@@ -72,7 +72,7 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
     this.resultSet[layerPath].features = undefined;
 
     // Extra initialization of settings
-    setStoreInitialSettings(this.getMapId(), layerPath);
+    setStoreDataTableInitialSettings(this.getMapId(), layerPath);
   }
 
   /**
@@ -94,8 +94,8 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
    */
   protected override onDeleteFromStore(layerPath: string): void {
     // Remove it from data table info array
-    deleteStoreFeatureAllInfo(this.getMapId(), layerPath, () => {
-      this.mapViewer.controllers.uiController.hideTabButton('data-table');
+    deleteStoreDataTableFeatureAllInfo(this.getMapId(), layerPath, () => {
+      this.controllerRegistry.uiController.hideTabButton('data-table');
     });
   }
 

--- a/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
@@ -6,11 +6,9 @@ import type { AbstractBaseGVLayer } from '@/geo/layer/gv-layers/abstract-base-la
 import { AbstractLayerSet, type PropagationType } from '@/geo/layer/layer-sets/abstract-layer-set';
 import { GVKML } from '@/geo/layer/gv-layers/vector/gv-kml';
 import { GVEsriImage } from '@/geo/layer/gv-layers/raster/gv-esri-image';
-import {
-  deleteStoreDetailsFeatureInfo,
-  propagateStoreFeatureInfoDetails,
-  type TypeFeatureInfoResultSet,
-  type TypeFeatureInfoResultSetEntry,
+import type {
+  TypeFeatureInfoResultSet,
+  TypeFeatureInfoResultSetEntry,
 } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import { getStoreAppShowUnsymbolizedFeatures } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { RequestAbortedError } from '@/core/exceptions/core-exceptions';
@@ -84,7 +82,7 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
    */
   protected override onDeleteFromStore(layerPath: string): void {
     // Remove it from feature info array (propagating to the store)
-    deleteStoreDetailsFeatureInfo(this.getMapId(), layerPath);
+    this.controllerRegistry.detailsController.deleteFeatureInfo(layerPath);
   }
 
   /**
@@ -265,7 +263,7 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
    */
   #propagateToStore(resultSetEntry: TypeFeatureInfoResultSetEntry): void {
     // Propagate
-    propagateStoreFeatureInfoDetails(this.getMapId(), resultSetEntry);
+    this.controllerRegistry.detailsController.propagateFeatureInfo(resultSetEntry);
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
@@ -3,7 +3,8 @@ import type { QueryType, TypeFeatureInfoResult } from '@/api/types/map-schema-ty
 import type { AbstractBaseGVLayer } from '@/geo/layer/gv-layers/abstract-base-layer';
 import type { PropagationType } from '@/geo/layer/layer-sets/abstract-layer-set';
 import { AbstractLayerSet } from '@/geo/layer/layer-sets/abstract-layer-set';
-import { getStoreMapOrderedLayerInfo, setStoreMapHoverFeatureInfo } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { setStoreMapHoverFeatureInfo } from '@/core/stores/store-interface-and-intial-values/map-state';
+import { getStoreLayerInVisibleRangeLayerPaths } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import type {
   TypeHoverFeatureInfo,
   TypeHoverResultSet,
@@ -225,10 +226,10 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
    */
   #getOrderedLayerPaths(): string[] {
     // Get the map layer order
-    const mapLayerOrder = getStoreMapOrderedLayerInfo(this.getMapId()).filter((layer) => layer.inVisibleRange);
+    const layerPathsInVisibleRange = getStoreLayerInVisibleRangeLayerPaths(this.getMapId());
     const resultSetLayers = new Set(Object.keys(this.resultSet));
 
     // Filter and order the layers that are in our resultSet
-    return mapLayerOrder.map((layer) => layer.layerPath).filter((layerPath) => resultSetLayers.has(layerPath));
+    return layerPathsInVisibleRange.filter((layerPath) => resultSetLayers.has(layerPath));
   }
 }

--- a/packages/geoview-core/src/geo/layer/layer-sets/legends-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/legends-layer-set.ts
@@ -16,6 +16,7 @@ import {
   type TypeLegendResultSet,
   type TypeLegendResultSetEntry,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
 import type { LayerDomain } from '@/core/domains/layer-domain';
 import type { StyleChangedDelegate, StyleChangedEvent } from '@/geo/layer/gv-layers/abstract-gv-layer';
 import { AbstractGVLayer } from '@/geo/layer/gv-layers/abstract-gv-layer';
@@ -26,7 +27,6 @@ import { GVEsriDynamic } from '@/geo/layer/gv-layers/raster/gv-esri-dynamic';
 import { GVEsriFeature } from '@/geo/layer/gv-layers/vector/gv-esri-feature';
 import { GVEsriImage } from '@/geo/layer/gv-layers/raster/gv-esri-image';
 import type { MapViewer } from '@/geo/map/map-viewer';
-import type { LayerSetController } from '@/core/controllers/layer-set-controller';
 
 /**
  * A Layer-set working with the LayerSetController at handling a result set of registered layers and synchronizing
@@ -36,9 +36,6 @@ import type { LayerSetController } from '@/core/controllers/layer-set-controller
 export class LegendsLayerSet extends AbstractLayerSet {
   /** The resultSet object as existing in the base class, retyped here as a TypeLegendResultSet */
   declare resultSet: TypeLegendResultSet;
-
-  /** The layer set controller */
-  protected layerSetController: LayerSetController;
 
   /** A bounded reference to the handle layer status changed */
   #boundedHandleLayerStatusChanged: LayerStatusChangedDelegate;
@@ -53,12 +50,11 @@ export class LegendsLayerSet extends AbstractLayerSet {
    * Constructs a Legends LayerSet to manage layers legends.
    *
    * @param mapViewer - The map viewer
-   * @param layerSetController - The layer set controller
+   * @param controllerRegistry - The controller registry
    * @param layerDomain - The layer domain
    */
-  constructor(mapViewer: MapViewer, layerSetController: LayerSetController, layerDomain: LayerDomain) {
-    super(mapViewer, layerDomain);
-    this.layerSetController = layerSetController;
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry, layerDomain: LayerDomain) {
+    super(mapViewer, controllerRegistry, layerDomain);
     this.#boundedHandleLayerStatusChanged = this.#handleLayerStatusChanged.bind(this);
     this.#boundedHandleLayerStyleChanged = this.#handleLayerStyleChanged.bind(this);
     this.#boundedHandleLayerStyleApplied = this.#handleStyleApplied.bind(this);
@@ -257,7 +253,7 @@ export class LegendsLayerSet extends AbstractLayerSet {
    */
   #propagateToStore(resultSetEntry: TypeLegendResultSetEntry): void {
     // Propagate
-    this.layerSetController.propagateLegendToStore(resultSetEntry);
+    this.controllerRegistry.layerSetController.propagateLegendToStore(resultSetEntry);
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -37,7 +37,7 @@ import type {
   LayerPathDelegate,
   LayerPathEvent,
 } from '@/core/controllers/layer-creator-controller';
-import type { TypeOrderedLayerInfo } from '@/core/stores/store-interface-and-intial-values/map-state';
+
 import type { HoverFeatureInfoLayerSet } from '@/geo/layer/layer-sets/hover-feature-info-layer-set';
 import type { AllFeatureInfoLayerSet } from '@/geo/layer/layer-sets/all-feature-info-layer-set';
 import type { LegendsLayerSet } from '@/geo/layer/layer-sets/legends-layer-set';
@@ -66,9 +66,6 @@ export class LayerApi {
   /** Used to access geometry API to create and manage geometries */
   // TODO: REFACTOR (would be breaking change) - Remove this reference and favor using mapViewer.geometry instead
   geometry: GeometryApi;
-
-  /** Order to load layers */
-  initialLayerOrder: Array<TypeOrderedLayerInfo> = [];
 
   /** Used to access feature and bounding box highlighting */
   // TODO: REFACTOR (would be breaking change) - Remove this reference and favor using mapViewer.geometry instead

--- a/packages/geoview-core/src/geo/map/feature-highlight.ts
+++ b/packages/geoview-core/src/geo/map/feature-highlight.ts
@@ -11,10 +11,11 @@ import type { Color } from 'ol/color';
 
 import { type TypeHighlightColors, type TypeFeatureInfoEntry, DEFAULT_HIGHLIGHT_COLOR } from '@/api/types/map-schema-types';
 import { logger } from '@/core/utils/logger';
-import type { MapViewer } from '@/geo/map/map-viewer';
-import { PointMarkers } from './point-markers';
 import { getStoreMapFeatureHighlightColor } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { TIMEOUT } from '@/core/utils/constant';
+import type { MapController } from '@/core/controllers/map-controller';
+import type { MapViewer } from '@/geo/map/map-viewer';
+import { PointMarkers } from './point-markers';
 
 /**
  * A class to handle highlighting of features.
@@ -22,6 +23,9 @@ import { TIMEOUT } from '@/core/utils/constant';
 export class FeatureHighlight {
   /** Reference on the map viewer */
   mapViewer: MapViewer;
+
+  /** Reference on the map controller */
+  mapController: MapController;
 
   /** The vector source to use for the highlight features */
   highlightSource: VectorSource = new VectorSource();
@@ -56,9 +60,10 @@ export class FeatureHighlight {
    *
    * @param mapViewer - A reference to the map viewer
    */
-  constructor(mapViewer: MapViewer) {
+  constructor(mapViewer: MapViewer, mapController: MapController) {
     // Keep the reference
     this.mapViewer = mapViewer;
+    this.mapController = mapController;
   }
 
   /**
@@ -67,7 +72,7 @@ export class FeatureHighlight {
   init(): void {
     // Initialize the Feature Highlight (adding the map option sets zIndex to infinity because it is undefined)
     this.overlayLayer = new VectorLayer({ source: this.highlightSource, map: this.mapViewer.map });
-    this.pointMarkers = new PointMarkers(this.mapViewer, this);
+    this.pointMarkers = new PointMarkers(this.mapViewer, this.mapController, this);
     if (getStoreMapFeatureHighlightColor(this.mapViewer.mapId) !== DEFAULT_HIGHLIGHT_COLOR)
       this.changeHighlightColor(getStoreMapFeatureHighlightColor(this.mapViewer.mapId));
   }

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -1192,9 +1192,10 @@ export class MapViewer {
   }
 
   /**
-   * Show a marker on the map.
+   * Shows a marker on the map.
    *
    * @param marker - The marker to add
+   * @returns The projected coordinates of the marker
    */
   clickMarkerIconShow(marker: TypeClickMarker): number[] {
     // Project coords
@@ -2344,6 +2345,7 @@ export class MapViewer {
    * Registers a map init event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapInit(callback: MapInitDelegate): MapInitDelegate {
     // Register the event handler
@@ -2372,6 +2374,7 @@ export class MapViewer {
    * Registers a map ready event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapReady(callback: MapReadyDelegate): MapReadyDelegate {
     // Register the event handler
@@ -2400,6 +2403,7 @@ export class MapViewer {
    * Registers a map layers processed event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapLayersProcessed(callback: MapLayersProcessedDelegate): MapLayersProcessedDelegate {
     // Register the event handler
@@ -2428,6 +2432,7 @@ export class MapViewer {
    * Registers a map layers loaded event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapLayersLoaded(callback: MapLayersLoadedDelegate): MapLayersLoadedDelegate {
     // Register the event handler
@@ -2456,6 +2461,7 @@ export class MapViewer {
    * Registers a map move end event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapMoveEnd(callback: MapMoveEndDelegate): MapMoveEndDelegate {
     // Register the event handler
@@ -2486,6 +2492,7 @@ export class MapViewer {
    * Registers a map pointer move event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapPointerMove(callback: MapPointerMoveDelegate): MapPointerMoveDelegate {
     // Register the event handler
@@ -2516,6 +2523,7 @@ export class MapViewer {
    * Registers a map pointer stop event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapPointerStop(callback: MapPointerMoveDelegate): MapPointerMoveDelegate {
     // Register the event handler
@@ -2546,6 +2554,7 @@ export class MapViewer {
    * Registers a map single click event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapSingleClick(callback: MapSingleClickDelegate): MapSingleClickDelegate {
     // Register the event handler
@@ -2574,6 +2583,7 @@ export class MapViewer {
    * Registers a map zoom end event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapZoomEnd(callback: MapZoomEndDelegate): MapZoomEndDelegate {
     // Register the event handler
@@ -2602,6 +2612,7 @@ export class MapViewer {
    * Registers a map rotation event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapRotation(callback: MapRotationDelegate): MapRotationDelegate {
     // Register the event handler
@@ -2630,6 +2641,7 @@ export class MapViewer {
    * Registers a map change size event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapChangeSize(callback: MapChangeSizeDelegate): MapChangeSizeDelegate {
     // Register the event handler
@@ -2660,6 +2672,7 @@ export class MapViewer {
    * Registers a map projection change event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapProjectionChangeStarted(callback: MapProjectionChangedDelegate): MapProjectionChangedDelegate {
     // Register the event handler
@@ -2690,6 +2703,7 @@ export class MapViewer {
    * Registers a map projection change event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapProjectionChanged(callback: MapProjectionChangedDelegate): MapProjectionChangedDelegate {
     // Register the event handler
@@ -2718,6 +2732,7 @@ export class MapViewer {
    * Registers a component added event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapComponentAdded(callback: MapComponentAddedDelegate): MapComponentAddedDelegate {
     // Register the component added event handler
@@ -2746,6 +2761,7 @@ export class MapViewer {
    * Registers a component removed event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapComponentRemoved(callback: MapComponentRemovedDelegate): MapComponentRemovedDelegate {
     // Register the component removed event handler
@@ -2774,6 +2790,7 @@ export class MapViewer {
    * Registers a language changed event callback.
    *
    * @param callback - The callback to be executed whenever the event is emitted
+   * @returns The callback delegate that was registered
    */
   onMapLanguageChanged(callback: MapLanguageChangedDelegate): MapLanguageChangedDelegate {
     // Register the component removed event handler

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -37,6 +37,7 @@ import {
   VALID_DISPLAY_THEME,
   VALID_PROJECTION_CODES,
   MAP_ZOOM_LEVEL,
+  MAX_EXTENTS_RESTRICTION,
 } from '@/api/types/map-schema-types';
 import type { TypeLayerStatus } from '@/api/types/layer-schema-types';
 
@@ -67,35 +68,30 @@ import { delay, generateId, getLocalizedMessage, whenThisThen } from '@/core/uti
 import { debounce } from '@/core/utils/debounce';
 import type { TimeIANA } from '@/core/utils/date-mgt';
 import { logger } from '@/core/utils/logger';
-import { NORTH_POLE_POSITION, TIMEOUT } from '@/core/utils/constant';
+import { NORTH_POLE_POSITION_LONLAT, TIMEOUT } from '@/core/utils/constant';
 import type { TypeMapFeaturesConfig, TypeHTMLElement } from '@/core/types/global-types';
 import type { TypeClickMarker } from '@/core/components/click-marker/click-marker';
 import { Notifications } from '@/core/utils/notifications';
 import {
   getStoreMapBasemapOptions,
   getStoreMapGeolocatorSearchArea,
-  getStoreMapOrderedLayerInfo,
+  getStoreMapInteraction,
+  getStoreMapStateJson,
   setStoreMapLoaded,
-  setStoreMapClickMarkerIconHide,
+  setStoreMapClickMarker,
   setStoreMapZoom,
   setStoreMapHomeButtonView,
-  type TypeOrderedLayerInfo,
-  getStoreMapStateJson,
   setStoreMapDisplayed,
   setStoreMapPointerPosition,
   setStoreMapIsMouseInsideMap,
   setStoreMapRotation,
   setStoreMapScale,
   setStoreMapMoveEnd,
-  type TypeScaleInfo,
-  setStoreMapOverlayNorthMarker,
-  setStoreMapOverlayClickMarker,
-  getStoreMapCurrentProjectionEPSG,
-  getStoreMapInteraction,
   setStoreMapInteraction,
+  type TypeScaleInfo,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { getStoreAppDisplayTheme } from '@/core/stores/store-interface-and-intial-values/app-state';
-import { setStoreLayerSelectedLayersTabLayer, type TypeLegend } from '@/core/stores/store-interface-and-intial-values/layer-state';
+import { getStoreLayerOrderedLayerPaths, type TypeLegend } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { TIME_DELAY_BETWEEN_PROPAGATION_FOR_BATCH } from '@/core/stores/store-interface-and-intial-values/feature-info-state';
 import { GeoUtilities } from '@/geo/utils/utilities';
 import { GVGroupLayer } from '@/geo/layer/gv-layers/gv-group-layer';
@@ -189,13 +185,19 @@ export class MapViewer {
   // TODO: REFACTOR IMPORTANT - Ideally, the MapViewer class would be a proper 'Domain' class unaware of 'controllers'.
   // TO.DOCONT: We should review everywhere in this file where 'this.controllers.' is used - as those are backwards domain (MapViewer) calling a controller.
   // TO.DOCONT: However, we can only do this once we have another 'Application class' which holds the ControllersRegistry instead of the MapViewer itself.
-  // TO.DOCONT: That's another big refactor to come.
-  /** The controller registry owning all framework-level controllers */
+  // TO.DOCONT: At the same time, we should remove the 'store' imports (getStore, setStore, etc), because the MapViewer shouldn't 'know' about any stores.
+  // TO.DOCONT: That's another big refactor to come, because we sill use the MapViewer very much like an application class instead of a domain class when
+  // TO.DOCONT: we do things like cgpv.api.getMapViewer().doSomething.
+  /**
+   *  The controller registry owning all framework-level controllers
+   *
+   * @remarks Try not to use this accessor, as it creates a backwards dependency from the domain to the controllers.
+   * It is here for legacy reasons, but should be removed in the future.
+   */
   controllers: ControllerRegistry;
 
-  // max number of icons cached
   /** Max number of icons cached */
-  iconImageCacheSize: number;
+  iconImageCacheSize: number = 1;
 
   /** Indicates if the map has been initialized */
   #mapInit = false;
@@ -208,6 +210,12 @@ export class MapViewer {
 
   /** Indicates if the map has all its layers loaded upon launch */
   #mapLayersLoaded = false;
+
+  /** The click marker overlay */
+  #clickMarkerOverlay?: Overlay;
+
+  /** The north pole marker overlay */
+  #northPoleMarkerOverlay?: Overlay;
 
   /** Callback delegates for the map init event */
   #onMapInitHandlers: MapInitDelegate[] = [];
@@ -244,6 +252,9 @@ export class MapViewer {
 
   /** Callback delegates for the map change size event */
   #onMapChangeSizeHandlers: MapChangeSizeDelegate[] = [];
+
+  /** Callback delegates for the map projection changed event */
+  #onMapProjectionChangeStartedHandlers: MapProjectionChangedDelegate[] = [];
 
   /** Callback delegates for the map projection changed event */
   #onMapProjectionChangedHandlers: MapProjectionChangedDelegate[] = [];
@@ -311,24 +322,22 @@ export class MapViewer {
     this.mapId = mapFeaturesConfig.mapId;
     this.mapFeaturesConfig = mapFeaturesConfig;
 
-    this.iconImageCacheSize = 1;
-
     // Initialize the ui domain
     this.#uiDomain = new UIDomain(i18instance, mapFeaturesConfig.displayLanguage ?? 'en');
     this.#layerDomain = new LayerDomain();
 
+    // Initialize the controller registry
+    this.controllers = new ControllerRegistry(this, this.#uiDomain, this.#layerDomain);
+    this.controllers.hookControllers();
+
     // The geometry api
     this.geometry = new GeometryApi(this);
 
-    // The feature highligh api
-    this.featureHighlight = new FeatureHighlight(this);
-
-    // Initialize the controller registry
-    this.controllers = new ControllerRegistry(this, this.#uiDomain, this.#layerDomain, this.geometry, this.featureHighlight);
-    this.controllers.hookControllers();
+    // The feature highlight api
+    this.featureHighlight = new FeatureHighlight(this, this.controllers.mapController);
 
     this.appBarApi = new AppBarApi(this.controllers.uiController);
-    this.navBarApi = new NavBarApi();
+    this.navBarApi = new NavBarApi(this.controllers.uiController);
     this.footerBarApi = new FooterBarApi(this.controllers.uiController);
     this.stateApi = new StateApi(this.controllers.layerController);
     this.notifications = new Notifications(this.controllers.uiController);
@@ -336,7 +345,7 @@ export class MapViewer {
     this.modal = new ModalApi();
 
     // create basemap and pass in the map id to be able to access the map instance
-    this.basemap = new BasemapApi(this, getStoreMapBasemapOptions(this.mapId));
+    this.basemap = new BasemapApi(this, this.controllers.mapController, getStoreMapBasemapOptions(this.mapId));
 
     // Initialize layer api
     this.layer = new LayerApi(this.controllers, this.#layerDomain, this.geometry, this.featureHighlight);
@@ -436,6 +445,9 @@ export class MapViewer {
     // Load the core packages plugins
     await this.#loadCorePackages();
 
+    // Load plugins configured in footer-bar and app-bar tabs
+    await this.controllers.pluginController.loadConfiguredPlugins();
+
     // Reset the basemap - not awaited as we proceed with empty basemap while it loads
     this.controllers.mapController.resetBasemap().catch((error: unknown) => logger.logError('Basemap creation failed', error));
 
@@ -489,28 +501,24 @@ export class MapViewer {
     map.addControl(scaleBarMetric);
     map.addControl(scaleBarImperial);
 
-    // Get the projection
-    // TODO: CHECK - Do we really have to go through the store to get the map projection when we're in the map-viewer class itself?
-    // TO.DOCONT: Do a 'find-all-references' on 'getStoreMapCurrentProjection' and 'getStoreMapCurrentProjectionEPSG' to review them all.
-    const mapProjection = Projection.getProjectionFromString(getStoreMapCurrentProjectionEPSG(this.mapId));
-
-    // add map overlays
-    // create overlay for north pole icon
+    // Create an overlay for the north pole icon
     const northPoleId = `${mapId}-northpole`;
-    const projectionPosition = Projection.transformFromLonLat([NORTH_POLE_POSITION[1], NORTH_POLE_POSITION[0]], mapProjection);
-
-    const northPoleMarker = new Overlay({
+    const northPolePosition = Projection.transformFromLonLat(
+      [NORTH_POLE_POSITION_LONLAT[1], NORTH_POLE_POSITION_LONLAT[0]],
+      this.getProjection()
+    );
+    this.#northPoleMarkerOverlay = new Overlay({
       id: northPoleId,
-      position: projectionPosition,
+      position: northPolePosition,
       positioning: 'center-center',
       element: document.getElementById(northPoleId) as HTMLElement,
       stopEvent: false,
     });
-    map.addOverlay(northPoleMarker);
+    map.addOverlay(this.#northPoleMarkerOverlay);
 
-    // create overlay for click marker icon
+    // Create an overlay for click marker icon
     const clickMarkerId = `${mapId}-clickmarker`;
-    const clickMarkerOverlay = new Overlay({
+    this.#clickMarkerOverlay = new Overlay({
       id: clickMarkerId,
       position: [-1, -1],
       positioning: 'center-center',
@@ -518,11 +526,7 @@ export class MapViewer {
       element: document.getElementById(clickMarkerId) as HTMLElement,
       stopEvent: false,
     });
-    map.addOverlay(clickMarkerOverlay);
-
-    // Save to the store
-    setStoreMapOverlayNorthMarker(mapId, northPoleMarker);
-    setStoreMapOverlayClickMarker(mapId, clickMarkerOverlay);
+    map.addOverlay(this.#clickMarkerOverlay);
 
     // Get the size
     const size = await this.getMapSize();
@@ -538,6 +542,26 @@ export class MapViewer {
 
     // Save to the store
     setStoreMapInteraction(mapId, getStoreMapInteraction(mapId));
+  }
+
+  /**
+   * Returns the click marker overlay.
+   *
+   * @returns The click marker overlay
+   */
+  getClickMarkerOverlay(): Overlay {
+    // GV Using '!' here, because initMapControls is always supposed to be executed
+    return this.#clickMarkerOverlay!;
+  }
+
+  /**
+   * Returns the north pole marker overlay.
+   *
+   * @returns The north pole marker overlay
+   */
+  getNorthPoleMarkerOverlay(): Overlay {
+    // GV Using '!' here, because initMapControls is always supposed to be executed
+    return this.#northPoleMarkerOverlay!;
   }
 
   // #region MAP STATES
@@ -708,7 +732,8 @@ export class MapViewer {
   }
 
   /**
-   * Gets the map projection
+   * Gets the map projection.
+   *
    * @returns The map projection
    */
   getProjection(): OLProjection {
@@ -716,20 +741,91 @@ export class MapViewer {
   }
 
   /**
-   * Gets the map projection number
-   * @returns The map projection number
+   * Gets the map projection EPSG string.
+   *
+   * @returns The map projection EPSG string
    */
-  getProjectionNumber(): number | undefined {
-    return Projection.readEPSGNumber(this.getProjection());
+  getProjectionEPSG(): string {
+    return this.getProjection().getCode();
   }
 
   /**
-   * Gets the ordered layer info.
+   * Gets the map projection number.
    *
-   * @returns The ordered layer info
+   * @returns The map projection number
    */
-  getMapLayerOrderInfo(): TypeOrderedLayerInfo[] {
-    return getStoreMapOrderedLayerInfo(this.mapId);
+  getProjectionNumber(): TypeValidMapProjectionCodes {
+    return Projection.readEPSGNumber(this.getProjection()) as TypeValidMapProjectionCodes;
+  }
+
+  /**
+   * Set the display projection of the map.
+   *
+   * @param projectionNumber - The projection code (3978, 3857)
+   * @param maxExtent - Optional max extent for the view
+   * @returns True if the projection was changed, false if the projection code is unsupported
+   */
+  setProjection(projectionNumber: TypeValidMapProjectionCodes, maxExtent: number[] | undefined): boolean {
+    if (VALID_PROJECTION_CODES.includes(Number(projectionNumber))) {
+      // Get the current projection
+      const currentProjection = this.getProjection();
+
+      // Get the new projection
+      const newProjection = Projection.PROJECTIONS[projectionNumber];
+
+      // Get view status (center and projection) to calculate new center
+      const currentView = this.map.getView();
+      const currentCenter = currentView.getCenter();
+      const currentProjectionCode = currentProjection.getCode();
+      const centerLatLng = Projection.transformPoints([currentCenter!], currentProjectionCode, Projection.PROJECTION_NAMES.LONLAT)[0] as [
+        number,
+        number,
+      ];
+
+      // Create new view settings
+      const newView: TypeViewSettings = {
+        initialView: { zoomAndCenter: [currentView.getZoom() as number, centerLatLng] },
+        minZoom: currentView.getMinZoom(),
+        maxZoom: currentView.getMaxZoom(),
+        maxExtent: maxExtent ?? MAX_EXTENTS_RESTRICTION[projectionNumber],
+        projection: projectionNumber,
+      };
+
+      // Emit about the projection change has started
+      this.#emitMapProjectionChangeStarted({ projection: newProjection, previousProjection: currentProjection });
+
+      // Before changing the view, clear the basemaps right away to prevent a moment where a
+      // vector tile basemap might, momentarily, be in different projection than the view.
+      // Note: It seems that since OpenLayers 10.5 OpenLayers throws an exception about this. So this line was added.
+      this.basemap.clearBasemaps();
+
+      // Set the view
+      this.setView(newView);
+
+      // Update the north pole position based on the new projection
+      const northPolePosition = Projection.transformFromLonLat(
+        [NORTH_POLE_POSITION_LONLAT[1], NORTH_POLE_POSITION_LONLAT[0]],
+        newProjection
+      );
+      this.getNorthPoleMarkerOverlay().setPosition(northPolePosition);
+
+      // Emit to outside
+      this.#emitMapProjectionChanged({ projection: newProjection, previousProjection: currentProjection });
+      return true;
+    }
+
+    // Unsupported
+    this.notifications.addNotificationError('validation.changeDisplayProjection');
+    return false;
+  }
+
+  /**
+   * Gets the ordered layer paths.
+   *
+   * @returns The ordered layer paths
+   */
+  getMapLayerOrderPaths(): string[] {
+    return getStoreLayerOrderedLayerPaths(this.mapId);
   }
 
   /**
@@ -825,29 +921,6 @@ export class MapViewer {
   }
 
   /**
-   * Set the display projection of the map.
-   *
-   * @param projectionCode - The projection code (3978, 3857)
-   * @returns A promise that resolves when the projection change is complete
-   */
-  setProjection(projectionCode: TypeValidMapProjectionCodes): Promise<void> {
-    if (VALID_PROJECTION_CODES.includes(Number(projectionCode))) {
-      // Propagate to the store
-      const promise = this.controllers.mapController.setProjection(projectionCode);
-
-      // Emit to outside
-      this.#emitMapProjectionChanged({ projection: Projection.PROJECTIONS[projectionCode] });
-
-      // Return the promise
-      return promise;
-    }
-
-    // Unsupported
-    this.notifications.addNotificationError('validation.changeDisplayProjection');
-    return Promise.resolve();
-  }
-
-  /**
    * Rotates the view to align it at the given degrees.
    *
    * @param degree - The degrees to rotate the map to
@@ -884,7 +957,7 @@ export class MapViewer {
    * @returns The closest scale for the given zoom number, or undefined if meters per unit is unavailable
    */
   getMapScaleFromZoom(zoom: number): number | undefined {
-    const projection = this.getView().getProjection();
+    const projection = this.getProjection();
     const mpu = projection.getMetersPerUnit();
     if (!mpu) return undefined;
 
@@ -907,7 +980,7 @@ export class MapViewer {
    */
   getMapResolutionFromScale(targetScale: number | undefined, dpiValue: number = MapViewer.DEFAULT_DPI): number | undefined {
     if (!targetScale) return undefined;
-    const projection = this.getView().getProjection();
+    const projection = this.getProjection();
     const mpu = projection.getMetersPerUnit()!;
 
     // Resolution = Scale / ( metersPerUnit * inchesPerMeter * DPI )
@@ -1119,21 +1192,28 @@ export class MapViewer {
   }
 
   /**
-   * Hide a click marker from the map
-   */
-  clickMarkerIconHide(): void {
-    // Save to the store
-    setStoreMapClickMarkerIconHide(this.mapId);
-  }
-
-  /**
    * Show a marker on the map.
    *
    * @param marker - The marker to add
    */
-  clickMarkerIconShow(marker: TypeClickMarker): void {
-    // Redirect to the processor
-    this.controllers.mapController.clickMarkerIconShow(marker);
+  clickMarkerIconShow(marker: TypeClickMarker): number[] {
+    // Project coords
+    const projectedCoords = Projection.transformPoints(
+      [marker.lonlat],
+      Projection.PROJECTION_NAMES.LONLAT,
+      this.getProjection().getCode()
+    )[0];
+
+    // Set it on the MapViewer
+    this.getClickMarkerOverlay().setPosition(projectedCoords);
+
+    // Save in store
+    // TODO: REFACTOR - This set in the store shouldn't be here, it should be in the controller, but since
+    // TO.DOCONT: this clickMarkerIconShow function is accessed directly by external code, a refactoring needs to be done to adjust that.
+    setStoreMapClickMarker(this.mapId, projectedCoords);
+
+    // Return the projected coordinates
+    return projectedCoords;
   }
 
   /**
@@ -1235,8 +1315,10 @@ export class MapViewer {
             styleCount += legend.styleConfig[geom as TypeStyleGeometry]!.info.length;
         }
       });
+
     // Set the openlayers icon image cache
     iconImageCache.setSize(styleCount);
+
     // Update the cache size for the map viewer
     this.iconImageCacheSize = styleCount;
   }
@@ -1522,7 +1604,7 @@ export class MapViewer {
 
     // GV: Sometime, the getCoordinateFromPixel return null... use await
     const pixel = await this.getCoordinateFromPixel(pointXY, TIMEOUT.northPoleVisibility);
-    const pt = Projection.transformToLonLat(pixel, this.getView().getProjection());
+    const pt = Projection.transformToLonLat(pixel, this.getProjection());
 
     // If user is pass north, long value will start to be positive (other side of the earth).
     // This will work only for LCC Canada.
@@ -1538,11 +1620,11 @@ export class MapViewer {
   getNorthArrowAngle(): string {
     try {
       // north value
-      const pointA = { x: NORTH_POLE_POSITION[1], y: NORTH_POLE_POSITION[0] };
+      const pointA = { x: NORTH_POLE_POSITION_LONLAT[1], y: NORTH_POLE_POSITION_LONLAT[0] };
 
       // map center (we use botton parallel to introduce less distortion)
       const extent = this.getView().calculateExtent();
-      const center: Coordinate = Projection.transformToLonLat([(extent[0] + extent[2]) / 2, extent[1]], this.getView().getProjection());
+      const center: Coordinate = Projection.transformToLonLat([(extent[0] + extent[2]) / 2, extent[1]], this.getProjection());
       const pointB = { x: center[0], y: center[1] };
 
       // set info on longitude and latitude
@@ -1831,7 +1913,7 @@ export class MapViewer {
   #handleMapPointerMove(event: MapBrowserEvent): void {
     try {
       // Get the projection code
-      const projCode = this.getView().getProjection().getCode();
+      const projCode = this.getProjection().getCode();
 
       // Get the pointer position information based on the map event
       const pointerPosition: TypeMapMouseInfo = GeoUtilities.getPointerPositionFromMapEvent(event, projCode);
@@ -1855,7 +1937,7 @@ export class MapViewer {
   #handleMapPointerStopped(event: MapBrowserEvent): void {
     try {
       // Get the projection code
-      const projCode = this.getView().getProjection().getCode();
+      const projCode = this.getProjection().getCode();
 
       // Get the pointer position information based on the map event
       const pointerPosition: TypeMapMouseInfo = GeoUtilities.getPointerPositionFromMapEvent(event, projCode);
@@ -1876,7 +1958,7 @@ export class MapViewer {
   #handleMapSingleClick(event: MapBrowserEvent): void {
     try {
       // Get the projection code
-      const projCode = this.getView().getProjection().getCode();
+      const projCode = this.getProjection().getCode();
 
       // Get the pointer position information based on the map event
       const pointerPosition: TypeMapMouseInfo = GeoUtilities.getPointerPositionFromMapEvent(event, projCode);
@@ -2077,7 +2159,7 @@ export class MapViewer {
     // If there's a layer path that should be selected in footerBar or appBar configs, select it
     const selectedLayerPath =
       this.mapFeaturesConfig.footerBar?.selectedLayersLayerPath || this.mapFeaturesConfig.appBar?.selectedLayersLayerPath;
-    if (selectedLayerPath) setStoreLayerSelectedLayersTabLayer(this.mapId, selectedLayerPath);
+    if (selectedLayerPath) this.controllers.layerController.setSelectedLayerPath(selectedLayerPath);
 
     // Await for all layers to be 'loaded'
     await this.#checkMapLayersLoaded();
@@ -2124,7 +2206,7 @@ export class MapViewer {
     const centerCoordinates = await this.getCenter();
 
     // Get the projection code
-    const projCode = this.getView().getProjection().getCode();
+    const projCode = this.getProjection().getCode();
 
     // Get the pointer position
     const pointerPosition = {
@@ -2263,9 +2345,9 @@ export class MapViewer {
    *
    * @param callback - The callback to be executed whenever the event is emitted
    */
-  onMapInit(callback: MapInitDelegate): void {
+  onMapInit(callback: MapInitDelegate): MapInitDelegate {
     // Register the event handler
-    EventHelper.onEvent(this.#onMapInitHandlers, callback);
+    return EventHelper.onEvent(this.#onMapInitHandlers, callback);
   }
 
   /**
@@ -2291,9 +2373,9 @@ export class MapViewer {
    *
    * @param callback - The callback to be executed whenever the event is emitted
    */
-  onMapReady(callback: MapReadyDelegate): void {
+  onMapReady(callback: MapReadyDelegate): MapReadyDelegate {
     // Register the event handler
-    EventHelper.onEvent(this.#onMapReadyHandlers, callback);
+    return EventHelper.onEvent(this.#onMapReadyHandlers, callback);
   }
 
   /**
@@ -2319,9 +2401,9 @@ export class MapViewer {
    *
    * @param callback - The callback to be executed whenever the event is emitted
    */
-  onMapLayersProcessed(callback: MapLayersProcessedDelegate): void {
+  onMapLayersProcessed(callback: MapLayersProcessedDelegate): MapLayersProcessedDelegate {
     // Register the event handler
-    EventHelper.onEvent(this.#onMapLayersProcessedHandlers, callback);
+    return EventHelper.onEvent(this.#onMapLayersProcessedHandlers, callback);
   }
 
   /**
@@ -2347,9 +2429,9 @@ export class MapViewer {
    *
    * @param callback - The callback to be executed whenever the event is emitted
    */
-  onMapLayersLoaded(callback: MapLayersLoadedDelegate): void {
+  onMapLayersLoaded(callback: MapLayersLoadedDelegate): MapLayersLoadedDelegate {
     // Register the event handler
-    EventHelper.onEvent(this.#onMapLayersLoadedHandlers, callback);
+    return EventHelper.onEvent(this.#onMapLayersLoadedHandlers, callback);
   }
 
   /**
@@ -2375,9 +2457,9 @@ export class MapViewer {
    *
    * @param callback - The callback to be executed whenever the event is emitted
    */
-  onMapMoveEnd(callback: MapMoveEndDelegate): void {
+  onMapMoveEnd(callback: MapMoveEndDelegate): MapMoveEndDelegate {
     // Register the event handler
-    EventHelper.onEvent(this.#onMapMoveEndHandlers, callback);
+    return EventHelper.onEvent(this.#onMapMoveEndHandlers, callback);
   }
 
   /**
@@ -2493,9 +2575,9 @@ export class MapViewer {
    *
    * @param callback - The callback to be executed whenever the event is emitted
    */
-  onMapZoomEnd(callback: MapZoomEndDelegate): void {
+  onMapZoomEnd(callback: MapZoomEndDelegate): MapZoomEndDelegate {
     // Register the event handler
-    EventHelper.onEvent(this.#onMapZoomEndHandlers, callback);
+    return EventHelper.onEvent(this.#onMapZoomEndHandlers, callback);
   }
 
   /**
@@ -2521,9 +2603,9 @@ export class MapViewer {
    *
    * @param callback - The callback to be executed whenever the event is emitted
    */
-  onMapRotation(callback: MapRotationDelegate): void {
+  onMapRotation(callback: MapRotationDelegate): MapRotationDelegate {
     // Register the event handler
-    EventHelper.onEvent(this.#onMapRotationHandlers, callback);
+    return EventHelper.onEvent(this.#onMapRotationHandlers, callback);
   }
 
   /**
@@ -2549,9 +2631,9 @@ export class MapViewer {
    *
    * @param callback - The callback to be executed whenever the event is emitted
    */
-  onMapChangeSize(callback: MapChangeSizeDelegate): void {
+  onMapChangeSize(callback: MapChangeSizeDelegate): MapChangeSizeDelegate {
     // Register the event handler
-    EventHelper.onEvent(this.#onMapChangeSizeHandlers, callback);
+    return EventHelper.onEvent(this.#onMapChangeSizeHandlers, callback);
   }
 
   /**
@@ -2569,7 +2651,37 @@ export class MapViewer {
    *
    * @param event - The projection change event
    */
-  #emitMapProjectionChanged(event: { projection: OLProjection }): void {
+  #emitMapProjectionChangeStarted(event: MapProjectionChangedEvent): void {
+    // Emit the event
+    EventHelper.emitEvent(this, this.#onMapProjectionChangeStartedHandlers, event);
+  }
+
+  /**
+   * Registers a map projection change event callback.
+   *
+   * @param callback - The callback to be executed whenever the event is emitted
+   */
+  onMapProjectionChangeStarted(callback: MapProjectionChangedDelegate): MapProjectionChangedDelegate {
+    // Register the event handler
+    return EventHelper.onEvent(this.#onMapProjectionChangeStartedHandlers, callback);
+  }
+
+  /**
+   * Unregisters a map projection changed event callback.
+   *
+   * @param callback - The callback to stop being called whenever the event is emitted
+   */
+  offMapProjectionChangeStarted(callback: MapProjectionChangedDelegate): void {
+    // Unregister the event handler
+    EventHelper.offEvent(this.#onMapProjectionChangeStartedHandlers, callback);
+  }
+
+  /**
+   * Emits a map projection changed event.
+   *
+   * @param event - The projection change event
+   */
+  #emitMapProjectionChanged(event: MapProjectionChangedEvent): void {
     // Emit the event
     EventHelper.emitEvent(this, this.#onMapProjectionChangedHandlers, event);
   }
@@ -2579,9 +2691,9 @@ export class MapViewer {
    *
    * @param callback - The callback to be executed whenever the event is emitted
    */
-  onMapProjectionChanged(callback: MapProjectionChangedDelegate): void {
+  onMapProjectionChanged(callback: MapProjectionChangedDelegate): MapProjectionChangedDelegate {
     // Register the event handler
-    EventHelper.onEvent(this.#onMapProjectionChangedHandlers, callback);
+    return EventHelper.onEvent(this.#onMapProjectionChangedHandlers, callback);
   }
 
   /**
@@ -2589,9 +2701,9 @@ export class MapViewer {
    *
    * @param callback - The callback to stop being called whenever the event is emitted
    */
-  offMapProjectionChanged(callback: MapChangeSizeDelegate): void {
+  offMapProjectionChanged(callback: MapProjectionChangedDelegate): void {
     // Unregister the event handler
-    EventHelper.offEvent(this.#onMapChangeSizeHandlers, callback);
+    EventHelper.offEvent(this.#onMapProjectionChangedHandlers, callback);
   }
 
   /**
@@ -2607,9 +2719,9 @@ export class MapViewer {
    *
    * @param callback - The callback to be executed whenever the event is emitted
    */
-  onMapComponentAdded(callback: MapComponentAddedDelegate): void {
+  onMapComponentAdded(callback: MapComponentAddedDelegate): MapComponentAddedDelegate {
     // Register the component added event handler
-    EventHelper.onEvent(this.#onMapComponentAddedHandlers, callback);
+    return EventHelper.onEvent(this.#onMapComponentAddedHandlers, callback);
   }
 
   /**
@@ -2635,9 +2747,9 @@ export class MapViewer {
    *
    * @param callback - The callback to be executed whenever the event is emitted
    */
-  onMapComponentRemoved(callback: MapComponentRemovedDelegate): void {
+  onMapComponentRemoved(callback: MapComponentRemovedDelegate): MapComponentRemovedDelegate {
     // Register the component removed event handler
-    EventHelper.onEvent(this.#onMapComponentRemovedHandlers, callback);
+    return EventHelper.onEvent(this.#onMapComponentRemovedHandlers, callback);
   }
 
   /**
@@ -2663,9 +2775,9 @@ export class MapViewer {
    *
    * @param callback - The callback to be executed whenever the event is emitted
    */
-  onMapLanguageChanged(callback: MapLanguageChangedDelegate): void {
+  onMapLanguageChanged(callback: MapLanguageChangedDelegate): MapLanguageChangedDelegate {
     // Register the component removed event handler
-    EventHelper.onEvent(this.#onMapLanguageChangedHandlers, callback);
+    return EventHelper.onEvent(this.#onMapLanguageChangedHandlers, callback);
   }
 
   /**
@@ -2788,6 +2900,7 @@ export type MapChangeSizeDelegate = EventDelegateBase<MapViewer, MapChangeSizeEv
  */
 export type MapProjectionChangedEvent = {
   projection: OLProjection;
+  previousProjection: OLProjection;
 };
 
 /**

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -37,7 +37,7 @@ import {
   VALID_DISPLAY_THEME,
   VALID_PROJECTION_CODES,
   MAP_ZOOM_LEVEL,
-  MAX_EXTENTS_RESTRICTION,
+  MAX_EXTENTS_RESTRICTION_LONLAT,
 } from '@/api/types/map-schema-types';
 import type { TypeLayerStatus } from '@/api/types/layer-schema-types';
 
@@ -89,6 +89,7 @@ import {
   setStoreMapMoveEnd,
   setStoreMapInteraction,
   type TypeScaleInfo,
+  getStoreMapConfigViewSettings,
 } from '@/core/stores/store-interface-and-intial-values/map-state';
 import { getStoreAppDisplayTheme } from '@/core/stores/store-interface-and-intial-values/app-state';
 import { getStoreLayerOrderedLayerPaths, type TypeLegend } from '@/core/stores/store-interface-and-intial-values/layer-state';
@@ -649,26 +650,29 @@ export class MapViewer {
   /**
    * Set the map viewSettings (coordinate values in lon/lat).
    *
-   * @param mapView - Map viewSettings object
+   * @param mapViewSettings - Map viewSettings object
    */
-  setView(mapView: TypeViewSettings): void {
+  setView(mapViewSettings: TypeViewSettings): void {
     const currentView = this.getView();
     const viewOptions: ViewOptions = {};
-    viewOptions.projection = `EPSG:${mapView.projection}`;
-    viewOptions.zoom = mapView.initialView?.zoomAndCenter ? mapView.initialView?.zoomAndCenter[0] : currentView.getZoom();
-    viewOptions.center = mapView.initialView?.zoomAndCenter
-      ? Projection.transformFromLonLat(mapView.initialView?.zoomAndCenter[1], Projection.getProjectionFromString(viewOptions.projection))
+    viewOptions.projection = `EPSG:${mapViewSettings.projection}`;
+    viewOptions.zoom = mapViewSettings.initialView?.zoomAndCenter ? mapViewSettings.initialView?.zoomAndCenter[0] : currentView.getZoom();
+    viewOptions.center = mapViewSettings.initialView?.zoomAndCenter
+      ? Projection.transformFromLonLat(
+          mapViewSettings.initialView?.zoomAndCenter[1],
+          Projection.getProjectionFromString(viewOptions.projection)
+        )
       : Projection.transformFromLonLat(
           Projection.transformToLonLat(currentView.getCenter()!, currentView.getProjection()),
           Projection.getProjectionFromString(viewOptions.projection)
         );
-    viewOptions.minZoom = mapView.minZoom ? mapView.minZoom : currentView.getMinZoom();
-    viewOptions.maxZoom = mapView.maxZoom ? mapView.maxZoom : currentView.getMaxZoom();
-    viewOptions.rotation = mapView.rotation ? mapView.rotation : currentView.getRotation();
+    viewOptions.minZoom = mapViewSettings.minZoom ? mapViewSettings.minZoom : currentView.getMinZoom();
+    viewOptions.maxZoom = mapViewSettings.maxZoom ? mapViewSettings.maxZoom : currentView.getMaxZoom();
+    viewOptions.rotation = mapViewSettings.rotation ? mapViewSettings.rotation : currentView.getRotation();
 
-    if (mapView.maxExtent) {
-      const projObj = Projection.getProjectionFromString(`EPSG:${mapView.projection}`);
-      viewOptions.extent = MapViewer.#computeViewExtent(Number(mapView.projection), mapView.maxExtent, projObj);
+    if (mapViewSettings.maxExtent) {
+      const projObj = Projection.getProjectionFromString(`EPSG:${mapViewSettings.projection}`);
+      viewOptions.extent = MapViewer.#computeViewExtent(Number(mapViewSettings.projection), mapViewSettings.maxExtent, projObj);
     }
 
     const newView = new View(viewOptions);
@@ -765,13 +769,16 @@ export class MapViewer {
    * @param maxExtent - Optional max extent for the view
    * @returns True if the projection was changed, false if the projection code is unsupported
    */
-  setProjection(projectionNumber: TypeValidMapProjectionCodes, maxExtent: number[] | undefined): boolean {
+  setProjection(projectionNumber: TypeValidMapProjectionCodes): boolean {
     if (VALID_PROJECTION_CODES.includes(Number(projectionNumber))) {
       // Get the current projection
       const currentProjection = this.getProjection();
 
       // Get the new projection
       const newProjection = Projection.PROJECTIONS[projectionNumber];
+
+      // Get the view settings as configured
+      const viewSettings = getStoreMapConfigViewSettings(this.mapId);
 
       // Get view status (center and projection) to calculate new center
       const currentView = this.map.getView();
@@ -782,12 +789,22 @@ export class MapViewer {
         number,
       ];
 
+      // GV The extent is different between LCC and WM and switching from one to the other may introduce weird constraint.
+      // GV We may have to keep extent as array for configuration file but, technically, user does not change projection often.
+      // GV A wider LCC extent like [-125, 30, -60, 89] (minus -125) will introduce distortion on larger screen...
+      // GV It is why we apply the max extent only on native projection, otherwise we send undefined so that it applies default
+      // If we're switching to the projection as configured
+      let maxExtent4326 = MAX_EXTENTS_RESTRICTION_LONLAT[projectionNumber];
+      if (projectionNumber === viewSettings?.projection && viewSettings.maxExtent) {
+        maxExtent4326 = viewSettings.maxExtent;
+      }
+
       // Create new view settings
       const newView: TypeViewSettings = {
         initialView: { zoomAndCenter: [currentView.getZoom() as number, centerLatLng] },
         minZoom: currentView.getMinZoom(),
         maxZoom: currentView.getMaxZoom(),
-        maxExtent: maxExtent ?? MAX_EXTENTS_RESTRICTION[projectionNumber],
+        maxExtent: maxExtent4326,
         projection: projectionNumber,
       };
 

--- a/packages/geoview-core/src/geo/map/point-markers.ts
+++ b/packages/geoview-core/src/geo/map/point-markers.ts
@@ -11,6 +11,7 @@ import type { MapViewer } from '@/geo/map/map-viewer';
 import { logger } from '@/core/utils/logger';
 import type { TypePointMarker } from '@/api/types/map-schema-types';
 import { getStoreMapPointMarkers } from '@/core/stores/store-interface-and-intial-values/map-state';
+import type { MapController } from '@/core/controllers/map-controller';
 
 /**
  * A class to handle point markers.
@@ -20,10 +21,10 @@ export class PointMarkers {
   #featureHighlight: FeatureHighlight;
 
   /** The map viewer */
-  mapViewer: MapViewer;
+  #mapViewer: MapViewer;
 
-  /** The map ID */
-  mapId: string;
+  /** The map controller */
+  #mapController: MapController;
 
   /** Array to track marker feature IDs */
   #featureIds: string[] = [];
@@ -32,13 +33,15 @@ export class PointMarkers {
    * Initializes point marker classes.
    *
    * @param mapViewer - The map viewer
+   * @param mapController - The map controller
    * @param featureHighlight - The feature highlight class
    */
-  constructor(mapViewer: MapViewer, featureHighlight: FeatureHighlight) {
-    this.mapViewer = mapViewer;
-    this.mapId = mapViewer.mapId;
+  constructor(mapViewer: MapViewer, mapController: MapController, featureHighlight: FeatureHighlight) {
+    this.#mapViewer = mapViewer;
+    this.#mapController = mapController;
     this.#featureHighlight = featureHighlight;
-    if (Object.keys(getStoreMapPointMarkers(this.mapId)).length) this.updatePointMarkers(getStoreMapPointMarkers(this.mapId));
+    if (Object.keys(getStoreMapPointMarkers(this.#mapViewer.mapId)).length)
+      this.updatePointMarkers(getStoreMapPointMarkers(this.#mapViewer.mapId));
   }
 
   /**
@@ -68,7 +71,7 @@ export class PointMarkers {
             Projection.transformPoints(
               [point.coordinate],
               `EPSG:${point.projectionCode || 4326}`,
-              this.mapViewer.getProjection().getCode()
+              this.#mapViewer.getProjection().getCode()
             )[0]
           ),
         });
@@ -106,7 +109,7 @@ export class PointMarkers {
   // TODO: REFACTOR - These functions should likely be removed from here and just be handled in the map controller, but for now they are left here to avoid breaking changes with the point marker API
   addPointMarkers(group: string, pointMarkers: TypePointMarker[]): void {
     // Redirect to map controller
-    this.mapViewer.controllers.mapController.addPointMarkers(group, pointMarkers);
+    this.#mapController.addPointMarkers(group, pointMarkers);
   }
 
   /**
@@ -118,7 +121,7 @@ export class PointMarkers {
   // TODO: REFACTOR - These functions should likely be removed from here and just be handled in the map controller, but for now they are left here to avoid breaking changes with the point marker API
   removePointMarkersOrGroup(group: string, idsOrCoordinates?: string[] | Coordinate[]): void {
     // Redirect to map controller
-    this.mapViewer.controllers.mapController.removePointMarkersOrGroup(group, idsOrCoordinates);
+    this.#mapController.removePointMarkersOrGroup(group, idsOrCoordinates);
   }
 
   /**
@@ -127,7 +130,7 @@ export class PointMarkers {
    * @param group - The group to zoom to
    */
   zoomToPointMarkerGroup(group: string): void {
-    const groupMarkers = getStoreMapPointMarkers(this.mapId)[group];
+    const groupMarkers = getStoreMapPointMarkers(this.#mapViewer.mapId)[group];
 
     if (groupMarkers) {
       // Create list of feature IDs
@@ -152,7 +155,7 @@ export class PointMarkers {
     // Get extent of point markers and zoom to it
     const extent = this.getExtentFromMarkerIds(idList);
     if (extent)
-      this.mapViewer.controllers.mapController.zoomToExtent(extent).catch((error: unknown) => {
+      this.#mapController.zoomToExtent(extent).catch((error: unknown) => {
         // Log
         logger.logPromiseFailed('zoomToExtent in zoomToPointMarkersOrGroup in PointMarkers.zoomToPointMarkers', error);
       });

--- a/packages/geoview-core/src/ui/slider/slider.tsx
+++ b/packages/geoview-core/src/ui/slider/slider.tsx
@@ -122,8 +122,6 @@ function SliderUI(props: SliderProps): JSX.Element {
     // Log
     logger.logTraceUseMemo('SLIDER - memoProcessedMarks', marks);
 
-    logger.logTraceUseMemo('SLIDER - memoProcessedMarks', marks);
-
     if (!marks || marks.length === 0) return marks;
 
     const maxVisibleMarks = 30;

--- a/packages/geoview-core/src/ui/slider/slider.tsx
+++ b/packages/geoview-core/src/ui/slider/slider.tsx
@@ -183,28 +183,31 @@ function SliderUI(props: SliderProps): JSX.Element {
   /**
    * Handles when the user drags the slider thumb to change the value.
    */
-  const handleChange = useCallback((event: React.SyntheticEvent | Event, newValue: number | number[], activeThumb: number): void => {
-    // Track which thumb is active
-    activeThumbRef.current = activeThumb;
+  const handleChange = useCallback(
+    (event: React.SyntheticEvent | Event, newValue: number | number[], activeThumb: number): void => {
+      // Update the internal state if not controlled, meaning 'value' isn't provided by the parent component
+      if (!isControlled) {
+        setInternalValue(newValue);
+      }
 
-    // Update the internal state if not controlled, meaning 'value' isn't provided by the parent component
-    if (!isControlled) {
-      setInternalValue(newValue);
-    }
+      event.preventDefault();
 
-    event.preventDefault();
-
-    // Callback
-    onChange?.(newValue, activeThumb);
-  }, [isControlled, onChange, setInternalValue]);
+      // Callback
+      onChange?.(newValue, activeThumb);
+    },
+    [isControlled, onChange, setInternalValue]
+  );
 
   /**
    * Handles when the user completes a slider drag (mouseup).
    */
-  const handleChangeCommitted = useCallback((event: React.SyntheticEvent | Event, newValue: number | number[]): void => {
-    // Callback
-    onChangeCommitted?.(newValue);
-  }, [onChangeCommitted]);
+  const handleChangeCommitted = useCallback(
+    (event: React.SyntheticEvent | Event, newValue: number | number[]): void => {
+      // Callback
+      onChangeCommitted?.(newValue);
+    },
+    [onChangeCommitted]
+  );
 
   // #endregion
 

--- a/packages/geoview-core/src/ui/slider/slider.tsx
+++ b/packages/geoview-core/src/ui/slider/slider.tsx
@@ -100,7 +100,10 @@ function SliderUI(props: SliderProps): JSX.Element {
 
   // Hooks
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('SLIDER - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   // Ref
   const sliderRef = useRef<HTMLDivElement>(null);
@@ -117,6 +120,8 @@ function SliderUI(props: SliderProps): JSX.Element {
    */
   const memoProcessedMarks = useMemo((): Mark[] | undefined => {
     // Log
+    logger.logTraceUseMemo('SLIDER - memoProcessedMarks', marks);
+
     logger.logTraceUseMemo('SLIDER - memoProcessedMarks', marks);
 
     if (!marks || marks.length === 0) return marks;
@@ -165,6 +170,7 @@ function SliderUI(props: SliderProps): JSX.Element {
     // Log
     logger.logTraceUseMemo('SLIDER - memoFinalClassName', sliderValue, orientation);
 
+    logger.logTraceUseMemo('SLIDER - memoFinalClassName', sliderValue, orientation, className);
     const shouldSpreadLabel = Array.isArray(sliderValue) && sliderValue.length >= 2 && (!orientation || orientation === 'horizontal');
 
     if (!shouldSpreadLabel) return className;
@@ -175,9 +181,9 @@ function SliderUI(props: SliderProps): JSX.Element {
   // #region Handlers
 
   /**
-   * Handles when the user drags the slider thumb to change the value
+   * Handles when the user drags the slider thumb to change the value.
    */
-  const handleChange = (event: React.SyntheticEvent | Event, newValue: number | number[], activeThumb: number): void => {
+  const handleChange = useCallback((event: React.SyntheticEvent | Event, newValue: number | number[], activeThumb: number): void => {
     // Track which thumb is active
     activeThumbRef.current = activeThumb;
 
@@ -190,15 +196,15 @@ function SliderUI(props: SliderProps): JSX.Element {
 
     // Callback
     onChange?.(newValue, activeThumb);
-  };
+  }, [isControlled, onChange, setInternalValue]);
 
   /**
-   * Handles when the user completes a slider drag (mouseup)
+   * Handles when the user completes a slider drag (mouseup).
    */
-  const handleChangeCommitted = (event: React.SyntheticEvent | Event, newValue: number | number[]): void => {
+  const handleChangeCommitted = useCallback((event: React.SyntheticEvent | Event, newValue: number | number[]): void => {
     // Callback
     onChangeCommitted?.(newValue);
-  };
+  }, [onChangeCommitted]);
 
   // #endregion
 
@@ -363,7 +369,7 @@ function SliderUI(props: SliderProps): JSX.Element {
     <MaterialSlider
       {...properties}
       id={containerId}
-      sx={disabled ? null : sxClasses.slider}
+      sx={disabled ? null : memoSxClasses.slider}
       className={memoFinalClassName}
       ref={sliderRef}
       orientation={orientation}

--- a/packages/geoview-core/src/ui/switch/switch.tsx
+++ b/packages/geoview-core/src/ui/switch/switch.tsx
@@ -43,7 +43,10 @@ function SwitchUI(props: ExtendedSwitchProps): JSX.Element {
   // Hooks
   const switchId = useId(); // WCAG - Unique ID to associate label with switch
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('SWITCH - memoSxClasses', theme);
+    return getSxClasses(theme);
+  }, [theme]);
 
   return (
     <MaterialFormControlLabel
@@ -64,7 +67,7 @@ function SwitchUI(props: ExtendedSwitchProps): JSX.Element {
         />
       }
       label={label}
-      sx={sxClasses.formControl}
+      sx={memoSxClasses.formControl}
     />
   );
 }

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -144,6 +144,9 @@ const extractTabId = (fullId: string, mapId: string): string => {
  * @see {@link https://mui.com/material-ui/react-tabs/}
  */
 function TabsUI(props: TypeTabsProps): JSX.Element {
+  // Log
+  logger.logTraceRender('ui/tabs/tabs');
+
   const {
     // NOTE: need this shellContainer, so that mobile dropdown can be rendered on top fullscreen window.
     mapId,
@@ -176,7 +179,10 @@ function TabsUI(props: TypeTabsProps): JSX.Element {
   const [value, setValue] = useState<number | boolean>(0);
   const [tabPanels, setTabPanels] = useState([tabs[0]]);
   const tabPanelRef = useRef<HTMLDivElement | null>(null);
-  const sxClasses = useMemo((): SxStyles => getSxClasses(theme, isFullScreen, appHeight), [theme, isFullScreen, appHeight]);
+  const memoSxClasses = useMemo((): SxStyles => {
+    logger.logTraceUseMemo('UI.TABS - memoSxClasses', theme, isFullScreen, appHeight);
+    return getSxClasses(theme, isFullScreen, appHeight);
+  }, [theme, isFullScreen, appHeight]);
 
   // #region Handlers
 
@@ -312,7 +318,7 @@ function TabsUI(props: TypeTabsProps): JSX.Element {
   }, [selectedTab, isCollapsed, tabs, onCloseKeyboard, mapId]);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sxMerged: any = { ...sxClasses.panel, visibility: TabContentVisibilty };
+  const sxMerged: any = { ...memoSxClasses.panel, visibility: TabContentVisibilty };
 
   /**
    * Filters out hidden tabs from the tab list.
@@ -367,7 +373,7 @@ function TabsUI(props: TypeTabsProps): JSX.Element {
                     iconPosition="start"
                     id={createTabId(mapId, tab.id)}
                     onClick={handleClick}
-                    sx={sxClasses.tab}
+                    sx={memoSxClasses.tab}
                     aria-controls={createPanelId(mapId, tab.id)}
                     tabIndex={0}
                     value={tab.value}
@@ -377,7 +383,7 @@ function TabsUI(props: TypeTabsProps): JSX.Element {
               })}
             </MaterialTabs>
           ) : (
-            <Box sx={sxClasses.mobileDropdown}>
+            <Box sx={memoSxClasses.mobileDropdown}>
               <Select
                 labelId={`${mapId}-footerBarDropdownLabel`}
                 label=""
@@ -394,7 +400,7 @@ function TabsUI(props: TypeTabsProps): JSX.Element {
             </Box>
           )}
         </Grid>
-        <Grid size={{ xs: 5, sm: 2 }} sx={sxClasses.rightIcons}>
+        <Grid size={{ xs: 5, sm: 2 }} sx={memoSxClasses.rightIcons}>
           {rightButtons as ReactNode}
         </Grid>
       </Grid>

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -254,13 +254,14 @@ function TabsUI(props: TypeTabsProps): JSX.Element {
 
     // If a selected tab is defined
     if (selectedTab !== undefined) {
-      const newPanels = [...tabPanels];
-      newPanels[selectedTab] = tabs[selectedTab];
-      setTabPanels(newPanels);
+      setTabPanels((prev) => {
+        const next = [...prev];
+        next[selectedTab] = tabs[selectedTab];
+        return next;
+      });
       // Make sure internal state follows
       setValue(selectedTab);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedTab, tabs]);
   // Do not add dependency on onToggleCollapse or isCollapse, because then on re-render after the change, the useEffect just re-collapses/re-expands...
 

--- a/packages/geoview-custom-legend/src/components/group-item.tsx
+++ b/packages/geoview-custom-legend/src/components/group-item.tsx
@@ -80,8 +80,6 @@ export function GroupItem({ item, sxClasses, itemPath }: GroupItemProps): JSX.El
   // Check if all child layers are visible
   const allVisible = useStoreLayerArrayVisibility(memoLayerPaths);
 
-  if (!isGroupLayer(item)) return;
-
   // #region HANDLERS
 
   /**
@@ -107,6 +105,8 @@ export function GroupItem({ item, sxClasses, itemPath }: GroupItemProps): JSX.El
 
   // Get current item text and path for children
   const currentPath = itemPath || item.itemId || `group-${item.text.toLowerCase().replace(/\s+/g, '-')}`;
+
+  if (!isGroupLayer(item)) return;
 
   return (
     <ListItem sx={sxClasses.legendListItem} disablePadding className="layerListItem groupItem">

--- a/packages/geoview-custom-legend/src/components/group-item.tsx
+++ b/packages/geoview-custom-legend/src/components/group-item.tsx
@@ -94,7 +94,7 @@ export function GroupItem({ item, sxClasses, itemPath }: GroupItemProps): JSX.El
 
     // Toggle all child layers
     layerPaths.forEach((layerPath) => {
-      layerController.setOrToggleLayerVisibilityIfExists(layerPath, newVisibility);
+      layerController.setOrToggleLayerVisibility(layerPath, newVisibility);
     });
   };
 

--- a/packages/geoview-custom-legend/src/components/group-item.tsx
+++ b/packages/geoview-custom-legend/src/components/group-item.tsx
@@ -97,7 +97,13 @@ export function GroupItem({ item, sxClasses, itemPath }: GroupItemProps): JSX.El
 
     // Toggle all child layers
     memoLayerPaths.forEach((layerPath) => {
-      layerController.setOrToggleLayerVisibility(layerPath, newVisibility);
+      try {
+        // Toggle the visibility
+        layerController.setOrToggleLayerVisibility(layerPath, newVisibility);
+      } catch (error) {
+        // Log
+        logger.logWarning(`Failed to toggle visibility for layer at path ${layerPath}:`, error);
+      }
     });
   }, [allVisible, layerController, memoLayerPaths]);
 

--- a/packages/geoview-custom-legend/src/components/group-item.tsx
+++ b/packages/geoview-custom-legend/src/components/group-item.tsx
@@ -50,7 +50,7 @@ export function GroupItem({ item, sxClasses, itemPath }: GroupItemProps): JSX.El
 
   const { cgpv } = window as TypeWindow;
   const { ui, reactUtilities } = cgpv;
-  const { useState, useMemo } = reactUtilities.react;
+  const { useState, useCallback, useMemo } = reactUtilities.react;
   const {
     Box,
     ListItem,
@@ -72,31 +72,38 @@ export function GroupItem({ item, sxClasses, itemPath }: GroupItemProps): JSX.El
   const [collapsed, setCollapsed] = useState<boolean>(isGroupLayer(item) ? (item.collapsed ?? false) : false);
 
   // Collect all layer paths from children
-  const layerPaths = useMemo(() => collectLayerPaths(item.children), [item.children]);
+  const memoLayerPaths = useMemo(() => {
+    logger.logTraceUseMemo('GROUP-ITEM - memoLayerPaths', item.children);
+    return collectLayerPaths(item.children);
+  }, [item.children]);
 
   // Check if all child layers are visible
-  const allVisible = useStoreLayerArrayVisibility(layerPaths);
+  const allVisible = useStoreLayerArrayVisibility(memoLayerPaths);
 
   if (!isGroupLayer(item)) return;
 
-  /**
-   * Handles when the user toggles the group collapse state
-   */
-  const handleToggleCollapse = (): void => {
-    setCollapsed((prev) => !prev);
-  };
+  // #region HANDLERS
 
   /**
-   * Handles when the user toggles the visibility of all child layers
+   * Handles when the user toggles the group collapse state.
    */
-  const handleToggleVisibility = (): void => {
+  const handleToggleCollapse = useCallback((): void => {
+    setCollapsed((prev) => !prev);
+  }, []);
+
+  /**
+   * Handles when the user toggles the visibility of all child layers.
+   */
+  const handleToggleVisibility = useCallback((): void => {
     const newVisibility = !allVisible;
 
     // Toggle all child layers
-    layerPaths.forEach((layerPath) => {
+    memoLayerPaths.forEach((layerPath) => {
       layerController.setOrToggleLayerVisibility(layerPath, newVisibility);
     });
-  };
+  }, [allVisible, layerController, memoLayerPaths]);
+
+  // #endregion HANDLERS
 
   // Get current item text and path for children
   const currentPath = itemPath || item.itemId || `group-${item.text.toLowerCase().replace(/\s+/g, '-')}`;

--- a/packages/geoview-custom-legend/src/components/group-item.tsx
+++ b/packages/geoview-custom-legend/src/components/group-item.tsx
@@ -1,7 +1,7 @@
 import type { TypeWindow } from 'geoview-core/core/types/global-types';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import { logger } from 'geoview-core/core/utils/logger';
-import { useStoreMapLayerArrayVisibility } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreLayerArrayVisibility } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
 import { useLayerController } from 'geoview-core/core/controllers/use-controllers';
 
@@ -75,7 +75,7 @@ export function GroupItem({ item, sxClasses, itemPath }: GroupItemProps): JSX.El
   const layerPaths = useMemo(() => collectLayerPaths(item.children), [item.children]);
 
   // Check if all child layers are visible
-  const allVisible = useStoreMapLayerArrayVisibility(layerPaths);
+  const allVisible = useStoreLayerArrayVisibility(layerPaths);
 
   if (!isGroupLayer(item)) return;
 
@@ -94,7 +94,7 @@ export function GroupItem({ item, sxClasses, itemPath }: GroupItemProps): JSX.El
 
     // Toggle all child layers
     layerPaths.forEach((layerPath) => {
-      layerController.setOrToggleMapLayerVisibility(layerPath, newVisibility);
+      layerController.setOrToggleLayerVisibilityIfExists(layerPath, newVisibility);
     });
   };
 

--- a/packages/geoview-drawer/src/buttons/geometry-picker.tsx
+++ b/packages/geoview-drawer/src/buttons/geometry-picker.tsx
@@ -98,18 +98,15 @@ export function GeometryPickerButton(): JSX.Element {
 
   const geomType = useStoreDrawerActiveGeom();
   const style = useStoreDrawerStyle();
-  const memoIconStyle = useMemo(
-    () => {
-      logger.logTraceUseMemo('GEOMETRY-PICKER - GeomIcon - memoIconStyle', style);
-      return {
-        fillColor: style.fillColor,
-        strokeColor: style.strokeColor,
-        textColor: style.textColor,
-        textHaloColor: style.textHaloColor,
-      };
-    },
-    [style]
-  );
+  const memoIconStyle = useMemo(() => {
+    logger.logTraceUseMemo('GEOMETRY-PICKER - GeomIcon - memoIconStyle', style);
+    return {
+      fillColor: style.fillColor,
+      strokeColor: style.strokeColor,
+      textColor: style.textColor,
+      textHaloColor: style.textHaloColor,
+    };
+  }, [style]);
 
   if (geomType === 'Point') return <PointIcon IconComponent={PlaceIcon} />;
   if (geomType === 'Text') return <TextFieldsIcon sx={{ color: memoIconStyle.textColor }} stroke={memoIconStyle.textHaloColor} />;
@@ -145,18 +142,15 @@ export function GeometryPickerPanel(props: GeometryPickerPanelProps): JSX.Elemen
   const isDrawing = useStoreDrawerIsDrawing();
   const drawerController = useDrawerController();
 
-  const memoIconStyle = useMemo(
-    () => {
-      logger.logTraceUseMemo('GEOMETRY-PICKER - GeometryPickerPanel - memoIconStyle', style);
-      return {
-        color: style.fillColor,
-        stroke: style.strokeColor,
-        textColor: style.textColor,
-        textHaloColor: style.textHaloColor,
-      };
-    },
-    [style]
-  );
+  const memoIconStyle = useMemo(() => {
+    logger.logTraceUseMemo('GEOMETRY-PICKER - GeometryPickerPanel - memoIconStyle', style);
+    return {
+      color: style.fillColor,
+      stroke: style.strokeColor,
+      textColor: style.textColor,
+      textHaloColor: style.textHaloColor,
+    };
+  }, [style]);
 
   // Styles
   const sxClasses = {

--- a/packages/geoview-drawer/src/buttons/geometry-picker.tsx
+++ b/packages/geoview-drawer/src/buttons/geometry-picker.tsx
@@ -1,8 +1,7 @@
 import ReactDOMServer from 'react-dom/server';
-import { useStoreGeoViewMapId, type TypeWindow } from 'geoview-core';
+import type { TypeWindow } from 'geoview-core';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import {
-  setStoreDrawerIconSrc,
   useStoreDrawerActiveGeom,
   useStoreDrawerIsDrawing,
   useStoreDrawerStyle,
@@ -37,8 +36,8 @@ export function PointIcon(props: PointIconProps): JSX.Element {
   const { IconComponent } = props;
 
   // Store
-  const mapId = useStoreGeoViewMapId();
   const { fillColor, strokeColor, strokeWidth } = useStoreDrawerStyle();
+  const drawerController = useDrawerController();
 
   useEffect(() => {
     logger.logTraceUseEffect('POINT ICON - Icon style sync', IconComponent, fillColor, strokeColor, strokeWidth);
@@ -76,11 +75,11 @@ export function PointIcon(props: PointIconProps): JSX.Element {
     const dataUrl = `data:image/svg+xml;base64,${btoa(svgStr)}`;
 
     // Store the URL
-    setStoreDrawerIconSrc(mapId, dataUrl);
+    drawerController.setDrawerIconSrc(dataUrl);
 
     // Clean up when component unmounts
     return () => URL.revokeObjectURL(dataUrl);
-  }, [IconComponent, fillColor, mapId, strokeColor, strokeWidth]);
+  }, [IconComponent, fillColor, drawerController, strokeColor, strokeWidth]);
 
   return <IconComponent sx={{ fill: fillColor, stroke: strokeColor, strokeWidth }} />;
 }

--- a/packages/geoview-drawer/src/buttons/geometry-picker.tsx
+++ b/packages/geoview-drawer/src/buttons/geometry-picker.tsx
@@ -98,24 +98,27 @@ export function GeometryPickerButton(): JSX.Element {
 
   const geomType = useStoreDrawerActiveGeom();
   const style = useStoreDrawerStyle();
-  const iconStyle = useMemo(
-    () => ({
-      fillColor: style.fillColor,
-      strokeColor: style.strokeColor,
-      textColor: style.textColor,
-      textHaloColor: style.textHaloColor,
-    }),
+  const memoIconStyle = useMemo(
+    () => {
+      logger.logTraceUseMemo('GEOMETRY-PICKER - GeomIcon - memoIconStyle', style);
+      return {
+        fillColor: style.fillColor,
+        strokeColor: style.strokeColor,
+        textColor: style.textColor,
+        textHaloColor: style.textHaloColor,
+      };
+    },
     [style]
   );
 
   if (geomType === 'Point') return <PointIcon IconComponent={PlaceIcon} />;
-  if (geomType === 'Text') return <TextFieldsIcon sx={{ color: iconStyle.textColor }} stroke={iconStyle.textHaloColor} />;
-  if (geomType === 'LineString') return <ShowChartIcon sx={{ color: iconStyle.strokeColor }} />;
-  if (geomType === 'Polygon') return <HexagonIcon sx={{ color: iconStyle.fillColor }} stroke={iconStyle.strokeColor} />;
-  if (geomType === 'Rectangle') return <RectangleIcon sx={{ color: iconStyle.fillColor }} stroke={iconStyle.strokeColor} />;
-  if (geomType === 'Circle') return <CircleIcon sx={{ color: iconStyle.fillColor }} stroke={iconStyle.strokeColor} />;
-  if (geomType === 'Star') return <StarIcon sx={{ color: iconStyle.fillColor }} stroke={iconStyle.strokeColor} />;
-  return <ShapeLineIcon sx={{ color: iconStyle.fillColor }} stroke={iconStyle.strokeColor} />;
+  if (geomType === 'Text') return <TextFieldsIcon sx={{ color: memoIconStyle.textColor }} stroke={memoIconStyle.textHaloColor} />;
+  if (geomType === 'LineString') return <ShowChartIcon sx={{ color: memoIconStyle.strokeColor }} />;
+  if (geomType === 'Polygon') return <HexagonIcon sx={{ color: memoIconStyle.fillColor }} stroke={memoIconStyle.strokeColor} />;
+  if (geomType === 'Rectangle') return <RectangleIcon sx={{ color: memoIconStyle.fillColor }} stroke={memoIconStyle.strokeColor} />;
+  if (geomType === 'Circle') return <CircleIcon sx={{ color: memoIconStyle.fillColor }} stroke={memoIconStyle.strokeColor} />;
+  if (geomType === 'Star') return <StarIcon sx={{ color: memoIconStyle.fillColor }} stroke={memoIconStyle.strokeColor} />;
+  return <ShapeLineIcon sx={{ color: memoIconStyle.fillColor }} stroke={memoIconStyle.strokeColor} />;
 }
 
 /**
@@ -143,12 +146,15 @@ export function GeometryPickerPanel(props: GeometryPickerPanelProps): JSX.Elemen
   const drawerController = useDrawerController();
 
   const memoIconStyle = useMemo(
-    () => ({
-      color: style.fillColor,
-      stroke: style.strokeColor,
-      textColor: style.textColor,
-      textHaloColor: style.textHaloColor,
-    }),
+    () => {
+      logger.logTraceUseMemo('GEOMETRY-PICKER - GeometryPickerPanel - memoIconStyle', style);
+      return {
+        color: style.fillColor,
+        stroke: style.strokeColor,
+        textColor: style.textColor,
+        textHaloColor: style.textHaloColor,
+      };
+    },
     [style]
   );
 

--- a/packages/geoview-drawer/src/buttons/style.tsx
+++ b/packages/geoview-drawer/src/buttons/style.tsx
@@ -69,10 +69,8 @@ export function StylePanel(): JSX.Element {
   const displayLanguage = useStoreAppDisplayLanguage();
   const drawerController = useDrawerController();
 
-  const memoCurrentGeomType = useMemo(() => {
-    logger.logTraceUseMemo('STYLE-PANEL - memoCurrentGeomType', activeGeom, selectedDrawingType);
-    return selectedDrawingType ?? activeGeom;
-  }, [activeGeom, selectedDrawingType]);
+  /** The current geometry type, using the selected drawing type or active geometry as fallback. */
+  const currentGeomType = selectedDrawingType ?? activeGeom;
 
   // Local state for color inputs
   const [localFillColor, setLocalFillColor] = useState(style.fillColor);
@@ -313,7 +311,7 @@ export function StylePanel(): JSX.Element {
   return (
     <List sx={{ p: 2 }}>
       {/* Text-specific controls */}
-      {memoCurrentGeomType === 'Text' && (
+      {currentGeomType === 'Text' && (
         <>
           <ListItem sx={sxClasses.listItem}>
             <Typography variant="subtitle2" sx={sxClasses.label}>
@@ -444,7 +442,7 @@ export function StylePanel(): JSX.Element {
       )}
 
       {/* Fill color - hide for LineString and Text */}
-      {memoCurrentGeomType !== 'LineString' && memoCurrentGeomType !== 'Text' && (
+      {currentGeomType !== 'LineString' && currentGeomType !== 'Text' && (
         <ListItem sx={sxClasses.listItem}>
           <Typography variant="subtitle2" sx={sxClasses.label}>
             {getLocalizedMessage(displayLanguage, 'drawer.fillColour')}
@@ -454,7 +452,7 @@ export function StylePanel(): JSX.Element {
       )}
 
       {/* Point-specific controls */}
-      {memoCurrentGeomType === 'Point' && (
+      {currentGeomType === 'Point' && (
         <ListItem sx={sxClasses.listItem}>
           <Typography variant="subtitle2" sx={sxClasses.label}>
             {getLocalizedMessage(displayLanguage, 'drawer.iconSize')}
@@ -474,7 +472,7 @@ export function StylePanel(): JSX.Element {
       )}
 
       {/* Stroke controls - show for all except Text */}
-      {memoCurrentGeomType !== 'Text' && (
+      {currentGeomType !== 'Text' && (
         <>
           <ListItem sx={sxClasses.listItem}>
             <Typography variant="subtitle2" sx={sxClasses.label}>

--- a/packages/geoview-drawer/src/buttons/style.tsx
+++ b/packages/geoview-drawer/src/buttons/style.tsx
@@ -70,6 +70,7 @@ export function StylePanel(): JSX.Element {
   const drawerController = useDrawerController();
 
   const memoCurrentGeomType = useMemo(() => {
+    logger.logTraceUseMemo('STYLE-PANEL - memoCurrentGeomType', activeGeom, selectedDrawingType);
     return selectedDrawingType ?? activeGeom;
   }, [activeGeom, selectedDrawingType]);
 

--- a/packages/geoview-drawer/src/buttons/style.tsx
+++ b/packages/geoview-drawer/src/buttons/style.tsx
@@ -57,7 +57,7 @@ export function StylePanel(): JSX.Element {
 
   const { cgpv } = window as TypeWindow;
   const { ui, reactUtilities } = cgpv;
-  const { useCallback, useEffect, useMemo } = reactUtilities.react;
+  const { useCallback, useEffect } = reactUtilities.react;
 
   // Components
   const { Box, List, ListItem, Typography, TextField, IconButton, FormatBoldIcon, FormatItalicIcon } = ui.elements;

--- a/packages/geoview-geochart/src/geochart-panel.tsx
+++ b/packages/geoview-geochart/src/geochart-panel.tsx
@@ -5,19 +5,18 @@ import { Layout } from 'geoview-core/core/components/common';
 import { checkSelectedLayerPathList } from 'geoview-core/core/components/common/comp-common';
 import { Typography } from 'geoview-core/ui/typography/typography';
 import { Box } from 'geoview-core/ui';
+import { useStoreMapClickCoordinates } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
 import {
-  useStoreMapClickCoordinates,
-  useStoreMapAllVisibleandInRangeLayers,
-  useStoreMapIsLayerHiddenOnMapSet,
-} from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
-import { useStoreLayerNameSet, useStoreLayerStatusSet } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
+  useStoreLayerAllVisibleAndInRangeLayers,
+  useStoreLayerIsHiddenOnMapSet,
+  useStoreLayerNameSet,
+  useStoreLayerStatusSet,
+} from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 import type { TypeGeochartResultSetEntry } from 'geoview-core/core/stores/store-interface-and-intial-values/geochart-state';
 import {
   useStoreGeochartChartsConfig,
   useStoreGeochartLayerDataArrayBatch,
   useStoreGeochartSelectedLayerPath,
-  setStoreGeochartLayerDataArrayBatchLayerPathBypass,
-  setStoreGeochartSelectedLayerPath,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/geochart-state';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import { getLocalizedMessage } from 'geoview-core/core/utils/utilities';
@@ -27,6 +26,7 @@ import { CONTAINER_TYPE, TABS } from 'geoview-core/core/utils/constant';
 import { GeoChart } from './geochart';
 import type { GeoViewGeoChartRootConfig } from './geochart-types';
 import { convertGeoViewGeoChartConfigFromCore } from './geochart-types';
+import { useGeoChartController } from 'geoview-core/core/controllers/use-controllers';
 
 /** Properties for the GeoChartPanel component. */
 interface GeoChartPanelProps {
@@ -52,13 +52,14 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
   // Get states and actions from store
   const configObj = useStoreGeochartChartsConfig();
   const displayLanguage = useStoreAppDisplayLanguage();
-  const visibleInRangeLayers = useStoreMapAllVisibleandInRangeLayers();
+  const visibleInRangeLayers = useStoreLayerAllVisibleAndInRangeLayers();
   const mapClickCoordinates = useStoreMapClickCoordinates();
-  const layerHiddenSet = useStoreMapIsLayerHiddenOnMapSet();
+  const layerHiddenSet = useStoreLayerIsHiddenOnMapSet();
   const layerNames = useStoreLayerNameSet();
   const layerStatuses = useStoreLayerStatusSet();
   const storeArrayOfLayerData = useStoreGeochartLayerDataArrayBatch();
   const selectedLayerPath = useStoreGeochartSelectedLayerPath();
+  const geoChartController = useGeoChartController();
 
   // Create the validator shared for all the charts in the footer
   const [schemaValidator] = useState<SchemaValidator>(new SchemaValidator());
@@ -121,8 +122,7 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
 
       return label;
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [mapId, displayLanguage]
+    [displayLanguage]
   );
 
   /**
@@ -133,9 +133,9 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
   const handleLayerChange = useCallback(
     (layer: LayerListEntry): void => {
       // Set the selected layer path in the store which will in turn trigger the store listeners on this component
-      setStoreGeochartSelectedLayerPath?.(mapId, layer.layerPath);
+      geoChartController.setSelectedLayerPath(layer.layerPath);
     },
-    [mapId]
+    [geoChartController]
   );
 
   // #endregion
@@ -199,9 +199,9 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
 
     // Set the layer data array batch bypass to the currently selected layer
     if (selectedLayerPath) {
-      setStoreGeochartLayerDataArrayBatchLayerPathBypass?.(mapId, selectedLayerPath);
+      geoChartController.setLayerDataArrayBatchLayerPathBypass(selectedLayerPath);
     }
-  }, [mapId, selectedLayerPath]);
+  }, [geoChartController, selectedLayerPath]);
 
   /**
    * Effect used to persist or alter the current layer selection based on the layers list changes.
@@ -215,14 +215,13 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
     if (selectedLayerPath) {
       // Redirect to the keep selected layer path logic
       checkSelectedLayerPathList(
-        mapId,
-        setStoreGeochartLayerDataArrayBatchLayerPathBypass,
-        setStoreGeochartSelectedLayerPath,
+        (lyrPath) => geoChartController.setLayerDataArrayBatchLayerPathBypass(lyrPath),
+        (lyrPath) => geoChartController.setSelectedLayerPath(lyrPath),
         memoLayerSelectedItem,
         memoLayersList
       );
     }
-  }, [mapId, memoLayerSelectedItem, memoLayersList, selectedLayerPath]);
+  }, [geoChartController, memoLayerSelectedItem, memoLayersList, selectedLayerPath]);
 
   /**
    * Selects a layer after a map click happened on the map.
@@ -235,9 +234,9 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
     if (mapClickCoordinates && memoLayersList?.length && !selectedLayerPath?.length) {
       const selectedLayer = memoLayersList.find((layer) => !!layer.numOffeatures);
       // Select the first layer that has features
-      setStoreGeochartSelectedLayerPath(mapId, selectedLayer?.layerPath ?? '');
+      geoChartController.setSelectedLayerPath(selectedLayer?.layerPath ?? '');
     }
-  }, [mapId, mapClickCoordinates, memoLayersList, selectedLayerPath?.length]);
+  }, [geoChartController, mapClickCoordinates, memoLayersList, selectedLayerPath?.length]);
 
   // #endregion HOOKS
 

--- a/packages/geoview-geochart/src/geochart-panel.tsx
+++ b/packages/geoview-geochart/src/geochart-panel.tsx
@@ -100,10 +100,10 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
    * @param key - The GeoChart unique key of the child component
    * @param theCallbackRedraw - The callback to execute whenever we want to redraw the GeoChart
    */
-  const handleProvideCallbackRedraw = (key: string, theCallbackRedraw: () => void): void => {
+  const handleProvideCallbackRedraw = useCallback((key: string, theCallbackRedraw: () => void): void => {
     // Keep the callback
     redrawGeochart.current[key] = theCallbackRedraw;
-  };
+  }, []);
 
   // #region HOOKS
 
@@ -142,6 +142,9 @@ export function GeoChartPanel(props: GeoChartPanelProps): JSX.Element {
 
   // Convert the config object from core to geoview-geochart type-equivalent
   const memoConfigObj = useMemo(() => {
+    // Log
+    logger.logTraceUseMemo('GEOCHART-PANEL - memoConfigObj', configObj);
+
     // Memoize a better config object using the geoview-geochart type-equivalent instead of the store's
     return configObj
       ? Object.fromEntries(

--- a/packages/geoview-geochart/src/geochart.tsx
+++ b/packages/geoview-geochart/src/geochart.tsx
@@ -3,7 +3,7 @@ import { GeoChart as GeoChartComponent } from 'geochart';
 
 import {
   useStoreAppDisplayLanguageById,
-  useStoreDisplayDateTimezone,
+  useStoreAppDisplayDateTimezone,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import { useStoreLayerDisplayDateFormatShort } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 import type { TypeGeochartResultSetEntry } from 'geoview-core/core/stores/store-interface-and-intial-values/geochart-state';
@@ -57,8 +57,8 @@ export function GeoChart(props: GeoChartProps): JSX.Element {
 
   // Use Store
   const displayLanguage = useStoreAppDisplayLanguageById(mapId);
+  const displayDateTimezone = useStoreAppDisplayDateTimezone();
   const displayDateFormatShort = useStoreLayerDisplayDateFormatShort(layerPath);
-  const displayDateTimezone = useStoreDisplayDateTimezone();
   const uiController = useUIController();
   const layerController = useLayerController();
 

--- a/packages/geoview-geochart/src/geochart.tsx
+++ b/packages/geoview-geochart/src/geochart.tsx
@@ -122,6 +122,9 @@ export function GeoChart(props: GeoChartProps): JSX.Element {
    * Memoizes the fetching of the correct config based on the provided layers array.
    */
   const memoAllInfo = useMemo(() => {
+    // Log
+    logger.logTraceUseMemo('GEOVIEW-GEOCHART - memoAllInfo', layers);
+
     // Find the right config/layer/data for what we want based on the layerDataArray
     const [foundConfigChart, foundConfigChartLyr, foundLayerEntry, foundData]: [
       GeoViewGeoChartConfig | undefined,

--- a/packages/geoview-geochart/src/index.tsx
+++ b/packages/geoview-geochart/src/index.tsx
@@ -8,7 +8,6 @@ import defaultConfig from '../default-config-geochart.json';
 import { GeoChartPanel } from './geochart-panel';
 import type { PluginGeoChartConfig } from './geochart-types';
 import { convertGeoViewGeoChartConfigToCore } from './geochart-types';
-import { initStoreGeochartCharts } from 'geoview-core/core/stores/store-interface-and-intial-values/geochart-state';
 import { logger } from 'geoview-core/core/utils/logger';
 
 /**
@@ -86,12 +85,13 @@ class GeoChartFooterPlugin extends FooterPlugin {
     // Initialize the store with geochart provided configuration if there is one
     if (this.getConfig().charts) {
       const configs = this.getConfig().charts.map((config) => convertGeoViewGeoChartConfigToCore(config));
+
       // Init the charts to the store
-      initStoreGeochartCharts(this.mapViewer.mapId, configs);
+      this.controllerRegistry.geoChartController?.initCharts(configs);
 
       // If there is charts, tab should be shown
       if (configs.length) {
-        this.mapViewer.controllers.uiController.showTabButton('geochart');
+        this.controllerRegistry.uiController.showTabButton('geochart');
       }
 
       // Log

--- a/packages/geoview-swiper/src/index.tsx
+++ b/packages/geoview-swiper/src/index.tsx
@@ -7,13 +7,6 @@ import defaultConfig from '../default-config-swiper.json';
 import type { ConfigProps } from './swiper';
 import { Swiper } from './swiper';
 import type { SwipeOrientation } from './swiper-types';
-import {
-  addStoreSwiperLayerPath,
-  removeAllStoreSwipers,
-  removeStoreSwiperLayerPath,
-  setStoreSwiperLayerPaths,
-  setStoreSwiperOrientation,
-} from 'geoview-core/core/stores/store-interface-and-intial-values/swiper-state';
 
 /**
  * Create a class for the plugin instance.
@@ -77,8 +70,8 @@ class SwiperPlugin extends MapPlugin {
     super.onAdd();
 
     // Initialize the store with swiper provided configuration
-    setStoreSwiperLayerPaths(this.mapViewer.mapId, this.getConfig().layers);
-    setStoreSwiperOrientation(this.mapViewer.mapId, this.getConfig().orientation);
+    this.controllerRegistry.swiperController?.setLayerPaths(this.getConfig().layers);
+    this.controllerRegistry.swiperController?.setOrientation(this.getConfig().orientation);
   }
 
   /**
@@ -87,7 +80,7 @@ class SwiperPlugin extends MapPlugin {
    * @returns The JSX.Element representing the Swiper Plugin
    */
   override onCreateContent(): JSX.Element {
-    return <Swiper viewer={this.mapViewer} config={this.getConfig()} />;
+    return <Swiper viewer={this.mapViewer} controllerRegistry={this.controllerRegistry} config={this.getConfig()} />;
   }
 
   /**
@@ -97,11 +90,8 @@ class SwiperPlugin extends MapPlugin {
    */
   activateForLayer(layerPath: string): void {
     try {
-      // Check if the layer exists on the map, this call throws when it doesn't exist
-      this.mapViewer.controllers.layerController.getGeoviewLayer(layerPath);
-
-      // Add the layer path in the store
-      addStoreSwiperLayerPath(this.mapViewer.mapId, layerPath);
+      // Add the layer path
+      this.controllerRegistry.swiperController?.addLayerPath(layerPath);
     } catch (error: unknown) {
       // Log
       logger.logError(error);
@@ -114,16 +104,21 @@ class SwiperPlugin extends MapPlugin {
    * @param layerPath - The layer path to deactivate swiper functionality
    */
   deActivateForLayer(layerPath: string): void {
-    // Remove the layer from the store
-    removeStoreSwiperLayerPath(this.mapViewer.mapId, layerPath);
+    try {
+      // Remove the layer
+      this.controllerRegistry.swiperController?.removeLayerPath(layerPath);
+    } catch (error: unknown) {
+      // Log
+      logger.logError(error);
+    }
   }
 
   /**
-   * Deactivates the swiper for the layer indicated by the given layer path.
+   * Deactivates the swiper for all layers.
    */
   deActivateAll(): void {
-    // Remove all layers from the store
-    removeAllStoreSwipers(this.mapViewer.mapId);
+    // Remove all layers
+    this.controllerRegistry.swiperController?.removeAllLayerPaths();
   }
 
   /**
@@ -133,7 +128,7 @@ class SwiperPlugin extends MapPlugin {
    */
   setOrientation(orientation: SwipeOrientation): void {
     // Set the orientation in the store
-    setStoreSwiperOrientation(this.mapViewer.mapId, orientation);
+    this.controllerRegistry.swiperController?.setOrientation(orientation);
   }
 }
 

--- a/packages/geoview-swiper/src/swiper.tsx
+++ b/packages/geoview-swiper/src/swiper.tsx
@@ -16,14 +16,29 @@ import { logger } from 'geoview-core/core/utils/logger';
 import { getLocalizedMessage, delay } from 'geoview-core/core/utils/utilities';
 import { debounce } from 'geoview-core/core/utils/debounce';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
-import { useStoreMapSize, useStoreMapVisibleLayers } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreMapSize } from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
+import { useStoreLayerVisibleLayers } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 import type { MapViewer } from 'geoview-core/geo/map/map-viewer';
+import type { ControllerRegistry } from 'geoview-core/core/controllers/base/controller-registry';
 import { TIMEOUT } from 'geoview-core/core/utils/constant';
 import { getSxClasses } from './swiper-style';
 
 /** Properties for the Swiper component. */
 type SwiperProps = {
+  /**
+   * The MapViewer associated with the Swiper component.*
+   *
+   * @remarks The controller registry has to be provided via params, because the Swiper itself resides outside of the MapViewer context.
+   */
   viewer: MapViewer;
+
+  /**
+   * The ControllerRegistry associated with the Swiper component.
+   *
+   * @remarks The controller registry has to be provided via params, because the Swiper itself resides outside of the MapViewer context.
+   */
+  controllerRegistry: ControllerRegistry;
+
   // We have this eslint here for "standardization between plugins"
   // eslint-disable-next-line react/no-unused-prop-types
   config: ConfigProps;
@@ -50,7 +65,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
   // Log
   logger.logTraceRender('geoview-swiper/swiper');
 
-  const { viewer } = props;
+  const { viewer, controllerRegistry } = props;
 
   const { cgpv } = window;
   const { ui, reactUtilities } = cgpv;
@@ -77,7 +92,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
   // Get store values
   const layerPaths = useStoreSwiperLayerPaths();
   const displayLanguage = useStoreAppDisplayLanguage();
-  const visibleLayers = useStoreMapVisibleLayers();
+  const visibleLayers = useStoreLayerVisibleLayers();
   const orientation = useStoreSwiperOrientation();
 
   // Grab reference
@@ -227,7 +242,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
     async (layerPath: string) => {
       try {
         // Get the layer at the layer path
-        const olLayer = await viewer.controllers.layerController.getOLLayerAsync(layerPath, CONST_LAYERS_WAIT, CONST_LAYERS_RETRY);
+        const olLayer = await controllerRegistry.layerController.getOLLayerAsync(layerPath, CONST_LAYERS_WAIT, CONST_LAYERS_RETRY);
 
         // Set the OL layers
         setOlLayers((prevArray) => [...prevArray, olLayer]);
@@ -242,13 +257,13 @@ export function Swiper(props: SwiperProps): JSX.Element {
         // Log
         logger.logError(
           'SWIPER - Failed to attach layer events',
-          viewer.controllers.layerController.getGeoviewLayerIds(),
+          controllerRegistry.layerController.getGeoviewLayerIds(),
           layerPath,
           error
         );
       }
     },
-    [viewer, prerender]
+    [controllerRegistry, prerender]
   );
 
   // #endregion
@@ -282,7 +297,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
       associatedLayerPaths.forEach((layerPath: string) => {
         try {
           // Get the layer at the layer path
-          const olLayer = viewer.controllers.layerController.getGeoviewLayerIfExists(layerPath)?.getOLLayer();
+          const olLayer = controllerRegistry.layerController.getGeoviewLayerIfExists(layerPath)?.getOLLayer();
           if (olLayer) {
             // Unwire the events on the layer
             olLayer.un(['precompose' as EventTypes, 'prerender' as EventTypes], prerender);
@@ -303,7 +318,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
       // Empty layers array
       setOlLayers([]);
     };
-  }, [viewer, layerPaths, attachLayerEventsOnPath, prerender, visibleLayers]);
+  }, [controllerRegistry, layerPaths, attachLayerEventsOnPath, prerender, visibleLayers]);
 
   /**
    * UseEffect for WCAG keyboard navigation.

--- a/packages/geoview-swiper/src/swiper.tsx
+++ b/packages/geoview-swiper/src/swiper.tsx
@@ -80,7 +80,10 @@ export function Swiper(props: SwiperProps): JSX.Element {
 
   // SxClasses
   const mapHeight = useStoreMapSize()[1];
-  const sxClasses = useMemo(() => getSxClasses(mapHeight), [mapHeight]);
+  const memoSxClasses = useMemo(() => {
+    logger.logTraceUseMemo('SWIPER - memoSxClasses', mapHeight);
+    return getSxClasses(mapHeight);
+  }, [mapHeight]);
 
   // States
   const [olLayers, setOlLayers] = useState<BaseLayer[]>([]);
@@ -358,7 +361,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
   if (layerPaths && layerPaths.length > 0) {
     // Use a swiper
     return (
-      <Box sx={sxClasses.layerSwipe}>
+      <Box sx={memoSxClasses.layerSwipe}>
         <Draggable
           key={orientation} // This forces recreation when orientation changes
           axis={orientation === 'vertical' ? 'x' : 'y'}
@@ -369,11 +372,11 @@ export function Swiper(props: SwiperProps): JSX.Element {
           onStop={onStop}
           onDrag={onStop}
         >
-          <Box sx={[orientation === 'vertical' ? sxClasses.vertical : sxClasses.horizontal, sxClasses.bar]} tabIndex={0} ref={swiperRef}>
+          <Box sx={[orientation === 'vertical' ? memoSxClasses.vertical : memoSxClasses.horizontal, memoSxClasses.bar]} tabIndex={0} ref={swiperRef}>
             <Tooltip title={getLocalizedMessage(displayLanguage, 'swiper.tooltip')}>
               <Box className="handleContainer">
-                <HandleIcon sx={sxClasses.handle} className="handleL" />
-                <HandleIcon sx={sxClasses.handle} className="handleR" />
+                <HandleIcon sx={memoSxClasses.handle} className="handleL" />
+                <HandleIcon sx={memoSxClasses.handle} className="handleR" />
               </Box>
             </Tooltip>
           </Box>

--- a/packages/geoview-swiper/src/swiper.tsx
+++ b/packages/geoview-swiper/src/swiper.tsx
@@ -372,7 +372,11 @@ export function Swiper(props: SwiperProps): JSX.Element {
           onStop={onStop}
           onDrag={onStop}
         >
-          <Box sx={[orientation === 'vertical' ? memoSxClasses.vertical : memoSxClasses.horizontal, memoSxClasses.bar]} tabIndex={0} ref={swiperRef}>
+          <Box
+            sx={[orientation === 'vertical' ? memoSxClasses.vertical : memoSxClasses.horizontal, memoSxClasses.bar]}
+            tabIndex={0}
+            ref={swiperRef}
+          >
             <Tooltip title={getLocalizedMessage(displayLanguage, 'swiper.tooltip')}>
               <Box className="handleContainer">
                 <HandleIcon sx={memoSxClasses.handle} className="handleL" />

--- a/packages/geoview-test-suite/src/index.tsx
+++ b/packages/geoview-test-suite/src/index.tsx
@@ -85,28 +85,28 @@ class TestSuitePlugin extends AbstractPlugin {
     this.getConfig().suites.forEach((suite) => {
       if (suite === 'suite-core') {
         // Instanciate the GeoView Test Suite
-        this.addTestSuite(new GVTestSuiteCore(window.cgpv.api, this.mapViewer));
+        this.addTestSuite(new GVTestSuiteCore(window.cgpv.api, this.mapViewer, this.controllerRegistry));
       } else if (suite === 'suite-config') {
         // Instanciate the GeoView Test Suite
-        this.addTestSuite(new GVTestSuiteConfig(window.cgpv.api, this.mapViewer));
+        this.addTestSuite(new GVTestSuiteConfig(window.cgpv.api, this.mapViewer, this.controllerRegistry));
       } else if (suite === 'suite-map') {
         // Instanciate the GeoView Test Suite
-        this.addTestSuite(new GVTestSuiteMapVaria(window.cgpv.api, this.mapViewer));
+        this.addTestSuite(new GVTestSuiteMapVaria(window.cgpv.api, this.mapViewer, this.controllerRegistry));
       } else if (suite === 'suite-layer') {
         // Instanciate the GeoView Test Suite
-        this.addTestSuite(new GVTestSuiteLayer(window.cgpv.api, this.mapViewer));
+        this.addTestSuite(new GVTestSuiteLayer(window.cgpv.api, this.mapViewer, this.controllerRegistry));
       } else if (suite === 'suite-geochart') {
         // Instanciate the GeoView Test Suite
-        this.addTestSuite(new GVTestSuiteGeochart(window.cgpv.api, this.mapViewer));
+        this.addTestSuite(new GVTestSuiteGeochart(window.cgpv.api, this.mapViewer, this.controllerRegistry));
       } else if (suite === 'suite-map-config') {
         // Instanciate the GeoView Test Suite
-        this.addTestSuite(new GVTestSuiteMapConfig(window.cgpv.api, this.mapViewer));
+        this.addTestSuite(new GVTestSuiteMapConfig(window.cgpv.api, this.mapViewer, this.controllerRegistry));
       } else if (suite === 'suite-ui') {
         // Instanciate the GeoView Test Suite
-        this.addTestSuite(new GVTestSuiteUI(window.cgpv.api, this.mapViewer));
+        this.addTestSuite(new GVTestSuiteUI(window.cgpv.api, this.mapViewer, this.controllerRegistry));
       } else if (suite === 'suite-details') {
         // Instanciate the GeoView Test Suite
-        this.addTestSuite(new GVTestSuiteDetails(window.cgpv.api, this.mapViewer));
+        this.addTestSuite(new GVTestSuiteDetails(window.cgpv.api, this.mapViewer, this.controllerRegistry));
       } else {
         // Throw
         throw new TestSuiteInitializationError(suite, this.mapViewer.mapId);

--- a/packages/geoview-test-suite/src/tests/suites/abstract-gv-test-suite.ts
+++ b/packages/geoview-test-suite/src/tests/suites/abstract-gv-test-suite.ts
@@ -13,18 +13,23 @@ export abstract class GVAbstractTestSuite extends AbstractTestSuite {
   /** The MapViewer */
   #mapViewer: MapViewer;
 
+  /** The ControllerRegistry */
+  #controllerRegistry: ControllerRegistry;
+
   /**
    * Constructs an {@link GVAbstractTestSuite} instance.
    *
    * @param api - The api, mainly used to retrieve the MapViewer
    * @param mapViewer - The map viewer
+   * @param controllerRegistry - The controller registry, used to pass to testers that need it
    */
-  protected constructor(api: API, mapViewer: MapViewer) {
+  protected constructor(api: API, mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
     super();
 
     // Keep attributes
     this.#api = api;
     this.#mapViewer = mapViewer;
+    this.#controllerRegistry = controllerRegistry;
   }
 
   /**
@@ -51,7 +56,7 @@ export abstract class GVAbstractTestSuite extends AbstractTestSuite {
    * @returns The controllers registry
    */
   getControllersRegistry(): ControllerRegistry {
-    return this.getMapViewer().controllers;
+    return this.#controllerRegistry;
   }
 
   /**

--- a/packages/geoview-test-suite/src/tests/suites/suite-config.ts
+++ b/packages/geoview-test-suite/src/tests/suites/suite-config.ts
@@ -2,6 +2,7 @@ import type { API } from 'geoview-core/api/api';
 import type { MapViewer } from 'geoview-core/geo/map/map-viewer';
 import { GVAbstractTestSuite } from './abstract-gv-test-suite';
 import { ConfigTester } from '../testers/config-tester';
+import type { ControllerRegistry } from 'geoview-core/core/controllers/base/controller-registry';
 
 /**
  * The GeoView Test Suite.
@@ -15,12 +16,13 @@ export class GVTestSuiteConfig extends GVAbstractTestSuite {
    *
    * @param api - The shared api
    * @param mapViewer - The map viewer
+   * @param controllerRegistry - The controller registry
    */
-  constructor(api: API, mapViewer: MapViewer) {
-    super(api, mapViewer);
+  constructor(api: API, mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(api, mapViewer, controllerRegistry);
 
     // Create the Config tester
-    this.#configTester = new ConfigTester(api, mapViewer);
+    this.#configTester = new ConfigTester(api, mapViewer, controllerRegistry);
     this.addTester(this.#configTester);
   }
 

--- a/packages/geoview-test-suite/src/tests/suites/suite-core.ts
+++ b/packages/geoview-test-suite/src/tests/suites/suite-core.ts
@@ -2,6 +2,7 @@ import type { API } from 'geoview-core/api/api';
 import type { MapViewer } from 'geoview-core/geo/map/map-viewer';
 import { CoreTester } from '../testers/core-tester';
 import { GVAbstractTestSuite } from './abstract-gv-test-suite';
+import type { ControllerRegistry } from 'geoview-core/core/controllers/base/controller-registry';
 
 /**
  * The GeoView Test Suite.
@@ -15,12 +16,13 @@ export class GVTestSuiteCore extends GVAbstractTestSuite {
    *
    * @param api - The shared api
    * @param mapViewer - The map viewer
+   * @param controllerRegistry - The controller registry
    */
-  constructor(api: API, mapViewer: MapViewer) {
-    super(api, mapViewer);
+  constructor(api: API, mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(api, mapViewer, controllerRegistry);
 
     // Create the Geochart tester
-    this.#coreTester = new CoreTester(api, mapViewer);
+    this.#coreTester = new CoreTester(api, mapViewer, controllerRegistry);
     this.addTester(this.#coreTester);
   }
 

--- a/packages/geoview-test-suite/src/tests/suites/suite-details.ts
+++ b/packages/geoview-test-suite/src/tests/suites/suite-details.ts
@@ -4,6 +4,7 @@ import { TestSuiteCannotExecuteError } from '../core/exceptions';
 import { GVAbstractTester } from '../testers/abstract-gv-tester';
 import { DetailsTester } from '../testers/details-tester';
 import { GVAbstractTestSuite } from './abstract-gv-test-suite';
+import type { ControllerRegistry } from 'geoview-core/core/controllers/base/controller-registry';
 
 /**
  * The GeoView Test Suite.
@@ -17,12 +18,13 @@ export class GVTestSuiteDetails extends GVAbstractTestSuite {
    *
    * @param api - The shared api
    * @param mapViewer - The map viewer
+   * @param controllerRegistry - The controller registry
    */
-  constructor(api: API, mapViewer: MapViewer) {
-    super(api, mapViewer);
+  constructor(api: API, mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(api, mapViewer, controllerRegistry);
 
     // Create the Geochart tester
-    this.#detailsTester = new DetailsTester(api, mapViewer);
+    this.#detailsTester = new DetailsTester(api, mapViewer, controllerRegistry);
     this.addTester(this.#detailsTester);
   }
 

--- a/packages/geoview-test-suite/src/tests/suites/suite-geochart.ts
+++ b/packages/geoview-test-suite/src/tests/suites/suite-geochart.ts
@@ -4,6 +4,7 @@ import { TestSuiteCannotExecuteError } from '../core/exceptions';
 import { GVAbstractTester } from '../testers/abstract-gv-tester';
 import { GeochartTester } from '../testers/geochart-tester';
 import { GVAbstractTestSuite } from './abstract-gv-test-suite';
+import type { ControllerRegistry } from 'geoview-core/core/controllers/base/controller-registry';
 
 /**
  * The GeoView Test Suite.
@@ -17,12 +18,13 @@ export class GVTestSuiteGeochart extends GVAbstractTestSuite {
    *
    * @param api - The shared api
    * @param mapViewer - The map viewer
+   * @param controllerRegistry - The controller registry
    */
-  constructor(api: API, mapViewer: MapViewer) {
-    super(api, mapViewer);
+  constructor(api: API, mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(api, mapViewer, controllerRegistry);
 
     // Create the Geochart tester
-    this.#geochartTester = new GeochartTester(api, mapViewer);
+    this.#geochartTester = new GeochartTester(api, mapViewer, controllerRegistry);
     this.addTester(this.#geochartTester);
   }
 

--- a/packages/geoview-test-suite/src/tests/suites/suite-layer.ts
+++ b/packages/geoview-test-suite/src/tests/suites/suite-layer.ts
@@ -2,6 +2,7 @@ import type { API } from 'geoview-core/api/api';
 import type { MapViewer } from 'geoview-core/geo/map/map-viewer';
 import { GVAbstractTestSuite } from './abstract-gv-test-suite';
 import { LayerTester } from '../testers/layer-tester';
+import type { ControllerRegistry } from 'geoview-core/core/controllers/base/controller-registry';
 
 /**
  * The GeoView Test Suite.
@@ -15,12 +16,13 @@ export class GVTestSuiteLayer extends GVAbstractTestSuite {
    *
    * @param api - The shared api
    * @param mapViewer - The map viewer
+   * @param controllerRegistry - The controller registry
    */
-  constructor(api: API, mapViewer: MapViewer) {
-    super(api, mapViewer);
+  constructor(api: API, mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(api, mapViewer, controllerRegistry);
 
     // Create the Geocore tester
-    this.#layerTester = new LayerTester(api, mapViewer);
+    this.#layerTester = new LayerTester(api, mapViewer, controllerRegistry);
     this.addTester(this.#layerTester);
   }
 

--- a/packages/geoview-test-suite/src/tests/suites/suite-map-config.ts
+++ b/packages/geoview-test-suite/src/tests/suites/suite-map-config.ts
@@ -52,7 +52,7 @@ export class GVTestSuiteMapConfig extends GVAbstractTestSuite {
   protected override async onLaunchTestSuite(): Promise<unknown> {
     // // GV START DEBUG SECTION TO NOT HAVE TO TEST EVERYTHING EVERYTIME
     // // Test DEBUG
-    // const pDevTest0 = this.#mapConfigTester.testDataTableSelectedTabFooterBar();
+    // const pDevTest0 = this.#mapConfigTester.testInitialViewLayerIdsSetExtent();
 
     // // Resolve when all
     // return Promise.all([pDevTest0]);

--- a/packages/geoview-test-suite/src/tests/suites/suite-map-config.ts
+++ b/packages/geoview-test-suite/src/tests/suites/suite-map-config.ts
@@ -2,6 +2,7 @@ import type { API } from 'geoview-core/api/api';
 import type { MapViewer } from 'geoview-core/geo/map/map-viewer';
 import { GVAbstractTestSuite } from './abstract-gv-test-suite';
 import { MapConfigTester } from '../testers/map-config-tester';
+import type { ControllerRegistry } from 'geoview-core/core/controllers/base/controller-registry';
 
 /**
  * The GeoView Test Suite for Map Configuration.
@@ -15,12 +16,13 @@ export class GVTestSuiteMapConfig extends GVAbstractTestSuite {
    *
    * @param api - The shared api
    * @param mapViewer - The map viewer
+   * @param controllerRegistry - The controller registry
    */
-  constructor(api: API, mapViewer: MapViewer) {
-    super(api, mapViewer);
+  constructor(api: API, mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(api, mapViewer, controllerRegistry);
 
     // Create the Map Config tester
-    this.#mapConfigTester = new MapConfigTester(api, mapViewer);
+    this.#mapConfigTester = new MapConfigTester(api, mapViewer, controllerRegistry);
     this.addTester(this.#mapConfigTester);
   }
 

--- a/packages/geoview-test-suite/src/tests/suites/suite-map-varia.ts
+++ b/packages/geoview-test-suite/src/tests/suites/suite-map-varia.ts
@@ -2,6 +2,7 @@ import type { API } from 'geoview-core/api/api';
 import type { MapViewer } from 'geoview-core/geo/map/map-viewer';
 import { MapTester } from '../testers/map-tester';
 import { GVAbstractTestSuite } from './abstract-gv-test-suite';
+import type { ControllerRegistry } from 'geoview-core/core/controllers/base/controller-registry';
 
 /**
  * The GeoView Test Suite.
@@ -15,12 +16,13 @@ export class GVTestSuiteMapVaria extends GVAbstractTestSuite {
    *
    * @param api - The shared api
    * @param mapViewer - The map viewer
+   * @param controllerRegistry - The controller registry
    */
-  constructor(api: API, mapViewer: MapViewer) {
-    super(api, mapViewer);
+  constructor(api: API, mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(api, mapViewer, controllerRegistry);
 
     // Create the Map tester
-    this.#mapTester = new MapTester(api, mapViewer);
+    this.#mapTester = new MapTester(api, mapViewer, controllerRegistry);
     this.addTester(this.#mapTester);
   }
 

--- a/packages/geoview-test-suite/src/tests/suites/suite-ui.ts
+++ b/packages/geoview-test-suite/src/tests/suites/suite-ui.ts
@@ -2,6 +2,7 @@ import type { API } from 'geoview-core/api/api';
 import type { MapViewer } from 'geoview-core/geo/map/map-viewer';
 import { GVAbstractTestSuite } from './abstract-gv-test-suite';
 import { UITester } from '../testers/ui-tester';
+import type { ControllerRegistry } from 'geoview-core/core/controllers/base/controller-registry';
 
 /**
  * The GeoView Test Suite for UI.
@@ -15,12 +16,13 @@ export class GVTestSuiteUI extends GVAbstractTestSuite {
    *
    * @param api - The shared api
    * @param mapViewer - The map viewer
+   * @param controllerRegistry - The controller registry
    */
-  constructor(api: API, mapViewer: MapViewer) {
-    super(api, mapViewer);
+  constructor(api: API, mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(api, mapViewer, controllerRegistry);
 
     // Create the UI tester
-    this.#uiTester = new UITester(api, mapViewer);
+    this.#uiTester = new UITester(api, mapViewer, controllerRegistry);
     this.addTester(this.#uiTester);
   }
 

--- a/packages/geoview-test-suite/src/tests/testers/abstract-gv-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/abstract-gv-tester.ts
@@ -503,15 +503,6 @@ export abstract class GVAbstractTester extends AbstractTester {
   }
 
   /**
-   * Sets the MapViewer.
-   *
-   * @param mapViewer - The MapViewer to set
-   */
-  setMapViewer(mapViewer: MapViewer): void {
-    this.#mapViewer = mapViewer;
-  }
-
-  /**
    * Gets the Map Id.
    *
    * @returns The Map Id
@@ -535,6 +526,16 @@ export abstract class GVAbstractTester extends AbstractTester {
    */
   getControllersRegistry(): ControllerRegistry {
     return this.#controllerRegistry;
+  }
+
+  /**
+   * Sets the MapViewer and the Controller registry for the current test.
+   *
+   * @param mapViewer - The MapViewer to set
+   */
+  reassignMapViewerAndControllers(mapViewer: MapViewer): void {
+    this.#mapViewer = mapViewer;
+    this.#controllerRegistry = mapViewer.controllers;
   }
 
   /**

--- a/packages/geoview-test-suite/src/tests/testers/abstract-gv-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/abstract-gv-tester.ts
@@ -465,18 +465,23 @@ export abstract class GVAbstractTester extends AbstractTester {
   /** The Map Viewer for the tests */
   #mapViewer: MapViewer;
 
+  /** The Controller Registry for the tests */
+  #controllerRegistry: ControllerRegistry;
+
   /**
    * Constructs a GeoView specific tester.
    *
    * @param api - The api
    * @param mapViewer - The map viewer
+   * @param controllerRegistry - The controller registry
    */
-  constructor(api: API, mapViewer: MapViewer) {
+  constructor(api: API, mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
     super();
 
     // Keep the attributes
     this.#api = api;
     this.#mapViewer = mapViewer;
+    this.#controllerRegistry = controllerRegistry;
   }
 
   /**
@@ -529,7 +534,7 @@ export abstract class GVAbstractTester extends AbstractTester {
    * @returns The controller registry
    */
   getControllersRegistry(): ControllerRegistry {
-    return this.getMapViewer().controllers;
+    return this.#controllerRegistry;
   }
 
   /**

--- a/packages/geoview-test-suite/src/tests/testers/details-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/details-tester.ts
@@ -6,7 +6,6 @@ import { delay } from 'geoview-core/core/utils/utilities';
 import type { TypeFeatureInfoEntry } from 'geoview-core/api/types/map-schema-types';
 import { logger } from 'geoview-core/core/utils/logger';
 import { getStoreUIActiveFooterBarTab } from 'geoview-core/core/stores/store-interface-and-intial-values/ui-state';
-import { setStoreDetailsSelectedLayerPath } from 'geoview-core/core/stores/store-interface-and-intial-values/feature-info-state';
 import { getStoreLayerItemVisibility } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
 import type { AbstractGVLayer } from 'geoview-core/geo/layer/gv-layers/abstract-gv-layer';
 
@@ -43,7 +42,7 @@ export class DetailsTester extends GVAbstractTester {
         const resultsOntarioResults = await this.helperStepQueryLayerAtCoordinate(test, layer, lonlat1);
 
         // Check that the details panel was selected for the layer
-        await DetailsTester.helperStepCheckDetailsPanel(test, this.getMapId(), layerPath);
+        await this.helperStepCheckDetailsPanel(test, layerPath);
 
         // Make the layer invisible
         layer.setVisible(false);
@@ -211,7 +210,6 @@ export class DetailsTester extends GVAbstractTester {
    *
    * @template T - The type parameter for the test instance
    * @param test - The test instance used to log each step of the details setup process
-   * @param mapViewer - The map viewer containing the layer and UI context
    * @param layerPath - The unique path or ID of the layer to interact with
    * @param lonlat - The longitude/latitude coordinate at which to query the layer
    * @returns A promise that resolves to the layer after setup is complete
@@ -238,11 +236,10 @@ export class DetailsTester extends GVAbstractTester {
    *
    * @template T - The type parameter for the test instance
    * @param test - The test instance used to log each step
-   * @param mapId - The ID of the map containing the layer and UI context
    * @param layerPath - The unique path or ID of the layer to check
    * @returns A promise that resolves when the check is complete
    */
-  static async helperStepCheckDetailsPanel<T>(test: Test<T>, mapId: string, layerPath: string): Promise<void> {
+  async helperStepCheckDetailsPanel<T>(test: Test<T>, layerPath: string): Promise<void> {
     // Update the step
     test.addStep(`Waiting on UI to refresh...`);
 
@@ -253,6 +250,6 @@ export class DetailsTester extends GVAbstractTester {
     test.addStep(`Selecting the details for the added layer...`);
 
     // Select the right layer path
-    setStoreDetailsSelectedLayerPath(mapId, layerPath);
+    this.getControllersRegistry().detailsController.setSelectedLayerPath(layerPath);
   }
 }

--- a/packages/geoview-test-suite/src/tests/testers/geochart-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/geochart-tester.ts
@@ -7,7 +7,6 @@ import { getStoreUIActiveFooterBarTab } from 'geoview-core/core/stores/store-int
 import {
   getStoreGeochartChartsConfig,
   getStoreGeochartSelectedLayerPath,
-  setStoreGeochartSelectedLayerPath,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/geochart-state';
 
 /**
@@ -197,7 +196,7 @@ export class GeochartTester extends GVAbstractTester {
     test.addStep(`Selecting the geochart for the added layer...`);
 
     // Select the right layer path
-    setStoreGeochartSelectedLayerPath(this.getMapId(), layerPath);
+    this.getControllersRegistry().geoChartController?.setSelectedLayerPath(layerPath);
 
     // Wait purposely on the UI, this waiting period isn't necessary for the test, but it's good to see it happen in real-time
     await delay(1000);

--- a/packages/geoview-test-suite/src/tests/testers/map-config-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/map-config-tester.ts
@@ -306,7 +306,7 @@ export class MapConfigTester extends GVAbstractTester {
 
         // Get the layer bounds
         test.addStep('Getting layer bound extent...');
-        const geoviewLayer = newMapViewer.controllers.layerController.getGeoviewLayerRegular('geojsonLYR5/polygons.json');
+        const geoviewLayer = this.getControllersRegistry().layerController.getGeoviewLayerRegular('geojsonLYR5/polygons.json');
         Test.assertIsDefined('geoviewLayer', geoviewLayer);
         const layerExtent = getStoreLayerBounds(this.getMapId(), 'geojsonLYR5/polygons.json');
         Test.assertIsArray(layerExtent);

--- a/packages/geoview-test-suite/src/tests/testers/map-config-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/map-config-tester.ts
@@ -516,14 +516,14 @@ export class MapConfigTester extends GVAbstractTester {
     test.addStep('Creating the map from config...');
     const mapViewer = await this.getApi().createMapFromConfigFast(mapId, JSON.stringify(baseConfig), 500);
 
-    // Replace the map viewer in the tester with the new one created from config
-    this.setMapViewer(mapViewer);
+    // Replace the map viewer and the controller registry in the tester with the new one created from config
+    this.reassignMapViewerAndControllers(mapViewer);
 
     // Wait for layer to load and data table to initialize
     test.addStep('Waiting for layers to get loaded...');
-    await mapViewer.waitForLayersLoaded();
+    const loadedLayersCount = await mapViewer.waitForLayersLoaded();
 
-    test.addStep('Layers loaded');
+    test.addStep(`Layers loaded (${loadedLayersCount})`);
     return mapViewer;
   }
 

--- a/packages/geoview-test-suite/src/tests/testers/map-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/map-tester.ts
@@ -8,7 +8,6 @@ import type { Extent, TypeBasemapId, TypeMapState, TypeValidMapProjectionCodes }
 import {
   getStoreDetailsFeatures,
   getStoreDetailsSelectedLayerPath,
-  setStoreDetailsSelectedLayerPath,
   type TypeFeatureInfoResultSetEntry,
   type TypeHoverFeatureInfo,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/feature-info-state';
@@ -17,6 +16,7 @@ import { Projection } from 'geoview-core/geo/utils/projection';
 import {
   getStoreUIActiveAppBarTab,
   getStoreUIActiveFooterBarTab,
+  getStoreUIFooterTabs,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/ui-state';
 import { getStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import {
@@ -88,7 +88,7 @@ export class MapTester extends GVAbstractTester {
 
         // Perform a zoom
         test.addStep('Performing zoom...');
-        await this.getMapViewer().controllers.mapController.zoomMap(zoomEnd, zoomDuration);
+        await this.getControllersRegistry().mapController.zoomMap(zoomEnd, zoomDuration);
 
         // Return the result
         return zoomEnd;
@@ -101,7 +101,7 @@ export class MapTester extends GVAbstractTester {
       async (test) => {
         // Unzooms to original position
         test.addStep('Unzooms to the original zoom...');
-        await this.getMapViewer().controllers.mapController.zoomMap(currentZoom, zoomDuration);
+        await this.getControllersRegistry().mapController.zoomMap(currentZoom, zoomDuration);
       }
     );
   }
@@ -127,7 +127,7 @@ export class MapTester extends GVAbstractTester {
     zoomLevel: number
   ): Promise<Test<Extent>> {
     // Zoom to initial extent
-    await this.getMapViewer().controllers.mapController.zoomToInitialExtent();
+    await this.getControllersRegistry().mapController.zoomToInitialExtent();
 
     // Get the current init extent
     const { mapExtent, currentProjection } = getStoreMapStateJson(this.getMapId());
@@ -142,25 +142,25 @@ export class MapTester extends GVAbstractTester {
 
         // Perform a projection switch
         test.addStep(`Performing projection switch to ${secondProjection}...`);
-        await this.getMapViewer().controllers.mapController.setProjection(secondProjection);
+        await this.getControllersRegistry().mapController.setProjection(secondProjection);
 
         // Update the step
         test.addStep(`Performing zoom to level ${zoomLevel}...`);
 
         // Perform a zoom
-        await this.getMapViewer().controllers.mapController.zoomMap(zoomLevel, 1000);
+        await this.getControllersRegistry().mapController.zoomMap(zoomLevel, 1000);
 
         // Update the step
         test.addStep('Performing projection switch to original...');
 
         // Perform a projection switch
-        await this.getMapViewer().controllers.mapController.setProjection(initialProjection);
+        await this.getControllersRegistry().mapController.setProjection(initialProjection);
 
         // Update the step
         test.addStep('Performing zomm to inital extent...');
 
         // Zoom to initial extent
-        await this.getMapViewer().controllers.mapController.zoomToInitialExtent();
+        await this.getControllersRegistry().mapController.zoomToInitialExtent();
 
         // Return the result
         return getStoreMapStateJson(this.getMapId()).mapExtent;
@@ -395,9 +395,9 @@ export class MapTester extends GVAbstractTester {
         return customTabId;
       },
       (test, result) => {
-        test.addStep('Verifying custom tab exists...');
-        const { tabs } = this.getMapViewer().footerBarApi;
-        const customTab = tabs.find((tab) => tab.id === result);
+        test.addStep('Verifying custom tab exists in store...');
+        const footerTabs = getStoreUIFooterTabs(this.getMapId());
+        const customTab = footerTabs.find((tab) => tab.id === result);
         Test.assertIsDefined('customTab', customTab);
 
         test.addStep('Verifying custom tab id...');
@@ -512,7 +512,7 @@ export class MapTester extends GVAbstractTester {
         // Switch to LCC projection if not already there
         if (currentProjection !== 3978) {
           test.addStep('Switching to LCC projection (3978)...');
-          await this.getMapViewer().controllers.mapController.setProjection(3978);
+          await this.getControllersRegistry().mapController.setProjection(3978);
         }
 
         test.addStep('Zooming to British Columbia extent...');
@@ -772,11 +772,11 @@ export class MapTester extends GVAbstractTester {
         test.addStep(`First selected layer: ${originalLayerPath}`);
 
         // The alternate layer
-        const altLayerPathh = originalLayerPath === layerPath1 ? layerPath2 : layerPath1;
+        const altLayerPath = originalLayerPath === layerPath1 ? layerPath2 : layerPath1;
 
         // Manually select the alternate layer
-        test.addStep(`Manually selecting the other layer '${altLayerPathh}'...`);
-        setStoreDetailsSelectedLayerPath(this.getMapId(), altLayerPathh);
+        test.addStep(`Manually selecting the other layer '${altLayerPath}'...`);
+        this.getControllersRegistry().detailsController.setSelectedLayerPath(altLayerPath);
 
         // Simulate a map click at second location
         test.addStep(`Performing second map click at [${clickCoordinates2.join(', ')}]...`);

--- a/packages/geoview-time-slider/src/index.tsx
+++ b/packages/geoview-time-slider/src/index.tsx
@@ -9,11 +9,6 @@ import { TimeSliderPanel } from './time-slider-panel';
 import schema from '../schema.json';
 import defaultConfig from '../default-config-time-slider-panel.json';
 import type { ConfigProps } from './time-slider-types';
-import {
-  setStoreTimeSliderDisplayDateFormat,
-  setStoreTimeSliderDisplayDateFormatShort,
-  setStoreTimeSliderDisplayDateTimezone,
-} from 'geoview-core/core/stores/store-interface-and-intial-values/time-slider-state';
 
 /** Properties for the slider filter configuration. */
 export interface SliderFilterProps {
@@ -174,12 +169,12 @@ class TimeSliderPlugin extends FooterPlugin {
    */
   initTimeSliderPlugin(): void {
     // Now the layerTimeDimension should be good on the layers
-    const orderedLayerPaths = this.mapViewer.controllers.layerController.getLayerEntryLayerPaths();
+    const orderedLayerPaths = this.controllerRegistry.layerController.getLayerEntryLayerPaths();
     const initialTimeSliderLayerPaths = this.#filterTimeSliderLayers(orderedLayerPaths);
     if (initialTimeSliderLayerPaths) {
       initialTimeSliderLayerPaths.forEach((layerPath) => {
         // Get the layer
-        const layer = this.mapViewer.controllers.layerController.getGeoviewLayerIfExists(layerPath);
+        const layer = this.controllerRegistry.layerController.getGeoviewLayerIfExists(layerPath);
 
         // If the layer was found and of right type
         if (layer instanceof AbstractGVLayer) {
@@ -187,7 +182,7 @@ class TimeSliderPlugin extends FooterPlugin {
           const timesliderConfig = this.getConfig().sliders.find((slider) => slider.layerPaths.includes(layerPath));
 
           // Check and add time slider layer when needed
-          this.mapViewer.controllers.timeSliderController?.checkInitTimeSliderLayerAndApplyFilters(layer, timesliderConfig);
+          this.controllerRegistry.timeSliderController?.checkInitTimeSliderLayerAndApplyFilters(layer, timesliderConfig);
         }
       });
     }
@@ -205,7 +200,7 @@ class TimeSliderPlugin extends FooterPlugin {
     if (typeof displayDateFormat === 'string') displayDateFormatToSet = { en: displayDateFormat, fr: displayDateFormat };
 
     // Save to the store
-    setStoreTimeSliderDisplayDateFormat(this.mapViewer.mapId, layerPath, displayDateFormatToSet);
+    this.controllerRegistry.timeSliderController?.setDisplayDateFormat(layerPath, displayDateFormatToSet);
   }
 
   /**
@@ -220,7 +215,7 @@ class TimeSliderPlugin extends FooterPlugin {
     if (typeof displayDateFormat === 'string') displayDateFormatToSet = { en: displayDateFormat, fr: displayDateFormat };
 
     // Save to the store
-    setStoreTimeSliderDisplayDateFormatShort(this.mapViewer.mapId, layerPath, displayDateFormatToSet);
+    this.controllerRegistry.timeSliderController?.setDisplayDateFormatShort(layerPath, displayDateFormatToSet);
   }
 
   /**
@@ -235,7 +230,7 @@ class TimeSliderPlugin extends FooterPlugin {
     DateMgt.validateTimezone(displayDateTimezone);
 
     // Save to the store
-    setStoreTimeSliderDisplayDateTimezone(this.mapViewer.mapId, layerPath, displayDateTimezone);
+    this.controllerRegistry.timeSliderController?.setDisplayDateTimezone(layerPath, displayDateTimezone);
   }
 
   /**
@@ -248,7 +243,7 @@ class TimeSliderPlugin extends FooterPlugin {
     // Return the layer paths for the layers that have a time dimension
     return layerPaths.filter((layerPath) => {
       // Get the layer
-      const layer = this.mapViewer.controllers.layerController.getGeoviewLayerIfExists(layerPath);
+      const layer = this.controllerRegistry.layerController.getGeoviewLayerIfExists(layerPath);
 
       // If of the right type
       if (layer instanceof AbstractGVLayer) {

--- a/packages/geoview-time-slider/src/time-slider-panel.tsx
+++ b/packages/geoview-time-slider/src/time-slider-panel.tsx
@@ -6,17 +6,14 @@ import type { TypeTimeSliderValues } from 'geoview-core/core/stores/store-interf
 import {
   useStoreTimeSliderLayers,
   useStoreTimeSliderSelectedLayerPath,
-  setStoreTimeSliderSelectedLayerPath,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/time-slider-state';
 import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/store-interface-and-intial-values/app-state';
 import {
-  useStoreMapAllVisibleandInRangeLayers,
-  useStoreMapIsLayerHiddenOnMapSet,
-} from 'geoview-core/core/stores/store-interface-and-intial-values/map-state';
-import {
+  useStoreLayerAllVisibleAndInRangeLayers,
   useStoreLayerDateTemporalModeSet,
   useStoreLayerDisplayDateFormatSet,
   useStoreLayerDisplayDateTimezoneSet,
+  useStoreLayerIsHiddenOnMapSet,
   useStoreLayerNameSet,
   useStoreLayerStatusSet,
 } from 'geoview-core/core/stores/store-interface-and-intial-values/layer-state';
@@ -27,6 +24,7 @@ import { CONTAINER_TYPE, TABS } from 'geoview-core/core/utils/constant';
 
 import { DateMgt } from 'geoview-core/core/utils/date-mgt';
 import { TimeSlider } from './time-slider';
+import { useTimeSliderController } from 'geoview-core/core/controllers/use-controllers';
 
 /** Properties for the TimeSliderPanel component. */
 interface TypeTimeSliderProps {
@@ -50,8 +48,8 @@ export function TimeSliderPanel(props: TypeTimeSliderProps): JSX.Element {
 
   // get values from store
   const displayLanguage = useStoreAppDisplayLanguage();
-  const layerHiddenSet = useStoreMapIsLayerHiddenOnMapSet();
-  const visibleInRangeLayers = useStoreMapAllVisibleandInRangeLayers();
+  const layerHiddenSet = useStoreLayerIsHiddenOnMapSet();
+  const visibleInRangeLayers = useStoreLayerAllVisibleAndInRangeLayers();
   const layerNames = useStoreLayerNameSet();
   const layerStatuses = useStoreLayerStatusSet();
   const layerDisplayDateFormats = useStoreLayerDisplayDateFormatSet();
@@ -59,6 +57,7 @@ export function TimeSliderPanel(props: TypeTimeSliderProps): JSX.Element {
   const layerTemporalModes = useStoreLayerDateTemporalModeSet();
   const timeSliderLayers = useStoreTimeSliderLayers()!;
   const selectedLayerPath = useStoreTimeSliderSelectedLayerPath();
+  const timeSliderController = useTimeSliderController();
 
   // #region Handlers
 
@@ -70,9 +69,9 @@ export function TimeSliderPanel(props: TypeTimeSliderProps): JSX.Element {
   const handleClickLayerList = useCallback(
     (layer: LayerListEntry) => {
       // Set the layer path
-      setStoreTimeSliderSelectedLayerPath?.(mapId, layer.layerPath);
+      timeSliderController.setSelectedLayerPathTimeSlider(layer.layerPath);
     },
-    [mapId]
+    [timeSliderController]
   );
 
   /**
@@ -199,9 +198,9 @@ export function TimeSliderPanel(props: TypeTimeSliderProps): JSX.Element {
 
     if (selectedLayerPath && !memoLayersList.some((layer) => layer.layerPath === selectedLayerPath)) {
       // Selected layer is no longer in the visible layers list, unselect it
-      setStoreTimeSliderSelectedLayerPath?.(mapId, '');
+      timeSliderController.setSelectedLayerPathTimeSlider('');
     }
-  }, [mapId, selectedLayerPath, memoLayersList]);
+  }, [timeSliderController, selectedLayerPath, memoLayersList]);
 
   /**
    * Renders the right panel content based on selected Layer path of time slider.

--- a/packages/geoview-time-slider/src/time-slider.tsx
+++ b/packages/geoview-time-slider/src/time-slider.tsx
@@ -1,12 +1,5 @@
 import { Box } from 'geoview-core/ui';
-import { useStoreGeoViewMapId } from 'geoview-core/core/stores/geoview-store';
-import {
-  setStoreTimeSliderDelay,
-  setStoreTimeSliderLocked,
-  setStoreTimeSliderReversed,
-  setStoreTimeSliderStep,
-  useStoreTimeSliderLayer,
-} from 'geoview-core/core/stores/store-interface-and-intial-values/time-slider-state';
+import { useStoreTimeSliderLayer } from 'geoview-core/core/stores/store-interface-and-intial-values/time-slider-state';
 import {
   useStoreLayerDateTemporalMode,
   useStoreLayerDisplayDateFormat,
@@ -72,7 +65,6 @@ export function TimeSlider(props: TimeSliderProps): JSX.Element {
   const sliderValueRef = useRef<number>();
   const sliderDeltaRef = useRef<number>();
 
-  const mapId = useStoreGeoViewMapId();
   const displayLanguage = useStoreAppDisplayLanguage();
 
   const {
@@ -312,8 +304,8 @@ export function TimeSlider(props: TimeSliderProps): JSX.Element {
    */
   const handleLock = useCallback((): void => {
     clearTimeout(playIntervalRef.current);
-    setStoreTimeSliderLocked(mapId, layerPath, !locked);
-  }, [mapId, layerPath, locked]);
+    timeSliderController.setLocked(layerPath, !locked);
+  }, [timeSliderController, layerPath, locked]);
 
   /**
    * Handles when the user clicks the play/pause button.
@@ -330,21 +322,21 @@ export function TimeSlider(props: TimeSliderProps): JSX.Element {
    */
   const handleReverse = useCallback((): void => {
     clearTimeout(playIntervalRef.current);
-    setStoreTimeSliderReversed(mapId, layerPath, !reversed);
+    timeSliderController.setReversed(layerPath, !reversed);
     if (isPlaying) {
       if (reversed) moveBack();
       else moveForward();
     }
-  }, [isPlaying, mapId, layerPath, moveBack, moveForward, reversed]);
+  }, [isPlaying, timeSliderController, layerPath, moveBack, moveForward, reversed]);
 
   /**
    * Handles when the user changes the time delay.
    */
   const handleTimeChange = useCallback(
     (event: React.ChangeEvent<HTMLSelectElement>): void => {
-      setStoreTimeSliderDelay(mapId, layerPath, Number(event.target.value));
+      timeSliderController.setDelay(layerPath, Number(event.target.value));
     },
-    [mapId, layerPath]
+    [timeSliderController, layerPath]
   );
 
   /**
@@ -352,9 +344,9 @@ export function TimeSlider(props: TimeSliderProps): JSX.Element {
    */
   const handleStepChange = useCallback(
     (event: React.ChangeEvent<HTMLSelectElement>): void => {
-      setStoreTimeSliderStep(mapId, layerPath, Number(event.target.value));
+      timeSliderController.setStep(layerPath, Number(event.target.value));
     },
-    [mapId, layerPath]
+    [timeSliderController, layerPath]
   );
 
   /**


### PR DESCRIPTION

# Description

- Improved the projection event handling in the drawer-controller to not rely on a store subscribe
- Refactoring Foootar-bar, app-bar, and nav-bar to simplify the 'api' usage, the misused useEffects and enhancing the ui-store management
- Moving the layerWmsStyleChanged, layerRasterFunctionChanged, mosaicRuleChanged events from controller to hook on domain
- Removed queryable and hoverable from the mapState to centralize usage to the layerState equivalent properties instead
- Removed visible, visibleInRange and visibleLayers from the mapState to centralize usage to the layerState instead
- Removed legendCollapsed from the mapState to centralize usage to the layerState instead
- Removed orderedLayerInfo from map-state completely!
- Removed initialFilters from the mapState to layerState instead
- Better naming in data-table-controller and redirecting some components on the data-table-controller instead of straight to the store to perform actions
- Hotfix to enhance support when Geocore service fails
- ClickMarker overlay removed from the store
- NorthPoleMarker overlay removed from the store
- Refactored the setProjection function between MapViewer and MapController
- Fixed an issue with the DataTable Panel not re-reading the features after a map projection switch
- Cleaned up some click marker icon show/hide actions
- Cleanup some setSelectedLayerPath components
- Cleanup of setFilterMap for DataTable
- Move vast majority of rogue setStoreXXXX
- Fix for GeoChart panel not showing up, fixes #3410
- Fixed some dependency injections between feature highlight and map controller and geometry and draw controller
- Fix to make sure the app bar tab is opened when it needs to be (one template page wasn't working)
- Fix when the selectedLayerPath for the data-table is set before the actual layer is registered, the data-panel has to wait for it
- Fix for the export missing some styles
- Trying to fix the should be visible for the overview-map better
- Fix when switching projection via the navbar button
- Fix the functional testing with the latest code enhancements
- Reimplemented fix when the layer only has 1 icon in the legend, don't reshow it in the description
- Executed BranchReview Agent
- Simplified some useMemo that were overkill
- Fixing a store mutation issue in the store with regards to the layersDataTableSetting property and its sub properties
- data-table component rendering improvements(!)
- Fixed an issue with the data-table column visibility states (there was no Zustand store property to associate the column visibility states - created one)
- Fixed another issue which was also present in upstream when clicking hide-all, show-all and hide-all again on the column visibility states in the data-table (it was crashing react (and the map) completely)

Fixes #3410

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

~~Hosted April 20th @ 14h : https://alex-nrcan.github.io/geoview/~~
~~Hosted April 22nd @ 11h20 : https://alex-nrcan.github.io/geoview/~~
~~Hosted April 22nd @ 12h00 : https://alex-nrcan.github.io/geoview/~~
~~Hosted April 23rd @ 13h50 : https://alex-nrcan.github.io/geoview/~~
~~Hosted April 24th @ 9h30 : https://alex-nrcan.github.io/geoview/~~
~~Hosted April 24th @ 11h30 : https://alex-nrcan.github.io/geoview/~~
~~Hosted April 24th @ 15h15 : https://alex-nrcan.github.io/geoview/~~
Hosted April 27th @ 13h00 : https://alex-nrcan.github.io/geoview/

# Checklist:

- [x] I have run the **Test Suite** and **No errors have been introduced**
- [x] I have run "@workspace review this branch diff (compare to upstream/develop) against GeoView coding standards" in my co pilot chat
- [x] I asked copilot to **audit JSDoc comments for a folder or file or diff branch againt upstream/develop** in my co pilot chat
- [x] I have build __(rush build)__ and deploy __(rush host)__ my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
-  ~~I have made corresponding changes to the documentation~~
-  ~~I have added tests that prove my fix is effective or that my feature works~~
-  ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3416)
<!-- Reviewable:end -->
