### PR TITLE
fix(bug): Multiple bug fixes

### DIFF
--- a/packages/geoview-core/public/configs/navigator/demos/26-complex-classifications.json
+++ b/packages/geoview-core/public/configs/navigator/demos/26-complex-classifications.json
@@ -39,6 +39,17 @@
         ]
       },
       {
+        "geoviewLayerId": "ESRIDynamicValueExpression",
+        "geoviewLayerName": "ESRI Dynamic with Value Expression to classify every 100 years",
+        "metadataAccessPath": "https://egisp.dfo-mpo.gc.ca/arcgis/rest/services/open_data_donnees_ouvertes/path/MapServer",
+        "geoviewLayerType": "esriDynamic",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "0"
+          }
+        ]
+      },
+      {
         "geoviewLayerId": "ESRIValueExpression",
         "geoviewLayerName": "ESRI Value Expression to classify every 100 years",
         "metadataAccessPath": "https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/historical_flood_event_en/MapServer",

--- a/packages/geoview-core/public/configs/navigator/layers/wms-cdtk.json
+++ b/packages/geoview-core/public/configs/navigator/layers/wms-cdtk.json
@@ -193,7 +193,12 @@
         "geoviewLayerType": "ogcWms",
         "listOfLayerEntryConfig": [
           {
-            "layerId": "DMF"
+            "layerId": "DMF",
+            "source": {
+              "featureInfo": {
+                "nameField": "label_en"
+              }
+            }
           }
         ]
       },

--- a/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
@@ -212,7 +212,22 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
    * @param layerStyleMetadata - Optional layer style metadata to use to help fill the blanks in our layer style config
    */
   initLayerStyleFromMetadata(layerStyleMetadata: TypeLayerStyleConfig | undefined): void {
-    this.#layerStyle = deepMerge(layerStyleMetadata, this.#layerStyle);
+    // If metadata exists, normalize geometry keys before merging
+    if (layerStyleMetadata) {
+      const normalizedMetadata: TypeLayerStyleConfig = {};
+
+      // Normalize Multi* geometry types to their simplified forms
+      Object.entries(layerStyleMetadata).forEach(([geometryType, styleConfig]) => {
+        // Convert MultiPolygon → Polygon, MultiPoint → Point, MultiLineString → LineString
+        const simplifiedType = geometryType.startsWith('Multi') ? geometryType.slice(5) : geometryType;
+
+        normalizedMetadata[simplifiedType as TypeStyleGeometry] = styleConfig;
+      });
+
+      this.#layerStyle = deepMerge(normalizedMetadata, this.#layerStyle);
+    } else {
+      this.#layerStyle = deepMerge(layerStyleMetadata, this.#layerStyle);
+    }
   }
 
   /**

--- a/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
@@ -212,22 +212,20 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
    * @param layerStyleMetadata - Optional layer style metadata to use to help fill the blanks in our layer style config
    */
   initLayerStyleFromMetadata(layerStyleMetadata: TypeLayerStyleConfig | undefined): void {
-    // If metadata exists, normalize geometry keys before merging
-    if (layerStyleMetadata) {
-      const normalizedMetadata: TypeLayerStyleConfig = {};
+    // If no metadata, nothing to do
+    if (!layerStyleMetadata) return;
 
-      // Normalize Multi* geometry types to their simplified forms
-      Object.entries(layerStyleMetadata).forEach(([geometryType, styleConfig]) => {
-        // Convert MultiPolygon → Polygon, MultiPoint → Point, MultiLineString → LineString
-        const simplifiedType = geometryType.startsWith('Multi') ? geometryType.slice(5) : geometryType;
+    const normalizedMetadata: TypeLayerStyleConfig = {};
 
-        normalizedMetadata[simplifiedType as TypeStyleGeometry] = styleConfig;
-      });
+    // Normalize Multi* geometry types to their simplified forms
+    Object.entries(layerStyleMetadata).forEach(([geometryType, styleConfig]) => {
+      // Convert MultiPolygon → Polygon, MultiPoint → Point, MultiLineString → LineString
+      const simplifiedType = geometryType.startsWith('Multi') ? geometryType.slice(5) : geometryType;
 
-      this.#layerStyle = deepMerge(normalizedMetadata, this.#layerStyle);
-    } else {
-      this.#layerStyle = deepMerge(layerStyleMetadata, this.#layerStyle);
-    }
+      normalizedMetadata[simplifiedType as TypeStyleGeometry] = styleConfig;
+    });
+
+    this.#layerStyle = deepMerge(normalizedMetadata, this.#layerStyle);
   }
 
   /**

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -229,8 +229,7 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
   const memoFeatureName = useMemo(() => {
     logger.logTraceUseMemo('FEATURE-INFO - memoFeatureName', feature.nameField);
     // Try to get the value at the fieldName
-    const effectiveNameField = feature.nameField ?? Object.keys(feature.fieldInfo ?? {})[0];
-    const value = effectiveNameField && (feature.fieldInfo?.[effectiveNameField]?.value as string);
+    const value = feature.nameField && (feature.fieldInfo?.[feature.nameField]?.value as string);
     return value ?? 'No name / Sans nom';
   }, [feature]);
 

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -229,7 +229,8 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
   const memoFeatureName = useMemo(() => {
     logger.logTraceUseMemo('FEATURE-INFO - memoFeatureName', feature.nameField);
     // Try to get the value at the fieldName
-    const value = feature.nameField && (feature.fieldInfo?.[feature.nameField]?.value as string);
+    const effectiveNameField = feature.nameField ?? Object.keys(feature.fieldInfo ?? {})[0];
+    const value = effectiveNameField && (feature.fieldInfo?.[effectiveNameField]?.value as string);
     return value ?? 'No name / Sans nom';
   }, [feature]);
 

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -417,7 +417,12 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
     // No checkbox for simple style layers
     if (layerStyleConfig[item.geometryType]?.type === 'simple') return null;
 
-    const isDisabled = layerHidden || !layerCanToggle;
+    // Check if layer is ESRI Dynamic with valueExpression
+    const styleConfig = layerStyleConfig[item.geometryType];
+    const hasValueExpression = styleConfig && 'valueExpression' in styleConfig && styleConfig.valueExpression;
+    const isEsriDynamic = layerSchemaTag === CONST_LAYER_TYPES.ESRI_DYNAMIC;
+
+    const isDisabled = layerHidden || !layerCanToggle || (isEsriDynamic && !!hasValueExpression);
 
     // Build the label content with icon and text
     const labelContent = (

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -451,7 +451,13 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   };
 
   const renderHeaderCheckbox = (): JSX.Element => {
-    const isDisabled = layerHidden || !layerCanToggle;
+    // Check if layer is ESRI Dynamic with valueExpression
+    const isEsriDynamic = layerSchemaTag === CONST_LAYER_TYPES.ESRI_DYNAMIC;
+    const hasValueExpression =
+      layerStyleConfig &&
+      Object.values(layerStyleConfig).some((styleConfig) => styleConfig && 'valueExpression' in styleConfig && styleConfig.valueExpression);
+
+    const isDisabled = layerHidden || !layerCanToggle || (isEsriDynamic && hasValueExpression);
 
     const labelContent = (
       <Box component="span" sx={{ fontWeight: 'bold', ...(layerHidden && hiddenStyle) }}>

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -487,7 +487,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
         justifyItems="stretch"
       >
         {layerItems?.map((item) => (
-          <Grid key={`${layerPath}/${item.name}`} sx={{ marginBottom: '5px' }}>
+          <Grid key={`${layerPath}/${item.geometryType}/${item.name}/${item.icon || 'no-icon'}`} sx={{ marginBottom: '5px' }}>
             {renderItemCheckbox(item)}
           </Grid>
         ))}

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -75,6 +75,7 @@ import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { DeleteUndoButton } from '@/core/components/layers/delete-undo-button';
 import type { TypeContainerBox } from '@/core/types/global-types';
 import { useLayerController, useLayerSetController } from '@/core/controllers/use-controllers';
+import type { TypeLayerStyleSettings } from '@/api/types/map-schema-types';
 
 interface LayerDetailsProps {
   /** The layer path for the layer to display. */
@@ -249,6 +250,23 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
         )
       : false;
   }, [layerStyleConfig]);
+
+  /**
+   * Determines if a style configuration allows item visibility toggling.
+   *
+   * Simple styles cannot be toggled. UniqueValue/classBreaks styles
+   * require multiple non-default classes to enable toggling.
+   */
+  const canToggleStyleItems = (styleConfig: TypeLayerStyleSettings | undefined): boolean => {
+    if (!styleConfig || styleConfig.type === 'simple') return false;
+
+    if (styleConfig.type === 'uniqueValue' || styleConfig.type === 'classBreaks') {
+      const nonDefaultCount = styleConfig.hasDefault ? styleConfig.info.length - 1 : styleConfig.info.length;
+      return nonDefaultCount > 1;
+    }
+
+    return true;
+  };
 
   /**
    * Resets active view to details when layer changes.
@@ -429,8 +447,9 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   const renderItemCheckbox = (item: TypeLegendItem): JSX.Element | null => {
     if (!layerStyleConfig) return null;
 
-    // No checkbox for simple style layers
-    if (layerStyleConfig[item.geometryType]?.type === 'simple') return null;
+    // Determine if style type allows toggling this item on/off
+    const styleConfig = layerStyleConfig[item.geometryType];
+    const canToggle = canToggleStyleItems(styleConfig);
 
     const isDisabled = layerHidden || !layerCanToggle || (isEsriDynamic && !!hasValueExpression);
 
@@ -443,6 +462,11 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
         </Box>
       </Box>
     );
+
+    // If not checkbox needed, just return the label content
+    if (!canToggle) {
+      return <Box sx={{ ...sxClasses.formControlLabelFull, paddingLeft: '9px' }}>{labelContent}</Box>;
+    }
 
     return (
       <FormControlLabel

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -235,6 +235,21 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   // Generate unique table details button ID
   const tableDetailsButtonId = `${mapId}-${containerType}-table-details`;
 
+  // Layer is ESRI Dynamic
+  const isEsriDynamic = layerSchemaTag === CONST_LAYER_TYPES.ESRI_DYNAMIC;
+
+  // Layer has a value expression in its style config
+  const hasValueExpression = useMemo((): boolean => {
+    // Log
+    logger.logTraceUseMemo('LAYER DETAILS - hasValueExpression', layerStyleConfig);
+
+    return layerStyleConfig
+      ? Object.values(layerStyleConfig).some(
+          (styleConfig) => styleConfig && 'valueExpression' in styleConfig && styleConfig.valueExpression
+        )
+      : false;
+  }, [layerStyleConfig]);
+
   /**
    * Resets active view to details when layer changes.
    */
@@ -417,11 +432,6 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
     // No checkbox for simple style layers
     if (layerStyleConfig[item.geometryType]?.type === 'simple') return null;
 
-    // Check if layer is ESRI Dynamic with valueExpression
-    const styleConfig = layerStyleConfig[item.geometryType];
-    const hasValueExpression = styleConfig && 'valueExpression' in styleConfig && styleConfig.valueExpression;
-    const isEsriDynamic = layerSchemaTag === CONST_LAYER_TYPES.ESRI_DYNAMIC;
-
     const isDisabled = layerHidden || !layerCanToggle || (isEsriDynamic && !!hasValueExpression);
 
     // Build the label content with icon and text
@@ -451,12 +461,6 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   };
 
   const renderHeaderCheckbox = (): JSX.Element => {
-    // Check if layer is ESRI Dynamic with valueExpression
-    const isEsriDynamic = layerSchemaTag === CONST_LAYER_TYPES.ESRI_DYNAMIC;
-    const hasValueExpression =
-      layerStyleConfig &&
-      Object.values(layerStyleConfig).some((styleConfig) => styleConfig && 'valueExpression' in styleConfig && styleConfig.valueExpression);
-
     const isDisabled = layerHidden || !layerCanToggle || (isEsriDynamic && hasValueExpression);
 
     const labelContent = (

--- a/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
@@ -7,12 +7,15 @@ import {
   useStoreLayerCanToggle,
   useStoreLayerControls,
   useStoreLayerIsHiddenOnMap,
+  useStoreLayerSchemaTag,
+  useStoreLayerStyleConfig,
 } from '@/core/stores/store-interface-and-intial-values/layer-state';
 import { getSxClasses } from './legend-styles';
 import { logger } from '@/core/utils/logger';
 import { generateId } from '@/core/utils/utilities';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { useLayerController } from '@/core/controllers/use-controllers';
+import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 
 interface ItemsListProps {
   items: TypeLegendItem[];
@@ -113,6 +116,8 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
   const layerHidden = useStoreLayerIsHiddenOnMap(layerPath);
   const canToggle = useStoreLayerCanToggle(layerPath);
   const canToggleItemVisibility = canToggle && layerControls?.visibility !== false;
+  const layerSchemaTag = useStoreLayerSchemaTag(layerPath);
+  const layerStyleConfig = useStoreLayerStyleConfig(layerPath);
   const layerController = useLayerController();
 
   /**
@@ -165,7 +170,12 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
     <List className="layerList" sx={memoSxClasses.layerList}>
       {items.map((item) => {
         const itemId = getItemId(item);
-        const canReallyToggle = Boolean(canToggleItemVisibility && !layerHidden);
+        const hasValueExpression = layerStyleConfig
+          ? Object.values(layerStyleConfig).some((config) => 'valueExpression' in config && config.valueExpression)
+          : false;
+        const isEsriDynamic = layerSchemaTag === CONST_LAYER_TYPES.ESRI_DYNAMIC;
+
+        const canReallyToggle = Boolean(canToggleItemVisibility && !layerHidden && !(isEsriDynamic && hasValueExpression));
 
         // Common properties for the legend list item
         const commonProps = {

--- a/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
+++ b/packages/geoview-core/src/core/components/legend/legend-layer-items.tsx
@@ -120,6 +120,19 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
   const layerStyleConfig = useStoreLayerStyleConfig(layerPath);
   const layerController = useLayerController();
 
+  // Layer is ESRI Dynamic
+  const isEsriDynamic = layerSchemaTag === CONST_LAYER_TYPES.ESRI_DYNAMIC;
+
+  // Layer has a value expression in its style config
+  const hasValueExpression = useMemo((): boolean => {
+    // Log
+    logger.logTraceUseMemo('LEGEND-LAYER-ITEMS - hasValueExpression', layerStyleConfig);
+
+    return layerStyleConfig
+      ? Object.values(layerStyleConfig).some((config) => 'valueExpression' in config && config.valueExpression)
+      : false;
+  }, [layerStyleConfig]);
+
   /**
    * Generates or retrieves a stable HTML ID for a legend item.
    * Uses a composite key (name + geometryType + icon) to uniquely identify items.
@@ -170,10 +183,6 @@ export const ItemsList = memo(function ItemsList({ items, layerPath }: ItemsList
     <List className="layerList" sx={memoSxClasses.layerList}>
       {items.map((item) => {
         const itemId = getItemId(item);
-        const hasValueExpression = layerStyleConfig
-          ? Object.values(layerStyleConfig).some((config) => 'valueExpression' in config && config.valueExpression)
-          : false;
-        const isEsriDynamic = layerSchemaTag === CONST_LAYER_TYPES.ESRI_DYNAMIC;
 
         const canReallyToggle = Boolean(canToggleItemVisibility && !layerHidden && !(isEsriDynamic && hasValueExpression));
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -34,6 +34,7 @@ import {
 } from '@/core/exceptions/layer-entry-config-exceptions';
 import { deepMergeObjects, generateId, normalizeDatacubeAccessPath } from '@/core/utils/utilities';
 import { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
+import { AbstractGeoViewVector } from '@/geo/layer/geoview-layers/vector/abstract-geoview-vector';
 import { GVWMS } from '@/geo/layer/gv-layers/raster/gv-wms';
 import type { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
 import { WfsRenderer } from '@/geo/utils/renderer/wfs-renderer';
@@ -1195,8 +1196,19 @@ export class WMS extends AbstractGeoViewRaster {
         // Override the outfields of the WMS to leverage possibilities working with a WMS layer, like knowing the field types when performing WMS queries
         layerConfig.setOutfields(outFields);
 
-        // Initialize the name field to the first field if not already set
-        layerConfig.initNameField(outFields?.[0]?.name);
+        // Validate and sync the nameField from WFS to WMS
+        const nameField = layerConfig.getNameField();
+        const nameFieldIsValid = nameField && outFields.some((field) => field.name === nameField);
+
+        if (!nameFieldIsValid) {
+          // WFS nameField is invalid or missing - warn and default to first field
+          if (nameField) {
+            logger.logWarning(
+              `The WFS-derived nameField '${nameField}' for WMS layer ${layerConfig.layerPath} does not exist in the outfields. Using best available field.`
+            );
+          }
+          layerConfig.setNameField(AbstractGeoViewVector.findBestNameField(outFields));
+        }
 
         // If no layer style defined
         if (!layerConfig.getLayerStyle()) {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -1195,6 +1195,9 @@ export class WMS extends AbstractGeoViewRaster {
         // Override the outfields of the WMS to leverage possibilities working with a WMS layer, like knowing the field types when performing WMS queries
         layerConfig.setOutfields(outFields);
 
+        // Initialize the name field to the first field if not already set
+        layerConfig.initNameField(outFields?.[0]?.name);
+
         // If no layer style defined
         if (!layerConfig.getLayerStyle()) {
           // If the service metadata offers GetStyles

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -271,21 +271,54 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
 
     // If no name field
     const nameField = layerConfig.getNameField();
-    if (!nameField) {
-      // Try to set nameField to a name field
-      const newNameField = this.NAME_FIELD_KEYWORDS.reduce<TypeOutfields | undefined>((found, keyword) => {
-        if (found) return found;
-        return outfields.find((field) => {
-          return new RegExp(keyword, 'i').test(field.name);
-        });
-      }, undefined);
+    if (nameField) {
+      // A nameField was provided (likely from metadata) - validate it exists in outfields
+      const fieldExists = outfields.some((field) => field.name === nameField);
+
+      if (!fieldExists) {
+        // The provided nameField doesn't exist in the actual data - need to replace it
+        logger.logWarning(
+          `The configured nameField '${nameField}' does not exist in the layer's outfields. Replacing with a default value.`
+        );
+
+        // Replace the invalid nameField with a smart default
+        layerConfig.setNameField(this.findBestNameField(outfields));
+      }
+      // If fieldExists is true, the nameField is valid - no action needed
+    } else {
+      // No nameField provided - try to set nameField to a name field
+      const newNameField = this.findBestNameField(outfields);
 
       // Set the name field to the first attribute by default if no nameField is specified already
-      layerConfig.initNameField(newNameField?.name ?? outfields?.[0]?.name);
+      layerConfig.initNameField(newNameField ?? outfields?.[0]?.name);
     }
 
     // Vector layer only queryable if there are fields
     layerConfig.initQueryableSource(outfields.length > 0);
+  }
+
+  /**
+   * Finds the best field to use as a name field by searching for common name-like field patterns.
+   *
+   * Searches the outfields array for fields matching predefined keywords (name, title, label) in priority order.
+   * If no keyword match is found, returns the first field as a fallback.
+   *
+   * @param outfields - Array of outfields to search
+   * @returns The name of the best matching field, or undefined if no fields available
+   */
+  static findBestNameField(outfields: TypeOutfields[]): string | undefined {
+    if (!outfields.length) return undefined;
+
+    // Try to find a field matching name keywords in priority order
+    const nameField = this.NAME_FIELD_KEYWORDS.reduce<TypeOutfields | undefined>((found, keyword) => {
+      if (found) return found;
+      return outfields.find((field) => {
+        return new RegExp(keyword, 'i').test(field.name);
+      });
+    }, undefined);
+
+    // Return the matched field name, or fall back to the first field
+    return nameField?.name ?? outfields[0]?.name;
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -1977,7 +1977,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
       type: TypeOutfieldsType;
       alias: string;
       domain?: codedValueType | rangeDomainType;
-    }> = outfields ?? feature.getKeys().map((name) => ({ name, type: 'string' as TypeOutfieldsType, alias: name }));
+    }> = outfields ?? feature.getKeys().map((name) => ({ name, type: 'string', alias: name }));
 
     for (const fieldEntry of fieldEntries) {
       // Skip geometry field

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -1968,62 +1968,46 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
   ): number {
     let fieldKeyCounter = fieldKeyCounterStart;
 
-    // If outfields exist, use that order to preserve service field order
-    if (outfields) {
-      for (const fieldEntry of outfields) {
-        // Skip geometry field
-        // eslint-disable-next-line no-continue
-        if (fieldEntry.name === 'geometry') continue;
+    // Build field entries: use outfields if available, otherwise create minimal entries from feature keys
+    // GV Note: We assume that if outfields are not provided, all fields are of type string and have no domain.
+    // GV This is a fallback and may not be accurate, but without outfield metadata we have no way to know the correct types or domains.
+    // GV And the alternative would be to skip and show no fields
+    const fieldEntries: Array<{
+      name: string;
+      type: TypeOutfieldsType;
+      alias: string;
+      domain?: codedValueType | rangeDomainType;
+    }> = outfields ?? feature.getKeys().map((name) => ({ name, type: 'string' as TypeOutfieldsType, alias: name }));
 
-        // Get the field value from the feature
-        const fieldValue = feature.get(fieldEntry.name);
+    for (const fieldEntry of fieldEntries) {
+      // Skip geometry field
+      // eslint-disable-next-line no-continue
+      if (fieldEntry.name === 'geometry') continue;
 
-        // Skip if field doesn't exist on the feature
-        // eslint-disable-next-line no-continue
-        if (fieldValue === undefined) continue;
+      // Get the field value from the feature
+      const fieldValue = feature.get(fieldEntry.name);
 
-        // Skip if field value is an object (but allow arrays)
-        // eslint-disable-next-line no-continue
-        if (fieldValue && typeof fieldValue === 'object' && !Array.isArray(fieldValue)) continue;
+      // Skip nested objects (but allow arrays)
+      // eslint-disable-next-line no-continue
+      if (fieldValue && typeof fieldValue === 'object' && !Array.isArray(fieldValue)) continue;
 
-        // Attach the fieldInfo property on the feature info entry
-        // eslint-disable-next-line no-param-reassign
-        featureInfoEntry.fieldInfo[fieldEntry.name] = {
-          fieldKey: fieldKeyCounter++,
-          value: callbackGetFieldValue(
-            feature,
-            fieldEntry.name,
-            fieldEntry.type,
-            fieldEntry.domain,
-            inputFormat,
-            inputTimezone,
-            inputTemporalMode
-          ),
-          dataType: fieldEntry.type,
-          alias: fieldEntry.alias,
-          domain: fieldEntry.domain,
-        };
-      }
-    } else {
-      // Fallback: if no outfields defined, use feature keys order (current behavior)
-      const featureFields = feature.getKeys();
-      for (const fieldName of featureFields) {
-        // eslint-disable-next-line no-continue
-        if (fieldName === 'geometry') continue;
-
-        const fieldValue = feature.get(fieldName);
-        // eslint-disable-next-line no-continue
-        if (fieldValue && typeof fieldValue === 'object' && !Array.isArray(fieldValue)) continue;
-
-        // Since no outfields, create a basic field entry
-        // eslint-disable-next-line no-param-reassign
-        featureInfoEntry.fieldInfo[fieldName] = {
-          fieldKey: fieldKeyCounter++,
-          value: fieldValue,
-          dataType: 'string',
-          alias: fieldName,
-        };
-      }
+      // Attach the fieldInfo property on the feature info entry
+      // eslint-disable-next-line no-param-reassign
+      featureInfoEntry.fieldInfo[fieldEntry.name] = {
+        fieldKey: fieldKeyCounter++,
+        value: callbackGetFieldValue(
+          feature,
+          fieldEntry.name,
+          fieldEntry.type,
+          fieldEntry.domain,
+          inputFormat,
+          inputTimezone,
+          inputTemporalMode
+        ),
+        dataType: fieldEntry.type,
+        alias: fieldEntry.alias,
+        domain: fieldEntry.domain,
+      };
     }
 
     // Return the counter

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -1966,22 +1966,26 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     inputTemporalMode: TemporalMode | undefined,
     callbackGetFieldValue: GetFieldValueDelegate
   ): number {
-    const featureFields = feature.getKeys();
     let fieldKeyCounter = fieldKeyCounterStart;
 
-    for (const fieldName of featureFields) {
-      // eslint-disable-next-line no-continue
-      if (fieldName === 'geometry') continue;
+    // If outfields exist, use that order to preserve service field order
+    if (outfields) {
+      for (const fieldEntry of outfields) {
+        // Skip geometry field
+        // eslint-disable-next-line no-continue
+        if (fieldEntry.name === 'geometry') continue;
 
-      const fieldValue = feature.get(fieldName);
-      // eslint-disable-next-line no-continue
-      if (fieldValue && typeof fieldValue === 'object' && !Array.isArray(fieldValue)) continue;
+        // Get the field value from the feature
+        const fieldValue = feature.get(fieldEntry.name);
 
-      // Find the field entry corresponding to the feature field
-      const fieldEntry = outfields?.find((outfield) => outfield.name === fieldName || outfield.alias === fieldName);
+        // Skip if field doesn't exist on the feature
+        // eslint-disable-next-line no-continue
+        if (fieldValue === undefined) continue;
 
-      // If the field entry was found
-      if (fieldEntry) {
+        // Skip if field value is an object (but allow arrays)
+        // eslint-disable-next-line no-continue
+        if (fieldValue && typeof fieldValue === 'object' && !Array.isArray(fieldValue)) continue;
+
         // Attach the fieldInfo property on the feature info entry
         // eslint-disable-next-line no-param-reassign
         featureInfoEntry.fieldInfo[fieldEntry.name] = {
@@ -1998,6 +2002,26 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
           dataType: fieldEntry.type,
           alias: fieldEntry.alias,
           domain: fieldEntry.domain,
+        };
+      }
+    } else {
+      // Fallback: if no outfields defined, use feature keys order (current behavior)
+      const featureFields = feature.getKeys();
+      for (const fieldName of featureFields) {
+        // eslint-disable-next-line no-continue
+        if (fieldName === 'geometry') continue;
+
+        const fieldValue = feature.get(fieldName);
+        // eslint-disable-next-line no-continue
+        if (fieldValue && typeof fieldValue === 'object' && !Array.isArray(fieldValue)) continue;
+
+        // Since no outfields, create a basic field entry
+        // eslint-disable-next-line no-param-reassign
+        featureInfoEntry.fieldInfo[fieldName] = {
+          fieldKey: fieldKeyCounter++,
+          value: fieldValue,
+          dataType: 'string',
+          alias: fieldName,
         };
       }
     }

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -963,7 +963,9 @@ export class GVWMS extends AbstractGVRaster {
     // If any found result
     if (featureMember) {
       // Format and return the information
-      return { results: GVWMS.#formatWmsFeatureInfoResult(wmsLayerConfig.layerPath, featureMember, clickCoordinate) };
+      return {
+        results: GVWMS.#formatWmsFeatureInfoResult(wmsLayerConfig.layerPath, wmsLayerConfig.getNameField(), featureMember, clickCoordinate),
+      };
     }
 
     // Failed
@@ -1391,6 +1393,7 @@ export class GVWMS extends AbstractGVRaster {
    */
   static #formatWmsFeatureInfoResult(
     layerPath: string,
+    nameField: string | undefined,
     featureMember: Record<string, unknown> | Record<string, unknown>[],
     clickCoordinate: Coordinate
   ): TypeFeatureInfoEntry[] {
@@ -1400,11 +1403,11 @@ export class GVWMS extends AbstractGVRaster {
     if (Array.isArray(featureMember)) {
       featureMember.forEach((feature) => {
         if (feature && typeof feature === 'object') {
-          results.push(this.#formatWmsFeatureInfoResultParser(feature, layerPath, clickCoordinate, featureKeyCounter++));
+          results.push(this.#formatWmsFeatureInfoResultParser(feature, layerPath, nameField, clickCoordinate, featureKeyCounter++));
         }
       });
     } else if (featureMember && typeof featureMember === 'object') {
-      results.push(this.#formatWmsFeatureInfoResultParser(featureMember, layerPath, clickCoordinate, featureKeyCounter++));
+      results.push(this.#formatWmsFeatureInfoResultParser(featureMember, layerPath, nameField, clickCoordinate, featureKeyCounter++));
     }
 
     return results;
@@ -1422,6 +1425,7 @@ export class GVWMS extends AbstractGVRaster {
   static #formatWmsFeatureInfoResultParser(
     feature: unknown,
     layerPath: string,
+    nameField: string | undefined,
     clickCoordinate: Coordinate,
     featureKey: number
   ): TypeFeatureInfoEntry {
@@ -1435,6 +1439,7 @@ export class GVWMS extends AbstractGVRaster {
       fieldInfo: {},
       supportZoomTo: true,
       layerPath,
+      nameField,
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
# Description

Small fix to disable toggling class visibility for ESRI Dynamic with value expressions since backwards evaluation of the expression to create the filter for the request to the server would be a high cost with little benefit.

(3434) Fixed an issue where classes with the same name in the same layer caused a unique key conflict in React resulting in elements not being properly removed from the layers list

(3435) Fixed an issue where if a user used a "MultiPolygon" layerStyle, it resulted in a "MultiPolygon" and a default "Polygon" style, meaning the "MultiPolygon" style was ignored. Instead, if a Multi variant is used, the Multi will be dropped to the simpler version so the style is applied properly.

(3368) Fixed an issue where the WMS wasn't having it's layerName initialized resulting in "No Name" default result in the details panel.

(3372) Ordered fields based on the "outFields" order. This fixes the WMS / WFS field ordering not matching the set order in the service and also gives the benefit of allowing users to set the order of layers using the outFields property.

Made Simple styles and styles with a single class show in the layer details, but with the checkbox to toggle visibility hidden.

Fixes #3434, #3435, #3368, and #3372

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
### Host updated 2026-05-01 @ 12:30PM

In the complex classifications, the ESRI dynamic layer with the value expression will have it's classes disabled in the layer list.
[**Complex Classifications Navigator Page**](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/demos/26-complex-classifications.json)

In the MultiPolygon Demo, the multipolygon will have the correct style and when switching between the layers, the classes won't persist and be duplicated. FYI, the multipolygon is showing the class in the layer-details because in the config it's set to "uniqueValue", even though there's only 1.
[**MultiPolygon Navigator Page**](https://matthewmuehlhausernrcan.github.io/geoview/layers-navigator.html?config=./configs/navigator/layers/geojson-multi.json)

In the CDTK page, clicking on something on the map should show the details with a name value. Specifically, the Completed Inventory has a nameField set in the config of "project_name_en" as well where others without will just show the first field. 
The order of those fields will also match the [service order](https://[qgis-stage.cdtk.geogc.ca/ows/iaac/assessment_inventory_en?SERVICE=WFS&VERSION=1.3.0&REQUEST=DescribeFeatureType&typeName=completed&outputFormat=application/json](https://qgis-stage.cdtk.geogc.ca/ows/iaac/assessment_inventory_en?SERVICE=WFS&VERSION=1.3.0&REQUEST=DescribeFeatureType&typeName=completed&outputFormat=application/json)).
[**WMS CDTK Navigator Page**](https://matthewmuehlhausernrcan.github.io/geoview/layers-navigator.html?config=./configs/navigator/layers/wms-cdtk.json)

You can also view the user set field order here in the U2 Tour locations layer (Venue (namefield), Event, Tour, City, Date) instead of (Date, City, Event, Tour, Venue).
[**ESRI Feature Navigator**](https://matthewmuehlhausernrcan.github.io/geoview/layers-navigator.html?config=./configs/navigator/layers/esri-feature.json)

For seeing the [simple styles (ESRI FEature)](https://matthewmuehlhausernrcan.github.io/geoview/layers-navigator.html?config=./configs/navigator/layers/esri-feature.json) and the styles with a [single class (MultiPolygon)](https://matthewmuehlhausernrcan.github.io/geoview/layers-navigator.html?config=./configs/navigator/layers/geojson-multi.json) in the layer panel.

# Checklist:

- [X] I have run the **Test Suite** and **No errors have been introduced**
- [X] I have run `@BranchReview` agent in VS Code Chat and addressed all violations
- [X] I have run `@DocUpdate` agent in VS Code Chat and documentation is in sync with code changes
- [X] I have run `@IssueReview` agent in VS Code Chat and the implementation aligns with the linked issue
- [X] I have build **(rush build)** and deploy **(rush host)** my PR
- [X] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3452)
<!-- Reviewable:end -->
