### PR TITLE
fix(layer): Fix duplicate geocore uuid or duplicate geoviewLayerId in…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -732,12 +732,12 @@ When the same geocore UUID appears multiple times in a map config, `Config.preva
 
 **Parent status propagation** — `#updateLayerStatusParentRec` in `config-base-class.ts` determines a parent group's status from its children:
 
-| Sibling states              | Parent status | Reason                                    |
-| --------------------------- | ------------- | ----------------------------------------- |
-| Any sibling is `loading`    | `loading`     | Still processing                          |
-| ALL siblings are `loaded`   | `loaded`      | Complete success                          |
+| Sibling states              | Parent status | Reason                                     |
+| --------------------------- | ------------- | ------------------------------------------ |
+| Any sibling is `loading`    | `loading`     | Still processing                           |
+| ALL siblings are `loaded`   | `loaded`      | Complete success                           |
 | Mix of `loaded` and `error` | `loaded`      | Partial success — at least one child works |
-| ALL siblings are `error`    | `error`       | Complete failure                          |
+| ALL siblings are `error`    | `error`       | Complete failure                           |
 
 **Critical rule:** A group with at least one loaded child is a **valid, loaded** group. The previous behavior (setting parent to `error` on any error child) caused groups with valid sub-layers to show as error/missing in the legend, even though their valid children were rendering on the map.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -704,6 +704,24 @@ items.forEach((item) => {
 - This keeps the map viewer initialization path alive so the basemap and UI still render with the remaining valid layers.
 - Treat this as the expected fix pattern for bad root layer types: **report-and-skip**, not fail-fast.
 
+### Duplicate Geocore UUID Handling & `orderedLayers`
+
+When the same geocore UUID appears multiple times in a map config, `Config.prevalidateGeoviewLayersConfig()` appends a `:generateId(8)` suffix to the duplicate's `geoviewLayerId` (e.g., `ccc75c12-...:eb637201`). This suffix must propagate correctly through the entire layer lifecycle:
+
+**Suffix propagation chain:**
+
+1. **`prevalidateGeoviewLayersConfig`** (config.ts) — Detects duplicate geocore `geoviewLayerId`s and appends `:suffix` to duplicates. Only modifies geocore entries; non-geocore duplicates are filtered out by `#deleteDuplicateAndMultipleUuidGeoviewLayerConfig`.
+2. **`GeoCore.createLayerConfigFromUUID`** (geocore.ts) — Strips suffix via `uuid.split(':')[0]` for the API call, then restores it on the response: `response.layers[0].geoviewLayerId = uuid`. **Critical:** This only updates `geoviewLayerId` on the parent config — it does NOT update `layerPath` on sub-entries in `listOfLayerEntryConfig`.
+3. **`generateOrderedLayerPaths`** (abstract-map-viewer-controller.ts) — For single-entry JSON configs, must use `geoviewLayerConfig.geoviewLayerId` (which includes the suffix) as the base path, NOT `layerEntryConfig.layerPath` (which is stale and lacks the suffix). The multi-entry branch already correctly uses `geoviewLayerId`.
+4. **`#registerForOrderedLayerInfo`** (layer-controller.ts) — Detects geocore placeholders in `orderedLayers` by checking if the parent path is a valid UUID. Must handle suffixed UUIDs by stripping the suffix before the `isValidUUID()` check (e.g., `parentLayerPath.split(':')[0]`), because `isValidUUID()` uses a strict regex that rejects `uuid:suffix` format.
+
+**`orderedLayers` population — two paths:**
+
+- **Initial load** (`loadListOfGeoviewLayer`): Generates paths via `generateOrderedLayerPaths` → pushes to local array → writes to store via `setMapOrderedLayersDirectly`. Must use `validGeoviewLayerConfigs` (filtered, no duplicates) not the original `mapConfigLayerEntries`. If `addGeoviewLayer` throws (e.g., `LayerCreatedTwiceError`), the catch block must remove the paths that were just pushed.
+- **Runtime add** (`addGeoviewLayerByGeoCoreUUID`): Adds a UUID placeholder to `orderedLayers`, then `#registerForOrderedLayerInfo` replaces it with actual layer paths when the layer registers.
+
+**Key pitfall:** `isValidUUID()` in `core/utils/utilities.ts` uses strict regex `/^[0-9a-f]{8}-...-[0-9a-f]{12}$/i` — it rejects suffixed UUIDs like `uuid:ab123456`. Any code using `isValidUUID` to detect geocore entries must account for the `:suffix` format.
+
 ### `initialSettings` Cascading (Parent → Child)
 
 The `ConfigValidation.#processLayerEntryConfig()` method handles how `initialSettings` propagate from parent layers to children. Understanding this cascading is critical for writing correct config tests.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -722,6 +722,31 @@ When the same geocore UUID appears multiple times in a map config, `Config.preva
 
 **Key pitfall:** `isValidUUID()` in `core/utils/utilities.ts` uses strict regex `/^[0-9a-f]{8}-...-[0-9a-f]{12}$/i` — it rejects suffixed UUIDs like `uuid:ab123456`. Any code using `isValidUUID` to detect geocore entries must account for the `:suffix` format.
 
+### Partial Layer Loading & Group Status Propagation
+
+**Partial loading** — When a GeoView layer has multiple sub-layers and some fail validation (e.g., invalid layer IDs), the valid sub-layers must still load and render. In `createGeoViewLayers()` (`abstract-geoview-layers.ts`):
+
+1. `this.olRootLayer = layer?.getOLLayer()` must be set **before** checking for errors
+2. Only throw (`#throwAggregatedLayerLoadErrors()`) when `!this.olRootLayer` (ALL sub-layers failed)
+3. When some sub-layers are valid, errors are recorded on individual configs (`status='error'`) and reported by the caller via `getLayerLoadErrors()` + `showLayerError()`
+
+**Parent status propagation** — `#updateLayerStatusParentRec` in `config-base-class.ts` determines a parent group's status from its children:
+
+| Sibling states              | Parent status | Reason                                    |
+| --------------------------- | ------------- | ----------------------------------------- |
+| Any sibling is `loading`    | `loading`     | Still processing                          |
+| ALL siblings are `loaded`   | `loaded`      | Complete success                          |
+| Mix of `loaded` and `error` | `loaded`      | Partial success — at least one child works |
+| ALL siblings are `error`    | `error`       | Complete failure                          |
+
+**Critical rule:** A group with at least one loaded child is a **valid, loaded** group. The previous behavior (setting parent to `error` on any error child) caused groups with valid sub-layers to show as error/missing in the legend, even though their valid children were rendering on the map.
+
+**`#processListOfLayerEntryConfig` behavior with error children:**
+
+- CASE 2 (multiple entries): Error entries return `undefined` and are skipped. Valid entries are processed and added to the group. The group is always returned (even if empty — empty groups get added to the parent OL tree).
+- CASE 1 (single entry): If the entry is a group, it recurses into children. If all children fail, the recursive call returns an empty group (non-null in CASE 2), so `groupReturned` is truthy and the empty group is still added.
+- Groups in CASE 2 have **no** `layerStatus === 'error'` guard — they're always processed regardless of status. Only non-group entries skip on error.
+
 ### `initialSettings` Cascading (Parent → Child)
 
 The `ConfigValidation.#processLayerEntryConfig()` method handles how `initialSettings` propagate from parent layers to children. Understanding this cascading is critical for writing correct config tests.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -741,6 +741,12 @@ When the same geocore UUID appears multiple times in a map config, `Config.preva
 
 **Critical rule:** A group with at least one loaded child is a **valid, loaded** group. The previous behavior (setting parent to `error` on any error child) caused groups with valid sub-layers to show as error/missing in the legend, even though their valid children were rendering on the map.
 
+**UI handling of error sublayers** — When a group has error children, the UI must handle them consistently across three places:
+
+1. **Toggle-all visibility** (`handleToggleAllVisibility` in `layer-details.tsx`): Skip children with `layerStatus === LAYER_STATUS.ERROR` — they have no valid GV layer on the map, so toggling them is meaningless and would cause errors.
+2. **"All visible" state check** (`utilAllChildrenVisible` in `layer-state.ts`): Treat error children as "don't care" in `Array.every()` — return `true` for error children so they don't prevent the toggle-all switch from reflecting the state of the remaining valid children.
+3. **Individual sublayer UI** (`Sublayer` component in `layer-details.tsx`): Disable the checkbox and force it unchecked for error layers. Style the label with grey/italic to visually indicate the broken state.
+
 **`#processListOfLayerEntryConfig` behavior with error children:**
 
 - CASE 2 (multiple entries): Error entries return `undefined` and are skipped. Valid entries are processed and added to the group. The group is always returned (even if empty — empty groups get added to the parent OL tree).

--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -188,6 +188,7 @@
     "errorUrlUnreachable": "The URL is not reachable.",
     "errorUrlHttps": "Only HTTPS URLs are supported.",
     "errorUrlInvalidUUID": "The UUID format is not valid.",
+    "errorUrlDuplicateUUID": "This layer (UUID) is already loaded on the map.",
     "errorNotLoaded": "An error occurred with the layer '{{layerName}}'.",
     "errorImageLoad": "An error occured with source image for layer '{{layerName}}'.",
     "errorImageLoadSizeLimitExceededWidth": "The image requested for layer '{{layerName}}' exceeds the maximum width allowed by the server ({{requestedWidth}}px > {{maxWidth}}px).",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -188,6 +188,7 @@
     "errorUrlUnreachable": "L'URL n'est pas accessible.",
     "errorUrlHttps": "Seules les URL HTTPS sont prises en charge.",
     "errorUrlInvalidUUID": "Le format UUID n'est pas valide.",
+    "errorUrlDuplicateUUID": "Cette couche (UUID) est déjà chargée sur la carte.",
     "errorNotLoaded": "Une erreur est survenue avec la couche '{{layerName}}'.",
     "errorImageLoad": "Une erreur est survenue avec l'image source pour la couche '{{layerName}}'.",
     "errorImageLoadSizeLimitExceededWidth": "L'image demandée pour la couche '{{layerName}}' dépasse la taille maximale en largeur autorisée par le serveur ({{requestedWidth}}px > {{maxWidth}}px).",

--- a/packages/geoview-core/src/api/config/validation-classes/config-base-class.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/config-base-class.ts
@@ -847,13 +847,18 @@ export abstract class ConfigBaseClass {
       return;
     }
 
-    // Get all siblings which are in error or loaded
-    const siblingsInError = siblings.filter((lyrConfig) => lyrConfig.layerStatus === 'error' || lyrConfig.layerStatus === 'loaded');
+    // Get all siblings which are in error or loaded (terminal states)
+    const siblingsInTerminalState = siblings.filter((lyrConfig) => lyrConfig.layerStatus === 'error' || lyrConfig.layerStatus === 'loaded');
 
-    // If all siblings are in fact in error or loaded
-    if (siblings.length === siblingsInError.length) {
-      // Set the parent layer status as error
-      parentLayerConfig.setLayerStatusError();
+    // If all siblings are in a terminal state (error or loaded)
+    if (siblings.length === siblingsInTerminalState.length) {
+      // If at least one sibling is loaded, the parent is loaded (partial success — some children loaded, some errored)
+      if (siblingsInLoaded.length > 0) {
+        parentLayerConfig.setLayerStatusLoaded();
+      } else {
+        // All siblings are in error
+        parentLayerConfig.setLayerStatusError();
+      }
       // Continue with the parent
       ConfigBaseClass.#updateLayerStatusParentRec(parentLayerConfig);
     }

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -837,7 +837,7 @@ export function AddNewLayer(): JSX.Element {
     }
     if (activeStep === 2 && layerIdsToAdd.length > 0) setStepButtonEnabled(true);
     if (activeStep === 2 && !layerIdsToAdd.length) setStepButtonEnabled(false);
-  }, [layerURL, activeStep, layerIdsToAdd, layerType, uiController]);
+  }, [layerURL, activeStep, layerIdsToAdd, layerType, uiController, layerController]);
 
   /**
    * Manages input focus when the active step changes.

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -784,6 +784,12 @@ export function AddNewLayer(): JSX.Element {
       const validateUrl = async (): Promise<void> => {
         // Allow blob URLs (local files) and GeoCore UUIDs without validation
         if (layerURL.startsWith('blob') || isValidUUID(layerURL.trim())) {
+          // Check if this UUID is already loaded on the map
+          if (isValidUUID(layerURL.trim()) && layerController.getGeoviewLayerIds().includes(layerURL.trim())) {
+            setStepButtonEnabled(false);
+            uiController.addMessage('error', 'layers.errorUrlDuplicateUUID', {}, false);
+            return;
+          }
           setStepButtonEnabled(true);
           return;
         }

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -101,7 +101,11 @@ const Sublayer = memo(function Sublayer({ layerPath }: SubLayerProps): JSX.Eleme
   const layerHidden = useStoreLayerIsHiddenOnMap(layerPath);
   const parentHidden = useStoreLayerIsParentHiddenOnMap(layerPath);
   const layerVisible = useStoreLayerVisible(layerPath);
+  const layerStatus = useStoreLayerStatus(layerPath);
   const layerController = useLayerController();
+
+  // A layer in error has no valid GV layer on the map — disable and uncheck its visibility control
+  const isError = layerStatus === LAYER_STATUS.ERROR;
 
   // Return the ui
   return (
@@ -111,9 +115,9 @@ const Sublayer = memo(function Sublayer({ layerPath }: SubLayerProps): JSX.Eleme
         control={
           <Checkbox
             color="primary"
-            checked={layerVisible === true}
+            checked={!isError && layerVisible === true}
             onChange={() => layerController.setOrToggleLayerVisibility(layerPath)}
-            disabled={parentHidden}
+            disabled={isError || parentHidden}
           />
         }
         label={
@@ -121,7 +125,7 @@ const Sublayer = memo(function Sublayer({ layerPath }: SubLayerProps): JSX.Eleme
             <LayerIcon layerPath={layerPath} />
             <Box
               component="span"
-              sx={{ ...sxClasses.tableIconLabel, ...(layerHidden && { color: theme.palette.grey[600], fontStyle: 'italic' }) }}
+              sx={{ ...sxClasses.tableIconLabel, ...((isError || layerHidden) && { color: theme.palette.grey[600], fontStyle: 'italic' }) }}
             >
               {layerName}
             </Box>
@@ -415,7 +419,7 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   }, []);
 
   /**
-   * Sets visibility for all children of the layer.
+   * Sets visibility for all children of the layer, skipping children in error state.
    */
   const handleToggleAllVisibility = useCallback((): void => {
     // Use the non-reactive getter to walk the tree — only needed at click time
@@ -424,6 +428,8 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
 
     const setRecursive = (legendLayer: typeof layer, newVisibility: boolean): void => {
       legendLayer.children.forEach((child) => {
+        // Skip children in error state — they have no valid GV layer on the map
+        if (child.layerStatus === LAYER_STATUS.ERROR) return;
         if (newVisibility) {
           if (!visibleLayers.includes(child.layerPath)) layerController.setOrToggleLayerVisibility(child.layerPath, true);
         } else if (visibleLayers.includes(child.layerPath)) layerController.setOrToggleLayerVisibility(child.layerPath, false);

--- a/packages/geoview-core/src/core/controllers/base/abstract-map-viewer-controller.ts
+++ b/packages/geoview-core/src/core/controllers/base/abstract-map-viewer-controller.ts
@@ -117,8 +117,11 @@ export class AbstractMapViewerController extends AbstractController {
           addSubLayerPathToLayerOrder(layerEntryConfig, layerPath);
         });
       } else {
+        // GV: Use geoviewLayerId instead of layerEntryConfig.layerPath because for duplicate geocore layers,
+        // GV: geocore.ts updates geoviewLayerId with the ':suffix' but does not propagate it to the sub-entries'
+        // GV: layerPath property. Using geoviewLayerId ensures the suffix is included in the ordered layer path.
         const layerEntryConfig = geoviewLayerConfig.listOfLayerEntryConfig[0];
-        addSubLayerPathToLayerOrder(layerEntryConfig, layerEntryConfig.layerPath);
+        addSubLayerPathToLayerOrder(layerEntryConfig, geoviewLayerConfig.geoviewLayerId);
       }
     } else {
       addSubLayerPathToLayerOrder(geoviewLayerConfig as TypeLayerEntryConfig, geoviewLayerConfig.layerPath);

--- a/packages/geoview-core/src/core/controllers/layer-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-controller.ts
@@ -2403,9 +2403,10 @@ export class LayerController extends AbstractMapViewerController {
       // Get the parent layer config, if any
       const parentLayerConfig = layerConfig.getParentLayerConfig();
 
-      // If the map index of a parent layer path has been set and it is a valid UUID, the ordered layer entry is a placeholder
-      // registered while the geocore layer info was fetched
-      if (getStoreLayerOrderedLayerIndexByPath(this.getMapId(), parentLayerPath) !== -1 && isValidUUID(parentLayerPath)) {
+      // If the map index of a parent layer path has been set and it is a valid UUID (or a suffixed UUID like uuid:suffix
+      // for duplicate geocore layers), the ordered layer entry is a placeholder registered while the geocore layer info was fetched
+      const parentLayerPathBase = parentLayerPath.includes(':') ? parentLayerPath.split(':')[0] : parentLayerPath;
+      if (getStoreLayerOrderedLayerIndexByPath(this.getMapId(), parentLayerPath) !== -1 && isValidUUID(parentLayerPathBase)) {
         // Replace the placeholder ordered layer paths
         this.replaceOrderedLayerPaths(layerConfig, parentLayerPath);
       } else if (parentLayerConfig) {

--- a/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
@@ -681,6 +681,13 @@ export class LayerCreatorController extends AbstractMapViewerController {
           // Add the layer on the map
           this.#addToMap(layerBeingAdded, geoviewLayerConfig);
 
+          // If there were partial errors (some sub-layers failed but valid ones were added), report them
+          const partialErrors = layerBeingAdded.getLayerLoadErrors();
+          if (partialErrors.length > 0) {
+            const error = partialErrors.length === 1 ? partialErrors[0] : new AggregateError(partialErrors);
+            this.showLayerError(error, geoviewLayerConfig.geoviewLayerId);
+          }
+
           // Resolve, done
           resolve();
 

--- a/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
@@ -120,12 +120,12 @@ export class LayerCreatorController extends AbstractMapViewerController {
   async loadListOfGeoviewLayer(mapConfigLayerEntries: MapConfigLayerEntry[]): Promise<void> {
     const validGeoviewLayerConfigs = this.#deleteDuplicateAndMultipleUuidGeoviewLayerConfig(mapConfigLayerEntries);
 
-    // Make sure to convert all map config layer entry into a GeoviewLayerConfig
+    // Make sure to convert all valid map config layer entry into a GeoviewLayerConfig (use filtered list to exclude duplicates)
     const promisesOfGeoviewLayers = LayerCreatorController.convertMapConfigsToGeoviewLayerConfig(
       this.getMapId(),
       this.getControllersRegistry().layerController.getGeoviewLayerIds(),
       this.getMapViewer().getDisplayLanguage(),
-      mapConfigLayerEntries,
+      validGeoviewLayerConfigs,
       (layerPath: string, geochartConfig: GeoViewGeoChartConfig) => {
         // Add the chart to the store
         this.getControllersRegistry().geoChartController?.addChart(layerPath, geochartConfig);
@@ -173,6 +173,15 @@ export class LayerCreatorController extends AbstractMapViewerController {
         } catch (error: unknown) {
           // An error happening here likely means a particular, trivial, config error.
           // The majority of typicaly errors happen in the addGeoviewLayer promise catcher, not here.
+
+          // Remove the layer paths that were added to orderedLayers before the error
+          if (geoviewLayerConfig.useAsBasemap !== true) {
+            const failedPaths = AbstractMapViewerController.generateOrderedLayerPaths(geoviewLayerConfig);
+            failedPaths.forEach((failedPath) => {
+              const idx = orderedLayers.indexOf(failedPath);
+              if (idx !== -1) orderedLayers.splice(idx, 1);
+            });
+          }
 
           // Show the error(s)
           this.showLayerError(error, geoviewLayerConfig.geoviewLayerId);

--- a/packages/geoview-core/src/core/stores/states/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/states/layer-state.ts
@@ -224,7 +224,11 @@ const utilDeleteLayerFromLegendLayers = (legendLayers: TypeLegendLayer[], layerP
  */
 const utilAllChildrenVisible = (layer: TypeLegendLayer, visibleLayers: string[]): boolean => {
   return layer.children.every(
-    (child) => visibleLayers.includes(child.layerPath) && (!child.children?.length || utilAllChildrenVisible(child, visibleLayers))
+    // Error children have no valid GV layer on the map — treat them as "don't care" so they
+    // don't prevent the toggle-all switch from reflecting the state of the remaining valid children.
+    (child) =>
+      child.layerStatus === 'error' ||
+      (visibleLayers.includes(child.layerPath) && (!child.children?.length || utilAllChildrenVisible(child, visibleLayers)))
   );
 };
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -454,11 +454,15 @@ export abstract class AbstractGeoViewLayer {
     // Process list of layers and await
     const layer = await this.#processListOfLayerEntryConfig(this.listOfLayerEntryConfig);
 
-    // If any errors were compiled, throw about it
-    this.#throwAggregatedLayerLoadErrors();
-
-    // Keep the OL reference
+    // Keep the OL reference before checking errors, so valid layers can still be added to the map
     this.olRootLayer = layer?.getOLLayer();
+
+    // If errors were compiled, only throw when ALL layers failed (no valid OL root layer was created).
+    // When some sub-layers are valid, the errors are recorded on individual configs (status='error')
+    // and will be reported by the caller via getLayerLoadErrors().
+    if (!this.olRootLayer) {
+      this.#throwAggregatedLayerLoadErrors();
+    }
 
     // Log the time it took thus far
     logger.logMarkerCheck(logTimingsKey, 'to create the layers');
@@ -589,6 +593,15 @@ export abstract class AbstractGeoViewLayer {
 
     // Set the layer status to error
     layerConfig?.setLayerStatusError();
+  }
+
+  /**
+   * Gets the list of errors accumulated during layer loading.
+   *
+   * @returns A shallow copy of the layer load error list
+   */
+  getLayerLoadErrors(): Error[] {
+    return [...this.#layerLoadError];
   }
 
   /**


### PR DESCRIPTION
… orderedLayers

Closes #3399, #3464

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #3339, #3464

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

Hosted, may 14th 11:20am

https://jolevesq.github.io/geoview/layers-navigator.html?config=./configs/navigator/layers/geocore-duplicates.json

- Try to reorder layers
- Look at layer state orderedLayers array and compare with upstream
- The Water layer group loads even if some sublayer are failing

# Checklist:

- [x] I have run the **Test Suite** and **No errors have been introduced**
- [x] I have run `@BranchReview` agent in VS Code Chat and addressed all violations
- [ ] I have run `@DocUpdate` agent in VS Code Chat and documentation is in sync with code changes
- [x] I have run `@IssueReview` agent in VS Code Chat and the implementation aligns with the linked issue
- [x] I have build **(rush build)** and deploy **(rush host)** my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~New and existing unit tests pass locally with my changes~~

# Pre-PR Copilot Agent Checks

Before creating your PR, run the following two Copilot agents in VS Code Chat to catch common issues automatically.

## Branch Review (`@BranchReview`)

Audits all changed `.ts`/`.tsx` files against the GeoView coding standards (JSDoc, logging, return types, naming, accessibility, imports, performance patterns).

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **BranchReview** agent from the agent picker (or type `@BranchReview`)
3. Type the target branch name (defaults to `develop`):
   ```
   @BranchReview  against upstream/develop
   ```
4. Review the violation report and fix flagged items (the agent can auto-fix most issues on approval)

- [ ] `@BranchReview` has been run and all violations have been addressed

## Documentation Update (`@DocUpdate`)

Checks that documentation in `docs/` is still consistent with the code you changed. Catches stale references, missing docs for new features, and incorrect code examples.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **DocUpdate** agent from the agent picker (or type `@DocUpdate`)
3. Run a full audit or target a specific section:
   ```
   @DocUpdate full audit of docs/programming/
   @DocUpdate check docs/app/layers/
   ```
4. Review the audit summary and approve any proposed documentation updates

- [ ] `@DocUpdate` has been run and documentation is in sync with code changes

## Issue Review (`@IssueReview`)

Compares your branch changes against the linked GitHub issue's proposed fix. Checks whether the implementation aligns with what was proposed, catches gaps, and provides feedback to improve future issue drafts.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **IssueReview** agent from the agent picker (or type `@IssueReview`)
3. Provide the issue number:
   ```
   @IssueReview #1234
   ```
4. Review the alignment report — it will flag items that were proposed but not implemented, unexpected changes, and root cause accuracy

- [ ] `@IssueReview` has been run and the alignment report has been reviewed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3476)
<!-- Reviewable:end -->
