### PR TITLE
fix(many): Fix time-slider switch direction, map-controller not reasy…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -680,13 +680,15 @@ export const getSxClasses = (theme: Theme): SxStyles => ({
 
 **`SxStyles`** is defined in `@/ui/style/types` as `Record<string, SxProps<Theme> | SxProps>`.
 
-**Usage in component:**
+**Usage in component** — always wrap in `useMemo` with `memo` prefix. This is a lightweight memoization that does **not** require JSDoc or `logTraceUseMemo` (exception to the general `useMemo` rules):
 
 ```typescript
 const theme = useTheme();
-const sxClasses = getSxClasses(theme);
+const memoSxClasses = useMemo((): SxStyles => {
+  return getSxClasses(theme);
+}, [theme]);
 // ...
-<Box sx={sxClasses.container}>
+<Box sx={memoSxClasses.container}>
 ```
 
 ### Theme Tokens
@@ -1277,6 +1279,14 @@ const memoColumns = useMemo<MRTColumnDef<ColumnsType>[]>(() => {
 
   // Implementation
 }, [dependencies]);
+```
+
+**Exception — `memoSxClasses`**: The `getSxClasses` memoization is a lightweight, standardized pattern that does **not** require JSDoc or `logTraceUseMemo`. Use the compact form:
+
+```typescript
+const memoSxClasses = useMemo((): SxStyles => {
+  return getSxClasses(theme);
+}, [theme]);
 ```
 
 ### useCallback Comment Pattern

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -242,6 +242,33 @@ const isVisible =
 
 **Config validation behavior for visibility** — In `ConfigValidation.#processLayerEntryConfig()`, when `parentInitialSettingsTrue?.states?.visible === false`, the child's `visible` property is **deleted** from the merged config (`delete initSettingsMerged.states?.visible`). This means the child defaults to `visible = true` in the store/legend, but is visually hidden because the parent OL layer is not visible.
 
+### Layer Style Item Visibility & Class Filters
+
+See [layer-filters.md](../docs/programming/layer-filters.md) for the full filter architecture documentation.
+
+**Four filter sources** — Layer filtering in GeoView comes from four independent sources, combined with AND logic:
+
+| Source                 | Store key                 | Producer                                                                             | Consumer                      |
+| ---------------------- | ------------------------- | ------------------------------------------------------------------------------------ | ----------------------------- |
+| **Style class filter** | `layerFilterClass`        | `GeoviewRenderer.getFilterFromStyle()` via `AbstractGVLayer.#setLayerFiltersClass()` | Data table, feature queries   |
+| **Time filter**        | `layerFilterTime`         | `TimeSliderController.#generateFilterString()`                                       | Data table, WMS/ESRI requests |
+| **Data filter**        | `tableFilters[layerPath]` | `buildFilterList()` → `DataTableController.applyMapFilters()`                        | Map rendering (source params) |
+| **Config filter**      | `#initialFilter`          | Map config `initialSettings.filters`                                                 | Feature queries               |
+
+These filters are joined by `LayerFilters.joinWithAnd()` when applied.
+
+**`getFilterFromStyle()` behavior by style type:**
+
+| Style type        | Returns     | Example                                             | Data table filtering       |
+| ----------------- | ----------- | --------------------------------------------------- | -------------------------- |
+| **`uniqueValue`** | SQL string  | `"status" = 'active' OR "status" = 'pending'`       | ✅ Rows filtered           |
+| **`classBreaks`** | SQL string  | `"population" >= 100000 AND "population" <= 500000` | ✅ Rows filtered           |
+| **`simple`**      | `undefined` | —                                                   | ❌ All rows remain visible |
+
+**Simple style limitation** — When a layer has multiple geometry types (e.g., Point + Polygon), toggling a geometry type's visibility in the legend works **only at the renderer level**. `processSimplePoint/LineString/Polygon` in `GeoviewRenderer` returns `undefined` (no OL style = invisible on map) when `styleSettings.info[0]?.visible === false`. However, `getFilterFromStyle()` returns `undefined` for simple styles because geometry type is not an attribute field — there is no SQL equivalent of `WHERE geometryType = 'Point'`. This means the data table cannot filter rows by geometry type and always shows all features regardless of which geometry types are toggled off.
+
+**Style item identity** — `setStoreLayerItemVisibility()` in `layer-state.ts` matches items by **both `name` AND `geometryType`** to disambiguate items that share the same name across different geometry types (e.g., a "Default" point style vs a "Default" polygon style on the same layer).
+
 ### Scale Limits & Visibility Range
 
 **Scale calculation normalization** — `MapViewer.getMapScaleFromZoom()` now rounds the computed denominator to the nearest unit (`Math.round`). This avoids floating-point artifacts like `159499.99999999983` and keeps visibility comparisons stable.
@@ -2206,6 +2233,7 @@ Controllers are the preferred path. MapViewer provides low-level OL access (tran
 - [event-helper.md](../docs/programming/event-helper.md) - Delegate event system
 - [controller-architecture.md](../docs/programming/controller-architecture.md) - Controller design & domain integration
 - [time-dimension.md](../docs/programming/time-dimension.md) - OGC/ESRI time dimension parsing & time slider
+- [layer-filters.md](../docs/programming/layer-filters.md) - Layer filter architecture (class, time, config filters)
 - [troubleshooting.md](../docs/programming/troubleshooting.md) - Service-specific fixes & known issues
 
 ## TypeDoc-First API Documentation Policy

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -165,9 +165,13 @@ Passing it directly without swapping interprets `[90, -95]` as map projection me
 const mapCoord = Projection.transformFromLonLat([lon, lat], projection);
 const pixel = map.getPixelFromCoordinate(mapCoord);
 const size = map.getSize();
-const isVisible = pixel && size
-  && pixel[0] >= 0 && pixel[0] <= size[0]
-  && pixel[1] >= 0 && pixel[1] <= size[1];
+const isVisible =
+  pixel &&
+  size &&
+  pixel[0] >= 0 &&
+  pixel[0] <= size[0] &&
+  pixel[1] >= 0 &&
+  pixel[1] <= size[1];
 ```
 
 **Screen-direction calculations** — When computing the visual direction from the viewport center to a map feature (e.g., north arrow pointing toward the pole), use pixel positions via `getPixelFromCoordinate` and `atan2`. Do NOT use geographic bearing formulas — they degenerate at projection singularities (e.g., `cos(90°) = 0` at the north pole). OL's `getPixelFromCoordinate` already accounts for view rotation internally.
@@ -262,6 +266,33 @@ Both effective scales are rounded, then expanded into tolerance boundaries using
 **Boundary semantics** — Base checks are inclusive (`>= minResolution` and `<= maxResolution`), but scale tolerance bands intentionally mark near-boundary scales as not visible to avoid unstable service behavior near thresholds.
 
 **Feature-query gating** — `AbstractLayerSet.queryLayerFeatures()` must gate queries with `isInVisibleRange(...)` using current resolution, current scale, and `computeEffectiveLayerScales(...)`, not zoom-only checks.
+
+### Time Dimension & Time Slider
+
+See [time-dimension.md](../docs/programming/time-dimension.md) for the full architecture documentation.
+
+**Two standards, one internal model** — OGC WMS uses `<Dimension>` XML in GetCapabilities; ESRI uses `timeInfo` JSON. Both are normalized into a `TimeDimension` type via `DateMgt.createDimensionFromOGC()` / `DateMgt.createDimensionFromESRI()`. ESRI metadata is converted to OGC-style strings so `createRangeOGC()` is the single shared parser.
+
+**Three range types** (detected from the OGC `values` string):
+
+| Type         | Format                          | Example                                         | `nearestValues` |
+| ------------ | ------------------------------- | ----------------------------------------------- | --------------- |
+| **Discrete** | Comma-separated dates           | `1696,1701,1734`                                | `'discrete'`    |
+| **Absolute** | `start/end/period`              | `2002-09-01T00:00:00Z/2025-01-01T00:00:00Z/P1Y` | `'discrete'`    |
+| **Relative** | `start/end` or `start/duration` | `2026-05-27T11:12:00Z/PT10M`                    | `'continuous'`  |
+
+**Handle count is driven by the `default` array length**, not `singleHandle` alone. The MUI Slider renders one thumb for `[value]` and two thumbs for `[start, end]`. For OGC WMS, `default` and `multipleValues` attributes are the two signals:
+
+- OGC `<Dimension default="...">` present → `defaultValues = [default]` → **1 thumb** (definitive signal)
+- OGC `<Dimension>` without `default`, `multipleValues="0"` → `defaultValues = [range[last]]` → **1 thumb** (server only accepts single value)
+- OGC `<Dimension>` without `default`, `multipleValues="1"` or absent → `defaultValues = [range[0], range[last]]` → **2 thumbs** (best guess)
+- ESRI → always `[range[0], range[last]]` → **2 thumbs**
+
+**Filter generation differs by layer type:**
+
+- **WMS**: `TIME=date1` or `TIME=date1/date2` (ISO range)
+- **ESRI Image**: `time=epoch1,epoch2` (raw milliseconds)
+- **ESRI Dynamic/Vector**: SQL-like `field >= date AND field <= date`
 
 ### Event Delegate System
 
@@ -1363,25 +1394,29 @@ const handleToggleKeyDown = useCallback(
 **Pattern:**
 
 ✅ **CORRECT** — Safe for external consumers:
+
 ```typescript
 // In style files and components
-theme.palette.geoViewColor?.primary.main
-theme.palette.geoViewColor?.secondary
-theme.palette.geoViewColor?.white
-theme.palette.geoViewColor?.textColor.main
-theme.palette.geoViewColor?.bgColor.dark[100]
+theme.palette.geoViewColor?.primary.main;
+theme.palette.geoViewColor?.secondary;
+theme.palette.geoViewColor?.white;
+theme.palette.geoViewColor?.textColor.main;
+theme.palette.geoViewColor?.bgColor.dark[100];
 ```
 
 ❌ **INCORRECT** — Crashes if external theme lacks extension:
+
 ```typescript
-theme.palette.geoViewColor.primary.main  // ❌ No optional chaining
+theme.palette.geoViewColor.primary.main; // ❌ No optional chaining
 ```
 
 **Examples:**
+
 - `packages/geoview-core/src/ui/slider/slider-style.ts` — ✅ Correct (all geoViewColor references use `?.`)
 - `packages/geoview-core/src/ui/tabs/tabs.tsx` — ✅ Correct (all geoViewColor references use `?.`)
 
 **Enforcement:**
+
 - During code generation: Auto-apply optional chaining to all custom theme extension refs
 - During branch reviews: Scan all `@/ui` and `@/core/components/ui` files for direct access violations
 - Add to pre-commit hook checklist: No direct `theme.palette.geoViewColor.` without `?.`
@@ -2170,6 +2205,7 @@ Controllers are the preferred path. MapViewer provides low-level OL access (tran
 - [using-store.md](../docs/programming/using-store.md) - Zustand usage patterns
 - [event-helper.md](../docs/programming/event-helper.md) - Delegate event system
 - [controller-architecture.md](../docs/programming/controller-architecture.md) - Controller design & domain integration
+- [time-dimension.md](../docs/programming/time-dimension.md) - OGC/ESRI time dimension parsing & time slider
 - [troubleshooting.md](../docs/programming/troubleshooting.md) - Service-specific fixes & known issues
 
 ## TypeDoc-First API Documentation Policy

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -482,6 +482,33 @@ const handleChange = useCallback(
 - Downcast only after `instanceof` check or type guard function
 - Avoid spreading objects with deep nesting - use `lodash.cloneDeep` instead
 
+### Prefer `undefined` Over `null`
+
+Use `undefined` as the default "no value" sentinel. Reserve `null` only for cases where it is semantically required:
+
+| Use `null`                                                                                               | Use `undefined`                                    |
+| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| React node return (`JSX.Element \| null`)                                                                | Optional function parameters and return values     |
+| DOM refs managed by React (`useRef<T>(null)`)                                                            | Mutable data refs (`useRef<T \| undefined>`)       |
+| Values coming from external APIs that use `null` (OpenLayers, browser DOM)                               | GeoView internal APIs and controller return values |
+| Explicit "set to nothing" in JSON / store state where `undefined` would be stripped during serialization | Optional properties on interfaces and types        |
+
+**Why:** `undefined` enables optional chaining (`value?.prop`) and nullish coalescing (`value ?? fallback`) without extra `null` checks. It also aligns with TypeScript's `?` optional property syntax, which produces `T | undefined`, not `T | null`.
+
+**Wrapping external `null` returns:** When an external API (e.g., OpenLayers) returns `null`, convert it to `undefined` at the boundary:
+
+```typescript
+// ✅ Good: Convert OL's null to undefined at the GeoView API boundary
+getPixelFromCoordinate(coord: Coordinate): Pixel | undefined {
+  return olMap.getPixelFromCoordinate(coord) ?? undefined;
+}
+
+// ❌ Bad: Propagating null through GeoView code
+getPixelFromCoordinate(coord: Coordinate): Pixel | null {
+  return olMap.getPixelFromCoordinate(coord);
+}
+```
+
 ### Reuse Over Duplication
 
 Before writing new logic, check whether a utility or helper already exists in the codebase. Do not duplicate logic that is available in a shared module.

--- a/docs/app/config/configuration-reference.md
+++ b/docs/app/config/configuration-reference.md
@@ -2458,7 +2458,7 @@ interface SliderConfig {
   - **nearestValues**: Slider behavior mode
     - `'discrete'` - Slider snaps only to values in the range array (default)
     - `'continuous'` - Slider allows any value between min/max, uses step for filtering
-  - **singleHandle**: Use single handle (true) or range handles (false)
+  - **singleHandle**: Use single handle (true) or range handles (false). GeoView auto-detects this from WMS metadata: if the `<Dimension>` has a `default` attribute or `multipleValues="0"`, it defaults to single handle; otherwise dual handle. Use this config property to override the auto-detected value.
   - **displayPattern**: Date/time display format configuration
   - **rangeItems**: Temporal range definition
     - **type**: Range type ('discrete', 'continuous')

--- a/docs/app/packages/geoview-core-packages.md
+++ b/docs/app/packages/geoview-core-packages.md
@@ -423,7 +423,7 @@ interface TypeTimeSliderValues {
   isMainLayerPath: boolean; // Is this the primary layer
   locked?: boolean; // Are handles locked together
   reversed?: boolean; // Is animation reversed
-  singleHandle: boolean; // Single vs range selection
+  singleHandle: boolean; // Single vs range selection (auto-detected from WMS metadata, overridable via config)
   title?: string; // Display title
   // Data
   minAndMax: number[]; // [min, max] timestamps (ms)

--- a/docs/programming/layer-filters.md
+++ b/docs/programming/layer-filters.md
@@ -1,0 +1,498 @@
+# Layer Filter Architecture
+
+> **TypeDoc Reference:** [AbstractGVLayer](https://canadian-geospatial-platform.github.io/geoview/public/docs/typedoc/classes/AbstractBaseGVLayer.html) · [GeoviewRenderer](https://canadian-geospatial-platform.github.io/geoview/public/docs/typedoc/classes/GeoviewRenderer.html) · [MapController](https://canadian-geospatial-platform.github.io/geoview/public/docs/typedoc/classes/MapController.html)
+
+## Overview
+
+GeoView uses four independent filter sources that are combined with AND logic to control which features are visible on the map, shown in the data table, and returned from feature queries. Each filter source is a SQL-like string fragment managed by the `LayerFilters` class.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────────────┐
+│                              FOUR FILTER SOURCES                                        │
+├──────────────────┬──────────────────┬──────────────────────┬───────────────────────────┤
+│  CLASS FILTER    │  TIME FILTER     │  DATA FILTER         │  CONFIG FILTER            │
+│  (Style-based)   │  (Time Slider)   │  (Data Table)        │  (Map Config)             │
+├──────────────────┼──────────────────┼──────────────────────┼───────────────────────────┤
+│ Legend item      │ Time slider UI   │ Data table column    │ initialSettings.filters   │
+│ toggle           │                  │ filters              │                           │
+│ GeoviewRenderer  │ TimeSlider       │ DataTableController  │ Applied at layer init     │
+│ .getFilterFrom   │ Controller.      │ .applyMapFilters()   │                           │
+│ Style()          │ #generateFilter  │                      │                           │
+│                  │ String()         │                      │                           │
+├──────────────────┴──────────────────┴──────────────────────┴───────────────────────────┤
+│                                                                                         │
+│              LayerFilters.joinWithAnd([config, class, data, time])                       │
+│                                                                                         │
+├─────────────────────────────────────────────────────────────────────────────────────────┤
+│                              CONSUMERS                                                  │
+├──────────────────────────┬──────────────────────────┬───────────────────────────────────┤
+│ Data Table               │ Map Rendering            │ Feature Queries                   │
+│ (client-side filter      │ (server-side for         │ (WFS GetFeature,                  │
+│  using class + time)     │  WMS/ESRI; client        │  ESRI query endpoint,             │
+│                          │  for vector)             │  client-side filter)              │
+└──────────────────────────┴──────────────────────────┴───────────────────────────────────┘
+```
+
+**Note:** The data table is both a **consumer** (reads class + time filters to filter displayed rows) and a **producer** (generates data filters from column filters that are applied back to the map).
+
+## LayerFilters Class
+
+**Location:** `packages/geoview-core/src/geo/layer/gv-layers/layer-filters.ts`
+
+Each `AbstractGVLayer` instance owns a `LayerFilters` object that aggregates the four filter fragments:
+
+| Property         | Source      | Description                                |
+| ---------------- | ----------- | ------------------------------------------ |
+| `#initialFilter` | Config      | Base filter from `initialSettings.filters` |
+| `#classFilter`   | Renderer    | SQL generated from style item visibility   |
+| `#dataFilter`    | Data table  | User-defined data table column filter      |
+| `#timeFilter`    | Time slider | Temporal range filter                      |
+
+### Key Methods
+
+| Method                    | Returns               | Purpose                                     |
+| ------------------------- | --------------------- | ------------------------------------------- |
+| `getClassFilter()`        | `string \| undefined` | Current class filter                        |
+| `getTimeFilter()`         | `string \| undefined` | Current time filter                         |
+| `getInitialFilter()`      | `string \| undefined` | Config filter                               |
+| `getDataFilter()`         | `string \| undefined` | Data table filter                           |
+| `getDataRelatedFilters()` | `string`              | `joinWithAnd([initial, class, data])`       |
+| `getAllFilters()`         | `string`              | `joinWithAnd([initial, class, data, time])` |
+| `getFilterEquation()`     | `FilterNodeType[]`    | Cached parsed AST of `getAllFilters()`      |
+| `hasClassFilter()`        | `boolean`             | `true` if class filter is set               |
+| `hasTimeFilter()`         | `boolean`             | `true` if time filter is set                |
+
+### Filter Combination: `joinWithAnd()`
+
+`LayerFilters.joinWithAnd()` is a static method that combines filter fragments:
+
+```typescript
+LayerFilters.joinWithAnd([undefined, "", 'status = "active"']);
+// → 'status = "active"'   (single valid → returned as-is)
+
+LayerFilters.joinWithAnd(['status = "active"', "population > 100000"]);
+// → '(status = "active") AND (population > 100000)'
+
+LayerFilters.joinWithAnd([undefined, undefined]);
+// → ''   (no valid filters → empty string)
+```
+
+Rules:
+
+- Ignores `undefined`, `null`, empty, and whitespace-only entries
+- Single valid filter is returned without extra parentheses
+- Multiple valid filters are each wrapped in `()` and joined with `AND`
+
+---
+
+## Filter Source 1: Class Filter (Style-Based)
+
+**Store key:** `layerFilterClass`
+
+The class filter is generated from the **visibility state of legend style items**. When a user toggles an item in the legend, the renderer recomputes a SQL filter string that includes only the visible items.
+
+### How It Works
+
+```
+User clicks legend item checkbox
+→ LayerController.setItemVisibility(layerPath, item, visible)
+  → AbstractGVLayer.setStyleItemVisibility(item, visible)
+    → mutates styleSettings.info[i].visible
+    → calls #setLayerFiltersClass()
+      → GeoviewRenderer.getFilterFromStyle(outFields, style, styleSettings)
+        → returns SQL string or undefined
+      → layer.getLayerFilters().setClassFilter(filter)
+  → setStoreLayerItemVisibility(mapId, layerPath, item, visible, classFilter)
+    → updates store: layerFilterClass = classFilter
+```
+
+### Filter Generation by Style Type
+
+| Style Type        | `getFilterFromStyle()` Returns  | Example                                             | Can Filter Data Table? |
+| ----------------- | ------------------------------- | --------------------------------------------------- | ---------------------- |
+| **`uniqueValue`** | SQL OR clause of visible values | `"status" = 'active' OR "status" = 'pending'`       | ✅ Yes                 |
+| **`classBreaks`** | SQL range of visible breaks     | `"population" >= 100000 AND "population" <= 500000` | ✅ Yes                 |
+| **`simple`**      | `undefined`                     | —                                                   | ❌ No                  |
+
+**When ALL items are visible**, `getFilterFromStyle()` returns `undefined` (no filter needed — show everything).
+
+**When SOME items are visible**, it builds a SQL condition from the visible items' field values.
+
+**When NO items are visible**, the resulting filter excludes all features.
+
+### Unique Value Example
+
+A layer styled by a `"status"` field with values `['active', 'pending', 'closed']`:
+
+- All visible → `undefined` (no filter)
+- Only `active` and `pending` visible → `"status" = 'active' OR "status" = 'pending'`
+- Only `closed` hidden → `"status" = 'active' OR "status" = 'pending'`
+
+### Simple Style Limitation
+
+**When a layer has multiple geometry types** (e.g., Point + Polygon), the legend shows one item per geometry type. Toggling visibility works at the **renderer level only**:
+
+- `processSimplePoint()` / `processSimpleLineString()` / `processSimplePolygon()` in `GeoviewRenderer` returns `undefined` (no OL style = invisible on map) when `styleSettings.info[0]?.visible === false`
+- However, `getFilterFromStyle()` returns `undefined` for simple styles because **geometry type is not an attribute field** — there is no SQL equivalent of `WHERE geometryType = 'Point'`
+
+**Consequence:** The data table cannot filter rows by geometry type. When a user hides "Point" features via the legend, they disappear from the map but remain visible in the data table.
+
+### Style Item Identity
+
+`setStoreLayerItemVisibility()` in `layer-state.ts` matches items by **both `name` AND `geometryType`** to disambiguate items that share the same name across different geometry types (e.g., a "Default" point style vs a "Default" polygon style on the same layer).
+
+---
+
+## Filter Source 2: Time Filter (Time Slider)
+
+**Store key:** `layerFilterTime` (in time slider store state)
+
+The time filter is generated when the user interacts with the time slider component. It encodes a temporal range that restricts which features are displayed.
+
+### How It Works
+
+```
+User moves time slider thumb(s)
+→ TimeSliderController.updateTimeSliderValues(layerPath, values)
+  → #generateFilterString(layer, timeSliderValues, field, filtering, values)
+    → returns filter string based on layer type
+  → layer.setLayerFiltersTime(filter)
+  → setStoreTimeSliderFilter(mapId, layerPath, filter)
+```
+
+### Filter Format by Layer Type
+
+| Layer Type              | Format             | Example                                                             |
+| ----------------------- | ------------------ | ------------------------------------------------------------------- |
+| **WMS** (single handle) | `TIME=date`        | `date_field = date '2023-01-01T00:00:00Z'`                          |
+| **WMS** (dual handle)   | `TIME=date1/date2` | `date_field = date '2023-01-01'/date '2023-12-31'`                  |
+| **ESRI Image**          | Epoch milliseconds | `time=1672531200000,1704067200000`                                  |
+| **ESRI Dynamic/Vector** | SQL date range     | `timestamp >= date '2023-01-01' AND timestamp <= date '2023-12-31'` |
+
+### Enable/Disable Filtering
+
+The time slider UI has a filtering toggle. When filtering is disabled:
+
+- `#generateFilterString()` returns an empty string
+- The time slider still displays the current range but no filter is applied
+- `hasTimeFilter()` returns `false`
+
+See [time-dimension.md](time-dimension.md) for the full time slider architecture.
+
+---
+
+## Filter Source 3: Config Filter (Initial Settings)
+
+**Store key:** Maps to `#initialFilter` in `LayerFilters`
+
+The config filter comes from the map configuration and is applied when the layer is created.
+
+### How It's Set
+
+In the map config JSON:
+
+```json
+{
+  "geoviewLayerType": "esriFeature",
+  "geoviewLayerId": "myLayer",
+  "listOfLayerEntryConfig": [
+    {
+      "layerId": "0",
+      "initialSettings": {
+        "filters": "status = 'active' AND year >= 2020"
+      }
+    }
+  ]
+}
+```
+
+During layer initialization, `initialSettings.filters` is passed to the `LayerFilters` constructor as `initialFilter`:
+
+```typescript
+new LayerFilters(
+  configLayerFilter, // initialFilter — from config
+  styleFilter, // classFilter — from renderer
+  undefined, // dataFilter — none at init
+  undefined, // timeFilter — none at init
+);
+```
+
+### Runtime Access
+
+- **Get:** `layer.getLayerConfig().getLayerFilter()` or `layer.getLayerFilters().getInitialFilter()`
+- **Set:** `layer.getLayerFilters().setInitialFilter(newFilter)` — can be changed at runtime
+- **Clear:** `layer.getLayerFilters().setInitialFilter(undefined)`
+
+---
+
+## Filter Source 4: Data Filter (Data Table Column Filters)
+
+**Store key:** `tableFilters[layerPath]` in data table state
+
+The data filter is generated when the user applies column filters in the data table UI. It flows back to the map to filter rendered features — making the data table both a filter **consumer** (reads class + time filters) and a filter **producer** (generates data filters applied to the map).
+
+### How It Works
+
+```
+User types in data table column filter
+→ MRT onChange event fires with column filter state
+→ buildFilterList() converts each column filter to a SQL-like string
+→ filterMap() joins strings with ' and '
+→ DataTableController.applyMapFilters(filterString)
+  → layer.setLayerFiltersData(filterString)
+    → LayerFilters.setDataFilter(filterString)
+    → emits LayerFilterChangedEvent (category: 'data')
+  → LayerController catches event
+    → setStoreDataTableFilter(mapId, layerPath, filter)
+  → applyViewFilterOnSource() applies filter to OL source
+```
+
+### Filter String Generation
+
+`buildFilterList()` in `data-table.tsx` converts MRT column filter state into SQL-like strings based on column type:
+
+| Column Type    | Filter Function      | Output Example                                                  |
+| -------------- | -------------------- | --------------------------------------------------------------- |
+| **String**     | `contains`           | `name contains 'Ottawa'`                                        |
+| **String**     | `equals`             | `status = 'active'`                                             |
+| **Numeric**    | `betweenInclusive`   | `population >= 100000 and population <= 500000`                 |
+| **Numeric**    | `greaterThan`        | `age > 25`                                                      |
+| **Date**       | `equals`             | `timestamp = date '2023-01-01T00:00:00Z'`                       |
+| **Date range** | `betweenInclusive`   | `created >= date '2023-01-01' and created <= date '2023-12-31'` |
+| **Null check** | `empty` / `notEmpty` | `field is null` / `field is not null`                           |
+
+Multiple column filters are joined with `and` into a single filter string.
+
+### Map Filtering Toggle
+
+The data table has a "Filter Map" toggle per layer (`mapFilteredRecord`). When disabled:
+
+- `applyMapFilters()` passes an empty string, clearing the data filter
+- Column filters remain visible in the data table but do not affect the map
+- `hasDataFilter()` returns `false`
+
+### Filter to Extent
+
+The data table also supports a "Filter to Extent" mode (`filterDataToExtent`) that limits data table rows to features within the current map viewport. This is independent of the four filter sources.
+
+### Runtime API
+
+```typescript
+// Apply column filter string to the map
+dataTableController.applyMapFilters(filterString);
+
+// Enable/disable map filtering for a layer
+dataTableController.setMapFilteredRecord(layerPath, true); // Enable
+dataTableController.setMapFilteredRecord(layerPath, false); // Disable (clears filter)
+
+// Clear: pass empty string
+layer.setLayerFiltersData("");
+```
+
+### How the Data Filter Is Consumed on the Map
+
+The data filter is included in `getDataRelatedFilters()` which returns `joinWithAnd([initial, class, data])`. This combined string is applied to WMS/ESRI sources:
+
+- **WMS:** Converted to OGC Filter XML → `FILTER` parameter
+- **ESRI Dynamic:** Applied as `layerDefs` SQL WHERE clause
+- **Vector layers:** Evaluated client-side via `featureRespectsFilterEquation()`
+
+---
+
+## Filter Consumers
+
+### Data Table
+
+**File:** `packages/geoview-core/src/core/components/data-table/data-table.tsx`
+
+The data table consumes **class filter** and **time filter** from the store:
+
+```typescript
+const layerClassFilter = useStoreLayerFilterClass(layerPath);
+const layerTimeFilter = useStoreTimeSliderFilter(layerPath);
+
+const memoFilteredFeatures = useMemo(() => {
+  // Combine class + time filters
+  const combined = LayerFilters.joinWithAnd([
+    layerClassFilter,
+    layerTimeFilter,
+  ]);
+
+  // Parse SQL string into AST nodes
+  const filterEquation = GeoviewRenderer.createFilterNodeFromFilter(combined);
+
+  // Evaluate each feature against the filter
+  return features.filter(
+    (entry) =>
+      entry.feature &&
+      GeoviewRenderer.featureRespectsFilterEquation(
+        entry.feature,
+        filterEquation,
+      ),
+  );
+}, [layerClassFilter, layerTimeFilter, features]);
+```
+
+**Key methods:**
+
+| Method                                                          | Purpose                                                          |
+| --------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `GeoviewRenderer.createFilterNodeFromFilter(filter)`            | Parses a SQL-like filter string into an AST (`FilterNodeType[]`) |
+| `GeoviewRenderer.featureRespectsFilterEquation(feature, nodes)` | Evaluates a feature's attributes against the parsed AST          |
+
+**What the data table does NOT filter:**
+
+- Geometry type (simple style toggle) — no SQL filter generated
+- Config filter — not directly consumed by data table (applied at query/source level)
+
+### Map Rendering
+
+Filters are applied differently depending on the layer type:
+
+**Server-side filtering (WMS, ESRI):**
+
+| Layer Type       | How Filters Are Applied                                          |
+| ---------------- | ---------------------------------------------------------------- |
+| **WMS**          | Time filter → `TIME` param; data filter → OGC `FILTER` XML param |
+| **ESRI Dynamic** | Filters → `layerDefs` param as SQL WHERE clause                  |
+| **ESRI Image**   | Time filter → `time` param as epoch range                        |
+
+Each GV layer class has an `applyViewFilterOnSource()` method that reads from its `LayerFilters` instance and applies the appropriate parameters to the OL source.
+
+**Client-side filtering (Vector layers):**
+
+For vector layers (GeoJSON, CSV, GeoPackage, etc.), filters are applied through the OL style function:
+
+```typescript
+// In the style function callback:
+if (!GeoviewRenderer.featureRespectsFilterEquation(feature, filterEquation)) {
+  return undefined; // No style = invisible
+}
+return computedStyle;
+```
+
+**Orchestration:** `MapController.applyLayerFilters(layerPath)` is the single entry point that:
+
+1. Gathers all active filters from the three sources
+2. Creates a `LayerFilters` instance
+3. Calls `layer.setLayerFilters(filters, true)` to apply to the source
+4. The `true` parameter triggers an OL layer change event (re-render)
+
+### Feature Queries
+
+**File:** `packages/geoview-core/src/geo/layer/layer-sets/abstract-layer-set.ts`
+
+Before querying, the layer set checks visibility guards:
+
+```typescript
+if (!layer.getVisibleIncludingParents() || !layer.isInVisibleRange(...)) {
+  return { results: [] };  // Short-circuit — no query
+}
+```
+
+Filters are applied differently per query type:
+
+- **WFS:** Class filter converted to OGC Filter XML in GetFeature request
+- **ESRI Feature:** Initial + class filters as SQL WHERE clause in query endpoint
+- **Client-side (vector):** Features evaluated against `featureRespectsFilterEquation()`
+
+---
+
+## Store Access Patterns
+
+### For React Components (Selector Hooks — Re-Render on Change)
+
+```typescript
+import { useStoreLayerFilterClass } from "@/core/stores/states/layer-state";
+
+const classFilter = useStoreLayerFilterClass(layerPath);
+// → string | undefined — re-renders when class filter changes
+```
+
+### For Controllers (Getters — Point-in-Time Snapshot)
+
+```typescript
+import { getStoreLayerFilterClass } from "@/core/stores/states/layer-state";
+
+const classFilter = getStoreLayerFilterClass(mapId, layerPath);
+// → string | undefined — no re-render
+```
+
+### For Controllers (Setters — Mutations)
+
+```typescript
+import { setStoreLayerItemVisibility } from "@/core/stores/states/layer-state";
+
+// Updates item visibility AND class filter in one call
+setStoreLayerItemVisibility(mapId, layerPath, item, visible, classFilter);
+```
+
+### Layer API
+
+```typescript
+// Get the LayerFilters object
+const filters = layer.getLayerFilters();
+
+// Read individual filters
+filters.getClassFilter(); // string | undefined
+filters.getTimeFilter(); // string | undefined
+filters.getInitialFilter(); // string | undefined
+filters.getDataFilter(); // string | undefined
+
+// Get combined filter
+filters.getAllFilters(); // string (all joined with AND)
+
+// Set individual filters
+layer.setLayerFiltersTime(filterString);
+layer.setLayerFiltersData(filterString);
+
+// Apply all filters to the OL source
+mapController.applyLayerFilters(layerPath);
+```
+
+---
+
+## Batch Operations and Filter Synchronization
+
+When controllers perform batch operations (e.g., "Toggle All" in the legend), individual event handlers are suppressed to avoid redundant processing. **After the batch completes, the store must be manually synchronized:**
+
+```typescript
+try {
+  this.#isBatchingLayerItemsVisibility = true;
+  // ... batch toggles (store NOT updated per item)
+} finally {
+  this.#isBatchingLayerItemsVisibility = false;
+}
+
+// CRITICAL: Manually sync store after batch
+items.forEach((item) => {
+  setStoreLayerItemVisibility(
+    mapId,
+    layerPath,
+    item,
+    item.isVisible,
+    classFilter,
+  );
+});
+```
+
+Without this sync, the data table and "Active Filters" UI display stale data. See Issue #3447.
+
+---
+
+## Summary Table
+
+| Filter     | Store Key                 | Producer                                                      | Consumers                                                   | Clearing                                                 |
+| ---------- | ------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------- | -------------------------------------------------------- |
+| **Class**  | `layerFilterClass`        | `GeoviewRenderer.getFilterFromStyle()`                        | Data table, map rendering, feature queries                  | Set all style items visible → filter becomes `undefined` |
+| **Time**   | `layerFilterTime`         | `TimeSliderController.#generateFilterString()`                | Data table, map rendering (TIME param)                      | Disable filtering toggle in time slider UI               |
+| **Config** | `#initialFilter`          | `initialSettings.filters` in map config                       | Feature queries, map rendering (source params)              | `layer.getLayerFilters().setInitialFilter(undefined)`    |
+| **Data**   | `tableFilters[layerPath]` | `buildFilterList()` → `DataTableController.applyMapFilters()` | Map rendering (source params via `getDataRelatedFilters()`) | Disable "Filter Map" toggle or clear column filters      |
+
+### Filter Combination Groups
+
+| Method                            | Includes                      | Used By                                                                          |
+| --------------------------------- | ----------------------------- | -------------------------------------------------------------------------------- |
+| `getDataRelatedFilters()`         | initial + class + data        | `applyViewFilterOnSource()` for WMS/ESRI source params                           |
+| `getAllFilters()`                 | initial + class + data + time | Cached filter equation for client-side evaluation                                |
+| Data table `memoFilteredFeatures` | class + time (from store)     | Data table row filtering (does NOT include data filter — that would be circular) |

--- a/docs/programming/time-dimension.md
+++ b/docs/programming/time-dimension.md
@@ -1,0 +1,518 @@
+# Time Dimension Architecture
+
+This document explains how GeoView handles temporal data from OGC (WMS) and ESRI services, how time dimensions are parsed into a unified internal model, and how the time slider UI is configured from that model.
+
+## Table of Contents
+
+- [Service Standards](#service-standards)
+  - [OGC WMS Time Dimension](#ogc-wms-time-dimension)
+  - [ESRI Time Dimension](#esri-time-dimension)
+  - [Comparison Table](#comparison-table)
+- [Internal Model](#internal-model)
+  - [TimeDimension Type](#timedimension-type)
+  - [RangeItems Type](#rangeitems-type)
+- [Range Types](#range-types)
+  - [Discrete Range](#discrete-range)
+  - [Absolute Range](#absolute-range)
+  - [Relative Range](#relative-range)
+  - [Detection Logic](#detection-logic)
+- [Data Flow Pipeline](#data-flow-pipeline)
+  - [OGC WMS Path](#ogc-wms-path)
+  - [ESRI Path](#esri-path)
+  - [Pipeline Diagram](#pipeline-diagram)
+- [Slider Handle Modes](#slider-handle-modes)
+  - [Single Handle vs Dual Handle](#single-handle-vs-dual-handle)
+  - [Handle Resolution Priority](#handle-resolution-priority)
+  - [Default Values](#default-values)
+- [Filter Generation](#filter-generation)
+  - [WMS TIME Parameter](#wms-time-parameter)
+  - [ESRI Image](#esri-image)
+  - [ESRI Dynamic / Vector](#esri-dynamic--vector)
+- [Nearest Values Modes](#nearest-values-modes)
+  - [Discrete Mode](#discrete-mode)
+  - [Continuous Mode](#continuous-mode)
+- [Plugin Config Override](#plugin-config-override)
+
+---
+
+## Service Standards
+
+### OGC WMS Time Dimension
+
+The WMS specification (OGC WMS 1.1.1 / 1.3.0) defines temporal extent via the `<Dimension>` element in GetCapabilities responses.
+
+**GetCapabilities example:**
+
+```xml
+<Dimension name="time" units="ISO8601" default="2025-01-01T05:00:00.000Z">
+  1696-01-01T05:00:00.000Z/2025-01-01T05:00:00.000Z/P1Y
+</Dimension>
+```
+
+**Parsed metadata fields:**
+
+| Field            | Description                                                                                   | Example                                                   |
+| ---------------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `name`           | Dimension name (always `"time"` for temporal)                                                 | `"time"`                                                  |
+| `units`          | Unit system                                                                                   | `"ISO8601"`                                               |
+| `default`        | Default value the server uses when TIME is omitted                                            | `"2025-01-01T05:00:00.000Z"`                              |
+| `multipleValues` | Whether the server accepts multiple values in a single TIME request (`"1"` = yes, `"0"` = no) | `"1"`                                                     |
+| `nearestValue`   | Whether the server snaps to the nearest available value (`"1"` = yes, `"0"` = no)             | `"0"`                                                     |
+| `values`         | The dimension extent — defines available time points                                          | `"1696-01-01T05:00:00.000Z/2025-01-01T05:00:00.000Z/P1Y"` |
+
+The `values` string determines the range type and follows three possible formats (see [Range Types](#range-types)).
+
+> **Note on `multipleValues`:** The OGC attribute `multipleValues="1"` indicates the server accepts comma-separated values (e.g., `TIME=date1,date2,date3`) or ranges in a single request. GeoView uses this attribute, together with the `default` attribute, as a signal for determining the slider handle count — see [Default Values and Handle Count](#default-values-and-handle-count).
+
+**WMS TIME request parameter:**
+
+The WMS `GetMap` / `GetFeatureInfo` request includes temporal filtering via the `TIME` parameter:
+
+```
+TIME=2020-01-01T00:00:00Z           (single value)
+TIME=2020-01-01T00:00:00Z/2025-01-01T00:00:00Z  (range)
+```
+
+### ESRI Time Dimension
+
+ESRI services (MapServer, ImageServer, FeatureServer) expose temporal metadata via the `timeInfo` object in the service's JSON metadata endpoint.
+
+**Service metadata example:**
+
+```json
+{
+  "timeInfo": {
+    "startTimeField": "event_date",
+    "endTimeField": "end_date",
+    "timeExtent": [1609459200000, 1672531200000],
+    "timeInterval": 1,
+    "timeIntervalUnits": "esriTimeUnitsYears",
+    "hasLiveData": false
+  }
+}
+```
+
+**Metadata fields:**
+
+| Field               | Description                                 | Example                          |
+| ------------------- | ------------------------------------------- | -------------------------------- |
+| `startTimeField`    | Field name for the start date               | `"event_date"`                   |
+| `endTimeField`      | Optional field name for the end date        | `"end_date"`                     |
+| `trackIdField`      | Optional field for tracking unique entities | `"station_id"`                   |
+| `timeExtent`        | `[startEpoch, endEpoch]` in milliseconds    | `[1609459200000, 1672531200000]` |
+| `timeInterval`      | Numeric interval between time steps         | `1`                              |
+| `timeIntervalUnits` | Unit for the interval                       | `"esriTimeUnitsYears"`           |
+| `hasLiveData`       | Whether the service has live/streaming data | `false`                          |
+
+**ESRI time interval units mapping:**
+
+| ESRI Unit             | ISO 8601 Duration |
+| --------------------- | ----------------- |
+| `esriTimeUnitsHours`  | `PTnH`            |
+| `esriTimeUnitsDays`   | `PnD`             |
+| `esriTimeUnitsWeeks`  | `PnW`             |
+| `esriTimeUnitsMonths` | `PnM`             |
+| `esriTimeUnitsYears`  | `PnY`             |
+
+### Comparison Table
+
+| Aspect                 | OGC WMS                                      | ESRI                                            |
+| ---------------------- | -------------------------------------------- | ----------------------------------------------- |
+| **Metadata source**    | GetCapabilities XML `<Dimension>`            | Service JSON `/MapServer?f=json` → `timeInfo`   |
+| **Date format**        | ISO 8601 strings                             | Epoch milliseconds                              |
+| **Extent definition**  | `values` string (3 formats)                  | `timeExtent: [start, end]`                      |
+| **Step/interval**      | ISO 8601 duration in values (`/P1Y`)         | `timeInterval` + `timeIntervalUnits`            |
+| **Field name**         | `name` (generic, e.g. `"time"`)              | `startTimeField` (actual DB field name)         |
+| **Default value**      | `default` attribute on `<Dimension>`         | Not provided (uses full extent)                 |
+| **Range support**      | `TIME=start/end` in request                  | `time=epoch1,epoch2` in request                 |
+| **Discrete dates**     | Comma-separated in `values`                  | Not natively supported (computed from interval) |
+| **Single/dual handle** | Inferred from `default` and `multipleValues` | No metadata indicator                           |
+
+**Key difference:** OGC WMS provides indirect signals for single vs dual handle via the `default` attribute (present → single handle) and `multipleValues` attribute (`"0"` → single handle). ESRI has no equivalent metadata. GeoView defaults to **dual handle** when no signal is present and allows plugin config override.
+
+---
+
+## Internal Model
+
+### TimeDimension Type
+
+Both OGC and ESRI metadata are normalized into a single `TimeDimension` type defined in `date-mgt.ts`:
+
+```typescript
+type TimeDimension = {
+  field: string; // Field name for filtering
+  default: string[]; // Default value(s) — 1 element (single) or 2 (range)
+  unitSymbol?: string; // Unit symbol (e.g. "ISO8601")
+  rangeItems: RangeItems; // Parsed range data
+  nearestValues: "discrete" | "continuous"; // Slider snap behavior
+  singleHandle: boolean; // Single or dual handle mode
+  displayDateFormat?: TypeDisplayDateFormat;
+  displayDateFormatShort?: TypeDisplayDateFormat;
+  serviceDateTemporalMode?: TemporalMode;
+  displayDateTimezone?: TimeIANA;
+  isValid: boolean; // Whether the dimension has a usable range
+};
+```
+
+### RangeItems Type
+
+```typescript
+type RangeItems = {
+  type: string; // 'discrete' | 'relative' | 'none'
+  range: string[]; // Array of ISO 8601 date strings
+};
+```
+
+Note: Absolute ranges are converted to discrete arrays during parsing, so `type` is `'discrete'` for both discrete and absolute inputs.
+
+---
+
+## Range Types
+
+The OGC `values` string (and the ESRI-to-OGC converted string) follows three possible patterns. Detection is based on string structure:
+
+### Discrete Range
+
+**Format:** Comma-separated individual dates.
+
+```
+1696,1701,1734,1741,1760
+2020-01-01T00:00:00Z,2021-01-01T00:00:00Z,2022-01-01T00:00:00Z
+```
+
+**Behavior:**
+
+- Each value is an explicit, known time point
+- No computation needed — values are used directly
+- Slider snaps to these exact values (`nearestValues: 'discrete'`)
+- `RangeItems.type = 'discrete'`
+
+**Use case:** Layers with sparse, irregular time points (e.g., specific survey dates).
+
+### Absolute Range
+
+**Format:** `start/end/period` — three slash-separated segments.
+
+```
+2002-09-01T00:00:00Z/2025-01-01T00:00:00Z/P1Y
+1696-01-01T05:00:00.000Z/2025-01-01T05:00:00.000Z/P1Y
+```
+
+**Behavior:**
+
+- `start` and `end` are ISO 8601 dates
+- `period` is an ISO 8601 duration (e.g., `P1Y`, `P1M`, `P1D`, `PT1H`)
+- GeoView expands this into a discrete array by iterating from start to end, adding the duration at each step
+- Has a 10,000-iteration safety guard to prevent infinite loops from malformed durations
+- `nearestValues: 'discrete'` (the expanded array acts like discrete points)
+- `RangeItems.type = 'discrete'`
+
+**Use case:** Most common for WMS/ESRI — regular intervals over a date range (yearly, monthly, daily data).
+
+### Relative Range
+
+**Format:** `start/end` or `start/duration` — two slash-separated segments.
+
+```
+2022-04-27T14:50:00Z/2022-04-27T17:50:00Z
+2022-04-27T14:50:00Z/PT10M
+```
+
+**Behavior:**
+
+- If the second segment is a valid ISO date → range is `[start, end]`
+- If the second segment is an ISO 8601 duration → end is computed as `start + duration`
+- Only produces a two-element array `[start, end]`
+- Slider allows free movement between min and max (`nearestValues: 'continuous'`)
+- GeoView computes an estimated step via `guessEstimatedStep()` based on the total interval length
+- `RangeItems.type = 'relative'`
+
+**Use case:** Near-real-time or live data with dense temporal coverage (e.g., weather radar updated every 10 minutes).
+
+### Detection Logic
+
+Detection is ordered and mutually exclusive:
+
+```typescript
+// 1. Discrete: comma-separated values
+if (values.split(',').length > 1) → discrete
+
+// 2. Relative: exactly 2 slash-separated segments (start/end OR start/duration)
+else if (values.split('/').length === 2) → relative
+
+// 3. Absolute: exactly 3 slash-separated segments (start/end/period)
+else if (values.split('/').length === 3) → absolute
+```
+
+---
+
+## Data Flow Pipeline
+
+### OGC WMS Path
+
+```
+WMS GetCapabilities
+  → XML <Dimension name="time" values="start/end/P1Y" default="...">
+  → Parsed into TypeMetadataWMSCapabilityLayerDimension { name, values, default, units }
+  → DateMgt.createDimensionFromOGC(dimensionObject)
+    → createRangeOGC(dimensionObject.values)
+      → Detects range type (discrete/relative/absolute)
+      → Returns RangeItems { type, range[] }
+    → Builds TimeDimension { singleHandle: false, nearestValues, default, ... }
+  → layerConfig.setTimeDimension(timeDimension)
+```
+
+### ESRI Path
+
+```
+ESRI Service JSON
+  → timeInfo: { startTimeField, timeExtent: [epoch1, epoch2], timeInterval, timeIntervalUnits }
+  → EsriLayerCommon.#commonProcessTimeDimension(layerConfig, timeInfo)
+    → DateMgt.createDimensionFromESRI(timeInfo, displayDateMode, singleHandle=false)
+      → Converts ESRI epochs to ISO dates + ESRI units to ISO duration
+      → Builds OGC-style string: "2020-01-01T00:00:00Z/2025-01-01T00:00:00Z/P1Y"
+      → createRangeOGC(dimensionValues)  ← Same parser as OGC
+      → Returns RangeItems { type, range[] }
+    → Builds TimeDimension { singleHandle: false, nearestValues, default, ... }
+  → layerConfig.setTimeDimension(timeDimension)
+```
+
+**Key design:** ESRI metadata is converted to OGC-style strings so that `createRangeOGC()` is the single shared parser for both standards.
+
+### Pipeline Diagram
+
+```
+┌─────────────────────┐    ┌──────────────────────┐
+│  WMS GetCapabilities │    │  ESRI Service JSON   │
+│  <Dimension> XML     │    │  timeInfo object     │
+└────────┬────────────┘    └──────────┬───────────┘
+         │                            │
+         ▼                            ▼
+  createDimensionFromOGC()    createDimensionFromESRI()
+         │                            │
+         │                  ┌─────────┘
+         │                  │ Convert epochs + units
+         │                  │ to OGC-style string
+         │                  ▼
+         └──────►  createRangeOGC()  ◄──────┘
+                       │
+                 ┌─────┼─────┐
+                 ▼     ▼     ▼
+            discrete  abs  relative
+                 │     │     │
+                 └─────┼─────┘
+                       ▼
+                  TimeDimension
+                       │
+                       ▼
+          TimeSliderController
+          #getInitialTimeSliderValues()
+                       │
+                       ▼
+            TypeTimeSliderValues
+                       │
+                       ▼
+              Zustand Store
+          (addStoreTimeSliderLayer)
+                       │
+                       ▼
+           TimeSlider Component
+            (MUI Slider UI)
+```
+
+---
+
+## Slider Handle Modes
+
+### Single Handle vs Dual Handle
+
+| Mode              | Handles | Default Values          | Filter Output                 | UI                        |
+| ----------------- | ------- | ----------------------- | ----------------------------- | ------------------------- |
+| **Single handle** | 1       | `[lastDate]`            | Single point or narrow window | One thumb, no lock button |
+| **Dual handle**   | 2       | `[firstDate, lastDate]` | Date range between two values | Two thumbs, lock button   |
+
+The MUI `<Slider>` component automatically shows the correct number of thumbs based on whether `value` is a single-element or two-element array.
+
+### Handle Resolution Priority
+
+The `singleHandle` value is resolved in `TimeSliderController.#getInitialTimeSliderValues()` with the following priority:
+
+```typescript
+const singleHandle =
+  configTimeDimension?.singleHandle ?? // 1. Plugin config (highest)
+  layerTimeDimensionInfo?.singleHandle ?? // 2. Layer metadata
+  false; // 3. Default (dual handle)
+```
+
+1. **Plugin config** (`corePackagesConfig → time-slider → sliders[n].timeDimension.singleHandle`) — Explicit override per slider
+2. **Layer metadata** (`TimeDimension.singleHandle`) — Set during metadata parsing
+3. **Default** — `false` (dual handle)
+
+Both OGC and ESRI default to `singleHandle: false` (dual handle). ESRI has no metadata that distinguishes single vs dual. OGC WMS provides two indirect signals: `default` and `multipleValues`.
+
+### Default Values and Handle Count
+
+**The number of slider thumbs is driven by the `default` array length**, not by `singleHandle` alone. The MUI `<Slider>` component renders one thumb when `value` is a single-element array and two thumbs when it is a two-element array.
+
+For **OGC WMS**, two attributes on `<Dimension>` act as signals:
+
+1. **`default` attribute** — The strongest signal:
+   - **Present** → `defaultValues = [default]` (1 element) → **1 thumb** (single handle)
+   - **Absent** → `defaultValues = [range[0], range[last]]` (2 elements) → **2 thumbs** (dual handle)
+
+2. **`multipleValues` attribute** — A secondary signal:
+   - **`multipleValues="0"`** → The server only accepts a single `TIME=date` value → **1 thumb** (single handle)
+   - **`multipleValues="1"`** → The server accepts multiple values or ranges → dual handle is appropriate
+   - **Absent** → No additional signal, fall back to the `default`-based heuristic
+
+**Resolution logic:** When `default` is present, it always wins (single handle). When `default` is absent and `multipleValues="0"`, the slider uses single handle because the server cannot accept a range. When both are absent, GeoView defaults to dual handle (best guess for interval selection).
+
+| `default` present? | `multipleValues` | Result       | Reasoning                             |
+| ------------------ | ---------------- | ------------ | ------------------------------------- |
+| Yes                | Any / absent     | **1 thumb**  | `default` is the definitive signal    |
+| No                 | `"0"`            | **1 thumb**  | Server only accepts single value      |
+| No                 | `"1"` / absent   | **2 thumbs** | Best guess — server can handle ranges |
+
+Examples from real services:
+
+```xml
+<!-- default present → 1 handle (near-real-time weather radar, 3-hour window) -->
+<Dimension name="time" default="2026-05-27T14:12:00Z">
+  2026-05-27T11:12:00Z/2026-05-27T14:12:00Z/PT6M
+</Dimension>
+
+<!-- default absent, multipleValues=1 → 2 handles (historical flood imagery) -->
+<Dimension name="time" units="ISO8601" multipleValues="1" nearestValue="0">
+  2005-05-01T10:25:07.000,2008-05-03T22:12:50.000,...
+</Dimension>
+
+<!-- default absent, multipleValues absent → 2 handles (historical data) -->
+<Dimension name="time">
+  1696-01-01T05:00:00.000Z/2025-01-01T05:00:00.000Z/P1Y
+</Dimension>
+
+<!-- default absent, multipleValues=0 → 1 handle (server only accepts single date) -->
+<Dimension name="time" multipleValues="0">
+  2020-01-01T00:00:00Z,2021-01-01T00:00:00Z,2022-01-01T00:00:00Z
+</Dimension>
+```
+
+For **ESRI**, `default` is always `[range[0], range[last]]` (2 elements, dual handle) since ESRI metadata does not provide a default time value or a `multipleValues` equivalent.
+
+| Source      | Condition                                    | Default Values            | Thumbs |
+| ----------- | -------------------------------------------- | ------------------------- | ------ |
+| **OGC WMS** | `default` present                            | `[default]`               | 1      |
+| **OGC WMS** | No `default`, `multipleValues="0"`           | `[range[last]]`           | 1      |
+| **OGC WMS** | No `default`, `multipleValues="1"` or absent | `[range[0], range[last]]` | 2      |
+| **ESRI**    | Always                                       | `[range[0], range[last]]` | 2      |
+
+---
+
+## Filter Generation
+
+Filter strings are generated by `TimeSliderController.#generateFilterString()` and differ by layer type:
+
+### WMS TIME Parameter
+
+```
+Single:  field = date 'YYYY-MM-DDTHH:mm:ssZ'
+Dual:    field = date 'YYYY-MM-DDTHH:mm:ssZ'/date 'YYYY-MM-DDTHH:mm:ssZ'
+```
+
+This filter string is then parsed in `GVWMS.applyViewFilterOnSource()`:
+
+1. Split on `=` to extract the date portion
+2. `parseDateTimeValuesEsriImageOrWMS()` normalizes each `date '...'` occurrence to ISO format
+3. Result is set as the WMS `TIME` source parameter (e.g., `TIME=2020-01-01T00:00:00Z/2025-01-01T00:00:00Z`)
+
+### ESRI Image
+
+```
+Single:  time=epoch
+Dual:    time=epoch1,epoch2
+```
+
+ESRI ImageServer uses raw epoch milliseconds with comma separator for ranges.
+
+### ESRI Dynamic / Vector
+
+SQL-like filter expressions using ISO date format:
+
+```
+Dual:               field >= date 'start' and field <= date 'end'
+Single (discrete):  field >= date 'start' and field < date 'nextStep'
+Single (continuous): field >= date 'start' and field < date 'start+step'
+```
+
+For single-handle discrete mode, `nextStep` is the next value in the `range` array after the current position. For continuous mode, the step is estimated via `guessEstimatedStep()`.
+
+---
+
+## Nearest Values Modes
+
+### Discrete Mode
+
+Set when `RangeItems.type` is `'discrete'` (from discrete or absolute range parsing).
+
+- Slider snaps to predefined positions only
+- Each position maps to an entry in the `range` array
+- Step selector is hidden in the UI
+- `TypeTimeSliderValues.discreteValues = true`
+
+### Continuous Mode
+
+Set when `RangeItems.type` is `'relative'`.
+
+- Slider allows free movement between `min` and `max`
+- Step selector is visible — controls the filter window size
+- Step is estimated from the total range span via `guessEstimatedStep()`:
+
+| Total Range | Estimated Step |
+| ----------- | -------------- |
+| > 2 months  | 1 day          |
+| > 2 years   | 1 month        |
+| > 10 years  | 1 year         |
+
+- `TypeTimeSliderValues.discreteValues = false`
+
+---
+
+## Plugin Config Override
+
+The time slider plugin config (`corePackagesConfig → time-slider`) can override any metadata-derived value:
+
+```json
+{
+  "time-slider": {
+    "sliders": [
+      {
+        "layerPaths": ["myLayer/0"],
+        "timeDimension": {
+          "singleHandle": true,
+          "nearestValues": "discrete",
+          "field": "custom_date_field",
+          "default": ["2020-01-01T00:00:00Z"],
+          "rangeItems": {
+            "type": "discrete",
+            "range": [
+              "2020-01-01T00:00:00Z",
+              "2021-01-01T00:00:00Z",
+              "2022-01-01T00:00:00Z"
+            ]
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+Config values take precedence over layer metadata for all `TimeDimension` properties. This allows overriding:
+
+- Handle mode (`singleHandle`)
+- Snap behavior (`nearestValues`)
+- Available dates (`rangeItems.range`)
+- Filter field name (`field`)
+- Default position (`default`)
+
+See [configuration-reference.md](../app/config/configuration-reference.md#time-slider-package) for the full plugin config schema.

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -53,6 +53,8 @@
   - [Controller Architecture](programming/controller-architecture.md)
   - [Using Store](programming/using-store.md)
   - [LayerSet Architecture](programming/layerset-architecture.md)
+  - [Layer Filters](programming/layer-filters.md)
+  - [Time Dimension](programming/time-dimension.md)
   - [Adding Layer Types](programming/adding-layer-types.md)
   - [Event Helper](programming/event-helper.md)
   - [Logging](programming/logging.md)

--- a/packages/geoview-core/public/configs/navigator/demos/11-package-time-slider.json
+++ b/packages/geoview-core/public/configs/navigator/demos/11-package-time-slider.json
@@ -62,12 +62,28 @@
       },
       {
         "geoviewLayerId": "historical-flood-wms",
-        "geoviewLayerName": "Hist. Flood - WMS (known issue, turn off time-slider toggle)",
+        "geoviewLayerName": "Hist. Flood - WMS",
         "metadataAccessPath": "https://maps-cartes.services.geo.ca/server_serveur/services/NRCan/historical_flood_event_en/MapServer/WMSServer",
         "geoviewLayerType": "ogcWms",
         "listOfLayerEntryConfig": [
           {
             "layerId": "0",
+            "initialSettings": {
+              "states": {
+                "visible": false
+              }
+            }
+          }
+        ]
+      },
+       {
+        "geoviewLayerId": "archive-flood-wms",
+        "geoviewLayerName": "Archive Flood - WMS CDTK",
+        "metadataAccessPath": "https://qgis-stage.cdtk.geogc.ca/ows/nrcan/EGS_Flood_Archive_DEV_en?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities",
+        "geoviewLayerType": "ogcWms",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "egs_flood_archive_dev_en",
             "initialSettings": {
               "states": {
                 "visible": false

--- a/packages/geoview-core/public/img/guide/navigation/measure.svg
+++ b/packages/geoview-core/public/img/guide/navigation/measure.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M21 6H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H3V8h2v4h2V8h2v4h2V8h2v4h2V8h2v4h2V8h2v4h1v2z"></path></svg>

--- a/packages/geoview-core/public/locales/en/guide.md
+++ b/packages/geoview-core/public/locales/en/guide.md
@@ -44,16 +44,17 @@ Navigation controls provide adjustments to the viewing extent, projection, rotat
 
 Depending on the viewer configuration, the map's bottom right corner contains the following navigation controls:
 
-| Symbol                                                                                                                    | Name              | Description                                                                                                                                                                                                                               |
-| ------------------------------------------------------------------------------------------------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <img src="{{assetsURL}}/img/guide/navigation/fullscreen.svg" alt="An icon representing the Fullscreen function" />        | Fullscreen        | Full screen presents map content using the entire page. Full screen toggles between the entire page and the initial size of the map.                                                                                                      |
-| <img src="{{assetsURL}}/img/guide/navigation/plus.svg" alt="An icon representing the Zoom in function" />                 | Zoom in           | Zoom in one level on the map to see more detailed content - bound to Plus key (+).                                                                                                                                                        |
-| <img src="{{assetsURL}}/img/guide/navigation/minus.svg" alt="An icon representing the Zoom out function" />               | Zoom out          | Zoom out one level on the map to see less detailed content - bound to Minus key (-).                                                                                                                                                      |
-| <img src="{{assetsURL}}/img/guide/navigation/360.svg" alt="An icon representing the Map Rotation function" />             | Map Rotation      | Control map rotation with a slider from -180° to +180°. The panel includes a **Fix North** toggle (available for LCC projection) to keep the map oriented with north at the top, and a reset button to return to the initial orientation. |
-| <img src="{{assetsURL}}/img/guide/navigation/geolocation.svg" alt="An icon representing the Geolocation function" />      | Geolocation       | Zoom and pan to your current geographical location.                                                                                                                                                                                       |
-| <img src="{{assetsURL}}/img/guide/navigation/home.svg" alt="An icon representing the Initial extent function" />          | Zoom to initial extent    | Zoom and pan map such that initial extent is visible.                                                                                                                                                                                     |
-| <img src="{{assetsURL}}/img/guide/navigation/basemapSelect.svg" alt="An icon representing the Change Basemap function" /> | Change Basemap    | Change the basemap.                                                                                                                                                                                                                       |
-| <img src="{{assetsURL}}/img/guide/navigation/projection.svg" alt="An icon representing the Change Projection function" /> | Change Projection | Change the map projection between Web Mercator and LCC.                                                                                                                                                                                   |
+| Symbol                                                                                                                    | Name                   | Description                                                                                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <img src="{{assetsURL}}/img/guide/navigation/fullscreen.svg" alt="An icon representing the Fullscreen function" />        | Fullscreen             | Full screen presents map content using the entire page. Full screen toggles between the entire page and the initial size of the map.                                                                                                      |
+| <img src="{{assetsURL}}/img/guide/navigation/plus.svg" alt="An icon representing the Zoom in function" />                 | Zoom in                | Zoom in one level on the map to see more detailed content - bound to Plus key (+).                                                                                                                                                        |
+| <img src="{{assetsURL}}/img/guide/navigation/minus.svg" alt="An icon representing the Zoom out function" />               | Zoom out               | Zoom out one level on the map to see less detailed content - bound to Minus key (-).                                                                                                                                                      |
+| <img src="{{assetsURL}}/img/guide/navigation/360.svg" alt="An icon representing the Map Rotation function" />             | Map Rotation           | Control map rotation with a slider from -180° to +180°. The panel includes a **Fix North** toggle (available for LCC projection) to keep the map oriented with north at the top, and a reset button to return to the initial orientation. |
+| <img src="{{assetsURL}}/img/guide/navigation/geolocation.svg" alt="An icon representing the Geolocation function" />      | Geolocation            | Zoom and pan to your current geographical location.                                                                                                                                                                                       |
+| <img src="{{assetsURL}}/img/guide/navigation/home.svg" alt="An icon representing the Initial extent function" />          | Zoom to initial extent | Zoom and pan map such that initial extent is visible.                                                                                                                                                                                     |
+| <img src="{{assetsURL}}/img/guide/navigation/measure.svg" alt="An icon representing the Measure function" />              | Measure                | Measure distances and areas on the map. Toggle between distance (line) and area (polygon) modes. Supports keyboard navigation — see the Keyboard Navigation section for details.                                                          |
+| <img src="{{assetsURL}}/img/guide/navigation/basemapSelect.svg" alt="An icon representing the Change Basemap function" /> | Change Basemap         | Change the basemap.                                                                                                                                                                                                                       |
+| <img src="{{assetsURL}}/img/guide/navigation/projection.svg" alt="An icon representing the Change Projection function" /> | Change Projection      | Change the map projection between Web Mercator and LCC.                                                                                                                                                                                   |
 
 You can also pan the map by using your left, right, up and down arrow keys, or by click-holding on the map and dragging. Using the mouse scroll wheel while hovering over the map will zoom the map in/out.
 
@@ -90,6 +91,16 @@ The map can quickly be focused using **Ctrl+M** anywhere within the GeoView appl
 Use the **arrow** keys to move the map and **+** / **-** keys or **Ctrl+Up** / **Ctrl+Down** to zoom in and out. Press **Shift+Up** / **Shift+Down** to increase or decrease how far the map pans with each arrow key press. Press **Enter** to select a feature under the crosshairs and display associated data in the **Details** panel.
 
 Information will be shown for supported features when the crosshair is positioned over them.
+
+### Measurement with Keyboard
+
+When the **Measure** tool is active and keyboard navigation is enabled, you can draw measurement geometries entirely from the keyboard:
+
+- Press **Enter** or **Spacebar** to place a vertex at the crosshair position
+- Press **Shift+Enter** or **Shift+Spacebar** to finish the geometry and complete the measurement
+- Use the **arrow** keys to move the crosshair between vertices
+
+The measurement result (distance or area) is announced to screen readers upon completion.
 
 Press **CTRL** and **Q** to exit keyboard navigation.
 
@@ -135,21 +146,21 @@ Activate editing mode by clicking the **Edit** button or pressing **Alt+E**. In 
 
 _Note: Keyboard shortcuts (except undo/redo/escape) can be toggled on/off via the shortcuts button in the drawer toolbar or using the backtick ` key. The undo, redo, and escape shortcuts are always active._
 
-| Shortcut | Action |
-|----------|--------|
-| **D** | Toggle Drawing mode |
-| **E** | Toggle Editing mode |
-| **G** | Cycle to next Geometry Type |
-| **Shift+G** | Cycle to previous Geometry Type |
-| **S** | Open Style Menu (customize colors, stroke width, text properties) |
-| **M** | Toggle Measurements visibility (show/hide distance and area measurements) |
-| **N** | Toggle Snapping (snap to existing geometry vertices while drawing) |
-| **Ctrl+Z** | Undo last action |
-| **Ctrl+Y** or **Ctrl+Shift+Z** | Redo action |
-| **Shift+S** | Save / Download all drawings as GeoJSON |
-| **Shift+O** | Open / Upload drawings from GeoJSON file |
-| **Shift+C** | Clear all drawings from the map |
-| **Escape** | Clear current selection / Exit edit mode |
+| Shortcut                       | Action                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------- |
+| **D**                          | Toggle Drawing mode                                                       |
+| **E**                          | Toggle Editing mode                                                       |
+| **G**                          | Cycle to next Geometry Type                                               |
+| **Shift+G**                    | Cycle to previous Geometry Type                                           |
+| **S**                          | Open Style Menu (customize colors, stroke width, text properties)         |
+| **M**                          | Toggle Measurements visibility (show/hide distance and area measurements) |
+| **N**                          | Toggle Snapping (snap to existing geometry vertices while drawing)        |
+| **Ctrl+Z**                     | Undo last action                                                          |
+| **Ctrl+Y** or **Ctrl+Shift+Z** | Redo action                                                               |
+| **Shift+S**                    | Save / Download all drawings as GeoJSON                                   |
+| **Shift+O**                    | Open / Upload drawings from GeoJSON file                                  |
+| **Shift+C**                    | Clear all drawings from the map                                           |
+| **Escape**                     | Clear current selection / Exit edit mode                                  |
 
 ## Crosshair Drawing and Editing
 
@@ -367,7 +378,7 @@ When a layer has multiple symbols, you can toggle visibility for individual item
 
 | Symbol                                                                                                                      | Name                   | Description                                                                                                                                   |
 | --------------------------------------------------------------------------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| <img src="{{assetsURL}}/img/guide/footer/layers_30.svg" alt="An icon representing the Link to layer function" />            | Manage layer   | Navigate to the corresponding layer in the Layers panel.                                                                                      |
+| <img src="{{assetsURL}}/img/guide/footer/layers_30.svg" alt="An icon representing the Link to layer function" />            | Manage layer           | Navigate to the corresponding layer in the Layers panel.                                                                                      |
 | <img src="{{assetsURL}}/img/guide/layers/scaleVisible.svg" alt="An icon representing the Zoom to visible scale function" /> | Zoom to visibile scale | Zoom to the visible scale of the layer, moving the map may be necessary to locate features. _Note: Only available when layer is out of zoom_. |
 | <img src="{{assetsURL}}/img/guide/footer/view_25.svg" alt="An icon representing the Toggle visibility function" />          | Toggle visibiity       | Toggle the layer visibility.                                                                                                                  |
 | <img src="{{assetsURL}}/img/guide/layers/highlight_60.svg" alt="An icon representing the Highlight function" />             | Highlight              | Brings layer to the top, decreases opacity of other layers and displays layer boundary.                                                       |
@@ -455,17 +466,17 @@ The right section header shows the layer name, a subtitle (e.g. number of visibl
 
 _Note: Some buttons may not be available depending on various factors such as layer type or configuration._
 
-| Symbol                                                                                                                | Name                      | Description                                                                                                                                                                              |
-| --------------------------------------------------------------------------------------------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <img src="{{assetsURL}}/img/guide/layers/settings_60.svg" alt="An icon representing the Settings function" />         | Settings                  | Opens the settings panel for the selected layer (_see Layer Settings Panel section below_). When active, the icon changes to a back arrow to return to the details view.                 |
-| <img src="{{assetsURL}}/img/guide/layers/info_60.svg" alt="An icon representing the Info function" />                 | Info                      | Opens the information panel for the selected layer (_see Layer Info Panel section below_). When active, the icon changes to a back arrow to return to the details view.                  |
-| <img src="{{assetsURL}}/img/guide/layers/table_view_60.svg" alt="An icon representing the Table details function" />  | Table details             | Opens the Data Table panel directly if available. Otherwise, opens a basic table view with simplified read-only functionality. |
-| <img src="{{assetsURL}}/img/guide/layers/time_slider_30.svg" alt="An icon representing the Time Slider function" />   | Access Time Slider panel | Opens the Time Slider panel for this layer, allowing you to visualize temporal data.                                                                                                     |
-| <img src="{{assetsURL}}/img/guide/layers/refresh_60.svg" alt="An icon representing the Reset layer function" />       | Reset layer               | Reset the layer to its initial state.                                                                                                                                                    |
-| <img src="{{assetsURL}}/img/guide/layers/highlight_60.svg" alt="An icon representing the Highlight layer function" /> | Highlight layer           | Brings layer to the top, decreases opacity of other layers and displays layer boundary.                                                                                                  |
-| <img src="{{assetsURL}}/img/guide/layers/zoom_60.svg" alt="An icon representing the Zoom to layer function" />        | Zoom to layer             | Pans and zooms the map so that the layer boundary is in view.                                                                                                                            |
-| <img src="{{assetsURL}}/img/guide/layers/remove_25.svg" alt="An icon representing the Remove function" />             | Remove                    | Remove the layer from the map.                                                                                                                                                           |
-| Slider                                                                                                                | Opacity                   | Slider to increase/decrease layer opacity.                                                                                                                                               |
+| Symbol                                                                                                                | Name                     | Description                                                                                                                                                              |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| <img src="{{assetsURL}}/img/guide/layers/settings_60.svg" alt="An icon representing the Settings function" />         | Settings                 | Opens the settings panel for the selected layer (_see Layer Settings Panel section below_). When active, the icon changes to a back arrow to return to the details view. |
+| <img src="{{assetsURL}}/img/guide/layers/info_60.svg" alt="An icon representing the Info function" />                 | Info                     | Opens the information panel for the selected layer (_see Layer Info Panel section below_). When active, the icon changes to a back arrow to return to the details view.  |
+| <img src="{{assetsURL}}/img/guide/layers/table_view_60.svg" alt="An icon representing the Table details function" />  | Table details            | Opens the Data Table panel directly if available. Otherwise, opens a basic table view with simplified read-only functionality.                                           |
+| <img src="{{assetsURL}}/img/guide/layers/time_slider_30.svg" alt="An icon representing the Time Slider function" />   | Access Time Slider panel | Opens the Time Slider panel for this layer, allowing you to visualize temporal data.                                                                                     |
+| <img src="{{assetsURL}}/img/guide/layers/refresh_60.svg" alt="An icon representing the Reset layer function" />       | Reset layer              | Reset the layer to its initial state.                                                                                                                                    |
+| <img src="{{assetsURL}}/img/guide/layers/highlight_60.svg" alt="An icon representing the Highlight layer function" /> | Highlight layer          | Brings layer to the top, decreases opacity of other layers and displays layer boundary.                                                                                  |
+| <img src="{{assetsURL}}/img/guide/layers/zoom_60.svg" alt="An icon representing the Zoom to layer function" />        | Zoom to layer            | Pans and zooms the map so that the layer boundary is in view.                                                                                                            |
+| <img src="{{assetsURL}}/img/guide/layers/remove_25.svg" alt="An icon representing the Remove function" />             | Remove                   | Remove the layer from the map.                                                                                                                                           |
+| Slider                                                                                                                | Opacity                  | Slider to increase/decrease layer opacity.                                                                                                                               |
 
 _Note: When the layer is hidden, functions affecting the layer on the map will be disabled._
 
@@ -594,12 +605,12 @@ The clear all higlights button <img src="{{assetsURL}}/img/guide/layers/clear_hi
 
 The feature details section displays information for the selected feature and provides the following tools:
 
-| Symbol                                                                                                                | Name                     | Description                                                                            |
-| --------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------- |
-| Arrows (← →)                                                                                                          | Feature navigation       | Browse through multiple features for the selected layer.                               |
-| <img src="{{assetsURL}}/img/guide/footer/chart_30.svg" alt="An icon representing the Access Chart panel function" /> | Access Chart panel      | Opens the Chart panel for this feature (only available if chart data is configured).   |
-| <img src="{{assetsURL}}/img/guide/layers/highlight_30.svg" alt="An icon representing the Highlight function" />       | Keep feature highlighted | Keep the feature highlighted on the map. When selected, the icon is filled with color. |
-| <img src="{{assetsURL}}/img/guide/datatable/zoom.svg" alt="An icon representing the Zoom function" />                 | Zoom to feature          | Zoom the map to the extent of the selected feature.                                    |
+| Symbol                                                                                                               | Name                     | Description                                                                            |
+| -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------- |
+| Arrows (← →)                                                                                                         | Feature navigation       | Browse through multiple features for the selected layer.                               |
+| <img src="{{assetsURL}}/img/guide/footer/chart_30.svg" alt="An icon representing the Access Chart panel function" /> | Access Chart panel       | Opens the Chart panel for this feature (only available if chart data is configured).   |
+| <img src="{{assetsURL}}/img/guide/layers/highlight_30.svg" alt="An icon representing the Highlight function" />      | Keep feature highlighted | Keep the feature highlighted on the map. When selected, the icon is filled with color. |
+| <img src="{{assetsURL}}/img/guide/datatable/zoom.svg" alt="An icon representing the Zoom function" />                | Zoom to feature          | Zoom the map to the extent of the selected feature.                                    |
 
 The number of features for the selected layer is shown in the upper left of the details section.
 

--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -62,6 +62,7 @@
     "area": "Area",
     "clear": "Clear",
     "segmentLabels": "Show segment labels",
+    "keyboardHint": "Enable keyboard navigation (Tab to map) to draw measurements with the keyboard. See the Guide for details.",
     "status": {
       "started": "{{type}} measurement started. Click on the map to begin.",
       "stopped": "Measurement mode disabled.",

--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -62,7 +62,6 @@
     "area": "Area",
     "clear": "Clear",
     "segmentLabels": "Show segment labels",
-    "keyboardHint": "Enable keyboard navigation (Tab to map) to draw measurements with the keyboard. See the Guide for details.",
     "status": {
       "started": "{{type}} measurement started. Click on the map to begin.",
       "stopped": "Measurement mode disabled.",

--- a/packages/geoview-core/public/locales/fr/guide.md
+++ b/packages/geoview-core/public/locales/fr/guide.md
@@ -51,7 +51,8 @@ Selon la configuration de la visionneuse, le coin inférieur droit de la carte c
 | <img src="{{assetsURL}}/img/guide/navigation/minus.svg" alt="Une icône représentant la fonction « Zoom arrière »" />                     | Zoom arrière             | Permet de faire un zoom arrière d'un niveau à la fois pour voir le contenu moins en détail; fonctionne aussi avec la touche de soustraction du clavier (-).                                                                                                                                    |
 | <img src="{{assetsURL}}/img/guide/navigation/360.svg" alt="Une icône représentant la fonction « Rotation de la carte »" />               | Rotation de la carte     | Permet de contrôler la rotation de la carte avec un curseur de -180° à +180°. Le panneau comprend un bouton à bascule **Nord fixe** (disponible pour la projection LCC) pour garder la carte orientée le nord au haut, et un bouton de réinitialisation pour revenir à l'orientation initiale. |
 | <img src="{{assetsURL}}/img/guide/navigation/geolocation.svg" alt="Une icône représentant la fonction « Géolocalisation »" />            | Géolocalisation          | Permet de zoomer et de déplacer la carte sur votre position géographique.                                                                                                                                                                                                                      |
-| <img src="{{assetsURL}}/img/guide/navigation/home.svg" alt="Une icône représentant la fonction « Vue initiale »" />                      | Zoom à la vue initiale             | Permet de zoomer et de déplacer la carte pour retourner à la vue initiale.                                                                                                                                                                                                                     |
+| <img src="{{assetsURL}}/img/guide/navigation/home.svg" alt="Une icône représentant la fonction « Vue initiale »" />                      | Zoom à la vue initiale   | Permet de zoomer et de déplacer la carte pour retourner à la vue initiale.                                                                                                                                                                                                                     |
+| <img src="{{assetsURL}}/img/guide/navigation/measure.svg" alt="Une icône représentant la fonction « Mesurer »" />                        | Mesurer                  | Permet de mesurer des distances et des surfaces sur la carte. Basculez entre les modes distance (ligne) et surface (polygone). Prend en charge la navigation au clavier — consultez la section Navigation avec le clavier pour plus de détails.                                                |
 | <img src="{{assetsURL}}/img/guide/navigation/basemapSelect.svg" alt="Une icône représentant la fonction « Changer la carte de base »" /> | Changer la carte de base | Permet de changer la carte de base.                                                                                                                                                                                                                                                            |
 | <img src="{{assetsURL}}/img/guide/navigation/projection.svg" alt="Une icône représentant la fonction « Changer la projection »" />       | Changer la projection    | Permet de changer la projection de la carte entre Web Mercator et LCC.                                                                                                                                                                                                                         |
 
@@ -91,6 +92,15 @@ Utilisez les touches **fléchées** pour déplacer la carte et les touches **+**
 
 Pour les éléments pris en charge, l’information s’affiche lorsque le pointeur en croix les survole.
 
+### Mesure avec le clavier
+
+Lorsque l'outil **Mesurer** est actif et que la navigation au clavier est activée, vous pouvez tracer des géométries de mesure entièrement au clavier :
+
+- Appuyez sur **Entrée** ou la **barre d'espace** pour placer un sommet à la position du pointeur en croix
+- Appuyez sur **Maj.+Entrée** ou **Maj.+barre d'espace** pour terminer la géométrie et compléter la mesure
+- Utilisez les touches **fléchées** pour déplacer le pointeur en croix entre les sommets
+
+Le résultat de la mesure (distance ou surface) est annoncé aux lecteurs d'écran une fois la mesure terminée.
 Appuyez sur **Ctrl** et **Q** pour quitter la navigation avec le clavier.
 
 _N.B. : La carte doit être focalisée pour que les combinaisons de touches fonctionnent. La carte est focalisée lorsque le pointeur en croix s’affiche._
@@ -134,21 +144,21 @@ Activez le mode édition en cliquant sur le bouton **Éditer** ou en appuyant su
 
 _Note : Les raccourcis clavier (sauf annuler/rétablir/échap) peuvent être activés/désactivés via le bouton de raccourcis dans la barre d'outils du drawer ou en utilisant la touche backtick ` . Les raccourcis annuler, rétablir et échap sont toujours actifs._
 
-| Raccourci | Action |
-|----------|--------|
-| **D** | Activer/désactiver le mode Dessin |
-| **E** | Activer/désactiver le mode Édition |
-| **G** | Passer au type de géométrie suivant |
-| **Maj.+G** | Passer au type de géométrie précédent |
-| **S** | Ouvrir le menu Style (personnaliser couleurs, épaisseur du trait, propriétés du texte) |
-| **M** | Activer/désactiver la visibilité des mesures (afficher/masquer les mesures de distance et d'aire) |
-| **N** | Activer/désactiver l'accrochage (accrocher aux sommets de géométries existantes lors du dessin) |
-| **Ctrl+Z** | Annuler la dernière action |
-| **Ctrl+Y** ou **Ctrl+Maj.+Z** | Rétablir l'action |
-| **Maj.+S** | Enregistrer / Télécharger tous les dessins au format GeoJSON |
-| **Maj.+O** | Ouvrir / Charger des dessins à partir d'un fichier GeoJSON |
-| **Maj.+C** | Effacer tous les dessins de la carte |
-| **Échap** | Effacer la sélection actuelle / Quitter le mode édition |
+| Raccourci                     | Action                                                                                            |
+| ----------------------------- | ------------------------------------------------------------------------------------------------- |
+| **D**                         | Activer/désactiver le mode Dessin                                                                 |
+| **E**                         | Activer/désactiver le mode Édition                                                                |
+| **G**                         | Passer au type de géométrie suivant                                                               |
+| **Maj.+G**                    | Passer au type de géométrie précédent                                                             |
+| **S**                         | Ouvrir le menu Style (personnaliser couleurs, épaisseur du trait, propriétés du texte)            |
+| **M**                         | Activer/désactiver la visibilité des mesures (afficher/masquer les mesures de distance et d'aire) |
+| **N**                         | Activer/désactiver l'accrochage (accrocher aux sommets de géométries existantes lors du dessin)   |
+| **Ctrl+Z**                    | Annuler la dernière action                                                                        |
+| **Ctrl+Y** ou **Ctrl+Maj.+Z** | Rétablir l'action                                                                                 |
+| **Maj.+S**                    | Enregistrer / Télécharger tous les dessins au format GeoJSON                                      |
+| **Maj.+O**                    | Ouvrir / Charger des dessins à partir d'un fichier GeoJSON                                        |
+| **Maj.+C**                    | Effacer tous les dessins de la carte                                                              |
+| **Échap**                     | Effacer la sélection actuelle / Quitter le mode édition                                           |
 
 ## Dessin et édition avec le pointeur en croix
 
@@ -365,7 +375,7 @@ Lorsqu'une couche comporte plusieurs symboles, vous pouvez activer ou désactive
 
 | Symbole                                                                                                                                  | Nom                                | Description                                                                                                                                                                        |
 | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <img src="{{assetsURL}}/img/guide/footer/layers_30.svg" alt="Une icône représentant la fonction « Lien vers la couche »" />              | Gérer la couche       | Naviguer vers la couche correspondante dans le panneau Couches.                                                                                                                    |
+| <img src="{{assetsURL}}/img/guide/footer/layers_30.svg" alt="Une icône représentant la fonction « Lien vers la couche »" />              | Gérer la couche                    | Naviguer vers la couche correspondante dans le panneau Couches.                                                                                                                    |
 | <img src="{{assetsURL}}/img/guide/layers/scaleVisible.svg" alt="Une icône représentant la fonction « Zoom sur l'échelle visible »" />    | Zoom sur l'échelle visible         | Zoom sur l'échelle visible de la couche, un déplacement de la carte peut être nécessaire pour localiser les éléments. _N.B. : Seulement disponible quand la couche est hors zoom_. |
 | <img src="{{assetsURL}}/img/guide/footer/view_25.svg" alt="Une icône représentant la fonction « Basculer la visibilité »" />             | Basculer la visibilité             | Basculer la visibilité de la couche.                                                                                                                                               |
 | <img src="{{assetsURL}}/img/guide/layers/highlight_60.svg" alt="Une icône représentant la fonction « Couche mise en évidence »" />       | Couche mise en évidence            | Place la couche au premier plan, diminue l'opacité des autres couches et affiche le périmètre de la couche.                                                                        |
@@ -453,17 +463,17 @@ L'en-tête de la section de droite affiche le nom de la couche, un sous-titre (p
 
 _N.B. : Les boutons accessibles dépendent de plusieurs facteurs, comme le type de couche et la configuration._
 
-| Symbole                                                                                                                            | Nom                                   | Description                                                                                                                                                                                                 |
-| ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <img src="{{assetsURL}}/img/guide/layers/settings_60.svg" alt="Une icône représentant la fonction « Paramètres »" />               | Paramètres                            | Ouvre le panneau des paramètres pour la couche sélectionnée (_voir la section Panneau des paramètres ci-dessous_). L'icône se change en flèche de retour pour revenir à la vue des détails.                 |
-| <img src="{{assetsURL}}/img/guide/layers/info_60.svg" alt="Une icône représentant la fonction « Info »" />                         | Info                                  | Ouvre le panneau d'information pour la couche sélectionnée (_voir la section Panneau d'information ci-dessous_). L'icône se change en flèche de retour pour revenir à la vue des détails.                   |
-| <img src="{{assetsURL}}/img/guide/layers/table_view_60.svg" alt="Une icône représentant la fonction « Table détaillée »" />        | Table détaillée                       | Ouvre le panneau Tableau de Données directement s'il est disponible. Sinon, ouvre une vue de table de base en lecture seule avec des fonctionnalités simplifiées. |
-| <img src="{{assetsURL}}/img/guide/layers/time_slider_30.svg" alt="Une icône représentant la fonction « Curseur Temporel »" />      | Accéder au panneau Curseur Temporel | Ouvre le panneau Curseur Temporel pour cette couche, vous permettant de visualiser les données temporelles.                                                                                                 |
-| <img src="{{assetsURL}}/img/guide/layers/refresh_60.svg" alt="Une icône représentant la fonction « Réinitialiser la couche »" />   | Réinitialiser la couche               | Réinitialiser la couche dans sont état initial.                                                                                                                                                             |
-| <img src="{{assetsURL}}/img/guide/layers/highlight_60.svg" alt="Une icône représentant la fonction « Couche mise en évidence »" /> | Couche mise en évidence               | Place la couche au premier plan, diminue l'opacité des autres couches et affiche le périmètre de la couche.                                                                                                 |
-| <img src="{{assetsURL}}/img/guide/layers/zoom_60.svg" alt="Une icône représentant la fonction « Zoom sur la couche »" />           | Zoom sur la couche                    | Déplace la carte et fait un zoom pour que le périmètre de la couche soit visible.                                                                                                                           |
-| <img src="{{assetsURL}}/img/guide/layers/remove_25.svg" alt="Une icône représentant la fonction Retirer" />                        | Retirer                               | Retirer cette couche de la carte.                                                                                                                                                                           |
-| Curseur                                                                                                                            | Opacité                               | Curseur permettant d'augmenter ou de diminuer l'opacité de la couche.                                                                                                                                       |
+| Symbole                                                                                                                            | Nom                                 | Description                                                                                                                                                                                 |
+| ---------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <img src="{{assetsURL}}/img/guide/layers/settings_60.svg" alt="Une icône représentant la fonction « Paramètres »" />               | Paramètres                          | Ouvre le panneau des paramètres pour la couche sélectionnée (_voir la section Panneau des paramètres ci-dessous_). L'icône se change en flèche de retour pour revenir à la vue des détails. |
+| <img src="{{assetsURL}}/img/guide/layers/info_60.svg" alt="Une icône représentant la fonction « Info »" />                         | Info                                | Ouvre le panneau d'information pour la couche sélectionnée (_voir la section Panneau d'information ci-dessous_). L'icône se change en flèche de retour pour revenir à la vue des détails.   |
+| <img src="{{assetsURL}}/img/guide/layers/table_view_60.svg" alt="Une icône représentant la fonction « Table détaillée »" />        | Table détaillée                     | Ouvre le panneau Tableau de Données directement s'il est disponible. Sinon, ouvre une vue de table de base en lecture seule avec des fonctionnalités simplifiées.                           |
+| <img src="{{assetsURL}}/img/guide/layers/time_slider_30.svg" alt="Une icône représentant la fonction « Curseur Temporel »" />      | Accéder au panneau Curseur Temporel | Ouvre le panneau Curseur Temporel pour cette couche, vous permettant de visualiser les données temporelles.                                                                                 |
+| <img src="{{assetsURL}}/img/guide/layers/refresh_60.svg" alt="Une icône représentant la fonction « Réinitialiser la couche »" />   | Réinitialiser la couche             | Réinitialiser la couche dans sont état initial.                                                                                                                                             |
+| <img src="{{assetsURL}}/img/guide/layers/highlight_60.svg" alt="Une icône représentant la fonction « Couche mise en évidence »" /> | Couche mise en évidence             | Place la couche au premier plan, diminue l'opacité des autres couches et affiche le périmètre de la couche.                                                                                 |
+| <img src="{{assetsURL}}/img/guide/layers/zoom_60.svg" alt="Une icône représentant la fonction « Zoom sur la couche »" />           | Zoom sur la couche                  | Déplace la carte et fait un zoom pour que le périmètre de la couche soit visible.                                                                                                           |
+| <img src="{{assetsURL}}/img/guide/layers/remove_25.svg" alt="Une icône représentant la fonction Retirer" />                        | Retirer                             | Retirer cette couche de la carte.                                                                                                                                                           |
+| Curseur                                                                                                                            | Opacité                             | Curseur permettant d'augmenter ou de diminuer l'opacité de la couche.                                                                                                                       |
 
 _N.B. : Lorsque la couche est cachée, les fonctions affectant la couche sur la carte sont désactivées._
 
@@ -592,12 +602,12 @@ Le bouton <img src="{{assetsURL}}/img/guide/layers/clear_highlight_30.svg" alt="
 
 La section des détails affiche les informations de l'élément sélectionné et fournit les outils suivants :
 
-| Symbole                                                                                                                               | Nom                              | Description                                                                                          |
-| ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Flèches (← →)                                                                                                                         | Navigation entre les éléments    | Parcourir les éléments multiples de la couche sélectionnée.                                          |
-| <img src="{{assetsURL}}/img/guide/footer/chart_30.svg" alt="Une icône représentant la fonction « Accéder au panneau Graphique »" /> | Accéder au panneau Graphique   | Ouvre le panneau Graphique pour cet élément (disponible uniquement si un graphique est configuré).   |
-| <img src="{{assetsURL}}/img/guide/layers/highlight_30.svg" alt="Une icône représentant la fonction « Mise en surbrillance »" />       | Garder l'élément en surbrillance | Garder l'élément en surbrillance sur la carte. Lorsque sélectionnée, l'icône est remplie de couleur. |
-| <img src="{{assetsURL}}/img/guide/datatable/zoom.svg" alt="Une icône représentant la fonction « Zoom »" />                            | Zoomer sur l'élément             | Zoomer la carte sur l'étendue de l'élément sélectionné.                                              |
+| Symbole                                                                                                                             | Nom                              | Description                                                                                          |
+| ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Flèches (← →)                                                                                                                       | Navigation entre les éléments    | Parcourir les éléments multiples de la couche sélectionnée.                                          |
+| <img src="{{assetsURL}}/img/guide/footer/chart_30.svg" alt="Une icône représentant la fonction « Accéder au panneau Graphique »" /> | Accéder au panneau Graphique     | Ouvre le panneau Graphique pour cet élément (disponible uniquement si un graphique est configuré).   |
+| <img src="{{assetsURL}}/img/guide/layers/highlight_30.svg" alt="Une icône représentant la fonction « Mise en surbrillance »" />     | Garder l'élément en surbrillance | Garder l'élément en surbrillance sur la carte. Lorsque sélectionnée, l'icône est remplie de couleur. |
+| <img src="{{assetsURL}}/img/guide/datatable/zoom.svg" alt="Une icône représentant la fonction « Zoom »" />                          | Zoomer sur l'élément             | Zoomer la carte sur l'étendue de l'élément sélectionné.                                              |
 
 Le nombre d'éléments pour la couche sélectionnée est indiqué en haut à gauche de la section des détails.
 

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -62,6 +62,7 @@
     "area": "Surface",
     "clear": "Effacer",
     "segmentLabels": "Afficher les étiquettes des segments",
+    "keyboardHint": "Activez la navigation au clavier (Tab vers la carte) pour tracer des mesures au clavier. Consultez le Guide pour plus de détails.",
     "status": {
       "started": "Mesure {{type}} démarrée. Cliquez sur la carte pour commencer.",
       "stopped": "Mode de mesure désactivé.",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -62,7 +62,6 @@
     "area": "Surface",
     "clear": "Effacer",
     "segmentLabels": "Afficher les étiquettes des segments",
-    "keyboardHint": "Activez la navigation au clavier (Tab vers la carte) pour tracer des mesures au clavier. Consultez le Guide pour plus de détails.",
     "status": {
       "started": "Mesure {{type}} démarrée. Cliquez sur la carte pour commencer.",
       "stopped": "Mode de mesure désactivé.",

--- a/packages/geoview-core/src/api/types/layer-schema-types.ts
+++ b/packages/geoview-core/src/api/types/layer-schema-types.ts
@@ -937,7 +937,7 @@ export interface TypeMetadataWMSCapabilityLayerDimension {
   '#text': string;
   '@attributes': TypeMetadataWMSCapabilityLayerDimensionAttribute;
   default?: string;
-  multipleValues?: boolean; // string for raw XML attribute (below), boolean for normalized value) is intentional
+  multipleValues?: boolean; // string for raw XML attribute (below), boolean for normalized value is intentional
   name?: string;
   units?: string;
   values?: string;

--- a/packages/geoview-core/src/api/types/layer-schema-types.ts
+++ b/packages/geoview-core/src/api/types/layer-schema-types.ts
@@ -937,7 +937,7 @@ export interface TypeMetadataWMSCapabilityLayerDimension {
   '#text': string;
   '@attributes': TypeMetadataWMSCapabilityLayerDimensionAttribute;
   default?: string;
-  multipleValues?: boolean;
+  multipleValues?: boolean; // string for raw XML attribute (below), boolean for normalized value) is intentional
   name?: string;
   units?: string;
   values?: string;

--- a/packages/geoview-core/src/api/types/layer-schema-types.ts
+++ b/packages/geoview-core/src/api/types/layer-schema-types.ts
@@ -937,6 +937,7 @@ export interface TypeMetadataWMSCapabilityLayerDimension {
   '#text': string;
   '@attributes': TypeMetadataWMSCapabilityLayerDimensionAttribute;
   default?: string;
+  multipleValues?: boolean;
   name?: string;
   units?: string;
   values?: string;
@@ -944,6 +945,7 @@ export interface TypeMetadataWMSCapabilityLayerDimension {
 
 export interface TypeMetadataWMSCapabilityLayerDimensionAttribute {
   default: string;
+  multipleValues?: string;
   name: string;
   units: string;
 }

--- a/packages/geoview-core/src/core/components/crosshair/crosshair.tsx
+++ b/packages/geoview-core/src/core/components/crosshair/crosshair.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { Box, Fade, Typography } from '@/ui';
+import type { SxStyles } from '@/ui/style/types';
 
 import { getSxClasses } from './crosshair-style';
 import { CrosshairIcon } from './crosshair-icon';
@@ -33,7 +34,9 @@ export const Crosshair = memo(function Crosshair({ mapTargetElement }: Crosshair
   // Hooks
   const { t } = useTranslation<string>();
   const theme = useTheme();
-  const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
+  const memoSxClasses = useMemo((): SxStyles => {
+    return getSxClasses(theme);
+  }, [theme]);
 
   //  Store
   const mapId = useStoreGeoViewMapId();
@@ -49,6 +52,8 @@ export const Crosshair = memo(function Crosshair({ mapTargetElement }: Crosshair
 
   // AbortController ref - aborts any in-flight coordinate info fetch on re-click
   const abortControllerRef = useRef<AbortController | null>(null);
+
+  // #region Handlers
 
   /**
    * Modifies the pixelDelta value for keyboard pan on Shift+Arrow up or down.
@@ -280,10 +285,15 @@ export const Crosshair = memo(function Crosshair({ mapTargetElement }: Crosshair
     [isCrosshairsActive, mapId, mapController, handleShiftClick, handleDefaultInteraction, handleDrawerInteraction, drawerController]
   );
 
+  // #endregion
+
   /**
    * Aborts any in-flight coordinate info request on unmount.
    */
   useEffect(() => {
+    // Log
+    logger.logTraceUseEffect('CROSSHAIR - cleanup on unmount');
+
     return (): void => {
       abortControllerRef.current?.abort();
       drawerController?.cancelGrabbedTransform();
@@ -294,6 +304,9 @@ export const Crosshair = memo(function Crosshair({ mapTargetElement }: Crosshair
    * Clears hover tooltip and initializes pointer position when crosshair becomes active.
    */
   useEffect(() => {
+    // Log
+    logger.logTraceUseEffect('CROSSHAIR - isCrosshairsActive changed', isCrosshairsActive);
+
     if (isCrosshairsActive) {
       layerSetController.hoverFeatureInfoLayerSet.clearResults();
 
@@ -310,13 +323,13 @@ export const Crosshair = memo(function Crosshair({ mapTargetElement }: Crosshair
   useEventListener<HTMLElement>('keydown', handleZoomControls, mapTargetElement, isCrosshairsActive);
 
   return (
-    <Box sx={{ ...sxClasses.crosshairContainer, visibility: isCrosshairsActive ? 'visible' : 'hidden' }}>
+    <Box sx={{ ...memoSxClasses.crosshairContainer, visibility: isCrosshairsActive ? 'visible' : 'hidden' }}>
       <Fade in={isCrosshairsActive}>
-        <Box sx={sxClasses.crosshairIcon}>
+        <Box sx={memoSxClasses.crosshairIcon}>
           <CrosshairIcon />
         </Box>
       </Fade>
-      <Box sx={sxClasses.crosshairInfo}>
+      <Box sx={memoSxClasses.crosshairInfo}>
         <Typography dangerouslySetInnerHTML={{ __html: t('mapctrl.crosshair') }} />
       </Box>
     </Box>

--- a/packages/geoview-core/src/core/components/crosshair/crosshair.tsx
+++ b/packages/geoview-core/src/core/components/crosshair/crosshair.tsx
@@ -6,7 +6,7 @@ import { Box, Fade, Typography } from '@/ui';
 import { getSxClasses } from './crosshair-style';
 import { CrosshairIcon } from './crosshair-icon';
 import { useStoreAppIsCrosshairsActive } from '@/core/stores/states/app-state';
-import { getStoreMapPointerPosition, useStoreMapZoom } from '@/core/stores/states/map-state';
+import { getStoreMapPointerPosition, setStoreMapPointerPosition, useStoreMapZoom } from '@/core/stores/states/map-state';
 import { getStoreDrawerIsEditing, getStoreDrawerIsDrawing, getStoreDrawerSelectedDrawingType } from '@/core/stores/states/drawer-state';
 import { logger } from '@/core/utils/logger';
 import { useEventListener } from '@/core/components/common/hooks/use-event-listener';
@@ -130,6 +130,17 @@ export const Crosshair = memo(function Crosshair({ mapTargetElement }: Crosshair
         event.preventDefault();
         event.stopPropagation();
 
+        // Check if measurement drawing is active
+        const measurementDraw = mapController.getActiveMeasurementDraw();
+        if (measurementDraw) {
+          if (event.shiftKey) {
+            measurementDraw.finishDrawing();
+          } else {
+            measurementDraw.appendCoordinates([currentPointerPosition.projected]);
+          }
+          return;
+        }
+
         abortControllerRef.current?.abort();
         const controller = new AbortController();
         abortControllerRef.current = controller;
@@ -252,8 +263,7 @@ export const Crosshair = memo(function Crosshair({ mapTargetElement }: Crosshair
         return;
       }
 
-      const currentPointerPosition = getStoreMapPointerPosition(mapId);
-      if (!currentPointerPosition) return;
+      const currentPointerPosition = getStoreMapPointerPosition(mapId) ?? mapController.getMapCenterPosition();
 
       // Handle Shift+Click logic first
       if (handleShiftClick(event, currentPointerPosition)) {
@@ -267,7 +277,7 @@ export const Crosshair = memo(function Crosshair({ mapTargetElement }: Crosshair
         handleDrawerInteraction(event, currentPointerPosition);
       }
     },
-    [isCrosshairsActive, mapId, handleShiftClick, handleDefaultInteraction, handleDrawerInteraction, drawerController]
+    [isCrosshairsActive, mapId, mapController, handleShiftClick, handleDefaultInteraction, handleDrawerInteraction, drawerController]
   );
 
   /**
@@ -281,13 +291,18 @@ export const Crosshair = memo(function Crosshair({ mapTargetElement }: Crosshair
   }, [drawerController]);
 
   /**
-   * Clears hover tooltip when crosshair becomes active.
+   * Clears hover tooltip and initializes pointer position when crosshair becomes active.
    */
   useEffect(() => {
     if (isCrosshairsActive) {
       layerSetController.hoverFeatureInfoLayerSet.clearResults();
+
+      // Initialize pointer position to map center so the coordinate display updates immediately
+      if (!getStoreMapPointerPosition(mapId)) {
+        setStoreMapPointerPosition(mapId, mapController.getMapCenterPosition());
+      }
     }
-  }, [isCrosshairsActive, layerSetController]);
+  }, [isCrosshairsActive, mapId, mapController, layerSetController]);
 
   // Event listeners
   useEventListener<HTMLElement>('keydown', handleCrosshairInteraction, mapTargetElement, isCrosshairsActive);

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-details.tsx
@@ -251,11 +251,16 @@ export function LayerDetails(props: LayerDetailsProps): JSX.Element | null {
   /**
    * Determines if a style configuration allows item visibility toggling.
    *
-   * Simple styles cannot be toggled. UniqueValue/classBreaks styles
-   * require multiple non-default classes to enable toggling.
+   * Simple styles can be toggled when the layer has multiple geometry types.
+   * UniqueValue/classBreaks styles require multiple non-default classes to enable toggling.
    */
   const canToggleStyleItems = (styleConfig: TypeLayerStyleSettings | undefined): boolean => {
-    if (!styleConfig || styleConfig.type === 'simple') return false;
+    if (!styleConfig) return false;
+
+    if (styleConfig.type === 'simple') {
+      // Simple styles can be toggled when there are multiple geometry types in the layer
+      return layerStyleConfig ? Object.keys(layerStyleConfig).length > 1 : false;
+    }
 
     if (styleConfig.type === 'uniqueValue' || styleConfig.type === 'classBreaks') {
       const nonDefaultCount = styleConfig.hasDefault ? styleConfig.info.length - 1 : styleConfig.info.length;

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/measurement.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/measurement.tsx
@@ -22,7 +22,7 @@ import NavbarPanelButton from '@/core/components/nav-bar/nav-bar-panel-button';
 import { formatLength, formatArea } from '@/core/utils/utilities';
 import type { Draw } from '@/geo/interaction/draw';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
-import { useStoreAppDisplayLanguage, useStoreAppGeoviewHTMLElement } from '@/core/stores/states/app-state';
+import { useStoreAppDisplayLanguage } from '@/core/stores/states/app-state';
 import { GeoUtilities } from '@/geo/utils/utilities';
 import { useMapController } from '@/core/controllers/use-controllers';
 
@@ -78,7 +78,6 @@ export default function Measurement(): JSX.Element {
   // Stores
   const mapId = useStoreGeoViewMapId();
   const displayLanguage = useStoreAppDisplayLanguage();
-  const mapElement = useStoreAppGeoviewHTMLElement().querySelector(`[id^="mapTargetElement-${mapId}"]`) as HTMLElement;
   const mapController = useMapController();
 
   // States
@@ -288,16 +287,15 @@ export default function Measurement(): JSX.Element {
       setDrawInstance(draw);
       setActiveMeasurement(type);
 
+      // Register the draw instance for keyboard accessibility via crosshair
+      // This also suppresses hover and click-marker handlers (like drawer does)
+      mapController.setActiveMeasurementDraw(draw);
+
       // Announce measurement mode started
       const measurementType = type === 'line' ? t('measurement.line') : t('measurement.area');
       setStatusMessage(t('measurement.status.started', { type: measurementType }));
-
-      // Set focus to map for WCAG keyboard interaction
-      if (mapElement) {
-        mapElement.focus();
-      }
     },
-    [drawInstance, mapElement, createSegmentStyle, mapController, displayLanguage, t]
+    [drawInstance, createSegmentStyle, mapController, displayLanguage, t]
   );
 
   /**
@@ -310,9 +308,12 @@ export default function Measurement(): JSX.Element {
     }
     setActiveMeasurement(null);
 
+    // Unregister the draw instance for keyboard accessibility
+    mapController.setActiveMeasurementDraw(null);
+
     // Announce measurement stopped
     setStatusMessage(t('measurement.status.stopped'));
-  }, [drawInstance, t]);
+  }, [drawInstance, mapController, t]);
 
   /**
    * Clears all measurements.
@@ -336,7 +337,7 @@ export default function Measurement(): JSX.Element {
   }, [stopMeasurement, mapController, measurementFeatures.length, t]);
 
   /**
-   * Handles measurement mode toggle.
+   * Handles the measurement enable/disable toggle switch.
    */
   const handleMeasurementToggle = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -424,13 +425,14 @@ export default function Measurement(): JSX.Element {
           {statusMessage}
         </Typography>
 
-        {/* On/Off Switch */}
+        {/* Enable/Disable Toggle */}
         <Switch
           label={!isMeasurementActive ? t('general.enable') : t('general.disable')}
           checked={isMeasurementActive}
           onChange={handleMeasurementToggle}
           size="small"
         />
+
         {/* Segment Labels Toggle */}
         <Switch
           label={t('measurement.segmentLabels')}

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/measurement.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/measurement.tsx
@@ -486,11 +486,6 @@ export default function Measurement(): JSX.Element {
         >
           <DeleteIcon fontSize="small" />
         </IconButton>
-
-        {/* Keyboard accessibility hint */}
-        <Typography variant="caption" sx={{ fontStyle: 'italic', opacity: 0.8 }}>
-          {t('measurement.keyboardHint')}
-        </Typography>
       </Box>
     );
   };

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/measurement.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/measurement.tsx
@@ -9,13 +9,12 @@ import type { StyleFunction } from 'ol/style/Style';
 import type { FeatureLike } from 'ol/Feature';
 import type Feature from 'ol/Feature';
 import type { Geometry } from 'ol/geom';
-import { HexagonOutlined as HexagonOutlinedIcon } from '@mui/icons-material';
 
 import type { TypePanelProps } from '@/ui/panel/panel-types';
 import type { IconButtonPropsExtend } from '@/ui/icon-button/icon-button';
 import { IconButton } from '@/ui/icon-button/icon-button';
 import { Box, Switch, ToggleButtonGroup, ToggleButton, Typography } from '@/ui';
-import { ShowChartIcon, DeleteIcon, StraightenIcon } from '@/ui/icons';
+import { ShowChartIcon, DeleteIcon, StraightenIcon, HexagonOutlinedIcon } from '@/ui/icons';
 import { visuallyHidden } from '@/ui/style/default';
 import { logger } from '@/core/utils/logger';
 import NavbarPanelButton from '@/core/components/nav-bar/nav-bar-panel-button';
@@ -487,6 +486,11 @@ export default function Measurement(): JSX.Element {
         >
           <DeleteIcon fontSize="small" />
         </IconButton>
+
+        {/* Keyboard accessibility hint */}
+        <Typography variant="caption" sx={{ fontStyle: 'italic', opacity: 0.8 }}>
+          {t('measurement.keyboardHint')}
+        </Typography>
       </Box>
     );
   };

--- a/packages/geoview-core/src/core/components/nav-bar/buttons/measurement.tsx
+++ b/packages/geoview-core/src/core/components/nav-bar/buttons/measurement.tsx
@@ -308,7 +308,7 @@ export default function Measurement(): JSX.Element {
     setActiveMeasurement(null);
 
     // Unregister the draw instance for keyboard accessibility
-    mapController.setActiveMeasurementDraw(null);
+    mapController.setActiveMeasurementDraw(undefined);
 
     // Announce measurement stopped
     setStatusMessage(t('measurement.status.stopped'));

--- a/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
+++ b/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
@@ -61,6 +61,7 @@ export const useManageArrow = (): ArrowReturn => {
     // Log
     logger.logTraceUseEffect('USE-MANAGE-ARROW - fixNorth changed', fixNorth);
 
+    angle.current = 0;
     prevRotationRef.current = 0;
     equalCountRef.current = 0;
   }, [fixNorth]);

--- a/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
+++ b/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
@@ -115,7 +115,7 @@ export const useManageArrow = (): ArrowReturn => {
         Projection.PROJECTION_NAMES.LONLAT,
         mapProjectionEPSG
       )[0];
-      const northPolePixel = northPoleMapCoord ? mapController.getPixelFromCoordinate(northPoleMapCoord) : null;
+      const northPolePixel = northPoleMapCoord ? mapController.getPixelFromCoordinate(northPoleMapCoord) : undefined;
 
       const arrowAngle = parseFloat(northArrowElement.degreeRotation);
 
@@ -163,7 +163,7 @@ export const useManageArrow = (): ArrowReturn => {
       // Calculate offset
       let newOffset = offsetX;
 
-      if (!fixNorth && northPolePixel !== null) {
+      if (!fixNorth && northPolePixel !== undefined) {
         const screenNorthPoint = northPolePixel;
         const mapCenter = mapController.getPixelFromCoordinate(mapCenterCoord);
         if (!mapCenter) return { memoCalculatedRotation: newRotation, memoCalculatedOffset: offsetX };

--- a/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
+++ b/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
@@ -154,6 +154,7 @@ export const useManageArrow = (): ArrowReturn => {
       if (!fixNorth && northPolePixel !== null) {
         const screenNorthPoint = northPolePixel;
         const mapCenter = mapController.getPixelFromCoordinate(mapCenterCoord);
+        if (!mapCenter) return { memoCalculatedRotation: newRotation, memoCalculatedOffset: offsetX };
 
         // Calculate distance from north pole using triangle
         const deltaX = screenNorthPoint[0] - mapCenter[0];

--- a/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
+++ b/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
@@ -163,7 +163,7 @@ export const useManageArrow = (): ArrowReturn => {
       // Calculate offset
       let newOffset = offsetX;
 
-      if (!fixNorth && northPolePixel !== undefined) {
+      if (!fixNorth && northPolePixel) {
         const screenNorthPoint = northPolePixel;
         const mapCenter = mapController.getPixelFromCoordinate(mapCenterCoord);
         if (!mapCenter) return { memoCalculatedRotation: newRotation, memoCalculatedOffset: offsetX };

--- a/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
+++ b/packages/geoview-core/src/core/components/north-arrow/hooks/useManageArrow.tsx
@@ -55,6 +55,17 @@ export const useManageArrow = (): ArrowReturn => {
   const equalCountRef = useRef(0);
 
   /**
+   * Resets rotation tracking refs when fixNorth is toggled to ensure fresh calculation.
+   */
+  useEffect(() => {
+    // Log
+    logger.logTraceUseEffect('USE-MANAGE-ARROW - fixNorth changed', fixNorth);
+
+    prevRotationRef.current = 0;
+    equalCountRef.current = 0;
+  }, [fixNorth]);
+
+  /**
    * Calculates the north arrow rotation and offset based on projection and map state.
    */
   const { memoCalculatedRotation, memoCalculatedOffset } = useMemo(() => {

--- a/packages/geoview-core/src/core/controllers/map-controller.ts
+++ b/packages/geoview-core/src/core/controllers/map-controller.ts
@@ -576,12 +576,12 @@ export class MapController extends AbstractMapViewerController {
    * Converts a map coordinate to a pixel position.
    *
    * @param coord - The map coordinate
-   * @returns The pixel position on the map viewport, or null if the map is not yet initialized
+   * @returns The pixel position on the map viewport, or undefined if the map is not yet initialized
    */
-  getPixelFromCoordinate(coord: Coordinate): Pixel | null {
+  getPixelFromCoordinate(coord: Coordinate): Pixel | undefined {
     const olMap = this.getMapViewer().map;
-    if (!olMap) return null;
-    return olMap.getPixelFromCoordinate(coord);
+    if (!olMap) return undefined;
+    return olMap.getPixelFromCoordinate(coord) ?? undefined;
   }
 
   /**

--- a/packages/geoview-core/src/core/controllers/map-controller.ts
+++ b/packages/geoview-core/src/core/controllers/map-controller.ts
@@ -572,10 +572,12 @@ export class MapController extends AbstractMapViewerController {
    * Converts a map coordinate to a pixel position.
    *
    * @param coord - The map coordinate
-   * @returns The pixel position on the map viewport
+   * @returns The pixel position on the map viewport, or null if the map is not yet initialized
    */
-  getPixelFromCoordinate(coord: Coordinate): Pixel {
-    return this.getMapViewer().map.getPixelFromCoordinate(coord);
+  getPixelFromCoordinate(coord: Coordinate): Pixel | null {
+    const olMap = this.getMapViewer().map;
+    if (!olMap) return null;
+    return olMap.getPixelFromCoordinate(coord);
   }
 
   /**

--- a/packages/geoview-core/src/core/controllers/map-controller.ts
+++ b/packages/geoview-core/src/core/controllers/map-controller.ts
@@ -138,7 +138,7 @@ export class MapController extends AbstractMapViewerController {
   #onGeolocatorSearchHandlers: GeolocatorSearchDelegate[] = [];
 
   /** The active measurement Draw interaction, if any. */
-  #activeMeasurementDraw: Draw | null = null;
+  #activeMeasurementDraw?: Draw;
 
   /**
    * Creates an instance of MapController.
@@ -579,9 +579,7 @@ export class MapController extends AbstractMapViewerController {
    * @returns The pixel position on the map viewport, or undefined if the map is not yet initialized
    */
   getPixelFromCoordinate(coord: Coordinate): Pixel | undefined {
-    const olMap = this.getMapViewer().map;
-    if (!olMap) return undefined;
-    return olMap.getPixelFromCoordinate(coord) ?? undefined;
+    return this.getMapViewer().map?.getPixelFromCoordinate(coord) ?? undefined;
   }
 
   /**
@@ -1214,9 +1212,9 @@ export class MapController extends AbstractMapViewerController {
    * When activating, suppresses hover and click-marker handlers (like drawer does).
    * When deactivating, restores them.
    *
-   * @param draw - The Draw interaction to register, or null to unregister
+   * @param draw - The Draw interaction to register, or undefined to unregister
    */
-  setActiveMeasurementDraw(draw: Draw | null): void {
+  setActiveMeasurementDraw(draw: Draw | undefined): void {
     const viewer = this.getMapViewer();
 
     if (draw) {
@@ -1235,9 +1233,9 @@ export class MapController extends AbstractMapViewerController {
   /**
    * Gets the active measurement Draw interaction.
    *
-   * @returns The active measurement Draw interaction, or null if none
+   * @returns The active measurement Draw interaction, or undefined if none
    */
-  getActiveMeasurementDraw(): Draw | null {
+  getActiveMeasurementDraw(): Draw | undefined {
     return this.#activeMeasurementDraw;
   }
 

--- a/packages/geoview-core/src/core/controllers/map-controller.ts
+++ b/packages/geoview-core/src/core/controllers/map-controller.ts
@@ -62,6 +62,7 @@ import {
   isStoreMapConfigInitialized,
   setStoreMapAttribution,
   setStoreMapClickCoordinates,
+  setStoreMapClickMarker,
   setStoreMapClickMarkerIconHide,
   setStoreMapCurrentBasemapOptions,
   setStoreMapFixNorth,
@@ -135,6 +136,9 @@ export class MapController extends AbstractMapViewerController {
 
   /** Callback delegates for the geolocator search event. */
   #onGeolocatorSearchHandlers: GeolocatorSearchDelegate[] = [];
+
+  /** The active measurement Draw interaction, if any. */
+  #activeMeasurementDraw: Draw | null = null;
 
   /**
    * Creates an instance of MapController.
@@ -578,6 +582,23 @@ export class MapController extends AbstractMapViewerController {
     const olMap = this.getMapViewer().map;
     if (!olMap) return null;
     return olMap.getPixelFromCoordinate(coord);
+  }
+
+  /**
+   * Gets the current map center as a TypeMapMouseInfo object.
+   *
+   * Useful as a fallback when the pointer position store has not been set yet
+   * (e.g., when the crosshair is first activated and the user hasn't panned).
+   *
+   * @returns The map center position info
+   */
+  getMapCenterPosition(): TypeMapMouseInfo {
+    const mapViewer = this.getMapViewer();
+    const view = mapViewer.map.getView();
+    const projected = view.getCenter()!;
+    const lonlat = Projection.transformToLonLat(projected, mapViewer.getProjection());
+    const pixel = mapViewer.map.getPixelFromCoordinate(projected);
+    return { lonlat, pixel, projected, dragging: false };
   }
 
   /**
@@ -1185,6 +1206,39 @@ export class MapController extends AbstractMapViewerController {
    */
   initDrawInteractions(geomGroupKey: string, type: string, style: TypeFeatureStyle): Draw {
     return this.getMapViewer().initDrawInteractions(geomGroupKey, type, style);
+  }
+
+  /**
+   * Sets the active measurement Draw interaction for keyboard accessibility.
+   *
+   * When activating, suppresses hover and click-marker handlers (like drawer does).
+   * When deactivating, restores them.
+   *
+   * @param draw - The Draw interaction to register, or null to unregister
+   */
+  setActiveMeasurementDraw(draw: Draw | null): void {
+    const viewer = this.getMapViewer();
+
+    if (draw) {
+      // Suppress hover and details while measuring
+      viewer.unregisterMapPointerHandlers(viewer.map);
+      this.getControllersRegistry().layerSetController.hoverFeatureInfoLayerSet.clearResults();
+      setStoreMapClickMarker(this.getMapId(), undefined);
+    } else if (this.#activeMeasurementDraw) {
+      // Restore hover and details when stopping measurement
+      viewer.registerMapPointerHandlers(viewer.map);
+    }
+
+    this.#activeMeasurementDraw = draw;
+  }
+
+  /**
+   * Gets the active measurement Draw interaction.
+   *
+   * @returns The active measurement Draw interaction, or null if none
+   */
+  getActiveMeasurementDraw(): Draw | null {
+    return this.#activeMeasurementDraw;
   }
 
   // #endregion PUBLIC METHODS - GEOMETRY API FOR DRAWING TOOLS

--- a/packages/geoview-core/src/core/controllers/time-slider-controller.ts
+++ b/packages/geoview-core/src/core/controllers/time-slider-controller.ts
@@ -439,7 +439,11 @@ export class TimeSliderController extends AbstractMapViewerController {
     if (filtering) {
       // ---- GVWMS ----
       if (layer instanceof GVWMS) {
-        filter = `${field} = ${helperEsriDate(values[0])}`;
+        if (values.length > 1) {
+          filter = `${field} = ${helperEsriDate(values[0])}/${helperEsriDate(values[1])}`;
+        } else {
+          filter = `${field} = ${helperEsriDate(values[0])}`;
+        }
       } else if (layer instanceof GVEsriImage) {
         // ---- Esri Image ----
         // Esri Image layers expect the date to be an Epoch timestamp, not an ISO format

--- a/packages/geoview-core/src/core/controllers/ui-controller.ts
+++ b/packages/geoview-core/src/core/controllers/ui-controller.ts
@@ -32,6 +32,7 @@ import {
   setStoreAppFullScreenActive,
   setStoreAppGuide,
 } from '@/core/stores/states/app-state';
+import { getStoreMapConfigNavBar } from '@/core/stores/states/map-state';
 import { DateMgt, type TimeIANA } from '@/core/utils/date-mgt';
 import type { TypeHTMLElement } from '@/core/types/global-types';
 import { formatError } from '@/core/exceptions/core-exceptions';
@@ -484,6 +485,12 @@ export class UIController extends AbstractMapViewerController {
     try {
       // Create the guide
       const guide = await createGuideObject(language, getStoreAppGeoviewAssetsURL(mapId));
+
+      // Remove sections that depend on optional packages not present in this map config
+      const navBar = getStoreMapConfigNavBar(mapId);
+      if (!navBar?.includes('drawer')) {
+        delete guide.drawingTools;
+      }
 
       // Save in store
       setStoreAppGuide(mapId, guide);

--- a/packages/geoview-core/src/core/stores/states/layer-state.ts
+++ b/packages/geoview-core/src/core/stores/states/layer-state.ts
@@ -1838,7 +1838,7 @@ export const setStoreLayerItemVisibility = (
 ): void => {
   getStoreLayerState(mapId).actions.updateLayerByPath(layerPath, (layer) => ({
     ...layer,
-    items: layer.items.map((i) => (i.name === item.name ? { ...i, isVisible: visibility } : i)),
+    items: layer.items.map((i) => (i.name === item.name && i.geometryType === item.geometryType ? { ...i, isVisible: visibility } : i)),
     layerFilterClass: classFilter,
   }));
 };

--- a/packages/geoview-core/src/core/utils/date-mgt.ts
+++ b/packages/geoview-core/src/core/utils/date-mgt.ts
@@ -899,7 +899,7 @@ export abstract class DateMgt {
       unitSymbol: dimensionObject.unitSymbol || '',
       rangeItems,
       nearestValues: rangeItems.type === 'relative' ? 'continuous' : 'discrete',
-      singleHandle: false,
+      singleHandle: defaultValues.length === 1,
       displayDateFormat: guessedInfo?.displayDateFormat,
       displayDateFormatShort: guessedInfo?.displayDateFormatShort,
       displayDateTimezone: guessedInfo?.displayDateTimezone,

--- a/packages/geoview-core/src/core/utils/date-mgt.ts
+++ b/packages/geoview-core/src/core/utils/date-mgt.ts
@@ -880,13 +880,26 @@ export abstract class DateMgt {
     // Guess the display time information
     const guessedInfo = this.guessDisplayDateInformationFromTimeDimension(rangeItems.range, displayDateMode);
 
+    // Determine the slider handle count from OGC metadata signals:
+    // 1. default attribute present → single-element array [default] → 1 thumb (definitive signal)
+    // 2. default absent + multipleValues=false → single-element array [last] → 1 thumb (server only accepts single value)
+    // 3. default absent + multipleValues=true or absent → two-element array [first, last] → 2 thumbs (best guess)
+    let defaultValues: string[];
+    if (dimensionObject.default) {
+      defaultValues = [dimensionObject.default];
+    } else if (dimensionObject.multipleValues === false) {
+      defaultValues = [rangeItems.range[rangeItems.range.length - 1]];
+    } else {
+      defaultValues = [rangeItems.range[0], rangeItems.range[rangeItems.range.length - 1]];
+    }
+
     const timeDimension: TimeDimension = {
       field: dimensionObject.name,
-      default: [dimensionObject.default || rangeItems.range[0]],
+      default: defaultValues,
       unitSymbol: dimensionObject.unitSymbol || '',
       rangeItems,
       nearestValues: rangeItems.type === 'relative' ? 'continuous' : 'discrete',
-      singleHandle: true, // TODO: WMS time dimensions enhancements to support dual handles? Would need to also update the controller updateFilters function accordingly
+      singleHandle: false,
       displayDateFormat: guessedInfo?.displayDateFormat,
       displayDateFormatShort: guessedInfo?.displayDateFormatShort,
       displayDateTimezone: guessedInfo?.displayDateTimezone,

--- a/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
@@ -994,10 +994,13 @@ export abstract class GeoviewRenderer {
     options?: TypeStyleProcessorOptions
   ): Style | undefined {
     // Read options
-    const { filterEquation, visualVariables } = options || {};
+    const { filterEquation, bypassVisibility, visualVariables } = options || {};
 
     // If feature doesn't respect filter, no style
     if (feature && !this.featureRespectsFilterEquation(feature, filterEquation)) return undefined;
+
+    // If the simple style info is not visible and we're not bypassing visibility, no style
+    if (!bypassVisibility && styleSettings.type === 'simple' && styleSettings.info[0]?.visible === false) return undefined;
 
     const settings = (styleSettings.type === 'simple' ? styleSettings.info[0].settings : styleSettings) as TypeKindOfVectorSettings;
     let style: Style | undefined;
@@ -1032,10 +1035,13 @@ export abstract class GeoviewRenderer {
     options?: TypeStyleProcessorOptions
   ): Style | undefined {
     // Read options
-    const { filterEquation, visualVariables } = options || {};
+    const { filterEquation, bypassVisibility, visualVariables } = options || {};
 
     // If feature doesn't respect filter, no style
     if (feature && !this.featureRespectsFilterEquation(feature, filterEquation)) return undefined;
+
+    // If the simple style info is not visible and we're not bypassing visibility, no style
+    if (!bypassVisibility && styleSettings.type === 'simple' && styleSettings.info[0]?.visible === false) return undefined;
 
     const settings = (styleSettings.type === 'simple' ? styleSettings.info[0].settings : styleSettings) as TypeKindOfVectorSettings;
     const geometry = feature?.getGeometry() as Geometry;
@@ -1264,10 +1270,13 @@ export abstract class GeoviewRenderer {
     options?: TypeStyleProcessorOptions
   ): Style | undefined {
     // Read options
-    const { filterEquation, visualVariables } = options || {};
+    const { filterEquation, bypassVisibility, visualVariables } = options || {};
 
     // If feature doesn't respect filter, no style
     if (feature && !this.featureRespectsFilterEquation(feature, filterEquation)) return undefined;
+
+    // If the simple style info is not visible and we're not bypassing visibility, no style
+    if (!bypassVisibility && styleSettings.type === 'simple' && styleSettings.info[0]?.visible === false) return undefined;
 
     const settings = (styleSettings.type === 'simple' ? styleSettings.info[0].settings : styleSettings) as TypeKindOfVectorSettings;
     const geometry = feature?.getGeometry() as Geometry;

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -612,6 +612,11 @@ export abstract class GeoUtilities {
       dimension.default ??= dimension['@attributes'].default;
       // eslint-disable-next-line no-param-reassign
       dimension.units ??= dimension['@attributes'].units;
+      // Only set multipleValues when the attribute is explicitly present in the XML (absent means unknown, not false)
+      if (dimension.multipleValues === undefined && dimension['@attributes'].multipleValues !== undefined) {
+        // eslint-disable-next-line no-param-reassign
+        dimension.multipleValues = dimension['@attributes'].multipleValues === '1';
+      }
       // eslint-disable-next-line no-param-reassign
       dimension.values ??= dimension['#text'];
     });

--- a/packages/geoview-core/src/ui/icons/index.ts
+++ b/packages/geoview-core/src/ui/icons/index.ts
@@ -58,6 +58,7 @@ export {
   GitHub as GitHubIcon,
   Help as HelpIcon,
   Hexagon as HexagonIcon,
+  HexagonOutlined as HexagonOutlinedIcon,
   HighlightOutlined as HighlightOutlinedIcon,
   Highlight as HighlightIcon,
   Home as HomeIcon,

--- a/packages/geoview-core/src/ui/modal/modal-style.ts
+++ b/packages/geoview-core/src/ui/modal/modal-style.ts
@@ -41,6 +41,7 @@ export const getSxClasses = (theme: Theme, width?: string | number, height?: str
     justifyContent: 'space-between',
     alignItems: 'center',
     padding: '5px 10px',
+    borderBottom: `1px solid ${theme.palette.geoViewColor?.bgColor.dark[300]}`,
   },
   modalTitleLabel: {
     display: 'flex',

--- a/packages/geoview-time-slider/src/time-slider.tsx
+++ b/packages/geoview-time-slider/src/time-slider.tsx
@@ -632,6 +632,7 @@ export function TimeSlider(props: TimeSliderProps): JSX.Element {
                 aria-pressed={locked}
                 tooltip={getLockTooltip()}
                 tooltipPlacement="top"
+                aria-disabled={isPlaying}
                 onClick={handleLock}
               >
                 {locked ? <LockIcon /> : <LockOpenIcon />}
@@ -678,6 +679,7 @@ export function TimeSlider(props: TimeSliderProps): JSX.Element {
               aria-pressed={reversed}
               tooltip={t('timeSlider.slider.changeDirection')}
               tooltipPlacement="top"
+              aria-disabled={isPlaying}
               onClick={handleReverse}
             >
               {reversed ? <SwitchRightIcon /> : <SwitchLeftIcon />}

--- a/packages/geoview-time-slider/src/time-slider.tsx
+++ b/packages/geoview-time-slider/src/time-slider.tsx
@@ -312,9 +312,11 @@ export function TimeSlider(props: TimeSliderProps): JSX.Element {
    * Handles when the user clicks the lock button.
    */
   const handleLock = useCallback((): void => {
+    if (isPlaying) return;
+
     clearTimeout(playIntervalRef.current);
     timeSliderController.setLocked(layerPath, !locked);
-  }, [timeSliderController, layerPath, locked]);
+  }, [timeSliderController, layerPath, locked, isPlaying]);
 
   /**
    * Handles when the user clicks the play/pause button.
@@ -330,13 +332,11 @@ export function TimeSlider(props: TimeSliderProps): JSX.Element {
    * Handles when the user clicks the reverse button.
    */
   const handleReverse = useCallback((): void => {
+    if (isPlaying) return;
+
     clearTimeout(playIntervalRef.current);
     timeSliderController.setReversed(layerPath, !reversed);
-    if (isPlaying) {
-      if (reversed) moveBack();
-      else moveForward();
-    }
-  }, [isPlaying, timeSliderController, layerPath, moveBack, moveForward, reversed]);
+  }, [isPlaying, timeSliderController, layerPath, reversed]);
 
   /**
    * Handles when the user changes the time delay.


### PR DESCRIPTION
…, toggle layer multi geom

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Fix time slider weird effect when using switch direction/lock while playing
- Fix the map-controller not ready for setting north arrow on slow map (outlier geoAI demo)
- Fix the multi geometries layer toggling class (outlier style demo)
- Fix the fix north not working when set again at the same position
- Add a border between header and content for modal component (like right panel full screen)
- Fix time slider for WMS when dual handle is needed
- Fix measure navBar to be keyboard accessible + update guide
- Only show drawer when the package is enable
- Add docs for filters and time dimension
- Update rule for useMemo memoSxClasses

Fixes #3097 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

hosted May 28th, 11:30am

GeoAI
https://jolevesq.github.io/geoview/outlier-GeoAI.html
- Now the page loads

Toggle multi geometries layer
https://jolevesq.github.io/geoview/outlier-style.html
- Check legend and layers panel for Point and Polygon and toggle class visibility
- LIMITATION - data table is not filter by class toggle has it is not a real class, it is geometry. It would need another type of filter.

Fix North
https://jolevesq.github.io/geoview/demos-navigator.html?config=./configs/navigator/demos/02-basemap-LCC-SL.json
- Toggle the fix north from map rotation without moving the map in between

Time Slider Jumping
https://jolevesq.github.io/geoview/demos-navigator.html?config=./configs/navigator/demos/11-package-time-slider.json
- Now lock and direction are disable when playing

WMS Dual handle time slider
https://jolevesq.github.io/geoview/demos-navigator.html?config=./configs/navigator/demos/11-package-time-slider.json
- Try the Hist. Flood - WMS AND Floods in Canada - Archive - Product Extents

Measure keyboard
https://jolevesq.github.io/geoview/demos-navigator.html?config=./configs/navigator/demos/01-basemap-LCC-TLS.json
- Test keyboard to deal with measures

Data table details border
- Any data table, click on details, see there is a border between header and content

Drawer guide
- Compare guide with a map with and without drawer


# Checklist:

- [ ] I have run the **Test Suite** and **No errors have been introduced**
- [x] I have run `@BranchReview` agent in VS Code Chat and addressed all violations
- [x] I have run `@DocUpdate` agent in VS Code Chat and documentation is in sync with code changes
- [ ] I have run `@IssueReview` agent in VS Code Chat and the implementation aligns with the linked issue
- [x] I have build **(rush build)** and deploy **(rush host)** my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~New and existing unit tests pass locally with my changes~~

# Pre-PR Copilot Agent Checks

Before creating your PR, run the following two Copilot agents in VS Code Chat to catch common issues automatically.

## Branch Review (`@BranchReview`)

Audits all changed `.ts`/`.tsx` files against the GeoView coding standards (JSDoc, logging, return types, naming, accessibility, imports, performance patterns).

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **BranchReview** agent from the agent picker (or type `@BranchReview`)
3. Type the target branch name (defaults to `develop`):
   ```
   @BranchReview  against upstream/develop
   ```
4. Review the violation report and fix flagged items (the agent can auto-fix most issues on approval)

- [ ] `@BranchReview` has been run and all violations have been addressed

## Documentation Update (`@DocUpdate`)

Checks that documentation in `docs/` is still consistent with the code you changed. Catches stale references, missing docs for new features, and incorrect code examples.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **DocUpdate** agent from the agent picker (or type `@DocUpdate`)
3. Run a full audit or target a specific section:
   ```
   @DocUpdate full audit of docs/programming/
   @DocUpdate check docs/app/layers/
   ```
4. Review the audit summary and approve any proposed documentation updates

- [ ] `@DocUpdate` has been run and documentation is in sync with code changes

## Issue Review (`@IssueReview`)

Compares your branch changes against the linked GitHub issue's proposed fix. Checks whether the implementation aligns with what was proposed, catches gaps, and provides feedback to improve future issue drafts.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **IssueReview** agent from the agent picker (or type `@IssueReview`)
3. Provide the issue number:
   ```
   @IssueReview #1234
   ```
4. Review the alignment report — it will flag items that were proposed but not implemented, unexpected changes, and root cause accuracy

- [ ] `@IssueReview` has been run and the alignment report has been reviewed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3497)
<!-- Reviewable:end -->
