### PR TITLE
feature(wms-vnd.ogc.gml) - Added support for the application/vnd.ogc.gml for getFeatureInfo of WMS layers

### DIFF
--- a/docs/app/layers/layers.md
+++ b/docs/app/layers/layers.md
@@ -195,10 +195,9 @@ interface TypeGeoviewLayerConfig {
 
   // Temporal settings
   serviceDateFormat?: string; // Server date format
-  externalDateFormat?: string; // User-facing date format
-
-  // Filter
-  layerFilter?: string; // OGC CQL filter
+  displayDateFormat?: string; // User-facing date format
+  displayDateFormatShort?: string; // Optional short display date format
+  displayDateTimezone?: string; // Optional display timezone
 }
 ```
 
@@ -327,7 +326,7 @@ If your service uses a different date format:
   serviceDateFormat: 'MM/DD/YYYY HH:mm:ss-05:00',
 
   // Tell GeoView how to display dates to users
-  externalDateFormat: 'YYYY-MM-DD[THH:mm:ssZ]'
+  displayDateFormat: 'YYYY-MM-DD[THH:mm:ssZ]'
 }
 ```
 
@@ -349,18 +348,18 @@ Use square brackets to remove date/time components from display:
 
 ```typescript
 // Show only date, hide time
-externalDateFormat: "YYYY-MM-DD[THH:MM:SSZ]";
+displayDateFormat: "YYYY-MM-DD[THH:MM:SSZ]";
 
 // Show only year
-externalDateFormat: "YYYY[-MM-DDTHH:MM:SSZ]";
+displayDateFormat: "YYYY[-MM-DDTHH:MM:SSZ]";
 
 // Show month and year
-externalDateFormat: "MM-YYYY[THH:MM:SSZ]";
+displayDateFormat: "MM-YYYY[THH:MM:SSZ]";
 ```
 
 ### Temporal Filtering
 
-Temporal layers can be filtered using the layer's built-in filter mechanisms. Layer filters are applied through the layer configuration:
+Temporal layers can be filtered using the layer's built-in filter mechanisms. Layer filters are applied on layer entry configuration:
 
 ```typescript
 // Set a layer filter in the configuration

--- a/docs/programming/adding-layer-types.md
+++ b/docs/programming/adding-layer-types.md
@@ -22,7 +22,7 @@ Config JSON (TypeGeoviewLayerConfig)
 LayerCreatorController.createLayerConfigFromType()
         ↓
 GeoView Layer (e.g., new EsriDynamic)
-   1. onFetchAndSetServiceMetadata()
+   1. onFetchServiceMetadata()
    2. onValidateListOfLayerEntryConfig()
    3. onProcessLayerMetadata()
    4. onProcessOneLayerEntry()
@@ -146,7 +146,7 @@ export class ImageStatic extends AbstractGeoViewRaster {
     return new GVImageStatic(source, layerConfig);
   }
 
-  // Implement other abstract methods (onFetchAndSetServiceMetadata, etc.)
+  // Implement other abstract methods (onFetchServiceMetadata, etc.)
 }
 ```
 
@@ -215,7 +215,7 @@ export interface TypeImageStaticLayerConfig extends Omit<
 
 ## Step 5: Add Source Type
 
-Add your source type to `packages/geoview-core/src/geo/map/map-schema-types.ts`:
+Add your source type to `packages/geoview-core/src/api/types/layer-schema-types.ts`:
 
 ```typescript
 /**
@@ -293,8 +293,11 @@ The base class defines exactly **4 abstract methods**:
 protected abstract onFetchServiceMetadata<T>(abortSignal?: AbortSignal): Promise<T>;
 protected abstract onInitLayerEntries(): Promise<TypeGeoviewLayerConfig>;
 protected abstract onProcessLayerMetadata(
-  layerConfig: AbstractBaseLayerEntryConfig
-): Promise<void>;
+  layerConfig: AbstractBaseLayerEntryConfig,
+  displayDateMode: DisplayDateMode,
+  mapProjection?: OLProjection,
+  abortSignal?: AbortSignal
+): Promise<AbstractBaseLayerEntryConfig>;
 protected abstract onCreateGVLayer(
   layerConfig: AbstractBaseLayerEntryConfig
 ): AbstractGVLayer;
@@ -316,9 +319,9 @@ export class ImageStatic extends AbstractGeoViewRaster {
   /**
    * Fetches service metadata (not needed for static images).
    */
-  protected async onFetchServiceMetadata(): Promise<void> {
+  protected async onFetchServiceMetadata<T>(abortSignal?: AbortSignal): Promise<T> {
     // Static images don't have service metadata
-    return Promise.resolve();
+    return Promise.resolve(undefined as T);
   }
 
   /**
@@ -334,8 +337,12 @@ export class ImageStatic extends AbstractGeoViewRaster {
    */
   protected async onProcessLayerMetadata(
     layerConfig: AbstractBaseLayerEntryConfig,
-  ): Promise<void> {
+    displayDateMode: DisplayDateMode,
+    mapProjection?: OLProjection,
+    abortSignal?: AbortSignal,
+  ): Promise<AbstractBaseLayerEntryConfig> {
     // Process metadata for this layer entry
+    return layerConfig;
   }
 
   /**
@@ -350,24 +357,15 @@ export class ImageStatic extends AbstractGeoViewRaster {
 }
 ```
 
-## Step 8: Add to Layer Loading
+## Step 8: Add to Layer Creation Flow
 
-Add your layer type to the loading process in `packages/geoview-core/src/geo/layer/layer.ts`:
+Register your new layer type in the layer-creation orchestration path in `packages/geoview-core/src/core/controllers/layer-creator-controller.ts`.
 
-```typescript
-import {
-  ImageStatic,
-  layerConfigIsImageStatic,
-} from "./geoview-layers/raster/image-static";
+Specifically:
 
-// In the EVENT_ADD_LAYER handler:
-if (layerConfigIsImageStatic(layerConfig)) {
-  const imageStatic = new ImageStatic(this.mapId, layerConfig);
-  imageStatic.createGeoViewLayers().then(() => {
-    this.addToMap(imageStatic);
-  });
-}
-```
+1. Update `createLayerConfigFromType(...)` (or equivalent factory branch) so your new `geoviewLayerType` resolves to the right config class.
+2. Ensure your GeoView layer class is instantiated through the normal `addGeoviewLayer(...)` workflow (do not add an alternate event-specific loading path).
+3. Keep creation in controller flow so layer registration and layer-set/store synchronization stay consistent.
 
 ## Step 9: Update JSON Schema
 
@@ -449,7 +447,7 @@ Export your new types and classes from the appropriate index files:
 export * from "./image-static";
 ```
 
-### In `packages/geoview-core/src/geo/map/map-schema-types.ts`
+### In `packages/geoview-core/src/api/types/layer-schema-types.ts`
 
 ```typescript
 export type { TypeImageStaticLayerConfig, TypeImageStaticLayerEntryConfig };
@@ -610,7 +608,7 @@ protected applyStyle(olLayer: BaseLayer, styleConfig: any): void {
 
 ### Type Errors
 
-1. Verify all types are exported from `map-schema-types.ts`
+1. Verify all types are exported from `layer-schema-types.ts`
 2. Check type guard function signatures
 3. Ensure source type is added to union type
 
@@ -624,8 +622,8 @@ protected applyStyle(olLayer: BaseLayer, styleConfig: any): void {
 
 - **[GeoView Layers Guide](app/layers/layers.md)** - User-facing layer documentation
 - **[Layer API Reference](app/api/layer-api.md)** - API methods
-- **[Event Helper](programming/event-helper.md)** - Delegate event system
-- **[Best Practices](programming/best-practices.md)** - General coding standards
+- **[Event Helper](event-helper.md)** - Delegate event system
+- **[Best Practices](best-practices.md)** - General coding standards
 
 ## Example: Complete Layer Implementation
 

--- a/docs/programming/controller-architecture.md
+++ b/docs/programming/controller-architecture.md
@@ -36,14 +36,14 @@ UI Components  --> Controllers  --> Trigger actions / domain operations
 ### Design Principles
 
 1. **UI components** should:
-   - Read state values directly from store hooks (`useMapZoom()`, `useLayerLegendLayers()`)
+   - Read state values directly from store hooks (`useStoreMapZoom()`, `useStoreLayerSelectedLayerPath()`)
    - Access controllers via `useControllers()` hook to trigger actions
    - Never import Domains or store setter functions directly
 
 2. **Controllers** should:
    - Subscribe to Domain events and MapViewer events in `onHook()`
    - Perform actions on the domain
-   - Update the store via store helper functions (e.g., `setStoreActiveFooterBarTab()`) (at the moment the controllers also act as a store state adaptor)
+   - Update the store via store helper functions (e.g., `setStoreUIActiveFooterBarTab()`) (at the moment the controllers also act as a store state adaptor)
    - Delegate to other controllers via `getControllersRegistry()`
    - Clean up subscriptions in `onUnhook()`
 
@@ -54,7 +54,7 @@ UI Components  --> Controllers  --> Trigger actions / domain operations
 
 4. **Store state files** should:
    - Define the state interface (`IMapState`, `ILayerState`, etc.)
-   - Export React hooks for component consumption (`useMapZoom()`)
+   - Export React hooks for component consumption (`useStoreMapZoom()`)
    - Export store getter functions for non-component code (`getStoreMapZoom(mapId)`)
    - Define store adaptor functions to update the store via store actions
    - Define `actions` (setter functions that update state via `set()`)
@@ -71,7 +71,7 @@ UI Components  --> Controllers  --> Trigger actions / domain operations
 controllers.mapController.zoomMap(10);
 
 // ✅ New: Direct store update from within a controller
-setStoreActiveFooterBarTab(this.getMapId(), tab);
+setStoreUIActiveFooterBarTab(this.getMapId(), tab);
 ```
 
 ## Base Classes
@@ -107,10 +107,12 @@ Extends `AbstractController` with MapViewer access — the base class for all fr
 ```typescript
 export class AbstractMapViewerController extends AbstractController {
   #mapViewer: MapViewer;
+  #controllerRegistry: ControllerRegistry;
 
-  constructor(mapViewer: MapViewer) {
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
     super();
     this.#mapViewer = mapViewer;
+    this.#controllerRegistry = controllerRegistry;
   }
 
   protected getMapViewer(): MapViewer {
@@ -122,7 +124,7 @@ export class AbstractMapViewerController extends AbstractController {
   }
 
   protected getControllersRegistry(): ControllerRegistry {
-    return this.getMapViewer().controllers;
+    return this.#controllerRegistry;
   }
 }
 ```
@@ -313,8 +315,8 @@ export class CustomController extends AbstractMapViewerController {
   /** The bounded reference to the handle value changed */
   #boundedHandleValueChanged: DomainValueChangedDelegate;
 
-  constructor(mapViewer: MapViewer, customDomain: CustomDomain) {
-    super(mapViewer);
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry, customDomain: CustomDomain) {
+    super(mapViewer, controllerRegistry);
     this.#customDomain = customDomain;
 
     // Create bounded references in constructor for proper unhooking
@@ -374,8 +376,8 @@ For controllers that react to map events (clicks, pointer moves, etc.).
 
 ```typescript
 export class MapInteractionController extends AbstractMapViewerController {
-  constructor(mapViewer: MapViewer) {
-    super(mapViewer);
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(mapViewer, controllerRegistry);
   }
 
   protected override onHook(): void {
@@ -386,13 +388,13 @@ export class MapInteractionController extends AbstractMapViewerController {
   #handleMapClicked(mapViewer: MapViewer, event: MapSingleClickEvent): void {
     // Query layers, update store, etc.
     this.getControllersRegistry().layerSetController.queryAtLonLat(
-      event.longlat,
+      event.lonlat,
     );
   }
 
   #handlePointerMoved(mapViewer: MapViewer, event: MapPointerMoveEvent): void {
     // Update hover state in store
-    setStorePointerPosition(this.getMapId(), event.coordinate);
+    setStoreMapPointerPosition(this.getMapId(), event.coordinate);
   }
 }
 ```
@@ -403,8 +405,8 @@ For controllers that expose actions without subscribing to any events.
 
 ```typescript
 export class TimeSliderController extends AbstractMapViewerController {
-  constructor(mapViewer: MapViewer) {
-    super(mapViewer);
+  constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+    super(mapViewer, controllerRegistry);
   }
 
   // No onHook()/onUnhook() overrides needed
@@ -469,7 +471,7 @@ export class ControllerRegistry {
     geometryApi: GeometryApi,
   ) {
     // ... existing controllers ...
-    this.customController = new CustomController(mapViewer, customDomain);
+    this.customController = new CustomController(mapViewer, this, customDomain);
     this.allControllers.push(this.customController);
   }
 }
@@ -482,7 +484,7 @@ readonly customController?: CustomController;
 
 // In constructor
 if (hasCustomPlugin(getGeoViewStore(mapViewer.mapId))) {
-  this.customController = new CustomController(mapViewer);
+  this.customController = new CustomController(mapViewer, this, customDomain);
   this.allControllers.push(this.customController);
 }
 ```
@@ -511,11 +513,11 @@ export interface ICustomState {
 Components read state through selector hooks — one per state property:
 
 ```typescript
-// Naming pattern: use{SliceName}{PropertyName}
-export const useCustomSomeValue = (): string =>
+// Naming pattern: useStore{SliceName}{PropertyName}
+export const useStoreCustomSomeValue = (): string =>
   useStore(useGeoViewStore(), (state) => state.customState.someValue);
 
-export const useCustomItems = (): CustomItem[] =>
+export const useStoreCustomItems = (): CustomItem[] =>
   useStore(useGeoViewStore(), (state) => state.customState.items);
 ```
 
@@ -563,7 +565,7 @@ Controller calls store setter function (e.g., addStoreLayerEntry(mapId, layer))
   ↓
 Store updates state via actions
   ↓
-React hook (e.g., useLayerLegendLayers()) re-renders component
+React hook (e.g., useStoreLayerSelectedLayerPath()) re-renders component
 ```
 
 For UI-initiated actions:
@@ -599,7 +601,7 @@ checkInitTimeSliderLayerAndApplyFilters(layer: AbstractGVLayer): void {
 ```typescript
 // Inside LayerSetController
 #handleMapClicked(mapViewer: MapViewer, event: MapSingleClickEvent): void {
-  this.queryAtLonLat(event.longlat).catch((error: unknown) => {
+  this.queryAtLonLat(event.lonlat).catch((error: unknown) => {
     logger.logPromiseFailed('performQueryAtLonLat in #handleMapClicked', error);
   });
 }
@@ -635,7 +637,7 @@ checkInitTimeSliderLayerAndApplyFilters(layer: AbstractGVLayer): void {
 3. **Use store helper functions for state updates**
 
    ```typescript
-   setStoreActiveFooterBarTab(this.getMapId(), tab); // ✅ Clear intent
+   setStoreUIActiveFooterBarTab(this.getMapId(), tab); // ✅ Clear intent
    ```
 
 4. **Access sibling controllers through the registry**
@@ -689,10 +691,10 @@ checkInitTimeSliderLayerAndApplyFilters(layer: AbstractGVLayer): void {
 
    ```typescript
    // ❌ Bad: controller created but never hooked
-   this.customController = new CustomController(mapViewer);
+   this.customController = new CustomController(mapViewer, this, customDomain);
 
    // ✅ Good: added to the list for lifecycle management
-   this.customController = new CustomController(mapViewer);
+   this.customController = new CustomController(mapViewer, this, customDomain);
    this.allControllers.push(this.customController);
    ```
 
@@ -700,8 +702,8 @@ checkInitTimeSliderLayerAndApplyFilters(layer: AbstractGVLayer): void {
 
    ```typescript
    // ❌ Bad: subscribing in constructor (no cleanup guarantee)
-   constructor(mapViewer: MapViewer) {
-     super(mapViewer);
+   constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
+     super(mapViewer, controllerRegistry);
      this.#domain.onEvent(this.#handler);
    }
 
@@ -723,9 +725,11 @@ The following table summarizes all controllers, their purpose, dependencies, and
 | `LayerCreatorController` | Layer creation, removal, reload, GeoCore UUID resolution                                        | `LayerDomain`             | No (subscribes to GeoViewLayer events per-layer) | No                 |
 | `LayerSetController`     | Feature info queries, legends, layer sets                                                       | `LayerDomain`             | Yes (map click/pointer)                          | No                 |
 | `PluginController`       | Plugin loading, adding, removing                                                                | —                         | No                                               | No                 |
+| `DetailsController`      | Details panel feature info state and selection                                                  | —                         | No                                               | No                 |
 | `DataTableController`    | Data table filter operations                                                                    | —                         | No                                               | No                 |
 | `DrawerController`       | Drawing tools, transforms, undo/redo, styles                                                    | `UIDomain`, `GeometryApi` | Yes (language, projection)                       | Yes (drawer)       |
 | `TimeSliderController`   | Temporal filtering, time slider values                                                          | —                         | No                                               | Yes (time-slider)  |
+| `GeoChartController`     | Geochart panel state and chart-related actions                                                  | —                         | No                                               | Yes (geochart)     |
 
 ### UIController
 
@@ -819,7 +823,7 @@ LayerController.#handleLayerVisibleChanged receives it
   ↓
 LayerController updates the store via setStoreLayerVisibility()
   ↓
-React component re-renders via useLayerVisible() hook
+React component re-renders via useStoreLayerVisible() hook
 ```
 
 ## File Structure
@@ -849,9 +853,9 @@ packages/geoview-core/src/
 │   └── stores/
 │       ├── geoview-store.ts                    # Store composition (all slices)
 │       ├── stores-managers.ts                  # Store registry (getGeoViewStore)
-│       └── states/  # State slices
-│           ├── map-state.ts                    # useMapZoom(), getStoreMapZoom(), etc.
-│           ├── layer-state.ts                  # useLayerLegendLayers(), etc.
+│       └── states/                             # State slices
+│           ├── map-state.ts                    # useStoreMapZoom(), getStoreMapZoom(), etc.
+│           ├── layer-state.ts                  # useStoreLayerSelectedLayerPath(), etc.
 │           ├── ui-state.ts                     # useUIActiveFooterBarTab(), etc.
 │           ├── feature-info-state.ts
 │           ├── data-table-state.ts

--- a/docs/programming/event-helper.md
+++ b/docs/programming/event-helper.md
@@ -205,6 +205,6 @@ useEffect(() => {
 
 ## See Also
 
-- **[Using Zustand Store](programming/using-store.md)** — Store access patterns
-- **[Layer Set Architecture](programming/layerset-architecture.md)** — Layer sets use this event system
-- **[Best Practices](programming/best-practices.md)** — Coding standards
+- **[Using Zustand Store](using-store.md)** — Store access patterns
+- **[Layer Set Architecture](layerset-architecture.md)** — Layer sets use this event system
+- **[Best Practices](best-practices.md)** — Coding standards

--- a/docs/programming/using-store.md
+++ b/docs/programming/using-store.md
@@ -123,7 +123,7 @@ Inside a controller, access other controllers through `this.getControllersRegist
 
 ```ts
 // Inside a controller method
-this.getControllersRegistry().mapController.applyLayerFilters(layerPath);
+this.getControllersRegistry().layerSetController.triggerResetFeatureInfo(layerPath);
 this.getControllersRegistry().uiController.setCircularProgress(true);
 ```
 
@@ -152,5 +152,5 @@ this.mapViewer.controllers.timeSliderController?.checkInitTimeSliderLayerAndAppl
 
 ## See Also
 
-- **[Best Practices](programming/best-practices.md)** - Coding standards
-- **[Event Helper](programming/event-helper.md)** - Delegate event system
+- **[Best Practices](best-practices.md)** - Coding standards
+- **[Event Helper](event-helper.md)** - Delegate event system

--- a/packages/geoview-core/src/core/components/details/feature-info-table.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info-table.tsx
@@ -95,6 +95,7 @@ export const FeatureItem = memo(function FeatureItem({
   const { t } = useTranslation<string>();
   const theme = useTheme();
   const memoSxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const featureInfoItemIsTableFormat = featureInfoItem.alias !== 'html' && featureInfoItem.alias !== 'plain_text';
 
   /**
    * Gets the linkify options for converting text URLs into clickable links, memoized to avoid unnecessary recalculations.
@@ -114,7 +115,7 @@ export const FeatureItem = memo(function FeatureItem({
     [alias]
   );
 
-  if (alias === 'html') {
+  if (!featureInfoItemIsTableFormat) {
     return (
       <Box sx={memoSxClasses.featureInfoItemValue}>
         <UseHtmlToReact htmlContent={sanitizeHtmlContent(item)} />
@@ -182,6 +183,7 @@ export const FeatureRow = memo(function FeatureRow({
   const theme = useTheme();
   const memoSxClasses = useMemo(() => getSxClasses(theme), [theme]);
   const { alias, value } = featureInfoItem;
+  const featureInfoItemIsTableFormat = alias !== 'html' && alias !== 'plain_text';
 
   // Get the original value in an array
   let stringValues = useMemo(() => [''], []);
@@ -212,7 +214,7 @@ export const FeatureRow = memo(function FeatureRow({
 
   return (
     <TableRow className="feature-info-row" sx={memoSxClasses.featureInfoRow}>
-      {featureInfoItem.alias !== 'html' ? (
+      {featureInfoItemIsTableFormat ? (
         <>
           <TableCell component="th" scope="row">
             {alias}

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -106,6 +106,10 @@ const FeatureHeader = memo(function FeatureHeader({
   // Hooks
   const { t } = useTranslation<string>();
   const theme = useTheme();
+
+  /**
+   * Memoizes the style classes for the feature header.
+   */
   const memoSxClasses = useMemo(() => {
     logger.logTraceUseMemo('FEATURE-INFO - FeatureHeader - memoSxClasses', theme);
     return getSxClasses(theme);
@@ -202,6 +206,10 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
 
   // Hooks
   const theme = useTheme();
+
+  /**
+   * Memoizes the style classes for the feature info component.
+   */
   const memoSxClasses = useMemo(() => {
     logger.logTraceUseMemo('FEATURE-INFO - FeatureInfo - memoSxClasses', theme);
     return getSxClasses(theme);
@@ -243,17 +251,15 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
     logger.logTraceUseMemo('FEATURE-INFO - memoFeatureInfoList', feature.fieldInfo);
     if (!feature?.fieldInfo) return [];
 
-    return Object.entries(feature.fieldInfo)
-      .filter(([key]) => key !== feature.nameField)
-      .map(([fieldName, field]) => ({
-        fieldKey: field!.fieldKey,
-        value: field!.value,
-        dataType: field!.dataType,
-        alias:
-          feature.geoviewLayerType !== 'ogcWms' && feature.geoviewLayerType !== 'ogcWfs'
-            ? field!.alias || fieldName
-            : (field!.alias || fieldName).split('.').pop() || '',
-      }));
+    return Object.entries(feature.fieldInfo).map(([fieldName, field]) => ({
+      fieldKey: field!.fieldKey,
+      value: field!.value,
+      dataType: field!.dataType,
+      alias:
+        feature.geoviewLayerType !== 'ogcWms' && feature.geoviewLayerType !== 'ogcWfs'
+          ? field!.alias || fieldName
+          : (field!.alias || fieldName).split('.').pop() || '',
+    }));
   }, [feature]);
 
   /**

--- a/packages/geoview-core/src/core/components/details/feature-info.tsx
+++ b/packages/geoview-core/src/core/components/details/feature-info.tsx
@@ -236,8 +236,15 @@ export function FeatureInfo({ feature, containerType }: FeatureInfoProps): JSX.E
    */
   const memoFeatureName = useMemo(() => {
     logger.logTraceUseMemo('FEATURE-INFO - memoFeatureName', feature.nameField);
+
     // Try to get the value at the fieldName
-    const value = feature.nameField && (feature.fieldInfo?.[feature.nameField]?.value as string);
+    let value = feature.nameField && (feature.fieldInfo?.[feature.nameField]?.value as string);
+    // If nameField is 'html' or 'plain_text', treat it as undefined (WMS special fields)
+    if (feature.nameField === 'html' || feature.nameField === 'plain_text') {
+      value = undefined; // Clear the header value, because html or plain_text isn't a property -> value response
+    }
+
+    // Return the header value
     return value ?? 'No name / Sans nom';
   }, [feature]);
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/esri-layer-common.ts
@@ -495,7 +495,7 @@ export class EsriUtilities {
       layerConfig.initOutfieldsAliases();
 
       // Initialize the name field
-      layerConfig.initNameField(layerMetadataEsriDynamicLayer.displayField ?? outfields?.[0]?.name);
+      layerConfig.initNameField(layerMetadataEsriDynamicLayer.displayField);
     }
   }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -34,7 +34,6 @@ import {
 } from '@/core/exceptions/layer-entry-config-exceptions';
 import { deepMergeObjects, generateId, normalizeDatacubeAccessPath } from '@/core/utils/utilities';
 import { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
-import { AbstractGeoViewVector } from '@/geo/layer/geoview-layers/vector/abstract-geoview-vector';
 import { GVWMS } from '@/geo/layer/gv-layers/raster/gv-wms';
 import type { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
 import { WfsRenderer } from '@/geo/utils/renderer/wfs-renderer';
@@ -1195,20 +1194,6 @@ export class WMS extends AbstractGeoViewRaster {
 
         // Override the outfields of the WMS to leverage possibilities working with a WMS layer, like knowing the field types when performing WMS queries
         layerConfig.setOutfields(outFields);
-
-        // Validate and sync the nameField from WFS to WMS
-        const nameField = layerConfig.getNameField();
-        const nameFieldIsValid = nameField && outFields.some((field) => field.name === nameField);
-
-        if (!nameFieldIsValid) {
-          // WFS nameField is invalid or missing - warn and default to first field
-          if (nameField) {
-            logger.logWarning(
-              `The WFS-derived nameField '${nameField}' for WMS layer ${layerConfig.layerPath} does not exist in the outfields. Using best available field.`
-            );
-          }
-          layerConfig.setNameField(AbstractGeoViewVector.findBestNameField(outFields));
-        }
 
         // If no layer style defined
         if (!layerConfig.getLayerStyle()) {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -34,7 +34,6 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
     .concat(this.EXCLUDED_HEADERS_GEN)
     .concat(this.EXCLUDED_HEADERS_STYLE);
 
-  static readonly NAME_FIELD_KEYWORDS = ['^name$', '^title$', '^label$'];
   static readonly MAX_ESRI_FEATURES = 200000;
 
   // #region OVERRIDES
@@ -269,56 +268,8 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
     // Initialize the aliases
     layerConfig.initOutfieldsAliases();
 
-    // If no name field
-    const nameField = layerConfig.getNameField();
-    if (nameField) {
-      // A nameField was provided (likely from metadata) - validate it exists in outfields
-      const fieldExists = outfields.some((field) => field.name === nameField);
-
-      if (!fieldExists) {
-        // The provided nameField doesn't exist in the actual data - need to replace it
-        logger.logWarning(
-          `The configured nameField '${nameField}' does not exist in the layer's outfields. Replacing with a default value.`
-        );
-
-        // Replace the invalid nameField with a smart default
-        layerConfig.setNameField(this.findBestNameField(outfields));
-      }
-      // If fieldExists is true, the nameField is valid - no action needed
-    } else {
-      // No nameField provided - try to set nameField to a name field
-      const newNameField = this.findBestNameField(outfields);
-
-      // Set the name field to the first attribute by default if no nameField is specified already
-      layerConfig.initNameField(newNameField ?? outfields?.[0]?.name);
-    }
-
     // Vector layer only queryable if there are fields
     layerConfig.initQueryableSource(outfields.length > 0);
-  }
-
-  /**
-   * Finds the best field to use as a name field by searching for common name-like field patterns.
-   *
-   * Searches the outfields array for fields matching predefined keywords (name, title, label) in priority order.
-   * If no keyword match is found, returns the first field as a fallback.
-   *
-   * @param outfields - Array of outfields to search
-   * @returns The name of the best matching field, or undefined if no fields available
-   */
-  static findBestNameField(outfields: TypeOutfields[]): string | undefined {
-    if (!outfields.length) return undefined;
-
-    // Try to find a field matching name keywords in priority order
-    const nameField = this.NAME_FIELD_KEYWORDS.reduce<TypeOutfields | undefined>((found, keyword) => {
-      if (found) return found;
-      return outfields.find((field) => {
-        return new RegExp(keyword, 'i').test(field.name);
-      });
-    }, undefined);
-
-    // Return the matched field name, or fall back to the first field
-    return nameField?.name ?? outfields[0]?.name;
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
@@ -292,9 +292,6 @@ export class OgcFeature extends AbstractGeoViewVector {
 
     // Initialize the aliases
     layerConfig.initOutfieldsAliases();
-
-    // Initialize the name field
-    layerConfig.initNameField(outfields?.[0]?.name);
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -624,9 +624,6 @@ export class WFS extends AbstractGeoViewVector {
       // Set it
       layerConfig.setOutfields(outfields);
     }
-
-    // Set the name field to the first attribute by default if no nameField is specified already
-    layerConfig.initNameField(outfields?.[0]?.name);
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -31,6 +31,8 @@ import type {
   TypeFeatureInfoResult,
   codedValueType,
   rangeDomainType,
+  TypeDisplayLanguage,
+  TypeFieldEntry,
 } from '@/api/types/map-schema-types';
 import type {
   TypeLayerMetadataFields,
@@ -60,6 +62,22 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
 
   /** The default loading period before we show a message to the user about a layer taking a long time to render on map */
   static readonly DEFAULT_LOADING_PERIOD: number = 8 * 1000; // 8 seconds
+
+  /** Keywords used to identify name fields in the layer's outfields when none specified. */
+  static readonly NAME_FIELD_KEYWORDS = [
+    '^name$',
+    '^name_lang$', // GV Here and others, '_lang' suffix is a placeholder to favor the current language of the application
+    '^title$',
+    '^title_lang$',
+    '^label$',
+    '^label_lang$',
+    '^project_name$',
+    '^project_name_lang$',
+    '^display*',
+    '^id$',
+    '^objectid$',
+    '^oid$',
+  ];
 
   /** Counts the number of times the loading happened. */
   loadingCounter = 0;
@@ -366,12 +384,21 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    *
    * @param map - The Map so that we can grab the resolution/projection we want to get features on
    * @param layerFilters - The layer filters to apply when querying the features
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    * @throws {NotImplementedError} When the function isn't overridden by the children class
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected getAllFeatureInfo(map: OLMap, layerFilters: LayerFilters, abortController?: AbortController): Promise<TypeFeatureInfoResult> {
+  protected getAllFeatureInfo(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    map: OLMap,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    layerFilters: LayerFilters,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    abortController?: AbortController
+  ): Promise<TypeFeatureInfoResult> {
     // Crash on purpose
     throw new NotImplementedError(`getAllFeatureInfo not implemented on layer path ${this.getLayerPath()}`);
   }
@@ -382,6 +409,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    * @param map - The Map where to get Feature Info At Pixel from
    * @param location - The pixel coordinate that will be used by the query
    * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    */
@@ -389,10 +417,11 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     map: OLMap,
     location: Pixel,
     queryGeometry = true,
+    language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     abortController: AbortController | undefined = undefined
   ): Promise<TypeFeatureInfoResult> {
     // Redirect to getFeatureInfoAtCoordinate
-    return this.getFeatureInfoAtCoordinate(map, map.getCoordinateFromPixel(location), queryGeometry, abortController);
+    return this.getFeatureInfoAtCoordinate(map, map.getCoordinateFromPixel(location), queryGeometry, language, abortController);
   }
 
   /**
@@ -401,6 +430,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    * @param map - The Map where to get Feature Info At Coordinate from
    * @param location - The coordinate that will be used by the query
    * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    * @throws {NotImplementedError} When the function isn't overridden by the children class
@@ -410,6 +440,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     location: Coordinate,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     queryGeometry = true,
+    language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     abortController: AbortController | undefined = undefined
   ): Promise<TypeFeatureInfoResult> {
@@ -423,6 +454,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    * @param map - The Map where to get Feature Info At LonLat from
    * @param lonlat - The coordinate that will be used by the query
    * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    * @throws {NotImplementedError} When the function isn't overridden by the children class
@@ -432,6 +464,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     lonlat: Coordinate,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     queryGeometry = true,
+    language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     abortController: AbortController | undefined = undefined
   ): Promise<TypeFeatureInfoResult> {
@@ -445,6 +478,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    * @param map - The Map where to get Feature using BBox from
    * @param location - The bounding box that will be used by the query
    * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    * @throws {NotImplementedError} When the function isn't overridden by the children class
@@ -454,6 +488,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     location: Coordinate[],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     queryGeometry = true,
+    language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     abortController: AbortController | undefined = undefined
   ): Promise<TypeFeatureInfoResult> {
@@ -467,6 +502,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    * @param map - The Map where to get Feature Info using Polygon from
    * @param location - The polygon that will be used by the query
    * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    * @throws {NotImplementedError} When the function isn't overridden by the children class
@@ -476,6 +512,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     location: Coordinate[],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     queryGeometry = true,
+    language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     abortController: AbortController | undefined = undefined
   ): Promise<TypeFeatureInfoResult> {
@@ -845,6 +882,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    * @param queryType - The type of query to perform
    * @param location - A pixel, coordinate or polygon that will be used by the query
    * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    */
@@ -853,6 +891,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     queryType: QueryType,
     location: TypeLocation,
     queryGeometry = true,
+    language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     abortController: AbortController | undefined = undefined
   ): Promise<TypeFeatureInfoResult> {
     // Log
@@ -867,23 +906,23 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
         const layerFilters = new LayerFilters(this.getLayerFilters().getInitialFilter());
 
         // Get all feature info
-        promiseGetFeature = this.getAllFeatureInfo(map, layerFilters, abortController);
+        promiseGetFeature = this.getAllFeatureInfo(map, layerFilters, language, abortController);
         break;
       }
       case 'at_pixel':
-        promiseGetFeature = this.getFeatureInfoAtPixel(map, location as Pixel, queryGeometry, abortController);
+        promiseGetFeature = this.getFeatureInfoAtPixel(map, location as Pixel, queryGeometry, language, abortController);
         break;
       case 'at_coordinate':
-        promiseGetFeature = this.getFeatureInfoAtCoordinate(map, location as Coordinate, queryGeometry, abortController);
+        promiseGetFeature = this.getFeatureInfoAtCoordinate(map, location as Coordinate, queryGeometry, language, abortController);
         break;
       case 'at_lon_lat':
-        promiseGetFeature = this.getFeatureInfoAtLonLat(map, location as Coordinate, queryGeometry, abortController);
+        promiseGetFeature = this.getFeatureInfoAtLonLat(map, location as Coordinate, queryGeometry, language, abortController);
         break;
       case 'using_a_bounding_box':
-        promiseGetFeature = this.getFeatureInfoUsingBBox(map, location as Coordinate[], queryGeometry, abortController);
+        promiseGetFeature = this.getFeatureInfoUsingBBox(map, location as Coordinate[], queryGeometry, language, abortController);
         break;
       case 'using_a_polygon':
-        promiseGetFeature = this.getFeatureInfoUsingPolygon(map, location as Coordinate[], queryGeometry, abortController);
+        promiseGetFeature = this.getFeatureInfoUsingPolygon(map, location as Coordinate[], queryGeometry, language, abortController);
         break;
       default:
         // Not implemented
@@ -1080,6 +1119,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    *
    * @param features - Array of features to format
    * @param layerConfig - Configuration of the associated layer
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param serviceDateFormat - Optional date format used by the service
    * @param serviceDateIANA - Optional IANA time zone identifier used by the service
    * @param serviceDateTemporalMode - Optional temporal mode for date handling
@@ -1088,6 +1128,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
   protected formatFeatureInfoResult(
     features: Feature[],
     layerConfig: OgcWmsLayerEntryConfig | EsriDynamicLayerEntryConfig | EsriImageLayerEntryConfig | VectorLayerEntryConfig,
+    language: TypeDisplayLanguage,
     serviceDateFormat: string | undefined,
     serviceDateIANA: string | undefined,
     serviceDateTemporalMode: TemporalMode | undefined
@@ -1101,12 +1142,15 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     // Get the fields from metadata if any
     const domainsLookup = layerMetadataEsriDynamicLayer?.fields;
 
+    // Find the best name field and validate its existance at the same time when one was initially configured
+    const nameField = AbstractGVLayer.findBestNameField(layerConfig.getNameField(), layerConfig.getOutfields(), language);
+
     // Redirect
     return AbstractGVLayer.helperFormatFeatureInfoResult(
       features,
       layerConfig.layerPath,
       layerConfig.getSchemaTag(),
-      layerConfig.getNameField(),
+      nameField,
       layerConfig.getOutfields(),
       true,
       domainsLookup,
@@ -1357,7 +1401,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    * Sets the layer filters associated to the layer.
    *
    * @param layerFilters - The layer filters to apply
-   * @param refresh - Whether to trigger a layer re-render after setting filters
+   * @param filterCategoryChanged - The filter category that changed
    */
   #setLayerFilters(layerFilters: LayerFilters, filterCategoryChanged: FilterCategory): void {
     // Keep it
@@ -1775,6 +1819,58 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     if (layerConfig.getInitialSettings()?.states?.opacity !== undefined)
       // eslint-disable-next-line no-param-reassign
       layerOptions.opacity = layerConfig.getInitialSettings()?.states!.opacity;
+  }
+
+  /**
+   * Finds the best field to use as a name field by searching for common name-like field patterns.
+   *
+   * Searches field names for predefined keywords (name, title, label) in priority order.
+   * Supports both outfields arrays and field info dictionaries keyed by field name.
+   * If no keyword match is found, returns the first available field name as a fallback.
+   *
+   * @param nameField - Optional provided name field to validate and use first
+   * @param outfields - Outfields array or field info dictionary to search
+   * @param lang - The display language used to resolve `_lang` placeholders in keyword patterns
+   * @returns The name of the best matching field, or undefined if no fields available
+   */
+  static findBestNameField(
+    nameField: string | undefined,
+    outfields: TypeOutfields[] | Partial<Record<string, TypeFieldEntry>> | undefined = [],
+    lang: TypeDisplayLanguage = 'en'
+  ): string | undefined {
+    // Normalize to a simple list of field names regardless of input shape.
+    const fieldNames = Array.isArray(outfields)
+      ? outfields.map((field) => field.name)
+      : Object.keys(outfields).filter((key) => outfields[key] !== undefined);
+
+    if (!fieldNames.length) return undefined;
+
+    // If a nameField was provided, only keep it when it actually exists in the outfields.
+    const validProvidedNameField = nameField && fieldNames.includes(nameField) ? nameField : undefined;
+    if (validProvidedNameField) return validProvidedNameField;
+
+    const languagePriority: TypeDisplayLanguage[] = [
+      lang,
+      ...(['en', 'fr'] as TypeDisplayLanguage[]).filter((language) => language !== lang),
+    ];
+
+    // Try to find a field matching name keywords in priority order.
+    // For _lang keywords, try the requested language first, then the alternate language.
+    const resolvedNameField = this.NAME_FIELD_KEYWORDS.reduce<string | undefined>((found, keyword) => {
+      if (found) return found;
+
+      const resolvedKeywords = keyword.includes('_lang')
+        ? languagePriority.map((language) => keyword.replace('_lang', `_${language}`))
+        : [keyword];
+
+      return resolvedKeywords.reduce<string | undefined>((matchedFieldName, resolvedKeyword) => {
+        if (matchedFieldName) return matchedFieldName;
+        return fieldNames.find((fieldName) => new RegExp(resolvedKeyword, 'i').test(fieldName));
+      }, undefined);
+    }, undefined);
+
+    // Return the matched field name, or fall back to the first field.
+    return resolvedNameField ?? fieldNames[0];
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/gv-group-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/gv-group-layer.ts
@@ -26,8 +26,8 @@ export class GVGroupLayer extends AbstractBaseGVLayer {
   /**
    * Constructs a Group layer to manage an OpenLayer Group Layer.
    *
-   * @param layerGroupOptions - The OpenLayer group layer.
-   * @param layerConfig - The layer configuration.
+   * @param layerGroupOptions - The OpenLayer group layer
+   * @param layerConfig - The layer configuration
    */
   constructor(layerGroupOptions: LayerGroupOptions, layerConfig: GroupLayerEntryConfig) {
     super(layerConfig);
@@ -207,7 +207,7 @@ export class GVGroupLayer extends AbstractBaseGVLayer {
   /**
    * Adds a layer to the group layer.
    *
-   * @param layer - The layer to add.
+   * @param layer - The layer to add
    */
   addLayer(layer: AbstractBaseGVLayer): void {
     // Officially add it to the OL object
@@ -216,12 +216,8 @@ export class GVGroupLayer extends AbstractBaseGVLayer {
     // Set its parent right away
     layer.setParent(this);
 
-    // Re-apply the child's opacity through setOpacity to trigger capping by the parent's opacity.
-    // The initial opacity was set via OL constructor options which bypasses the GV onSetOpacity capping logic.
-    // Uses layer.getOpacity() (the child's own opacity) rather than this.getOpacity() (the parent's opacity),
-    // because onSetOpacity will clamp it to Math.min(parent.getOpacity(), childOpacity) internally.
-    // TODO: check why layer.setOpacity(this.getOpacity(), false) is not working properly for test Group 3, map config.
-    layer.setOpacity(layer.getOpacity(), false);
+    // Ensure the child respects the parent opacity cap as soon as it joins the group.
+    if (layer.getOpacity() > this.getOpacity()) layer.setOpacity(this.getOpacity(), false);
 
     // Add the layer to our list
     this.#layers.push(layer);
@@ -233,7 +229,8 @@ export class GVGroupLayer extends AbstractBaseGVLayer {
   /**
    * Removes a layer from the group layer.
    *
-   * @param layer - The layer to remove.
+   * @param layer - The layer to remove
+   * @throws {LayerNotFoundError} When the layer is not found in the group
    */
   removeLayer(layer: AbstractBaseGVLayer): void {
     // Try to find it
@@ -344,14 +341,10 @@ export class GVGroupLayer extends AbstractBaseGVLayer {
   // #endregion EVENTS
 }
 
-/**
- * Define an event for the delegate
- */
+/** Defines an event for the delegate. */
 export interface LayerGroupChildrenUpdatedEvent<T extends AbstractBaseGVLayer = AbstractBaseGVLayer> extends LayerBaseEvent {
   child: T;
 }
 
-/**
- * Define a delegate for the event handler function signature
- */
+/** Defines a delegate for the event handler function signature. */
 export type LayerGroupChildrenUpdatedDelegate = EventDelegateBase<GVGroupLayer, LayerGroupChildrenUpdatedEvent, void>;

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -22,6 +22,7 @@ import type {
   TypeValidMapProjectionCodes,
   TypeIconSymbolVectorConfig,
   TypeFeatureInfoEntryPartial,
+  TypeDisplayLanguage,
 } from '@/api/types/map-schema-types';
 import type { TypeLayerMetadataEsriExtent, TypeLegend } from '@/api/types/layer-schema-types';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
@@ -282,14 +283,16 @@ export class GVEsriDynamic extends AbstractGVRaster {
   /**
    * Overrides the get all feature information for all the features stored in the layer.
    *
-   * @param map - The Map so that we can grab the resolution/projection we want to get features on.
-   * @param layerFilters - The layer filters to apply when querying the features.
-   * @param abortController - Optional {@link AbortController} to cancel the operation.
+   * @param map - The Map so that we can grab the resolution/projection we want to get features on
+   * @param layerFilters - The layer filters to apply when querying the features
+   * @param language - The display language, used to guess the best name field for the 'nameField'
+   * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    */
   protected override async getAllFeatureInfo(
     map: OLMap,
     layerFilters: LayerFilters,
+    language: TypeDisplayLanguage,
     abortController?: AbortController
   ): Promise<TypeFeatureInfoResult> {
     // Get the layer config in a loaded phase
@@ -321,6 +324,7 @@ export class GVEsriDynamic extends AbstractGVRaster {
         results: this.formatFeatureInfoResult(
           features,
           layerConfig,
+          language,
           layerConfig.getServiceDateFormat(),
           layerConfig.getServiceDateTimezone(),
           layerConfig.getServiceDateTemporalMode()
@@ -335,32 +339,35 @@ export class GVEsriDynamic extends AbstractGVRaster {
   /**
    * Overrides the return of feature information at a given coordinate.
    *
-   * @param map - The Map where to get Feature Info At Coordinate from.
-   * @param location - The coordinate that will be used by the query.
-   * @param queryGeometry - Whether to include geometry in the query, default is true.
-   * @param abortController - Optional {@link AbortController} to cancel the operation.
+   * @param map - The Map where to get Feature Info At Coordinate from
+   * @param location - The coordinate that will be used by the query
+   * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field for the 'nameField'
+   * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    */
   protected override getFeatureInfoAtCoordinate(
     map: OLMap,
     location: Coordinate,
     queryGeometry = true,
+    language: TypeDisplayLanguage,
     abortController: AbortController | undefined = undefined
   ): Promise<TypeFeatureInfoResult> {
     // Transform coordinate from map projection to lntlat
     const projCoordinate = Projection.transformToLonLat(location, map.getView().getProjection());
 
     // Redirect to getFeatureInfoAtLonLat
-    return this.getFeatureInfoAtLonLat(map, projCoordinate, queryGeometry, abortController);
+    return this.getFeatureInfoAtLonLat(map, projCoordinate, queryGeometry, language, abortController);
   }
 
   /**
    * Overrides the return of feature information at the provided long lat coordinate.
    *
-   * @param map - The Map where to get Feature Info At LonLat from.
-   * @param lonlat - The coordinate that will be used by the query.
-   * @param queryGeometry - Whether to include geometry in the query, default is true.
-   * @param abortController - Optional {@link AbortController} to cancel the operation.
+   * @param map - The Map where to get Feature Info At LonLat from
+   * @param lonlat - The coordinate that will be used by the query
+   * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
+   * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    * @throws {LayerDataAccessPathMandatoryError} When the Data Access Path was undefined, likely because initDataAccessPath wasn't called.
    */
@@ -368,6 +375,7 @@ export class GVEsriDynamic extends AbstractGVRaster {
     map: OLMap,
     lonlat: Coordinate,
     queryGeometry = true,
+    language: TypeDisplayLanguage,
     abortController: AbortController | undefined = undefined
   ): Promise<TypeFeatureInfoResult> {
     // The FeatureInfoResult object that will be returned
@@ -445,6 +453,7 @@ export class GVEsriDynamic extends AbstractGVRaster {
     featureInfoResult.results = this.formatFeatureInfoResult(
       features,
       layerConfig,
+      language,
       layerConfig.getServiceDateFormatIdentify(),
       layerConfig.getServiceDateTimezone(),
       layerConfig.getServiceDateTemporalMode()

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-image.ts
@@ -16,6 +16,7 @@ import { logger } from '@/core/utils/logger';
 import { Fetch } from '@/core/utils/fetch-helper';
 import type { EsriImageLayerEntryConfig } from '@/api/config/validation-classes/raster-validation-classes/esri-image-layer-entry-config';
 import type {
+  TypeDisplayLanguage,
   TypeFeatureInfoEntry,
   TypeFeatureInfoResult,
   TypeFieldEntry,
@@ -238,28 +239,45 @@ export class GVEsriImage extends AbstractGVRaster {
   /**
    * Overrides the return of feature information at a given coordinate.
    *
-   * @param map - The Map where to get Feature Info At Coordinate from.
-   * @param location - The coordinate that will be used by the query.
-   * @param queryGeometry - Whether to include geometry in the query, default is true.
+   * @param map - The Map where to get Feature Info At Coordinate from
+   * @param location - The coordinate that will be used by the query
+   * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field for the 'nameField'
+   * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    */
-  protected override getFeatureInfoAtCoordinate(map: OLMap, location: Coordinate, queryGeometry = true): Promise<TypeFeatureInfoResult> {
+  protected override getFeatureInfoAtCoordinate(
+    map: OLMap,
+    location: Coordinate,
+    queryGeometry = true,
+    language: TypeDisplayLanguage,
+    abortController?: AbortController
+  ): Promise<TypeFeatureInfoResult> {
     // Transform coordinate from map projection to lntlat
     const projCoordinate = Projection.transformToLonLat(location, map.getView().getProjection());
 
     // Redirect to getFeatureInfoAtLonLat
-    return this.getFeatureInfoAtLonLat(map, projCoordinate, queryGeometry);
+    return this.getFeatureInfoAtLonLat(map, projCoordinate, queryGeometry, language, abortController);
   }
 
   /**
    * Overrides the return of feature information at the provided long lat coordinate.
    *
-   * @param map - The Map where to get Feature Info At LonLat from.
-   * @param lonlat - The coordinate that will be used by the query.
-   * @param queryGeometry - Optional, whether to include geometry in the query, default is true.
+   * @param map - The Map where to get Feature Info At LonLat from
+   * @param lonlat - The coordinate that will be used by the query
+   * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
+   * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    */
-  protected override async getFeatureInfoAtLonLat(map: OLMap, lonlat: Coordinate, queryGeometry = true): Promise<TypeFeatureInfoResult> {
+  protected override async getFeatureInfoAtLonLat(
+    map: OLMap,
+    lonlat: Coordinate,
+    queryGeometry = true,
+    language: TypeDisplayLanguage,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    abortController?: AbortController
+  ): Promise<TypeFeatureInfoResult> {
     const featureInfoResult: TypeFeatureInfoResult = { results: [] };
 
     // If invisible or not queryable, return empty result
@@ -373,6 +391,7 @@ export class GVEsriImage extends AbstractGVRaster {
     featureInfoResult.results = this.formatFeatureInfoResult(
       [feature],
       layerConfig,
+      language,
       layerConfig.getServiceDateFormat(),
       layerConfig.getServiceDateTimezone(),
       layerConfig.getServiceDateTemporalMode()
@@ -395,6 +414,7 @@ export class GVEsriImage extends AbstractGVRaster {
   protected override formatFeatureInfoResult(
     features: Feature[],
     layerConfig: EsriImageLayerEntryConfig,
+    language: TypeDisplayLanguage,
     serviceDateFormat: string | undefined,
     serviceDateIANA: string | undefined,
     serviceDateTemporalMode: TemporalMode | undefined
@@ -408,7 +428,14 @@ export class GVEsriImage extends AbstractGVRaster {
     }));
 
     // Call parent to get base formatting
-    const baseResults = super.formatFeatureInfoResult(features, layerConfig, serviceDateFormat, serviceDateIANA, serviceDateTemporalMode);
+    const baseResults = super.formatFeatureInfoResult(
+      features,
+      layerConfig,
+      language,
+      serviceDateFormat,
+      serviceDateIANA,
+      serviceDateTemporalMode
+    );
 
     // Get legend data for RGBA extraction and icon assignment
     const legend = this.getLegend();

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -1410,7 +1410,17 @@ export class GVWMS extends AbstractGVRaster {
       abortController
     );
 
-    // Read the response as json
+    // Check if the response is a WMS ServiceException XML
+    const parser = new DOMParser();
+    const xmlTestDoc = parser.parseFromString(responseData, 'application/xml');
+    if (
+      xmlTestDoc.documentElement?.localName?.toLowerCase() === 'serviceexceptionreport' ||
+      xmlTestDoc.documentElement?.localName?.toLowerCase() === 'serviceexception'
+    ) {
+      throw new LayerInvalidFeatureInfoFormatWMSError(layerConfig.layerPath, infoFormat, layerConfig.getLayerNameCascade());
+    }
+
+    // Read the response as html
     const xmlDomResponse = new DOMParser().parseFromString(responseData, 'text/html');
 
     // Get body text content and trim it
@@ -1463,9 +1473,19 @@ export class GVWMS extends AbstractGVRaster {
       abortController
     );
 
+    // Sanitize response by stripping any HTML/XML nodes and keeping only text content
+    const parser = new DOMParser();
+    const htmlDoc = parser.parseFromString(responseData, 'text/html');
+    const sanitizedText = htmlDoc.body?.textContent?.trim() || '';
+
+    // If no meaningful text remains after sanitization, treat as invalid
+    if (!sanitizedText) {
+      throw new LayerInvalidFeatureInfoFormatWMSError(layerConfig.layerPath, 'text/plain', layerConfig.getLayerNameCascade());
+    }
+
     // The response is in plain format
     // eslint-disable-next-line camelcase
-    return { plain_text: { '#text': responseData } };
+    return { plain_text: { '#text': sanitizedText } };
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -831,8 +831,6 @@ export class GVWMS extends AbstractGVRaster {
     // Log the various info format supported for the layer, keeping the line commented, useful for debugging
     // logger.logDebug(layerConfig.getLayerNameCascade(), featureInfoFormat);
 
-    // TODO: WMS - Add support for application/vnd.ogc.gml GV issue #3134
-
     // If the info format includes GEOJSON
     let featureMember: Record<string, unknown>[] | undefined;
     if (featureInfoFormat.includes('application/geojson')) {
@@ -883,6 +881,32 @@ export class GVWMS extends AbstractGVRaster {
         // Failed to retrieve featureMember using Json, eat the error, we'll try with another format
         logger.logError(
           `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using JSON, eat the error, we'll try with another format`,
+          error
+        );
+      }
+    }
+
+    // If not found and format includes application/vnd.ogc.gml
+    if (!featureMember && featureInfoFormat.includes('application/vnd.ogc.gml')) {
+      try {
+        // Try to get the feature member using GML format
+        featureMember = await GVWMS.#getFeatureInfoUsingGML(
+          wmsLayerConfig,
+          wmsSource,
+          clickCoordinate,
+          viewResolution,
+          this.getGetFeatureInfoTolerance(),
+          projectionCode,
+          this.getGetFeatureInfoFeatureCount(),
+          abortController
+        );
+
+        // Keep in mind, this output format works
+        this.#featureOutputFormatWMSWorked = 'application/vnd.ogc.gml';
+      } catch (error: unknown) {
+        // Failed to retrieve featureMember using GML, eat the error, we'll try with another format
+        logger.logError(
+          `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using GML, eat the error, we'll try with another format`,
           error
         );
       }
@@ -1140,6 +1164,97 @@ export class GVWMS extends AbstractGVRaster {
 
     // If found
     if (featureMember) {
+      // Success!
+      return featureMember;
+    }
+
+    // Failed
+    throw new LayerInvalidFeatureInfoFormatWMSError(layerConfig.layerPath, infoFormat, layerConfig.getLayerNameCascade());
+  }
+
+  /**
+   * Retrieves feature information from a WMS layer using the `application/vnd.ogc.gml` info format.
+   *
+   * This method performs a `GetFeatureInfo` request and parses namespaced GML responses into a
+   * standardized array of feature-member records. It supports both standard `gml:featureMember`
+   * payloads and fallback payloads that omit that wrapper.
+   *
+   * @param layerConfig - Configuration object for the target WMS layer
+   * @param wmsSource - The OpenLayers WMS source used to construct the request
+   * @param clickCoordinate - The coordinate on the map where the user clicked
+   * @param viewResolution - The current resolution of the map view
+   * @param qgisServerTolerance - The QGIS Server feature info pixel tolerance
+   * @param projectionCode - The projection in which the request should be made (e.g., 'EPSG:3857')
+   * @param maxFeatures - Optional maximum number of features to include in response when we want more than 1
+   * @param abortController - Optional {@link AbortController} to allow cancellation of the request
+   * @returns A promise that resolves with an array of feature member records
+   */
+  static async #getFeatureInfoUsingGML(
+    layerConfig: OgcWmsLayerEntryConfig,
+    wmsSource: ImageWMS,
+    clickCoordinate: Coordinate,
+    viewResolution: number,
+    qgisServerTolerance: number,
+    projectionCode: ProjectionLike,
+    maxFeatures: number | undefined,
+    abortController: AbortController | undefined = undefined
+  ): Promise<Record<string, unknown>[]> {
+    // The info format
+    const infoFormat = 'application/vnd.ogc.gml';
+
+    // Try to get the information using GML format
+    const responseData = await GVWMS.#readFeatureInfo(
+      layerConfig,
+      wmsSource,
+      clickCoordinate,
+      viewResolution,
+      qgisServerTolerance,
+      projectionCode,
+      infoFormat,
+      maxFeatures,
+      abortController
+    );
+
+    // Parse the content as XML
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(responseData, 'application/xml');
+
+    // Abort if XML could not be parsed
+    if (xmlDoc.getElementsByTagName('parsererror').length > 0) {
+      throw new LayerInvalidFeatureInfoFormatWMSError(layerConfig.layerPath, infoFormat, layerConfig.getLayerNameCascade());
+    }
+
+    // Preferred path: parse standard gml:featureMember entries using localName for namespace safety.
+    const allElements = Array.from(xmlDoc.getElementsByTagName('*'));
+    const featureMemberElements = allElements.filter((element) => element.localName === 'featureMember');
+
+    const featureMember: Record<string, unknown>[] = [];
+    featureMemberElements.forEach((featureMemberElement): void => {
+      const featureElements = GVWMS.#getXmlChildElements(featureMemberElement);
+
+      // A featureMember usually wraps exactly one feature element, but process all to be safe.
+      featureElements.forEach((featureElement): void => {
+        featureMember.push(GVWMS.#convertXmlElementToRecord(featureElement));
+      });
+    });
+
+    // Fallback path: some services don't use gml:featureMember.
+    if (featureMember.length === 0 && xmlDoc.documentElement) {
+      const fallbackCandidates = allElements.filter((element) => {
+        const children = GVWMS.#getXmlChildElements(element);
+        if (children.length === 0) return false;
+
+        // Candidate features have at least one non-GML direct child field.
+        return children.some((child) => child.prefix !== 'gml' && GVWMS.#getXmlChildElements(child).length === 0);
+      });
+
+      fallbackCandidates.forEach((candidate): void => {
+        featureMember.push(GVWMS.#convertXmlElementToRecord(candidate));
+      });
+    }
+
+    // If found
+    if (featureMember.length > 0) {
       // Success!
       return featureMember;
     }
@@ -1488,6 +1603,65 @@ export class GVWMS extends AbstractGVRaster {
   }
 
   /**
+   * Filters child nodes and returns only direct child Element nodes.
+   *
+   * @param element - The parent element whose children will be filtered
+   * @returns An array containing only Element-type child nodes
+   */
+  static #getXmlChildElements(element: Element): Element[] {
+    return Array.from(element.childNodes).filter((node): node is Element => node.nodeType === Node.ELEMENT_NODE);
+  }
+
+  /**
+   * Adds a property to a record, aggregating duplicate keys as arrays.
+   *
+   * When a property key already exists, the values are collected into an array.
+   * This is useful for XML elements that can have multiple children with the same tag name.
+   *
+   * @param record - The record to update
+   * @param key - The property key to add or update
+   * @param value - The value to add
+   * @returns A new record with the property added or updated
+   */
+  static #addXmlRecordProperty(record: Record<string, unknown>, key: string, value: unknown): Record<string, unknown> {
+    const currentValue = record[key];
+    if (currentValue === undefined) {
+      return { ...record, [key]: value };
+    }
+
+    if (Array.isArray(currentValue)) {
+      return { ...record, [key]: [...currentValue, value] };
+    }
+
+    return { ...record, [key]: [currentValue, value] };
+  }
+
+  /**
+   * Recursively converts an XML element and its children into an object record.
+   *
+   * Nested elements are converted to nested records. Text content is preserved,
+   * with empty strings maintained to distinguish from missing content.
+   *
+   * @param element - The XML element to convert
+   * @returns An object record representing the element and its descendants
+   */
+  static #convertXmlElementToRecord(element: Element): Record<string, unknown> {
+    let record: Record<string, unknown> = {};
+    const children = GVWMS.#getXmlChildElements(element);
+
+    children.forEach((child): void => {
+      const key = child.nodeName;
+      const childElements = GVWMS.#getXmlChildElements(child);
+
+      // Preserve empty values while still supporting nested structures.
+      const value: unknown = childElements.length > 0 ? GVWMS.#convertXmlElementToRecord(child) : (child.textContent?.trim() ?? '');
+      record = GVWMS.#addXmlRecordProperty(record, key, value);
+    });
+
+    return record;
+  }
+
+  /**
    * Gets the legend image of a layer.
    *
    * @param layerConfig - The layer configuration.
@@ -1650,6 +1824,7 @@ export class GVWMS extends AbstractGVRaster {
   // #endregion EVENTS
 }
 
+/** Defines the CRS override used to request WMS images in a different projection. */
 export type CRSOverride = { layerProjection: string; mapProjection: string };
 
 /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -45,7 +45,10 @@ export class GVWMS extends AbstractGVRaster {
   /** The max feature count returned by the GetFeatureInfo */
   static readonly DEFAULT_MAX_FEATURE_COUNT: number = 100;
 
-  /** The default Get Feature Info tolerance to use for QGIS Server services which are more picky by default (really needs to be zoomed in to get results, by default) */
+  /**
+   * The default Get Feature Info tolerance to use for QGIS Server services which are more picky by default (really needs to be zoomed in to get results, by default).
+   * WMS needed a bigger tolerance to pick up more results during the spatial queries (to make it look more like the tolerance for other layer types)
+   */
   static readonly DEFAULT_GET_FEATURE_INFO_TOLERANCE: number = 20;
 
   /** The Get Feature Info feature count to use */

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -16,7 +16,7 @@ import { GeoUtilities } from '@/geo/utils/utilities';
 import { GVLayerUtilities } from '@/geo/layer/gv-layers/utils';
 import { OgcWmsLayerEntryConfig } from '@/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config';
 import type { OgcWfsLayerEntryConfig } from '@/api/config/validation-classes/vector-validation-classes/wfs-layer-entry-config';
-import type { TypeFeatureInfoEntry, TypeOutfieldsType, TypeFeatureInfoResult } from '@/api/types/map-schema-types';
+import type { TypeFeatureInfoEntry, TypeOutfieldsType, TypeFeatureInfoResult, TypeDisplayLanguage } from '@/api/types/map-schema-types';
 import { CONFIG_PROXY_URL } from '@/api/types/map-schema-types';
 import type { TypeLegend, TypeMetadataFeatureInfo } from '@/api/types/layer-schema-types';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
@@ -219,32 +219,35 @@ export class GVWMS extends AbstractGVRaster {
   /**
    * Overrides the return of feature information at a given coordinate.
    *
-   * @param map - The Map where to get Feature Info At Coordinate from.
-   * @param location - The coordinate that will be used by the query.
-   * @param queryGeometry - Whether to include geometry in the query, default is true.
-   * @param abortController - Optional {@link AbortController} to cancel the operation.
+   * @param map - The Map where to get Feature Info At Coordinate from
+   * @param location - The coordinate that will be used by the query
+   * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field for the 'nameField'
+   * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    */
   protected override getFeatureInfoAtCoordinate(
     map: OLMap,
     location: Coordinate,
     queryGeometry = true,
+    language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     abortController: AbortController | undefined = undefined
   ): Promise<TypeFeatureInfoResult> {
     // Transform coordinate from map projection to lntlat
     const projCoordinate = Projection.transformToLonLat(location, map.getView().getProjection());
 
     // Redirect to getFeatureInfoAtLonLat
-    return this.getFeatureInfoAtLonLat(map, projCoordinate, queryGeometry, abortController);
+    return this.getFeatureInfoAtLonLat(map, projCoordinate, queryGeometry, language, abortController);
   }
 
   /**
    * Overrides the return of feature information at the provided long lat coordinate.
    *
-   * @param map - The Map where to get Feature Info At LonLat from.
-   * @param lonlat - The coordinate that will be used by the query.
-   * @param queryGeometry - Whether to include geometry in the query, default is true.
-   * @param abortController - Optional {@link AbortController} to cancel the operation.
+   * @param map - The Map where to get Feature Info At LonLat from
+   * @param lonlat - The coordinate that will be used by the query
+   * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
+   * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
    * @throws {LayerConfigWFSMissingError} When no WFS layer configuration is defined for this WMS layer.
    */
@@ -253,6 +256,7 @@ export class GVWMS extends AbstractGVRaster {
     lonlat: Coordinate,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     queryGeometry = true,
+    language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     abortController: AbortController | undefined = undefined
   ): Promise<TypeFeatureInfoResult> {
     // The FeatureInfoResult object that will be returned
@@ -305,6 +309,7 @@ export class GVWMS extends AbstractGVRaster {
           clickCoordinate,
           viewResolution,
           projectionCode,
+          language,
           this.getLayerFilters(),
           abortController
         );
@@ -315,7 +320,7 @@ export class GVWMS extends AbstractGVRaster {
     }
 
     // Try various info formats patterns to get feature info
-    return this.#getFeatureInfoUsingWMS(wmsLayerConfig, clickCoordinate, viewResolution, projectionCode, abortController);
+    return this.#getFeatureInfoUsingWMS(wmsLayerConfig, clickCoordinate, viewResolution, projectionCode, language, abortController);
   }
 
   /**
@@ -325,6 +330,7 @@ export class GVWMS extends AbstractGVRaster {
    *
    * @param map - The Map so that we can grab the resolution/projection we want to get features on.
    * @param layerFilters - The layer filters to apply when querying the features.
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param abortController - Optional {@link AbortController} to cancel the operation.
    * @returns A promise that resolves with the feature info result
    * @throws {LayerConfigWFSMissingError} When no WFS layer configuration is defined for this WMS layer.
@@ -337,6 +343,7 @@ export class GVWMS extends AbstractGVRaster {
   protected override getAllFeatureInfo(
     map: OLMap,
     layerFilters: LayerFilters,
+    language: TypeDisplayLanguage,
     abortController?: AbortController
   ): Promise<TypeFeatureInfoResult> {
     // Get the layer config and its initial settings
@@ -352,6 +359,7 @@ export class GVWMS extends AbstractGVRaster {
       undefined,
       undefined,
       map.getView().getProjection().getCode(),
+      language,
       layerFilters,
       abortController
     );
@@ -525,7 +533,12 @@ export class GVWMS extends AbstractGVRaster {
     );
 
     // Fetch and parse features
-    const parsedFeatures = await GVWMS.fetchAndParseFeaturesFromWFSUrl(urlWithOutputJson, wmsLayerConfig, wfsLayerConfig);
+    const parsedFeatures = await GVWMS.fetchAndParseFeaturesFromWFSUrl(
+      urlWithOutputJson,
+      wmsLayerConfig,
+      wfsLayerConfig,
+      'en' // Language isn't necessary here as we're interested in the features extent
+    );
 
     // For each feature
     let calculatedExtent: Extent | undefined;
@@ -647,12 +660,13 @@ export class GVWMS extends AbstractGVRaster {
    * - Returns an array of standardized `TypeFeatureInfoEntry` objects.
    *
    * @param urlWithOutputJson - The full WFS GetFeature request URL. Must specify an output format compatible
-   *   with GeoJSON (e.g., `outputFormat=application/json`).
+   *   with GeoJSON (e.g., `outputFormat=application/json`)
    * @param wmsLayerConfig - The associated WMS layer configuration. Styling and filter settings from this
-   *   config are applied when formatting the Feature Info results.
+   *   config are applied when formatting the Feature Info results
    * @param wfsLayerConfig - The WFS layer configuration used for schema tags, outfields, metadata, and
-   *   date formatting.
-   * @param abortController - Optional {@link AbortController} used to cancel the fetch request.
+   *   date formatting
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided in the WMS layer config
+   * @param abortController - Optional {@link AbortController} used to cancel the fetch request
    * @returns A promise that resolves with the feature info result
    * @throws {ResponseError} When the response is not OK (non-2xx).
    * @throws {ResponseEmptyError} When the JSON response is empty.
@@ -664,6 +678,7 @@ export class GVWMS extends AbstractGVRaster {
     urlWithOutputJson: string,
     wmsLayerConfig: OgcWmsLayerEntryConfig,
     wfsLayerConfig: OgcWfsLayerEntryConfig,
+    language: TypeDisplayLanguage,
     abortController: AbortController | undefined = undefined
   ): Promise<TypeFeatureInfoResult> {
     // Call the GetFeature
@@ -678,13 +693,16 @@ export class GVWMS extends AbstractGVRaster {
     // Read the features
     const features = GeoUtilities.readFeaturesFromGeoJSON(responseData, undefined);
 
+    // Find the best name field and validate its existance at the same time when one was initially configured
+    const nameField = AbstractGVLayer.findBestNameField(wmsLayerConfig.getNameField(), wfsLayerConfig.getOutfields(), language);
+
     // Parse the features
     const results = AbstractGVLayer.helperFormatFeatureInfoResult(
       features,
       wfsLayerConfig.layerPath,
       wfsLayerConfig.getSchemaTag(),
-      wmsLayerConfig.getNameField(),
-      wmsLayerConfig.getOutfields(),
+      nameField,
+      wfsLayerConfig.getOutfields(),
       wmsLayerConfig.hasOutfieldsPK(),
       undefined,
       wmsLayerConfig.getLayerStyle(), // The styles as read from the WMS layer config (not WFS in case it was overridden in the WMS)
@@ -710,15 +728,16 @@ export class GVWMS extends AbstractGVRaster {
    * 4. Builds a WFS GetFeature URL with the appropriate output format and filter.
    * 5. Fetches the WFS features and parses them into a consistent format.
    *
-   * @param wmsLayerConfig - The current WMS layer config of the WMS layer.
-   * @param wfsLayerConfig - The current WFS layer config of the WMS layer.
+   * @param wmsLayerConfig - The current WMS layer config of the WMS layer
+   * @param wfsLayerConfig - The current WFS layer config of the WMS layer
    * @param clickCoordinate - The clicked map coordinate
-   *        in the map projection. If undefined, the query is non-spatial.
+   *        in the map projection. If undefined, the query is non-spatial
    * @param viewResolution - Current map view resolution
-   *        (map units per pixel). Required for buffering the click location.
+   *        (map units per pixel). Required for buffering the click location
    * @param projectionCode - The map projection code (e.g., 'EPSG:3857')
-   *        to use for the WFS request and geometry serialization.
-   * @param layerFilters - Optional layer filters to use to filter the query.
+   *        to use for the WFS request and geometry serialization
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided in the WMS layer config
+   * @param layerFilters - Optional layer filters to use to filter the query
    * @param abortController - Optional {@link AbortController} to
    *        allow cancellation of the WFS request.
    * @returns A promise that resolves with the feature info result
@@ -729,6 +748,7 @@ export class GVWMS extends AbstractGVRaster {
     clickCoordinate: Coordinate | undefined,
     viewResolution: number | undefined,
     projectionCode: string,
+    language: TypeDisplayLanguage,
     layerFilters?: LayerFilters,
     abortController?: AbortController
   ): Promise<TypeFeatureInfoResult> {
@@ -794,7 +814,7 @@ export class GVWMS extends AbstractGVRaster {
     );
 
     // Fetch and parse features
-    return GVWMS.fetchAndParseFeaturesFromWFSUrl(urlWithOutputJson, wmsLayerConfig, wfsLayerConfig, abortController);
+    return GVWMS.fetchAndParseFeaturesFromWFSUrl(urlWithOutputJson, wmsLayerConfig, wfsLayerConfig, language, abortController);
   }
 
   /**
@@ -808,6 +828,7 @@ export class GVWMS extends AbstractGVRaster {
    * @param clickCoordinate - The coordinate on the map where the user clicked.
    * @param viewResolution - The current resolution of the map view.
    * @param projectionCode - The projection used for the request (e.g., 'EPSG:3857').
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param abortController - Optional {@link AbortController} to cancel the request if needed.
    * @returns A promise that resolves with the feature info result
    * @throws {LayerInvalidFeatureInfoFormatWMSError} When no supported format returns usable feature info data.
@@ -817,6 +838,7 @@ export class GVWMS extends AbstractGVRaster {
     clickCoordinate: Coordinate,
     viewResolution: number,
     projectionCode: ProjectionLike,
+    language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     abortController?: AbortController
   ): Promise<TypeFeatureInfoResult> {
     // Get the layer source
@@ -987,7 +1009,13 @@ export class GVWMS extends AbstractGVRaster {
     if (featureMember) {
       // Format and return the information
       return {
-        results: GVWMS.#formatWmsFeatureInfoResult(wmsLayerConfig.layerPath, wmsLayerConfig.getNameField(), featureMember, clickCoordinate),
+        results: GVWMS.#formatWmsFeatureInfoResult(
+          wmsLayerConfig.layerPath,
+          wmsLayerConfig.getNameField(),
+          language,
+          featureMember,
+          clickCoordinate
+        ),
       };
     }
 
@@ -1501,6 +1529,8 @@ export class GVWMS extends AbstractGVRaster {
    * Formats one or more WMS feature members into standardized feature info entries.
    *
    * @param layerPath - The layer path used to identify the WMS layer.
+   * @param nameField - The field name to use as the display name for features, if available.
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param featureMember - A single feature member or an array of feature members.
    * @param clickCoordinate - The coordinate where the user clicked on the map.
    * @returns An array of formatted feature info entries
@@ -1508,6 +1538,7 @@ export class GVWMS extends AbstractGVRaster {
   static #formatWmsFeatureInfoResult(
     layerPath: string,
     nameField: string | undefined,
+    language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     featureMember: Record<string, unknown> | Record<string, unknown>[],
     clickCoordinate: Coordinate
   ): TypeFeatureInfoEntry[] {
@@ -1517,11 +1548,15 @@ export class GVWMS extends AbstractGVRaster {
     if (Array.isArray(featureMember)) {
       featureMember.forEach((feature) => {
         if (feature && typeof feature === 'object') {
-          results.push(this.#formatWmsFeatureInfoResultParser(feature, layerPath, nameField, clickCoordinate, featureKeyCounter++));
+          results.push(
+            this.#formatWmsFeatureInfoResultParser(feature, layerPath, nameField, language, clickCoordinate, featureKeyCounter++)
+          );
         }
       });
     } else if (featureMember && typeof featureMember === 'object') {
-      results.push(this.#formatWmsFeatureInfoResultParser(featureMember, layerPath, nameField, clickCoordinate, featureKeyCounter++));
+      results.push(
+        this.#formatWmsFeatureInfoResultParser(featureMember, layerPath, nameField, language, clickCoordinate, featureKeyCounter++)
+      );
     }
 
     return results;
@@ -1532,6 +1567,8 @@ export class GVWMS extends AbstractGVRaster {
    *
    * @param feature - The raw feature object from a WMS GetFeatureInfo response.
    * @param layerPath - The WMS layer path.
+   * @param nameField - The field name to use as the display name for the feature, if available.
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param clickCoordinate - The map click coordinate.
    * @param featureKey - The unique feature key.
    * @returns The formatted feature info entry
@@ -1540,6 +1577,7 @@ export class GVWMS extends AbstractGVRaster {
     feature: unknown,
     layerPath: string,
     nameField: string | undefined,
+    language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     clickCoordinate: Coordinate,
     featureKey: number
   ): TypeFeatureInfoEntry {
@@ -1598,7 +1636,13 @@ export class GVWMS extends AbstractGVRaster {
       });
     };
 
+    // Call sub-function
     extractFields(feature);
+
+    // Find the best name field and validate its existance at the same time when one was initially configured
+    featureInfo.nameField = AbstractGVLayer.findBestNameField(featureInfo.nameField, featureInfo.fieldInfo, language);
+
+    // Return the gathered feature information
     return featureInfo;
   }
 

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
@@ -15,7 +15,7 @@ import type { EventDelegateBase } from '@/api/events/event-helper';
 import EventHelper from '@/api/events/event-helper';
 import { logger } from '@/core/utils/logger';
 import type { VectorLayerEntryConfig } from '@/api/config/validation-classes/vector-layer-entry-config';
-import type { TypeFeatureInfoResult, TypeLayerStyleConfig } from '@/api/types/map-schema-types';
+import type { TypeDisplayLanguage, TypeFeatureInfoResult, TypeLayerStyleConfig } from '@/api/types/map-schema-types';
 import type { FilterNodeType } from '@/geo/utils/renderer/geoview-renderer-types';
 import { GeoviewRenderer } from '@/geo/utils/renderer/geoview-renderer';
 import { GVLayerUtilities } from '@/geo/layer/gv-layers/utils';
@@ -235,14 +235,14 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
    *
    * @param map - The Map so that we can grab the resolution/projection we want to get features on.
    * @param layerFilters - The layer filters to apply when querying the features.
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param abortController - Optional {@link AbortController} to cancel the request.
    * @returns A promise that resolves with the feature info result.
    */
   protected override getAllFeatureInfo(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     map: OLMap,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     layerFilters: LayerFilters,
+    language: TypeDisplayLanguage,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     abortController?: AbortController
   ): Promise<TypeFeatureInfoResult> {
@@ -253,6 +253,7 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
       results: this.formatFeatureInfoResult(
         features,
         layerConfig,
+        language,
         layerConfig.getServiceDateFormat(),
         layerConfig.getServiceDateTimezone(),
         layerConfig.getServiceDateTemporalMode()
@@ -263,11 +264,22 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
   /**
    * Overrides the return of feature information at a given pixel location.
    *
-   * @param map - The Map where to get Feature Info At Pixel from.
-   * @param location - The pixel coordinate that will be used by the query.
-   * @returns A promise that resolves with the feature info result.
+   * @param map - The Map where to get Feature Info At Pixel from
+   * @param location - The pixel coordinate that will be used by the query
+   * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
+   * @param abortController - Optional {@link AbortController} to cancel the operation
+   * @returns A promise that resolves with the feature info result
    */
-  protected override getFeatureInfoAtPixel(map: OLMap, location: Pixel): Promise<TypeFeatureInfoResult> {
+  protected override getFeatureInfoAtPixel(
+    map: OLMap,
+    location: Pixel,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    queryGeometry = true,
+    language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    abortController: AbortController | undefined = undefined
+  ): Promise<TypeFeatureInfoResult> {
     // Get the layer source
     const layerSource = this.getOLSource();
 
@@ -292,6 +304,7 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
       results: this.formatFeatureInfoResult(
         features,
         layerConfig,
+        language,
         layerConfig.getServiceDateFormat(),
         layerConfig.getServiceDateTimezone(),
         layerConfig.getServiceDateTemporalMode()
@@ -302,46 +315,46 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
   /**
    * Overrides the return of feature information at a given coordinate.
    *
-   * @param map - The Map where to get Feature Info At Coordinate from.
-   * @param location - The coordinate that will be used by the query.
-   * @param queryGeometry - Whether to include geometry in the query, default is true.
-   * @param abortController - Optional {@link AbortController} to cancel the request.
-   * @returns A promise that resolves with the feature info result.
+   * @param map - The Map where to get Feature Info At Coordinate from
+   * @param location - The coordinate that will be used by the query
+   * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field for the 'nameField'
+   * @param abortController - Optional {@link AbortController} to cancel the request
+   * @returns A promise that resolves with the feature info result
    */
   protected override getFeatureInfoAtCoordinate(
     map: OLMap,
     location: Coordinate,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     queryGeometry = true,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    language: TypeDisplayLanguage,
     abortController: AbortController | undefined = undefined
   ): Promise<TypeFeatureInfoResult> {
     // Redirect to getFeatureInfoAtPixel
-    return this.getFeatureInfoAtPixel(map, map.getPixelFromCoordinate(location));
+    return this.getFeatureInfoAtPixel(map, map.getPixelFromCoordinate(location), queryGeometry, language, abortController);
   }
 
   /**
    * Overrides the return of feature information at the provided long lat coordinate.
    *
-   * @param map - The Map where to get Feature Info At LonLat from.
-   * @param lonlat - The coordinate that will be used by the query.
-   * @param queryGeometry - Whether to include geometry in the query, default is true.
-   * @param abortController - Optional {@link AbortController} to cancel the request.
-   * @returns A promise that resolves with the feature info result.
+   * @param map - The Map where to get Feature Info At LonLat from
+   * @param lonlat - The coordinate that will be used by the query
+   * @param queryGeometry - Whether to include geometry in the query, default is true
+   * @param language - The display language, used to guess the best name field if `nameField` is not provided
+   * @param abortController - Optional {@link AbortController} to cancel the operation
+   * @returns A promise that resolves with the feature info result
    */
   protected override getFeatureInfoAtLonLat(
     map: OLMap,
     lonlat: Coordinate,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     queryGeometry = true,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    language: TypeDisplayLanguage,
     abortController: AbortController | undefined = undefined
   ): Promise<TypeFeatureInfoResult> {
     // Convert Coordinates LonLat to map projection
     const projCoordinate = Projection.transformFromLonLat(lonlat, map.getView().getProjection());
 
     // Redirect to getFeatureInfoAtPixel
-    return this.getFeatureInfoAtPixel(map, map.getPixelFromCoordinate(projCoordinate));
+    return this.getFeatureInfoAtPixel(map, map.getPixelFromCoordinate(projCoordinate), queryGeometry, language, abortController);
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/layer-sets/abstract-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/abstract-layer-set.ts
@@ -1,4 +1,10 @@
-import type { QueryType, TypeFeatureInfoEntry, TypeFeatureInfoResult, TypeLocation } from '@/api/types/map-schema-types';
+import type {
+  QueryType,
+  TypeDisplayLanguage,
+  TypeFeatureInfoEntry,
+  TypeFeatureInfoResult,
+  TypeLocation,
+} from '@/api/types/map-schema-types';
 import { generateId, whenThisThen } from '@/core/utils/utilities';
 import { logger } from '@/core/utils/logger';
 import type { LayerDomain } from '@/core/domains/layer-domain';
@@ -249,6 +255,7 @@ export abstract class AbstractLayerSet {
    * @param queryType - The query type
    * @param location - The location for the query
    * @param queryGeometry - Optional whether to query geometry
+   * @param language - The display language to use for the query
    * @param abortController - Optional abort controller
    * @returns A promise that resolves with the query results
    */
@@ -257,6 +264,7 @@ export abstract class AbstractLayerSet {
     queryType: QueryType,
     location: TypeLocation,
     queryGeometry = true,
+    language: TypeDisplayLanguage,
     abortController?: AbortController
   ): Promise<TypeFeatureInfoResult> {
     // If the layer is invisible (or any of its parent(s) is invisible)
@@ -266,7 +274,7 @@ export abstract class AbstractLayerSet {
     if (!geoviewLayer.getInVisibleRange(this.mapViewer.getView().getZoom())) return Promise.resolve({ results: [] });
 
     // Get Feature Info
-    return geoviewLayer.getFeatureInfo(this.mapViewer.map, queryType, location, queryGeometry, abortController);
+    return geoviewLayer.getFeatureInfo(this.mapViewer.map, queryType, location, queryGeometry, language, abortController);
   }
 
   // #endregion PROTECTED METHODS

--- a/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/all-feature-info-layer-set.ts
@@ -112,7 +112,14 @@ export class AllFeatureInfoLayerSet extends AbstractLayerSet {
 
     try {
       // Process query on results data
-      const promiseResult = await this.queryLayerFeatures(layer, queryType, layerPath, false, this.#abortControllers[layerPath]);
+      const promiseResult = await this.queryLayerFeatures(
+        layer,
+        queryType,
+        layerPath,
+        false,
+        this.mapViewer.getDisplayLanguage(),
+        this.#abortControllers[layerPath]
+      );
 
       // Get the array of records in the results
       const arrayOfRecords = promiseResult.results;

--- a/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
@@ -182,6 +182,7 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
         FeatureInfoLayerSet.QUERY_TYPE,
         lonLatCoordinate,
         true,
+        this.mapViewer.getDisplayLanguage(),
         this.#abortController
       );
 

--- a/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
@@ -123,7 +123,14 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
 
     try {
       // Process query on results data using the shared abort controller for this call
-      const promiseResult = await this.queryLayerFeatures(layer, queryType, coordinate, false, this.#abortController);
+      const promiseResult = await this.queryLayerFeatures(
+        layer,
+        queryType,
+        coordinate,
+        false,
+        this.mapViewer.getDisplayLanguage(),
+        this.#abortController
+      );
 
       // If a newer queryLayers call has aborted this one, discard stale results
       if (signal.aborted) return;

--- a/packages/geoview-test-suite/src/tests/testers/layer-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/layer-tester.ts
@@ -1471,20 +1471,20 @@ export class LayerTester extends GVAbstractTester {
 
         // Find the "material" field
         test.addStep(`Finding the "${GVAbstractTester.WATER_NETWORK_DOMAIN_FIELD_NAME}" field...`);
-        const materialField = outfields!.find((f) => f.name === GVAbstractTester.WATER_NETWORK_DOMAIN_FIELD_NAME);
+        const materialField = outfields.find((f) => f.name === GVAbstractTester.WATER_NETWORK_DOMAIN_FIELD_NAME);
         Test.assertIsDefined('materialField', materialField);
 
         // Verify it has a domain
         test.addStep('Verifying the field has a domain...');
-        Test.assertIsDefined('materialField.domain', materialField!.domain);
+        Test.assertIsDefined('materialField.domain', materialField.domain);
 
         // Verify the domain type is codedValue
         test.addStep('Verifying the domain type is codedValue...');
-        Test.assertIsEqual(materialField!.domain!.type, 'codedValue');
+        Test.assertIsEqual(materialField.domain.type, 'codedValue');
 
         // Verify the domain has coded values
         test.addStep('Verifying the domain has coded values...');
-        const codedDomain = materialField!.domain! as { type: string; codedValues: unknown[] };
+        const codedDomain = materialField.domain as { type: string; codedValues: unknown[] };
         Test.assertIsDefined('codedValues', codedDomain.codedValues);
         Test.assertIsArrayLengthMinimal(codedDomain.codedValues, 1);
       },
@@ -1534,20 +1534,20 @@ export class LayerTester extends GVAbstractTester {
 
         // Find the "material" field
         test.addStep(`Finding the "${GVAbstractTester.WATER_NETWORK_DOMAIN_FIELD_NAME}" field...`);
-        const materialField = outfields!.find((f) => f.name === GVAbstractTester.WATER_NETWORK_DOMAIN_FIELD_NAME);
+        const materialField = outfields.find((f) => f.name === GVAbstractTester.WATER_NETWORK_DOMAIN_FIELD_NAME);
         Test.assertIsDefined('materialField', materialField);
 
         // Verify it has a domain
         test.addStep('Verifying the field has a domain...');
-        Test.assertIsDefined('materialField.domain', materialField!.domain);
+        Test.assertIsDefined('materialField.domain', materialField.domain);
 
         // Verify the domain type is codedValue
         test.addStep('Verifying the domain type is codedValue...');
-        Test.assertIsEqual(materialField!.domain!.type, 'codedValue');
+        Test.assertIsEqual(materialField.domain.type, 'codedValue');
 
         // Verify the domain has coded values
         test.addStep('Verifying the domain has coded values...');
-        const codedDomain = materialField!.domain! as { type: string; codedValues: unknown[] };
+        const codedDomain = materialField.domain as { type: string; codedValues: unknown[] };
         Test.assertIsDefined('codedValues', codedDomain.codedValues);
         Test.assertIsArrayLengthMinimal(codedDomain.codedValues, 1);
       },
@@ -1614,27 +1614,27 @@ export class LayerTester extends GVAbstractTester {
         test.addStep(`Getting the "${fieldName}" field from the feature...`);
         const materialFieldEntry = firstFeature.fieldInfo[fieldName];
         Test.assertIsDefined('materialFieldEntry', materialFieldEntry);
-        Test.assertIsDefined('materialFieldEntry.value', materialFieldEntry!.value);
+        Test.assertIsDefined('materialFieldEntry.value', materialFieldEntry.value);
 
         // Get the coded values from the domain on the field entry
         test.addStep('Verifying the field has a codedValue domain...');
-        Test.assertIsDefined('materialFieldEntry.domain', materialFieldEntry!.domain);
-        Test.assertIsEqual(materialFieldEntry!.domain!.type, 'codedValue');
+        Test.assertIsDefined('materialFieldEntry.domain', materialFieldEntry.domain);
+        Test.assertIsEqual(materialFieldEntry.domain.type, 'codedValue');
 
-        const codedDomain = materialFieldEntry!.domain! as codedValueType;
+        const codedDomain = materialFieldEntry.domain as codedValueType;
         const codedValueNames = codedDomain.codedValues.map((cv) => cv.name);
         const codedValueCodes = codedDomain.codedValues.map((cv) => cv.code);
 
         // Verify the value is one of the translated names, not a raw code
         test.addStep('Verifying the value is a domain-translated name...');
-        Test.assertArrayIncludes(codedValueNames, materialFieldEntry!.value as string);
+        Test.assertArrayIncludes(codedValueNames, materialFieldEntry.value as string);
 
         // Verify the value is NOT a raw code (unless name === code, which is unlikely)
         test.addStep('Verifying the value is not a raw code...');
         // Only assert if the translated name differs from the code for this value
-        const matchingEntry = codedDomain.codedValues.find((cv) => cv.name === materialFieldEntry!.value);
+        const matchingEntry = codedDomain.codedValues.find((cv) => cv.name === materialFieldEntry.value);
         if (matchingEntry && matchingEntry.code !== matchingEntry.name) {
-          Test.assertArrayExcludes(codedValueCodes as string[], materialFieldEntry!.value as string);
+          Test.assertArrayExcludes(codedValueCodes as string[], materialFieldEntry.value as string);
         }
       },
       (test) => {
@@ -1700,26 +1700,26 @@ export class LayerTester extends GVAbstractTester {
         test.addStep(`Getting the "${fieldName}" field from the feature...`);
         const materialFieldEntry = firstFeature.fieldInfo[fieldName];
         Test.assertIsDefined('materialFieldEntry', materialFieldEntry);
-        Test.assertIsDefined('materialFieldEntry.value', materialFieldEntry!.value);
+        Test.assertIsDefined('materialFieldEntry.value', materialFieldEntry.value);
 
         // Get the coded values from the domain on the field entry
         test.addStep('Verifying the field has a codedValue domain...');
-        Test.assertIsDefined('materialFieldEntry.domain', materialFieldEntry!.domain);
-        Test.assertIsEqual(materialFieldEntry!.domain!.type, 'codedValue');
+        Test.assertIsDefined('materialFieldEntry.domain', materialFieldEntry.domain);
+        Test.assertIsEqual(materialFieldEntry.domain.type, 'codedValue');
 
-        const codedDomain = materialFieldEntry!.domain! as codedValueType;
+        const codedDomain = materialFieldEntry.domain as codedValueType;
         const codedValueNames = codedDomain.codedValues.map((cv) => cv.name);
         const codedValueCodes = codedDomain.codedValues.map((cv) => cv.code);
 
         // Verify the value is one of the translated names, not a raw code
         test.addStep('Verifying the value is a domain-translated name...');
-        Test.assertArrayIncludes(codedValueNames, materialFieldEntry!.value as string);
+        Test.assertArrayIncludes(codedValueNames, materialFieldEntry.value as string);
 
         // Verify the value is NOT a raw code (unless name === code, which is unlikely)
         test.addStep('Verifying the value is not a raw code...');
-        const matchingEntry = codedDomain.codedValues.find((cv) => cv.name === materialFieldEntry!.value);
+        const matchingEntry = codedDomain.codedValues.find((cv) => cv.name === materialFieldEntry.value);
         if (matchingEntry && matchingEntry.code !== matchingEntry.name) {
-          Test.assertArrayExcludes(codedValueCodes as string[], materialFieldEntry!.value as string);
+          Test.assertArrayExcludes(codedValueCodes as string[], materialFieldEntry.value as string);
         }
       },
       (test) => {

--- a/packages/geoview-test-suite/src/tests/testers/map-config-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/map-config-tester.ts
@@ -475,13 +475,13 @@ export class MapConfigTester extends GVAbstractTester {
         test.addStep('Verifying overview-map is in components config...');
         const components = getStoreMapConfigComponents(mapId);
         Test.assertIsDefined('components', components);
-        Test.assertArrayIncludes(components!, 'overview-map');
+        Test.assertArrayIncludes(components, 'overview-map');
 
         // Verify overview map config exists with default hideOnZoom of 0
         test.addStep('Verifying overview map config has hideOnZoom 0...');
         const overviewMapConfig = getStoreMapConfigOverviewMap(mapId);
         Test.assertIsDefined('overviewMapConfig', overviewMapConfig);
-        Test.assertIsEqual(overviewMapConfig!.hideOnZoom, 0);
+        Test.assertIsEqual(overviewMapConfig.hideOnZoom, 0);
 
         // Verify overview map visibility is true (hideOnZoom=0 means always visible)
         test.addStep('Verifying overview map is visible...');
@@ -513,7 +513,7 @@ export class MapConfigTester extends GVAbstractTester {
         test.addStep('Verifying overview-map is not in components config...');
         const components = getStoreMapConfigComponents(mapId);
         Test.assertIsDefined('components', components);
-        Test.assertArrayExcludes(components!, 'overview-map');
+        Test.assertArrayExcludes(components, 'overview-map');
 
         // Verify overview map visibility is false
         test.addStep('Verifying overview map is not visible...');
@@ -546,7 +546,7 @@ export class MapConfigTester extends GVAbstractTester {
         test.addStep('Verifying hideOnZoom config is 7...');
         const overviewMapConfig = getStoreMapConfigOverviewMap(mapId);
         Test.assertIsDefined('overviewMapConfig', overviewMapConfig);
-        Test.assertIsEqual(overviewMapConfig!.hideOnZoom, 7);
+        Test.assertIsEqual(overviewMapConfig.hideOnZoom, 7);
 
         // At initial zoom 4.5, overview map should be hidden (below threshold of 7)
         // Wait for the overview map useEffect to settle (it sets visibility to false)
@@ -730,7 +730,7 @@ export class MapConfigTester extends GVAbstractTester {
         test.addStep('Verifying layer is not visible in store...');
         const legendLayer = getStoreLayerLegendLayerByPath(mapId, layerPath);
         Test.assertIsDefined('legendLayer', legendLayer);
-        Test.assertIsEqual(legendLayer!.visible, false);
+        Test.assertIsEqual(legendLayer.visible, false);
 
         test.addStep('Verifying layer is not visible on OL layer...');
         const gvLayer = this.getControllersRegistry().layerController.getGeoviewLayer(layerPath);
@@ -781,7 +781,7 @@ export class MapConfigTester extends GVAbstractTester {
         test.addStep('Verifying layer is not queryable in store...');
         const legendLayer = getStoreLayerLegendLayerByPath(mapId, layerPath);
         Test.assertIsDefined('legendLayer', legendLayer);
-        Test.assertIsEqual(legendLayer!.queryable, false);
+        Test.assertIsEqual(legendLayer.queryable, false);
 
         test.addStep('Verifying layer is not queryable on GV layer...');
         const gvLayer = this.getControllersRegistry().layerController.getGeoviewLayerRegular(layerPath);
@@ -809,7 +809,7 @@ export class MapConfigTester extends GVAbstractTester {
         test.addStep('Verifying layer is not hoverable in store...');
         const legendLayer = getStoreLayerLegendLayerByPath(mapId, layerPath);
         Test.assertIsDefined('legendLayer', legendLayer);
-        Test.assertIsEqual(legendLayer!.hoverable, false);
+        Test.assertIsEqual(legendLayer.hoverable, false);
 
         test.addStep('Verifying layer is not hoverable on GV layer...');
         const gvLayer = this.getControllersRegistry().layerController.getGeoviewLayerRegular(layerPath);
@@ -1000,7 +1000,7 @@ export class MapConfigTester extends GVAbstractTester {
         test.addStep('Verifying parent group is not visible in store legend...');
         const parentLegend = getStoreLayerLegendLayerByPath(mapId, groupLayerPath);
         Test.assertIsDefined('parentLegend', parentLegend);
-        Test.assertIsEqual(parentLegend!.visible, false);
+        Test.assertIsEqual(parentLegend.visible, false);
 
         // Verify subgroup OL layer is visible (its own state is not set to false)
         test.addStep('Verifying subgroup OL layer is visible (own state defaults to true)...');
@@ -1053,7 +1053,7 @@ export class MapConfigTester extends GVAbstractTester {
         test.addStep('Verifying states.queryable = false in store...');
         const legendLayer = getStoreLayerLegendLayerByPath(mapId, layerPath);
         Test.assertIsDefined('legendLayer', legendLayer);
-        Test.assertIsEqual(legendLayer!.queryable, false);
+        Test.assertIsEqual(legendLayer.queryable, false);
 
         // Verify getQueryable() returns false on the GV layer
         test.addStep('Verifying getQueryable() = false on GV layer...');
@@ -1104,7 +1104,7 @@ export class MapConfigTester extends GVAbstractTester {
         test.addStep('Verifying states.hoverable = false in store...');
         const legendLayer = getStoreLayerLegendLayerByPath(mapId, layerPath);
         Test.assertIsDefined('legendLayer', legendLayer);
-        Test.assertIsEqual(legendLayer!.hoverable, false);
+        Test.assertIsEqual(legendLayer.hoverable, false);
 
         // Verify getHoverable() returns false on the GV layer
         test.addStep('Verifying getHoverable() = false on GV layer...');

--- a/packages/geoview-test-suite/src/tests/testers/utilities-geo-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/utilities-geo-tester.ts
@@ -171,14 +171,14 @@ export class UtilitiesGeoTester extends GVAbstractTester {
       (test, results) => {
         test.addStep('Verifying union of overlapping extents...');
         Test.assertIsDefined('union', results[0]);
-        Test.assertIsEqual(results[0]![0], -100);
-        Test.assertIsEqual(results[0]![1], 40);
-        Test.assertIsEqual(results[0]![2], -70);
-        Test.assertIsEqual(results[0]![3], 55);
+        Test.assertIsEqual(results[0][0], -100);
+        Test.assertIsEqual(results[0][1], 40);
+        Test.assertIsEqual(results[0][2], -70);
+        Test.assertIsEqual(results[0][3], 55);
 
         test.addStep('Verifying union with undefined returns the other...');
         Test.assertIsDefined('singleExtent', results[1]);
-        Test.assertIsEqual(results[1]![0], -100);
+        Test.assertIsEqual(results[1][0], -100);
 
         test.addStep('Verifying both undefined returns undefined...');
         Test.assertIsUndefined('bothUndefined', results[2]);
@@ -385,24 +385,24 @@ export class UtilitiesGeoTester extends GVAbstractTester {
       (test, results) => {
         test.addStep('Verifying intersection of overlapping extents...');
         Test.assertIsDefined('intersection', results[0]);
-        Test.assertIsEqual(results[0]![0], -90);
-        Test.assertIsEqual(results[0]![1], 45);
-        Test.assertIsEqual(results[0]![2], -80);
-        Test.assertIsEqual(results[0]![3], 50);
+        Test.assertIsEqual(results[0][0], -90);
+        Test.assertIsEqual(results[0][1], 45);
+        Test.assertIsEqual(results[0][2], -80);
+        Test.assertIsEqual(results[0][3], 50);
 
         test.addStep('Verifying non-overlapping extents return degenerate extent...');
         Test.assertIsDefined('noOverlap', results[1]);
-        Test.assertIsEqual(results[1]![0], -60);
-        Test.assertIsEqual(results[1]![1], 60);
-        Test.assertIsEqual(results[1]![2], -80);
-        Test.assertIsEqual(results[1]![3], 50);
+        Test.assertIsEqual(results[1][0], -60);
+        Test.assertIsEqual(results[1][1], 60);
+        Test.assertIsEqual(results[1][2], -80);
+        Test.assertIsEqual(results[1][3], 50);
 
         test.addStep('Verifying undefined extentB returns extentA...');
         Test.assertIsDefined('undefinedInput', results[2]);
-        Test.assertIsEqual(results[2]![0], -100);
-        Test.assertIsEqual(results[2]![1], 40);
-        Test.assertIsEqual(results[2]![2], -80);
-        Test.assertIsEqual(results[2]![3], 50);
+        Test.assertIsEqual(results[2][0], -100);
+        Test.assertIsEqual(results[2][1], 40);
+        Test.assertIsEqual(results[2][2], -80);
+        Test.assertIsEqual(results[2][3], 50);
       }
     );
   }


### PR DESCRIPTION
# Description

- Support of application/vnd.ogc.gml for getFeatureInfo.
- Improved the 'nameField' interpretation to base it on the map current language. Moved the 'guessing' for a nameField outside of the config (because config is language agnostic) and added it into the gv-layers instead. This allows for map language switching and nameField to be reinterpreted on the next map features query.
- Fixing WMS Mundialis example that was returning the whole html response as the header in the details panel. Now the details panel is more aware when the data is property->value or when it's simple html or plain text.
- Improved the GV-WMS getFeatureInfoUsingWMS function by adding validations and simplifying the plain_text sanitization.

Fixes: #3134 and #3392

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

~~Hosted May 7th @ 11h30 : https://alex-nrcan.github.io/geoview/add-layers.html~~
~~Hosted May 7th @ 19h30 : https://alex-nrcan.github.io/geoview/add-layers.html~~
~~Hosted May 8th @ 15h00 : https://alex-nrcan.github.io/geoview/add-layers.html~~
Hosted May 12th @ 17h00 : https://alex-nrcan.github.io/geoview/add-layers.html
- Test with 7a5cda52-c7df-427f-9ced-26f19a8a64d6 and click on a feature on the map to view its details.
- Test with:
  - https://qgis-stage.cdtk.geogc.ca/ows/iaac/assessment_inventory_en?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities
  - https://qgis-stage.cdtk.geogc.ca/ows/iaac/assessment_inventory_fr?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities
  - and change the map language using:
    - cgpv.api.getMapViewer('map1').setLanguage('fr')
    - cgpv.api.getMapViewer('map1').setLanguage('en')
    - then re-query
- Test with Mundialis WMS layer and click on the map to view its feature details. Should be like upstream now.

# Checklist:

- [x] I have run the **Test Suite** and **No errors have been introduced**
- [x] I have run `@BranchReview` agent in VS Code Chat and addressed all violations
- [x] I have run `@DocUpdate` agent in VS Code Chat and documentation is in sync with code changes
- [x] I have run `@IssueReview` agent in VS Code Chat and the implementation aligns with the linked issue
- [x] I have build **(rush build)** and deploy **(rush host)** my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~New and existing unit tests pass locally with my changes~~

# Pre-PR Copilot Agent Checks

Before creating your PR, run the following two Copilot agents in VS Code Chat to catch common issues automatically.

## Branch Review (`@BranchReview`)

Audits all changed `.ts`/`.tsx` files against the GeoView coding standards (JSDoc, logging, return types, naming, accessibility, imports, performance patterns).

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **BranchReview** agent from the agent picker (or type `@BranchReview`)
3. Type the target branch name (defaults to `develop`):
   ```
   @BranchReview  against upstream/develop
   ```
4. Review the violation report and fix flagged items (the agent can auto-fix most issues on approval)

- [ ] `@BranchReview` has been run and all violations have been addressed

## Documentation Update (`@DocUpdate`)

Checks that documentation in `docs/` is still consistent with the code you changed. Catches stale references, missing docs for new features, and incorrect code examples.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **DocUpdate** agent from the agent picker (or type `@DocUpdate`)
3. Run a full audit or target a specific section:
   ```
   @DocUpdate full audit of docs/programming/
   @DocUpdate check docs/app/layers/
   ```
4. Review the audit summary and approve any proposed documentation updates

- [ ] `@DocUpdate` has been run and documentation is in sync with code changes

## Issue Review (`@IssueReview`)

Compares your branch changes against the linked GitHub issue's proposed fix. Checks whether the implementation aligns with what was proposed, catches gaps, and provides feedback to improve future issue drafts.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **IssueReview** agent from the agent picker (or type `@IssueReview`)
3. Provide the issue number:
   ```
   @IssueReview #1234
   ```
4. Review the alignment report — it will flag items that were proposed but not implemented, unexpected changes, and root cause accuracy

- [ ] `@IssueReview` has been run and the alignment report has been reviewed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3467)
<!-- Reviewable:end -->
