### PR TITLE
feat(es-lint-rule) eslint no-unused-param rule more strict

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -325,6 +325,24 @@ See [time-dimension.md](../docs/programming/time-dimension.md) for the full arch
 
 GeoView uses a lightweight typed delegate event system (see [event-helper.md](../docs/programming/event-helper.md)). Classes own private handler arrays (`#onXxxHandlers`) and expose `onXxx()`/`offXxx()` subscribe/unsubscribe methods. Events are emitted via `EventHelper.emitEvent()`. Controllers subscribe in `onHook()` and unsubscribe in `onUnhook()`.
 
+**Handler parameter naming convention (required):** For EventHelper delegate handlers, always name parameters `sender` and `event`.
+
+- Use `(sender, event)` even if one parameter is not used in the body.
+- `sender` and `event` are exception names in the no-unused-parameter ESLint rule.
+- Apply this convention in controllers, domains, APIs, and any callback wired to `onXxx()` EventHelper delegates.
+
+```typescript
+// ✅ Good
+mapViewer.onMapMoveEnd((sender, event) => {
+  logger.logDebug(event.lonlat);
+});
+
+// ❌ Avoid
+mapViewer.onMapMoveEnd((map, e) => {
+  logger.logDebug(e.lonlat);
+});
+```
+
 ## TypeScript Conventions
 
 ### Type Safety (Strict Enforcement)
@@ -350,6 +368,25 @@ function reset(force = true): void {}
 // ✅ Good: Type annotation IS needed when TypeScript cannot infer
 const layers: string[] = [];
 useState<TypeBasemapProps[]>([]);
+```
+
+- **Prefer optional property syntax for optional attributes/properties**: For class attributes and type/interface properties that may be absent, prefer `prop?: Type` over `prop?: Type | undefined`.
+
+```typescript
+// ✅ Good: concise optional property
+interface LayerConfig {
+  layerName?: string;
+}
+
+// ❌ Avoid in most cases: redundant undefined union on optional property
+interface LayerConfig {
+  layerName?: string | undefined;
+}
+
+// ✅ Exception: use this only when presence-vs-absence must be distinguished
+interface LayerState {
+  layerName: string | undefined;
+}
 ```
 
 - **Avoid name collisions**: Use `GVLayer` not `Layer` when OpenLayers has a `Layer` class

--- a/docs/programming/best-practices.md
+++ b/docs/programming/best-practices.md
@@ -270,7 +270,25 @@ In classes, functions should be ordered in the following way:
 - static private
 - event types
 
-## 12- React Performance Patterns
+## 12- EventHelper handler parameter naming
+
+When subscribing to events emitted through our `EventHelper` delegates, handler methods should use the parameter names `sender` and `event`.
+
+This naming is required for consistency and readability across the codebase. These names are also treated as exceptions in our no-unused-parameter ESLint rule, so they should be used even when one of the arguments is not consumed in the implementation.
+
+```ts
+// ✅ Good: EventHelper delegate naming convention
+this.getMapViewer().onMapMoveEnd((sender, event): void => {
+  logger.logDebug('Map moved', event.lonlat);
+});
+
+// ✅ Also good when one parameter is intentionally unused
+this.getMapViewer().onMapInit((sender, event): void => {
+  initializeSomething();
+});
+```
+
+## 13- React Performance Patterns
 
 ### useMemo Naming Convention
 

--- a/docs/programming/best-practices.md
+++ b/docs/programming/best-practices.md
@@ -38,6 +38,27 @@ async fetchMetadata(id: string): Promise<void> {
 const handleClick = useCallback((): void => { ... }, []);
 ```
 
+Prefer optional property syntax (`?:`) for class attributes and type/interface properties that may be absent. In most cases, this is clearer than using an explicit `| undefined` union.
+
+```ts
+// Preferred in most cases
+class LayerInfo {
+  layerName?: string;
+}
+
+type TypeLayerConfig = {
+  sourceUrl?: string;
+};
+
+// Use only when presence-vs-absence must be distinguished
+class LayerState {
+  // Property is always present, but value can be undefined
+  sourceUrl: string | undefined;
+}
+```
+
+Use `property: Type | undefined` only when that distinction is intentional and required by behavior (for example: serialization differences, merge semantics, or APIs that depend on checking whether a key exists).
+
 ## 2- Avoid using variable names that are too short.
 
 It is difficult to know what a variable with the name `e` refers to. Is it an `element`, an `event` or anything else whose name starts

--- a/packages/eslint.config.js
+++ b/packages/eslint.config.js
@@ -107,7 +107,7 @@ export default [
       'no-useless-constructor': 'off',
       '@typescript-eslint/no-useless-constructor': 'error',
       'no-unused-vars': 'off',
-      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-unused-vars': ["warn", { "args": "all", "argsIgnorePattern": "^_|^event$|^sender$" }],
       '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
       '@typescript-eslint/no-inferrable-types': 'warn',
       'no-use-before-define': 'off',

--- a/packages/geoview-core/src/api/types/layer-schema-types.ts
+++ b/packages/geoview-core/src/api/types/layer-schema-types.ts
@@ -468,7 +468,7 @@ export type RCSLayerConfig = {
   /**
    * The display name of the layer (English/French). This overrides the default name coming from the GeoCore API.
    */
-  geoviewLayerName?: string | undefined;
+  geoviewLayerName?: string;
 
   /** Initial settings to apply to the GeoCore layer at creation time. */
   initialSettings?: TypeLayerInitialSettings;
@@ -491,7 +491,7 @@ export type GeoPackageLayerConfig = {
   metadataAccessPath: string;
 
   /** The display name of the layer. This overrides the default name coming from the GeoCore API. */
-  geoviewLayerName?: string | undefined;
+  geoviewLayerName?: string;
 
   /** Initial settings to apply to the layer at creation time. */
   initialSettings?: TypeLayerInitialSettings;
@@ -514,7 +514,7 @@ export type ShapefileLayerConfig = {
   metadataAccessPath: string;
 
   /** The display name of the layer. This overrides the default name coming from the GeoCore API. */
-  geoviewLayerName?: string | undefined;
+  geoviewLayerName?: string;
 
   /** Initial settings to apply to the layer at creation time. */
   initialSettings?: TypeLayerInitialSettings;

--- a/packages/geoview-core/src/api/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/types/map-schema-types.ts
@@ -1049,7 +1049,7 @@ export type TypeFeatureInfoEntry = {
   uid?: string;
   feature?: Feature<Geometry>;
   geometry?: Geometry;
-  extent: Extent | undefined;
+  extent?: Extent;
   featureIcon?: string;
   fieldInfo: Partial<Record<string, TypeFieldEntry>>;
   nameField?: string;

--- a/packages/geoview-core/src/core/components/common/layer-list.tsx
+++ b/packages/geoview-core/src/core/components/common/layer-list.tsx
@@ -35,7 +35,7 @@ export interface LayerListEntry {
   /** Number of features in the layer. */
   numOffeatures?: number;
   /** Array of feature info entries. */
-  features?: TypeFeatureInfoEntry[] | undefined;
+  features?: TypeFeatureInfoEntry[];
   /** Unique DOM id for the layer list item. */
   layerUniqueId?: string;
   /** Whether the layer item is disabled. */

--- a/packages/geoview-core/src/core/components/data-table/export-button.tsx
+++ b/packages/geoview-core/src/core/components/data-table/export-button.tsx
@@ -17,7 +17,7 @@ interface ExportButtonProps {
   layerPath: string;
   rows: DataTableRow[];
   columns: MRTColumnDef<DataTableRow>[];
-  children?: ReactElement | undefined;
+  children?: ReactElement;
 }
 
 /** The columns to remove from the data when exporting */

--- a/packages/geoview-core/src/core/components/guide/guide.tsx
+++ b/packages/geoview-core/src/core/components/guide/guide.tsx
@@ -68,7 +68,7 @@ export const Guide = memo(function GuidePanel({ containerType }: GuideType): JSX
    * Handles search state changes from GuideSearch component.
    */
   const handleSearchStateChange = useCallback(
-    (newSearchTerm: string, newHighlightFunction: (content: string, sectionIndex: number) => string): void => {
+    (_newSearchTerm: string, newHighlightFunction: (content: string, sectionIndex: number) => string): void => {
       setHighlightFunction(() => newHighlightFunction);
     },
     []

--- a/packages/geoview-core/src/core/components/layers/delete-undo-button.tsx
+++ b/packages/geoview-core/src/core/components/layers/delete-undo-button.tsx
@@ -128,12 +128,10 @@ export function DeleteUndoButton(props: DeleteUndoButtonProps): JSX.Element {
     }
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleDeleteClick = (event: MouseEvent): void => {
     performDelete(false);
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleUndoClick = (event: MouseEvent): void => {
     performUndo(false);
   };

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-opacity-control/layer-opacity-control.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-opacity-control/layer-opacity-control.tsx
@@ -74,6 +74,7 @@ export function LayerOpacityControl({ layerPath }: LayerOpacityControlProps): JS
    * @param updateStore - Should the store be updated.
    */
   const handleSliderChange = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     (value: number | number[], activeThumb: number, updateStore = false): void => {
       const val = (Array.isArray(value) ? value[0] : value) / 100;
       const newValue = Math.min(val, layerParentOpacity);

--- a/packages/geoview-core/src/core/controllers/drawer-controller.ts
+++ b/packages/geoview-core/src/core/controllers/drawer-controller.ts
@@ -127,7 +127,7 @@ export class DrawerController extends AbstractMapViewerController {
   #selectedFeatureState?: {
     feature: Feature;
     originalGeometry: Geometry;
-    originalStyle?: StyleLike | undefined;
+    originalStyle?: StyleLike;
   };
 
   /** History stack for undo/redo functionality */

--- a/packages/geoview-core/src/core/controllers/layer-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-controller.ts
@@ -2030,7 +2030,7 @@ export class LayerController extends AbstractMapViewerController {
    * @param sender - The layer domain that fired the event
    * @param event - The event containing the unregistered layer
    */
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this, @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   #handleDomainLayerUnregistered(sender: LayerDomain, event: DomainLayerRegisteredEvent): void {
     //
     // Do something here....
@@ -2078,7 +2078,6 @@ export class LayerController extends AbstractMapViewerController {
    * @param sender - The layer domain that fired the event
    * @param event - The event containing the loading state change
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   #handleDomainLayerLoadingChanged(sender: LayerDomain, event: DomainLayerBaseEvent): void {
     // Update the store that at least 1 layer is loading
     setStoreLayersAreLoading(this.getMapId(), true);
@@ -2126,7 +2125,6 @@ export class LayerController extends AbstractMapViewerController {
    * @param sender - The layer domain that fired the event
    * @param event - The event containing the loaded state change
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   #handleDomainLayerAllLoaded(sender: LayerDomain, event: DomainLayerStatusChangedEvent): void {
     // Update the store that all layers are loaded at this point
     setStoreLayersAreLoading(this.getMapId(), false);

--- a/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
@@ -788,10 +788,10 @@ export class LayerCreatorController extends AbstractMapViewerController {
    *     cleanup actions tied to removal).
    *  3. Registers the new layer-entry configuration using `registerLayerConfigInit`.
    *
-   * @param geoviewLayer - The GeoView layer associated with this registration event
+   * @param sender - The GeoView layer associated with this registration event
    * @param event - The event containing the layer-entry configuration to be registered
    */
-  #handleLayerEntryRegisterInit(geoviewLayer: AbstractGeoViewLayer, event: LayerEntryRegisterInitEvent): void {
+  #handleLayerEntryRegisterInit(sender: AbstractGeoViewLayer, event: LayerEntryRegisterInitEvent): void {
     // Log
     logger.logTraceCore(
       `LAYERS - 1.5 - Registering an extra layer entry config ${event.config.layerPath} on map ${this.getMapId()}`,
@@ -824,10 +824,10 @@ export class LayerCreatorController extends AbstractMapViewerController {
    *  3. Emits a "layer created" event so external code can bind to it immediately.
    *  4. Calls the layer's `init()` method to finalize initialization.
    *
-   * @param geoviewLayer - The parent or context GeoView layer associated with this creation event
+   * @param sender - The parent or context GeoView layer associated with this creation event
    * @param event - The event containing the newly created GV layer instance and its configuration
    */
-  #handleLayerGVCreated(geoviewLayer: AbstractGeoViewLayer, event: LayerGVCreatedEvent): void {
+  #handleLayerGVCreated(sender: AbstractGeoViewLayer, event: LayerGVCreatedEvent): void {
     // Get the GV Layer and the config
     const gvLayer = event.layer;
     const layerConfig = gvLayer.getLayerConfig();
@@ -867,12 +867,10 @@ export class LayerCreatorController extends AbstractMapViewerController {
    *  2. Registers internal event handlers specific to group layers.
    *  3. Computes and stores the layer's initial "in visible range" state.
    *
-   * @param geoviewLayer - The parent or context layer
-   *   associated with this creation event.
-   * @param event - The event containing the newly
-   *   created group layer instance and its configuration.
+   * @param sender - The parent or context layer associated with this creation event.
+   * @param event - The event containing the newly created group layer instance and its configuration.
    */
-  #handleLayerGroupCreated(geoviewLayer: AbstractGeoViewLayer, event: LayerGroupCreatedEvent): void {
+  #handleLayerGroupCreated(sender: AbstractGeoViewLayer, event: LayerGroupCreatedEvent): void {
     // Get the Group Layer and the config
     const groupLayer = event.layer;
     const layerConfig = groupLayer.getLayerConfig();
@@ -891,7 +889,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
   /**
    * Handles layer-specific messages and displays them through the map viewer's notification system.
    *
-   * @param layer - The layer instance that triggered the message
+   * @param sender - The layer instance that triggered the message
    * @param layerMessageEvent - The message event containing notification details
    *
    * @example
@@ -902,7 +900,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
    *   notification: true
    * });
    */
-  #handleLayerMessage(layer: AbstractGeoViewLayer, layerMessageEvent: LayerMessageEvent): void {
+  #handleLayerMessage(sender: AbstractGeoViewLayer, layerMessageEvent: LayerMessageEvent): void {
     // Read event params for clarity
     const { messageType } = layerMessageEvent;
     const { messageKey } = layerMessageEvent;

--- a/packages/geoview-core/src/core/controllers/layer-set-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-set-controller.ts
@@ -542,10 +542,10 @@ export class LayerSetController extends AbstractMapViewerController {
   /**
    * Handles a single click on the map by querying all queryable layers at the click location.
    *
-   * @param mapViewer - The map viewer instance that fired the event
+   * @param sender - The map viewer instance that fired the event
    * @param event - The map single click event containing the click coordinates
    */
-  #handleMapClicked(mapViewer: MapViewer, event: MapSingleClickEvent): void {
+  #handleMapClicked(sender: MapViewer, event: MapSingleClickEvent): void {
     // Perform a query at the clicked lonlat
     this.queryAtLonLat(event.lonlat).catch((error: unknown) => {
       // Log
@@ -556,11 +556,10 @@ export class LayerSetController extends AbstractMapViewerController {
   /**
    * Handles the map pointer move event by clearing all hover feature info results.
    *
-   * @param mapViewer - The map viewer instance that fired the event
+   * @param sender - The map viewer instance that fired the event
    * @param event - The map pointer move event
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  #handleMapPointerMoved(mapViewer: MapViewer, event: MapPointerMoveEvent): void {
+  #handleMapPointerMoved(sender: MapViewer, event: MapPointerMoveEvent): void {
     // Clear all hover features
     this.hoverFeatureInfoLayerSet.clearResults();
   }
@@ -568,10 +567,10 @@ export class LayerSetController extends AbstractMapViewerController {
   /**
    * Handles the map pointer stop event by querying hoverable layers at the pointer position.
    *
-   * @param mapViewer - The map viewer instance that fired the event
+   * @param sender - The map viewer instance that fired the event
    * @param event - The map pointer move event containing the pixel coordinates
    */
-  #handleMapPointerStopped(mapViewer: MapViewer, event: MapPointerMoveEvent): void {
+  #handleMapPointerStopped(sender: MapViewer, event: MapPointerMoveEvent): void {
     // Query
     this.hoverFeatureInfoLayerSet.queryLayers(event.pixel).catch((error: unknown) => {
       // Log

--- a/packages/geoview-core/src/core/controllers/map-controller.ts
+++ b/packages/geoview-core/src/core/controllers/map-controller.ts
@@ -882,8 +882,6 @@ export class MapController extends AbstractMapViewerController {
               alias: 'Elevation',
             },
           },
-          extent: undefined,
-          geometry: undefined,
           featureKey: 0,
           geoviewLayerType: 'CSV',
           supportZoomTo: true,
@@ -1249,11 +1247,10 @@ export class MapController extends AbstractMapViewerController {
    * Shows a loading indicator, clears stale WMS override CRS layers and vector feature data,
    * hides the overview map, removes layer highlights, and strips incompatible vector tile layers.
    *
-   * @param mapViewer - The MapViewer instance that emitted the event
+   * @param sender - The MapViewer instance that emitted the event
    * @param event - The projection changed event containing the new and previous projections
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  #handleMapProjectionChangeStarted(mapViewer: MapViewer, event: MapProjectionChangedEvent): void {
+  #handleMapProjectionChangeStarted(sender: MapViewer, event: MapProjectionChangedEvent): void {
     // Show loading indicator while the projection change is being processed
     this.getControllersRegistry().uiController.setCircularProgress(true);
 
@@ -1294,10 +1291,10 @@ export class MapController extends AbstractMapViewerController {
    * restores the overview map, repeats the last feature query, and resolves the
    * pending projection change promise.
    *
-   * @param mapViewer - The MapViewer instance that emitted the event
+   * @param sender - The MapViewer instance that emitted the event
    * @param event - The projection changed event containing the new and previous projections
    */
-  #handleMapProjectionChanged(mapViewer: MapViewer, event: MapProjectionChangedEvent): void {
+  #handleMapProjectionChanged(sender: MapViewer, event: MapProjectionChangedEvent): void {
     // Save in the store
     setStoreMapProjection(this.getMapId(), Projection.readEPSGNumber(event.projection) as TypeValidMapProjectionCodes);
 

--- a/packages/geoview-core/src/core/domains/layer-domain.ts
+++ b/packages/geoview-core/src/core/domains/layer-domain.ts
@@ -752,20 +752,20 @@ export class LayerDomain {
    * Internal callback that is invoked when a layer configuration's status changes.
    * Forwards the event to domain listeners via emitLayerStatusChanged.
    *
-   * @param layerConfig - The layer configuration whose status changed
+   * @param sender - The layer configuration whose status changed
    * @param event - The layer status changed event
    */
-  #handleLayerStatusChanged(layerConfig: ConfigBaseClass, event: LayerStatusChangedEvent): void {
+  #handleLayerStatusChanged(sender: ConfigBaseClass, event: LayerStatusChangedEvent): void {
     // Emit about it
-    this.#emitLayerStatusChanged({ config: layerConfig, status: event.layerStatus });
+    this.#emitLayerStatusChanged({ config: sender, status: event.layerStatus });
 
     // If the config is a layer entry (not a group)
-    if (layerConfig instanceof AbstractBaseLayerEntryConfig) {
+    if (sender instanceof AbstractBaseLayerEntryConfig) {
       // Check if all layers are loaded/error right now
       const allLoaded = this.checkLayerStatusLoaded();
       if (allLoaded) {
         // Emit about it
-        this.#emitLayerAllLoaded({ config: layerConfig, status: event.layerStatus });
+        this.#emitLayerAllLoaded({ config: sender, status: event.layerStatus });
       }
     }
   }
@@ -776,12 +776,12 @@ export class LayerDomain {
    * Internal callback that is invoked when a layer's name changes.
    * Forwards the event to domain listeners via emitLayerNameChanged.
    *
-   * @param layer - The layer whose name changed
+   * @param sender - The layer whose name changed
    * @param event - The layer name changed event
    */
-  #handleLayerNameChanged(layer: AbstractBaseGVLayer, event: LayerNameChangedEvent): void {
+  #handleLayerNameChanged(sender: AbstractBaseGVLayer, event: LayerNameChangedEvent): void {
     // Emit about it
-    this.#emitLayerNameChanged({ layer, layerEvent: event });
+    this.#emitLayerNameChanged({ layer: sender, layerEvent: event });
   }
 
   /**
@@ -790,91 +790,91 @@ export class LayerDomain {
    * Internal callback that is invoked when a layer's visible state changes.
    * Forwards the event to domain listeners via emitLayerVisibleChanged.
    *
-   * @param layer - The layer whose visible state changed
+   * @param sender - The layer whose visible state changed
    * @param event - The layer visible changed event
    */
-  #handleLayerVisibleChanged(layer: AbstractBaseGVLayer, event: LayerVisibleChangedEvent): void {
+  #handleLayerVisibleChanged(sender: AbstractBaseGVLayer, event: LayerVisibleChangedEvent): void {
     // Emit about it
-    this.#emitLayerVisibleChanged({ layer, layerEvent: event });
+    this.#emitLayerVisibleChanged({ layer: sender, layerEvent: event });
   }
 
   /**
    * Handles layer loading events from registered layers.
    *
-   * @param layer - The layer entering the loading state
+   * @param sender - The layer entering the loading state
    * @param event - The layer base event
    */
-  #handleLayerLoading(layer: AbstractBaseGVLayer, event: LayerBaseEvent): void {
+  #handleLayerLoading(sender: AbstractBaseGVLayer, event: LayerBaseEvent): void {
     // Emit about it
-    this.#emitLayerLoading({ layer, layerEvent: event });
+    this.#emitLayerLoading({ layer: sender, layerEvent: event });
   }
 
   /**
    * Handles layer first loaded events from registered layers.
    *
-   * @param layer - The layer that has been loaded for the first time
+   * @param sender - The layer that has been loaded for the first time
    * @param event - The layer base event
    */
 
-  #handleLayerFirstLoaded(layer: AbstractBaseGVLayer, event: LayerBaseEvent): void {
+  #handleLayerFirstLoaded(sender: AbstractBaseGVLayer, event: LayerBaseEvent): void {
     // Emit about it
-    this.#emitLayerFirstLoaded({ layer, layerEvent: event });
+    this.#emitLayerFirstLoaded({ layer: sender, layerEvent: event });
   }
 
   /**
    * Handles layer loaded events from registered layers.
    *
-   * @param layer - The layer that finished loading
+   * @param sender - The layer that finished loading
    * @param event - The layer base event
    */
 
-  #handleLayerLoaded(layer: AbstractBaseGVLayer, event: LayerBaseEvent): void {
+  #handleLayerLoaded(sender: AbstractBaseGVLayer, event: LayerBaseEvent): void {
     // Emit about it
-    this.#emitLayerLoaded({ layer, layerEvent: event });
+    this.#emitLayerLoaded({ layer: sender, layerEvent: event });
   }
 
   /**
    * Handles layer error events from registered layers.
    *
-   * @param layer - The layer that encountered an error
+   * @param sender - The layer that encountered an error
    * @param event - The layer error event
    */
-  #handleLayerError(layer: AbstractGVLayer, event: LayerErrorEvent): void {
+  #handleLayerError(sender: AbstractGVLayer, event: LayerErrorEvent): void {
     // Emit about it
-    this.#emitLayerError({ layer, layerEvent: event });
+    this.#emitLayerError({ layer: sender, layerEvent: event });
   }
 
   /**
    * Handles layer message events from registered layers.
    *
-   * @param layer - The layer that emitted a message
+   * @param sender - The layer that emitted a message
    * @param event - The layer message event
    */
-  #handleLayerMessage(layer: AbstractGVLayer, event: LayerMessageEvent): void {
+  #handleLayerMessage(sender: AbstractGVLayer, event: LayerMessageEvent): void {
     // Emit about it
-    this.#emitLayerMessage({ layer, layerEvent: event });
+    this.#emitLayerMessage({ layer: sender, layerEvent: event });
   }
 
   /**
    * Handles when a layer is added to a group layer.
    *
-   * @param layer - The group layer that received the new child
+   * @param sender - The group layer that received the new child
    * @param event - The layer event containing the added layer
    */
-  #handleLayerGroupLayerAdded(layer: GVGroupLayer, event: LayerGroupChildrenUpdatedEvent): void {
+  #handleLayerGroupLayerAdded(sender: GVGroupLayer, event: LayerGroupChildrenUpdatedEvent): void {
     // Emit about it
-    this.#emitLayerGroupLayerAdded({ layer, layerEvent: event });
+    this.#emitLayerGroupLayerAdded({ layer: sender, layerEvent: event });
   }
 
   /**
    * Handles when a layer is removed from a group layer.
    *
-   * @param layer - The group layer that lost a child
+   * @param sender - The group layer that lost a child
    * @param event - The layer event containing the removed layer
    */
-  #handleLayerGroupLayerRemoved(layer: GVGroupLayer, event: LayerGroupChildrenUpdatedEvent): void {
+  #handleLayerGroupLayerRemoved(sender: GVGroupLayer, event: LayerGroupChildrenUpdatedEvent): void {
     // Emit about it
-    this.#emitLayerGroupLayerRemoved({ layer, layerEvent: event });
+    this.#emitLayerGroupLayerRemoved({ layer: sender, layerEvent: event });
   }
 
   /**
@@ -883,12 +883,12 @@ export class LayerDomain {
    * Internal callback that is invoked when a layer's opacity state changes.
    * Forwards the event to domain listeners via emitLayerOpacityChanged.
    *
-   * @param layer - The layer whose opacity state changed
+   * @param sender - The layer whose opacity state changed
    * @param event - The layer opacity changed event
    */
-  #handleLayerOpacityChanged(layer: AbstractBaseGVLayer, event: LayerOpacityChangedEvent): void {
+  #handleLayerOpacityChanged(sender: AbstractBaseGVLayer, event: LayerOpacityChangedEvent): void {
     // Emit about it
-    this.#emitLayerOpacityChanged({ layer, layerEvent: event });
+    this.#emitLayerOpacityChanged({ layer: sender, layerEvent: event });
   }
 
   /**
@@ -897,12 +897,12 @@ export class LayerDomain {
    * Internal callback that is invoked when a layer's hoverable state changes.
    * Forwards the event to domain listeners via emitLayerHoverableChanged.
    *
-   * @param layer - The layer whose hoverable state changed
+   * @param sender - The layer whose hoverable state changed
    * @param event - The layer hoverable changed event
    */
-  #handleLayerHoverableChanged(layer: AbstractGVLayer, event: LayerHoverableChangedEvent): void {
+  #handleLayerHoverableChanged(sender: AbstractGVLayer, event: LayerHoverableChangedEvent): void {
     // Emit about it
-    this.#emitLayerHoverableChanged({ layer, layerEvent: event });
+    this.#emitLayerHoverableChanged({ layer: sender, layerEvent: event });
   }
 
   /**
@@ -911,12 +911,12 @@ export class LayerDomain {
    * Internal callback that is invoked when a layer's queryable state changes.
    * Forwards the event to domain listeners via emitLayerQueryableChanged.
    *
-   * @param layer - The layer whose queryable state changed
+   * @param sender - The layer whose queryable state changed
    * @param event - The layer queryable changed event
    */
-  #handleLayerQueryableChanged(layer: AbstractGVLayer, event: LayerQueryableChangedEvent): void {
+  #handleLayerQueryableChanged(sender: AbstractGVLayer, event: LayerQueryableChangedEvent): void {
     // Emit about it
-    this.#emitLayerQueryableChanged({ layer, layerEvent: event });
+    this.#emitLayerQueryableChanged({ layer: sender, layerEvent: event });
   }
 
   /**
@@ -925,12 +925,12 @@ export class LayerDomain {
    * Internal callback that is invoked when a layer's item visibility state changes.
    * Forwards the event to domain listeners via emitLayerItemVisibilityChanged.
    *
-   * @param layer - The layer whose item visibility state changed
+   * @param sender - The layer whose item visibility state changed
    * @param event - The layer item visibility changed event
    */
-  #handleLayerItemVisibilityChanged(layer: AbstractGVLayer, event: LayerItemVisibilityChangedEvent): void {
+  #handleLayerItemVisibilityChanged(sender: AbstractGVLayer, event: LayerItemVisibilityChangedEvent): void {
     // Emit about it
-    this.#emitLayerItemVisibilityChanged({ layer, layerEvent: event });
+    this.#emitLayerItemVisibilityChanged({ layer: sender, layerEvent: event });
   }
 
   /**
@@ -939,12 +939,12 @@ export class LayerDomain {
    * Internal callback that is invoked when a layer's filter is applied.
    * Forwards the event to domain listeners via emitLayerFilterApplied.
    *
-   * @param layer - The layer whose filter was applied
+   * @param sender - The layer whose filter was applied
    * @param event - The layer filter applied event
    */
-  #handleLayerFilterApplied(layer: AbstractGVLayer, event: LayerFilterAppliedEvent): void {
+  #handleLayerFilterApplied(sender: AbstractGVLayer, event: LayerFilterAppliedEvent): void {
     // Emit about it
-    this.#emitLayerFilterApplied({ layer, layerEvent: event });
+    this.#emitLayerFilterApplied({ layer: sender, layerEvent: event });
   }
 
   /**
@@ -955,13 +955,13 @@ export class LayerDomain {
    * registered, which causes the raster layer to fall through to its
    * default error handling.
    *
-   * @param layer - The raster layer whose image failed to load
+   * @param sender - The raster layer whose image failed to load
    * @param event - The image load rescue event
    * @returns Whether the error was rescued by a listener
    */
-  #handleLayerImageLoadRescue(layer: AbstractGVRaster, event: ImageLoadRescueEvent): Promise<boolean> {
+  #handleLayerImageLoadRescue(sender: AbstractGVRaster, event: ImageLoadRescueEvent): Promise<boolean> {
     // Emit about it
-    return this.#emitLayerImageLoadRescue({ layer, layerEvent: event })?.[0];
+    return this.#emitLayerImageLoadRescue({ layer: sender, layerEvent: event })?.[0];
   }
 
   /**
@@ -969,12 +969,12 @@ export class LayerDomain {
    *
    * Forwards the event to domain listeners via emitLayerRasterFunctionChanged.
    *
-   * @param layer - The layer whose raster function changed
+   * @param sender - The layer whose raster function changed
    * @param event - The raster function changed event
    */
-  #handleLayerRasterFunctionChanged(layer: GVEsriImage, event: RasterFunctionChangedEvent): void {
+  #handleLayerRasterFunctionChanged(sender: GVEsriImage, event: RasterFunctionChangedEvent): void {
     // Emit about it
-    this.#emitLayerRasterFunctionChanged({ layer, layerEvent: event });
+    this.#emitLayerRasterFunctionChanged({ layer: sender, layerEvent: event });
   }
 
   /**
@@ -982,12 +982,12 @@ export class LayerDomain {
    *
    * Forwards the event to domain listeners via emitLayerMosaicRuleChanged.
    *
-   * @param layer - The layer whose mosaic rule changed
+   * @param sender - The layer whose mosaic rule changed
    * @param event - The mosaic rule changed event
    */
-  #handleLayerMosaicRuleChanged(layer: GVEsriImage, event: MosaicRuleChangedEvent): void {
+  #handleLayerMosaicRuleChanged(sender: GVEsriImage, event: MosaicRuleChangedEvent): void {
     // Emit about it
-    this.#emitLayerMosaicRuleChanged({ layer, layerEvent: event });
+    this.#emitLayerMosaicRuleChanged({ layer: sender, layerEvent: event });
   }
 
   /**
@@ -995,12 +995,12 @@ export class LayerDomain {
    *
    * Forwards the event to domain listeners via emitLayerWmsStyleChanged.
    *
-   * @param layer - The layer whose WMS style changed
+   * @param sender - The layer whose WMS style changed
    * @param event - The WMS style changed event
    */
-  #handleLayerWmsStyleChanged(layer: GVWMS, event: WMSStyleChangedEvent): void {
+  #handleLayerWmsStyleChanged(sender: GVWMS, event: WMSStyleChangedEvent): void {
     // Emit about it
-    this.#emitLayerWmsStyleChanged({ layer, layerEvent: event });
+    this.#emitLayerWmsStyleChanged({ layer: sender, layerEvent: event });
   }
 
   // #endregion PRIVATE LAYER HANDLERS

--- a/packages/geoview-core/src/core/utils/utilities.ts
+++ b/packages/geoview-core/src/core/utils/utilities.ts
@@ -984,7 +984,7 @@ export function safeStringify(obj: any, space = 2): string {
 
   return JSON.stringify(
     obj,
-    (key, value) => {
+    (_key, value) => {
       if (typeof value === 'object' && value !== null) {
         if (seen.has(value)) {
           return '{Circular JSON}'; // Or return undefined to remove the property

--- a/packages/geoview-core/src/geo/interaction/transform/transform-base.ts
+++ b/packages/geoview-core/src/geo/interaction/transform/transform-base.ts
@@ -1699,7 +1699,6 @@ export class OLTransform extends OLPointer {
    * @returns Whether the event was handled
    */
   // TODO: Rewrite the function name, if this function overrides a mother function, it probably shouldn't be prefixed with 'handle'.
-
   override handleUpEvent(event: MapBrowserEvent<PointerEvent>): boolean {
     if (this.#inHandleUpEvent) return false;
     this.#inHandleUpEvent = true;

--- a/packages/geoview-core/src/geo/interaction/transform/transform-base.ts
+++ b/packages/geoview-core/src/geo/interaction/transform/transform-base.ts
@@ -1699,7 +1699,7 @@ export class OLTransform extends OLPointer {
    * @returns Whether the event was handled
    */
   // TODO: Rewrite the function name, if this function overrides a mother function, it probably shouldn't be prefixed with 'handle'.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   override handleUpEvent(event: MapBrowserEvent<PointerEvent>): boolean {
     if (this.#inHandleUpEvent) return false;
     this.#inHandleUpEvent = true;

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -126,6 +126,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
   protected override onProcessLayerMetadata(
     layerConfig: EsriDynamicLayerEntryConfig,
     displayDateMode: DisplayDateMode,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     mapProjection?: OLProjection,
     abortSignal?: AbortSignal
   ): Promise<EsriDynamicLayerEntryConfig> {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
@@ -85,6 +85,7 @@ export class EsriImage extends AbstractGeoViewRaster {
   protected override onProcessLayerMetadata(
     layerConfig: EsriImageLayerEntryConfig,
     displayDateMode: DisplayDateMode,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     mapProjection?: OLProjection,
     abortSignal?: AbortSignal
   ): Promise<EsriImageLayerEntryConfig> {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/vector-tiles.ts
@@ -98,6 +98,7 @@ export class VectorTiles extends AbstractGeoViewRaster {
    */
   protected override async onProcessLayerMetadata(
     layerConfig: VectorTilesLayerEntryConfig,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     displayDateMode: DisplayDateMode,
     mapProjection?: OLProjection,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -95,7 +95,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
     sourceOptions.strategy = layerConfig.getSource().strategy === 'bbox' ? bbox : all;
 
     // eslint-disable-next-line no-param-reassign
-    sourceOptions.loader = (extent: Extent, resolution: number, projection: OLProjection, successCallback, failureCallback): void => {
+    sourceOptions.loader = (extent: Extent, _resolution: number, projection: OLProjection, successCallback, failureCallback): void => {
       // GV Use void IIFE so the outer function stays sync and avoids @typescript-eslint/no-misused-promises
       void (async (): Promise<void> => {
         try {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/csv.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/csv.ts
@@ -99,6 +99,7 @@ export class CSV extends AbstractGeoViewVector {
    */
   protected override async onCreateVectorSourceLoadFeatures(
     layerConfig: VectorLayerEntryConfig,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     sourceOptions: SourceOptions<Feature>,
     readOptions: ReadOptions
   ): Promise<Feature[]> {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -192,6 +192,7 @@ export class EsriFeature extends AbstractGeoViewVector {
   protected override onProcessLayerMetadata(
     layerConfig: EsriFeatureLayerEntryConfig,
     displayDateMode: DisplayDateMode,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     mapProjection?: OLProjection,
     abortSignal?: AbortSignal
   ): Promise<EsriFeatureLayerEntryConfig> {
@@ -209,6 +210,7 @@ export class EsriFeature extends AbstractGeoViewVector {
    */
   protected override async onCreateVectorSourceLoadFeatures(
     layerConfig: VectorLayerEntryConfig,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     sourceOptions: SourceOptions<Feature>,
     readOptions: ReadOptions
   ): Promise<Feature[]> {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/geojson.ts
@@ -193,6 +193,7 @@ export class GeoJSON extends AbstractGeoViewVector {
    */
   protected override async onCreateVectorSourceLoadFeatures(
     layerConfig: VectorLayerEntryConfig,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     sourceOptions: SourceOptions<Feature>,
     readOptions: ReadOptions
   ): Promise<Feature[]> {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/kml.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/kml.ts
@@ -99,6 +99,7 @@ export class KML extends AbstractGeoViewVector {
    */
   protected override async onCreateVectorSourceLoadFeatures(
     layerConfig: VectorLayerEntryConfig,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     sourceOptions: SourceOptions<Feature>,
     readOptions: ReadOptions
   ): Promise<Feature[]> {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/ogc-feature.ts
@@ -185,7 +185,9 @@ export class OgcFeature extends AbstractGeoViewVector {
    */
   protected override async onProcessLayerMetadata(
     layerConfig: VectorLayerEntryConfig,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     displayDateMode: DisplayDateMode,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     mapProjection?: OLProjection,
     abortSignal?: AbortSignal
   ): Promise<VectorLayerEntryConfig> {
@@ -215,6 +217,7 @@ export class OgcFeature extends AbstractGeoViewVector {
    */
   protected override async onCreateVectorSourceLoadFeatures(
     layerConfig: VectorLayerEntryConfig,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     sourceOptions: SourceOptions<Feature>,
     readOptions: ReadOptions
   ): Promise<Feature[]> {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -213,7 +213,9 @@ export class WFS extends AbstractGeoViewVector {
    */
   protected override async onProcessLayerMetadata(
     layerConfig: VectorLayerEntryConfig,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     displayDateMode: DisplayDateMode,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     mapProjection?: OLProjection,
     abortSignal?: AbortSignal
   ): Promise<VectorLayerEntryConfig> {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wkb.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wkb.ts
@@ -183,6 +183,7 @@ export class WKB extends AbstractGeoViewVector {
    */
   protected override async onCreateVectorSourceLoadFeatures(
     layerConfig: VectorLayerEntryConfig,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     sourceOptions: SourceOptions<Feature>,
     readOptions: ReadOptions
   ): Promise<Feature[]> {

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -349,8 +349,6 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    * @param event - The event which is being triggered
    * @returns A LayerFailedToLoadError error
    */
-  // We need to keep the 'this' context and the event param for overrides.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected onErrorDecipherError(event: Event): GeoViewError {
     // Try to read an error in the source object
     // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-explicit-any
@@ -367,8 +365,6 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    * @param event - The event which is being triggered
    * @returns A LayerImageFailedToLoadError error
    */
-  // We need to keep the 'this' context and the event param for overrides.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected onImageLoadErrorDecipherError(event: Event): GeoViewError {
     // Try to read an error in the source object
     // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-explicit-any
@@ -436,10 +432,13 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    * @throws {NotImplementedError} When the function isn't overridden by the children class
    */
   protected getFeatureInfoAtCoordinate(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     map: OLMap,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     location: Coordinate,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     queryGeometry = true,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     abortController: AbortController | undefined = undefined
@@ -460,10 +459,13 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    * @throws {NotImplementedError} When the function isn't overridden by the children class
    */
   protected getFeatureInfoAtLonLat(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     map: OLMap,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     lonlat: Coordinate,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     queryGeometry = true,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     abortController: AbortController | undefined = undefined
@@ -484,10 +486,13 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    * @throws {NotImplementedError} When the function isn't overridden by the children class
    */
   protected getFeatureInfoUsingBBox(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     map: OLMap,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     location: Coordinate[],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     queryGeometry = true,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     abortController: AbortController | undefined = undefined
@@ -508,10 +513,13 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
    * @throws {NotImplementedError} When the function isn't overridden by the children class
    */
   protected getFeatureInfoUsingPolygon(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     map: OLMap,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     location: Coordinate[],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     queryGeometry = true,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     language: TypeDisplayLanguage, // Used if we have to guess the field name for the 'nameField'
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     abortController: AbortController | undefined = undefined

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -929,8 +929,11 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     // Wait for results
     const arrayOfFeatureInfoEntries = await promiseGetFeature;
 
-    // Log
-    logger.logMarkerCheck(logMarkerKey, `to getFeatureInfo on ${this.getLayerPath()}`, arrayOfFeatureInfoEntries);
+    // If not aborted
+    if (!abortController?.signal.aborted) {
+      // Log
+      logger.logMarkerCheck(logMarkerKey, `to getFeatureInfo on ${this.getLayerPath()}`, arrayOfFeatureInfoEntries);
+    }
 
     // Return the result
     return arrayOfFeatureInfoEntries;

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-esri-dynamic.ts
@@ -301,6 +301,7 @@ export class GVEsriDynamic extends AbstractGVRaster {
    * @returns A promise that resolves with the feature info result
    */
   protected override async getAllFeatureInfo(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     map: OLMap,
     layerFilters: LayerFilters,
     language: TypeDisplayLanguage,

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -28,7 +28,7 @@ import {
   LayerInvalidFeatureInfoFormatWMSError,
   LayerInvalidLayerFilterError,
 } from '@/core/exceptions/layer-exceptions';
-import { formatError, NetworkError, ResponseContentError } from '@/core/exceptions/core-exceptions';
+import { formatError, NetworkError, RequestAbortedError, ResponseContentError } from '@/core/exceptions/core-exceptions';
 import { AbstractGVLayer } from '@/geo/layer/gv-layers/abstract-gv-layer';
 import type { EsriImageLayerEntryConfig } from '@/api/config/validation-classes/raster-validation-classes/esri-image-layer-entry-config';
 import { WfsRenderer } from '@/geo/utils/renderer/wfs-renderer';
@@ -48,6 +48,27 @@ import { logger } from '@/core/utils/logger';
 export class GVWMS extends AbstractGVRaster {
   /** The max feature count returned by the GetFeatureInfo */
   static readonly DEFAULT_MAX_FEATURE_COUNT: number = 100;
+
+  /** Mime/type for GEOJSON */
+  static readonly MIME_TYPE_FORMAT_GEOJSON = 'application/geojson';
+
+  /** Mime/type for JSON */
+  static readonly MIME_TYPE_FORMAT_JSON = 'application/json';
+
+  /** Mime/type for GML */
+  static readonly MIME_TYPE_FORMAT_GML = 'application/vnd.ogc.gml';
+
+  /** Mime/type for XML */
+  static readonly MIME_TYPE_FORMAT_APP_XML = 'application/xml';
+
+  /** Mime/type for XML */
+  static readonly MIME_TYPE_FORMAT_TEXT_XML = 'text/xml';
+
+  /** Mime/type for HTML */
+  static readonly MIME_TYPE_FORMAT_HTML = 'text/html';
+
+  /** Mime/type for Text */
+  static readonly MIME_TYPE_FORMAT_TEXT = 'text/plain';
 
   /**
    * The default Get Feature Info tolerance to use for QGIS Server services which are more picky by default (really needs to be zoomed in to get results, by default).
@@ -235,6 +256,8 @@ export class GVWMS extends AbstractGVRaster {
    * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param abortController - Optional {@link AbortController} to cancel the operation
    * @returns A promise that resolves with the feature info result
+   * @throws {RequestAbortedError} When the request was aborted by the caller's signal
+   * @throws {LayerInvalidFeatureInfoFormatWMSError} When no supported format returns usable feature info data
    */
   protected override async getFeatureInfoAtLonLat(
     map: OLMap,
@@ -288,22 +311,17 @@ export class GVWMS extends AbstractGVRaster {
 
     // If the layer has a WFS associated
     if (wfsLayerConfig) {
-      try {
-        // We're going to try performing a GetFeature using the WFS query instead of WMS, better chance to retrieve the geometry that way
-        return await this.#getFeatureInfoUsingWFS(
-          wmsLayerConfig,
-          wfsLayerConfig,
-          clickCoordinate,
-          viewResolution,
-          mapProjection.getCode(),
-          language,
-          this.getLayerFilters(),
-          abortController
-        );
-      } catch (error: unknown) {
-        // Failed to get feature info using WFS, continue with WMS
-        logger.logDebug(`Failed to getFeatureInfoUsingWFS for '${wmsLayerConfig.layerPath}'`, error);
-      }
+      // We're going to try performing a GetFeature using the WFS query instead of WMS, better chance to retrieve the geometry that way
+      return await this.#getFeatureInfoUsingWFS(
+        wmsLayerConfig,
+        wfsLayerConfig,
+        clickCoordinate,
+        viewResolution,
+        mapProjection.getCode(),
+        language,
+        this.getLayerFilters(),
+        abortController
+      );
     }
 
     // Try various info formats patterns to get feature info
@@ -512,10 +530,10 @@ export class GVWMS extends AbstractGVRaster {
     const xmlFilterReady = WfsRenderer.wrapOGCFilter(xmlFilter, 'wfs', wfsLayerConfig.getVersionOrDefault());
 
     // Get the supported info formats
-    const featureInfoFormat = wfsLayerConfig.getSupportedFormats('application/json'); // application/json by default (QGIS Server doesn't seem to provide the metadata for the output formats, use application/json)
+    const featureInfoFormat = wfsLayerConfig.getSupportedFormats(GVWMS.MIME_TYPE_FORMAT_JSON); // application/json by default (QGIS Server doesn't seem to provide the metadata for the output formats, use application/json)
 
     // If one of those contain application/json, use that format to get features
-    const outputFormat = featureInfoFormat.find((format) => format.toLowerCase().includes('application/json'));
+    const outputFormat = featureInfoFormat.find((format) => format.toLowerCase().includes(GVWMS.MIME_TYPE_FORMAT_JSON));
 
     // Format the url
     const urlWithOutputJson = GeoUtilities.ensureServiceRequestUrlGetFeature(
@@ -563,7 +581,7 @@ export class GVWMS extends AbstractGVRaster {
 
   // #endregion OVERRIDES
 
-  // #region METHODS
+  // #region PUBLIC METHODS
 
   /**
    * Gets if the CRS is to be overridden, because the layer struggles with the current map projection.
@@ -712,6 +730,10 @@ export class GVWMS extends AbstractGVRaster {
     return { results };
   }
 
+  // #endregion PUBLIC METHODS
+
+  // #region PRIVATE METHODS
+
   /**
    * Retrieves feature information from a WFS layer based on a clicked map location.
    *
@@ -737,6 +759,8 @@ export class GVWMS extends AbstractGVRaster {
    * @param abortController - Optional {@link AbortController} to
    *        allow cancellation of the WFS request.
    * @returns A promise that resolves with the feature info result
+   * @throws {RequestAbortedError} When the request was aborted by the caller's signal
+   * @throws {LayerInvalidFeatureInfoFormatWMSError} When no supported format returns usable feature info data
    */
   #getFeatureInfoUsingWFS(
     wmsLayerConfig: OgcWmsLayerEntryConfig,
@@ -748,69 +772,81 @@ export class GVWMS extends AbstractGVRaster {
     layerFilters?: LayerFilters,
     abortController?: AbortController
   ): Promise<TypeFeatureInfoResult> {
-    // Get the supported info formats
-    const featureInfoFormat = wfsLayerConfig.getSupportedFormats('application/json'); // application/json by default (QGIS Server doesn't seem to provide the metadata for the output formats, use application/json)
+    try {
+      // Get the supported info formats
+      const featureInfoFormat = wfsLayerConfig.getSupportedFormats(GVWMS.MIME_TYPE_FORMAT_JSON); // application/json by default (QGIS Server doesn't seem to provide the metadata for the output formats, use application/json)
 
-    // If one of those contain application/json, use that format to get features
-    const outputFormat = featureInfoFormat.find((format) => format.toLowerCase().includes('application/json'));
+      // If one of those contain application/json, use that format to get features
+      const outputFormat = featureInfoFormat.find((format) => format.toLowerCase().includes(GVWMS.MIME_TYPE_FORMAT_JSON));
 
-    // TODO: WMS - Add support for other formats. Not quite the GV issue #3134, but similar
+      // TODO: WMS - Add support for other formats. Not quite the GV issue #3134, but similar
 
-    // Create the filterXML from the sql filter
-    let gmlFilterAttribute;
-    let gmlFilterSpatial;
-    let fieldsToReturn = wfsLayerConfig.getOutfields();
+      // Create the filterXML from the sql filter
+      let gmlFilterAttribute;
+      let gmlFilterSpatial;
+      let fieldsToReturn = wfsLayerConfig.getOutfields();
 
-    // Total filter
-    const totalFilter = layerFilters?.getAllFilters();
+      // Total filter
+      const totalFilter = layerFilters?.getAllFilters();
 
-    // If any
-    if (totalFilter) {
-      // Build a OGC Filter for the filter
-      gmlFilterAttribute = WfsRenderer.sqlToOlFilterXml(
-        totalFilter,
+      // If any
+      if (totalFilter) {
+        // Build a OGC Filter for the filter
+        gmlFilterAttribute = WfsRenderer.sqlToOlFilterXml(
+          totalFilter,
+          wfsLayerConfig.getVersionOrDefault(),
+          wfsLayerConfig.getOutfields()?.[0]?.name!
+        );
+      }
+
+      // If performing a query based on a clicked coordinate, we want to filter spatially
+      if (clickCoordinate && viewResolution) {
+        // Get the geometry field name
+        const geomFieldName = wfsLayerConfig.getGeometryField()?.name || 'geometry'; // default: geometry
+
+        // Buffer the point into a polygon-circle to get features around the click point
+        const bufferedPoint = GVWMS.#buildBufferPolygon(clickCoordinate, viewResolution, this.getGetFeatureInfoTolerance());
+
+        // Write the polygon to GML
+        const polygonGML = GeoUtilities.writeGeometryToGML(bufferedPoint, projectionCode);
+
+        // Create the intersects filter
+        gmlFilterSpatial = `<Intersects><PropertyName>${geomFieldName}</PropertyName>${polygonGML}</Intersects>`;
+
+        // We want all fields in the response, to make sure the geometry is included, clear it
+        fieldsToReturn = undefined;
+      }
+
+      // Build attribute+spatial OGC filter
+      const xmlFilterTotal = WfsRenderer.combineGmlFilters(gmlFilterSpatial, gmlFilterAttribute);
+
+      // Wrap the ogc filter request
+      const xmlFilterReady = WfsRenderer.wrapOGCFilter(xmlFilterTotal, 'wfs', wfsLayerConfig.getVersionOrDefault());
+
+      // Format the url
+      const urlWithOutputJson = GeoUtilities.ensureServiceRequestUrlGetFeature(
+        wfsLayerConfig.getMetadataAccessPath()!,
+        wfsLayerConfig.layerId,
         wfsLayerConfig.getVersionOrDefault(),
-        wfsLayerConfig.getOutfields()?.[0]?.name!
+        outputFormat,
+        fieldsToReturn,
+        xmlFilterReady,
+        projectionCode
+      );
+
+      // Fetch and parse features
+      return GVWMS.fetchAndParseFeaturesFromWFSUrl(urlWithOutputJson, wmsLayerConfig, wfsLayerConfig, language, abortController);
+    } catch (error: unknown) {
+      // Log if the request was not aborted, when aborted, we don't really care for logging
+      GVWMS.#logErrorThrowIfAborted(error, `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve features from its WFS service`);
+
+      // Failed
+      throw new LayerInvalidFeatureInfoFormatWMSError(
+        wmsLayerConfig.layerPath,
+        GVWMS.MIME_TYPE_FORMAT_JSON,
+        wmsLayerConfig.getLayerNameCascade()
       );
     }
-
-    // If performing a query based on a clicked coordinate, we want to filter spatially
-    if (clickCoordinate && viewResolution) {
-      // Get the geometry field name
-      const geomFieldName = wfsLayerConfig.getGeometryField()?.name || 'geometry'; // default: geometry
-
-      // Buffer the point into a polygon-circle to get features around the click point
-      const bufferedPoint = GVWMS.#buildBufferPolygon(clickCoordinate, viewResolution, this.getGetFeatureInfoTolerance());
-
-      // Write the polygon to GML
-      const polygonGML = GeoUtilities.writeGeometryToGML(bufferedPoint, projectionCode);
-
-      // Create the intersects filter
-      gmlFilterSpatial = `<Intersects><PropertyName>${geomFieldName}</PropertyName>${polygonGML}</Intersects>`;
-
-      // We want all fields in the response, to make sure the geometry is included, clear it
-      fieldsToReturn = undefined;
-    }
-
-    // Build attribute+spatial OGC filter
-    const xmlFilterTotal = WfsRenderer.combineGmlFilters(gmlFilterSpatial, gmlFilterAttribute);
-
-    // Wrap the ogc filter request
-    const xmlFilterReady = WfsRenderer.wrapOGCFilter(xmlFilterTotal, 'wfs', wfsLayerConfig.getVersionOrDefault());
-
-    // Format the url
-    const urlWithOutputJson = GeoUtilities.ensureServiceRequestUrlGetFeature(
-      wfsLayerConfig.getMetadataAccessPath()!,
-      wfsLayerConfig.layerId,
-      wfsLayerConfig.getVersionOrDefault(),
-      outputFormat,
-      fieldsToReturn,
-      xmlFilterReady,
-      projectionCode
-    );
-
-    // Fetch and parse features
-    return GVWMS.fetchAndParseFeaturesFromWFSUrl(urlWithOutputJson, wmsLayerConfig, wfsLayerConfig, language, abortController);
   }
 
   /**
@@ -827,6 +863,7 @@ export class GVWMS extends AbstractGVRaster {
    * @param language - The display language, used to guess the best name field if `nameField` is not provided
    * @param abortController - Optional {@link AbortController} to cancel the request if needed
    * @returns A promise that resolves with the feature info result
+   * @throws {RequestAbortedError} When the request was aborted by the caller's signal
    * @throws {LayerInvalidFeatureInfoFormatWMSError} When no supported format returns usable feature info data
    */
   async #getFeatureInfoUsingWMS(
@@ -841,7 +878,9 @@ export class GVWMS extends AbstractGVRaster {
     const wmsSource = this.getOLSource();
 
     // Get the supported info formats
-    let featureInfoFormat = wmsLayerConfig.getServiceMetadata()?.Capability?.Request?.GetFeatureInfo?.Format || ['text/plain'];
+    let featureInfoFormat = wmsLayerConfig.getServiceMetadata()?.Capability?.Request?.GetFeatureInfo?.Format || [
+      GVWMS.MIME_TYPE_FORMAT_TEXT,
+    ];
 
     // If any output format has worked in the past
     if (this.#featureOutputFormatWMSWorked) featureInfoFormat = [this.#featureOutputFormatWMSWorked];
@@ -851,7 +890,7 @@ export class GVWMS extends AbstractGVRaster {
 
     // If the info format includes GEOJSON
     let featureMember: Record<string, unknown>[] | undefined;
-    if (featureInfoFormat.includes('application/geojson')) {
+    if (featureInfoFormat.includes(GVWMS.MIME_TYPE_FORMAT_GEOJSON)) {
       try {
         // Try to get the feature member using GEOJSON format
         featureMember = await GVWMS.#getFeatureInfoUsingJSON(
@@ -861,24 +900,24 @@ export class GVWMS extends AbstractGVRaster {
           viewResolution,
           this.getGetFeatureInfoTolerance(),
           projectionCode,
-          'application/geojson',
+          GVWMS.MIME_TYPE_FORMAT_GEOJSON,
           this.getGetFeatureInfoFeatureCount(),
           abortController
         );
 
         // Keep in mind, this output format works
-        this.#featureOutputFormatWMSWorked = 'application/geojson';
+        this.#featureOutputFormatWMSWorked = GVWMS.MIME_TYPE_FORMAT_GEOJSON;
       } catch (error: unknown) {
-        // Failed to retrieve featureMember using GeoJSON, eat the error, we'll try with another format
-        logger.logError(
-          `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using GeoJSON, eat the error, we'll try with another format`,
-          error
+        // Log if the request was not aborted, when aborted, we don't really care for logging
+        GVWMS.#logErrorThrowIfAborted(
+          error,
+          `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using GeoJSON, eat the error, we'll try with another format`
         );
       }
     }
 
     // If not found and format includes JSON
-    if (!featureMember && featureInfoFormat.includes('application/json')) {
+    if (!featureMember && featureInfoFormat.includes(GVWMS.MIME_TYPE_FORMAT_JSON)) {
       try {
         // Try to get the feature member using JSON format
         featureMember = await GVWMS.#getFeatureInfoUsingJSON(
@@ -888,24 +927,24 @@ export class GVWMS extends AbstractGVRaster {
           viewResolution,
           this.getGetFeatureInfoTolerance(),
           projectionCode,
-          'application/json',
+          GVWMS.MIME_TYPE_FORMAT_JSON,
           this.getGetFeatureInfoFeatureCount(),
           abortController
         );
 
         // Keep in mind, this output format works
-        this.#featureOutputFormatWMSWorked = 'application/json';
+        this.#featureOutputFormatWMSWorked = GVWMS.MIME_TYPE_FORMAT_JSON;
       } catch (error: unknown) {
-        // Failed to retrieve featureMember using Json, eat the error, we'll try with another format
-        logger.logError(
-          `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using JSON, eat the error, we'll try with another format`,
-          error
+        // Log if the request was not aborted, when aborted, we don't really care for logging
+        GVWMS.#logErrorThrowIfAborted(
+          error,
+          `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using JSON, eat the error, we'll try with another format`
         );
       }
     }
 
     // If not found and format includes application/vnd.ogc.gml
-    if (!featureMember && featureInfoFormat.includes('application/vnd.ogc.gml')) {
+    if (!featureMember && featureInfoFormat.includes(GVWMS.MIME_TYPE_FORMAT_GML)) {
       try {
         // Try to get the feature member using GML format
         featureMember = await GVWMS.#getFeatureInfoUsingGML(
@@ -920,18 +959,18 @@ export class GVWMS extends AbstractGVRaster {
         );
 
         // Keep in mind, this output format works
-        this.#featureOutputFormatWMSWorked = 'application/vnd.ogc.gml';
+        this.#featureOutputFormatWMSWorked = GVWMS.MIME_TYPE_FORMAT_GML;
       } catch (error: unknown) {
-        // Failed to retrieve featureMember using GML, eat the error, we'll try with another format
-        logger.logError(
-          `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using GML, eat the error, we'll try with another format`,
-          error
+        // Log if the request was not aborted, when aborted, we don't really care for logging
+        GVWMS.#logErrorThrowIfAborted(
+          error,
+          `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using GML, eat the error, we'll try with another format`
         );
       }
     }
 
     // If not found and format includes XML
-    if (!featureMember && featureInfoFormat.includes('text/xml')) {
+    if (!featureMember && featureInfoFormat.includes(GVWMS.MIME_TYPE_FORMAT_TEXT_XML)) {
       try {
         // Try to get the feature member using XML format
         const featMember = await GVWMS.#getFeatureInfoUsingXML(
@@ -946,18 +985,18 @@ export class GVWMS extends AbstractGVRaster {
         featureMember = [featMember];
 
         // Keep in mind, this output format works
-        this.#featureOutputFormatWMSWorked = 'text/xml';
+        this.#featureOutputFormatWMSWorked = GVWMS.MIME_TYPE_FORMAT_TEXT_XML;
       } catch (error: unknown) {
-        // Failed to retrieve featureMember using XML, eat the error, we'll try with another format
-        logger.logError(
-          `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using XML, eat the error, we'll try with another format`,
-          error
+        // Log if the request was not aborted, when aborted, we don't really care for logging
+        GVWMS.#logErrorThrowIfAborted(
+          error,
+          `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using XML, eat the error, we'll try with another format`
         );
       }
     }
 
     // If not found and format includes HTML
-    if (!featureMember && featureInfoFormat.includes('text/html')) {
+    if (!featureMember && featureInfoFormat.includes(GVWMS.MIME_TYPE_FORMAT_HTML)) {
       try {
         // Try to get the feature member using HTML format
         const featMember = await GVWMS.#getFeatureInfoUsingHTML(
@@ -971,10 +1010,10 @@ export class GVWMS extends AbstractGVRaster {
         );
         featureMember = [featMember];
       } catch (error: unknown) {
-        // Failed to retrieve featureMember using HTML, eat the error, we'll try with another format
-        logger.logError(
-          `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using HTML, eat the error, we'll try with another format`,
-          error
+        // Log if the request was not aborted, when aborted, we don't really care for logging
+        GVWMS.#logErrorThrowIfAborted(
+          error,
+          `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using HTML, eat the error, we'll try with another format`
         );
       }
     }
@@ -993,10 +1032,10 @@ export class GVWMS extends AbstractGVRaster {
         );
         featureMember = [featMember];
       } catch (error: unknown) {
-        // Failed to retrieve featureMember using plain text, eat the error, we'll handle the case below
-        logger.logError(
-          `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using plain text. Nothing can be done.`,
-          error
+        // Log if the request was not aborted, when aborted, we don't really care for logging
+        GVWMS.#logErrorThrowIfAborted(
+          error,
+          `${wmsLayerConfig.getLayerNameCascade()} - Failed to retrieve featureMember using plain text. Nothing can be done.`
         );
       }
     }
@@ -1019,7 +1058,7 @@ export class GVWMS extends AbstractGVRaster {
     throw new LayerInvalidFeatureInfoFormatWMSError(wmsLayerConfig.layerPath, featureInfoFormat, wmsLayerConfig.getLayerNameCascade());
   }
 
-  // #endregion METHODS
+  // #endregion PRIVATE METHODS
 
   // #region STATIC METHODS
 
@@ -1223,9 +1262,6 @@ export class GVWMS extends AbstractGVRaster {
     maxFeatures: number | undefined,
     abortController: AbortController | undefined = undefined
   ): Promise<Record<string, unknown>[]> {
-    // The info format
-    const infoFormat = 'application/vnd.ogc.gml';
-
     // Try to get the information using GML format
     const responseData = await GVWMS.#readFeatureInfo(
       layerConfig,
@@ -1234,18 +1270,18 @@ export class GVWMS extends AbstractGVRaster {
       viewResolution,
       qgisServerTolerance,
       projectionCode,
-      infoFormat,
+      GVWMS.MIME_TYPE_FORMAT_GML,
       maxFeatures,
       abortController
     );
 
     // Parse the content as XML
     const parser = new DOMParser();
-    const xmlDoc = parser.parseFromString(responseData, 'application/xml');
+    const xmlDoc = parser.parseFromString(responseData, GVWMS.MIME_TYPE_FORMAT_APP_XML);
 
     // Abort if XML could not be parsed
     if (xmlDoc.getElementsByTagName('parsererror').length > 0) {
-      throw new LayerInvalidFeatureInfoFormatWMSError(layerConfig.layerPath, infoFormat, layerConfig.getLayerNameCascade());
+      throw new LayerInvalidFeatureInfoFormatWMSError(layerConfig.layerPath, GVWMS.MIME_TYPE_FORMAT_GML, layerConfig.getLayerNameCascade());
     }
 
     // Preferred path: parse standard gml:featureMember entries using localName for namespace safety.
@@ -1284,7 +1320,7 @@ export class GVWMS extends AbstractGVRaster {
     }
 
     // Failed
-    throw new LayerInvalidFeatureInfoFormatWMSError(layerConfig.layerPath, infoFormat, layerConfig.getLayerNameCascade());
+    throw new LayerInvalidFeatureInfoFormatWMSError(layerConfig.layerPath, GVWMS.MIME_TYPE_FORMAT_GML, layerConfig.getLayerNameCascade());
   }
 
   /**
@@ -1310,9 +1346,6 @@ export class GVWMS extends AbstractGVRaster {
     projectionCode: ProjectionLike,
     abortController: AbortController | undefined = undefined
   ): Promise<Record<string, unknown>> {
-    // The info format
-    const infoFormat = 'text/xml';
-
     // Try to get the information using xml format
     const responseData = await GVWMS.#readFeatureInfo(
       layerConfig,
@@ -1321,7 +1354,7 @@ export class GVWMS extends AbstractGVRaster {
       viewResolution,
       qgisServerTolerance,
       projectionCode,
-      infoFormat,
+      GVWMS.MIME_TYPE_FORMAT_TEXT_XML,
       undefined,
       abortController
     );
@@ -1363,7 +1396,11 @@ export class GVWMS extends AbstractGVRaster {
     }
 
     // Failed
-    throw new LayerInvalidFeatureInfoFormatWMSError(layerConfig.layerPath, infoFormat, layerConfig.getLayerNameCascade());
+    throw new LayerInvalidFeatureInfoFormatWMSError(
+      layerConfig.layerPath,
+      GVWMS.MIME_TYPE_FORMAT_TEXT_XML,
+      layerConfig.getLayerNameCascade()
+    );
   }
 
   /**
@@ -1390,9 +1427,6 @@ export class GVWMS extends AbstractGVRaster {
     projectionCode: ProjectionLike,
     abortController: AbortController | undefined = undefined
   ): Promise<Record<string, unknown>> {
-    // The info format
-    const infoFormat = 'text/html';
-
     // Try to get the information using html format
     const responseData = await GVWMS.#readFeatureInfo(
       layerConfig,
@@ -1401,30 +1435,38 @@ export class GVWMS extends AbstractGVRaster {
       viewResolution,
       qgisServerTolerance,
       projectionCode,
-      infoFormat,
+      GVWMS.MIME_TYPE_FORMAT_HTML,
       undefined,
       abortController
     );
 
     // Check if the response is a WMS ServiceException XML
     const parser = new DOMParser();
-    const xmlTestDoc = parser.parseFromString(responseData, 'application/xml');
+    const xmlTestDoc = parser.parseFromString(responseData, GVWMS.MIME_TYPE_FORMAT_APP_XML);
     if (
       xmlTestDoc.documentElement?.localName?.toLowerCase() === 'serviceexceptionreport' ||
       xmlTestDoc.documentElement?.localName?.toLowerCase() === 'serviceexception'
     ) {
-      throw new LayerInvalidFeatureInfoFormatWMSError(layerConfig.layerPath, infoFormat, layerConfig.getLayerNameCascade());
+      throw new LayerInvalidFeatureInfoFormatWMSError(
+        layerConfig.layerPath,
+        GVWMS.MIME_TYPE_FORMAT_HTML,
+        layerConfig.getLayerNameCascade()
+      );
     }
 
     // Read the response as html
-    const xmlDomResponse = new DOMParser().parseFromString(responseData, 'text/html');
+    const xmlDomResponse = new DOMParser().parseFromString(responseData, GVWMS.MIME_TYPE_FORMAT_HTML);
 
     // Get body text content and trim it
     const bodyContent = xmlDomResponse.body?.textContent?.trim();
 
     // Check if it's empty or only whitespace
     if (!bodyContent) {
-      throw new LayerInvalidFeatureInfoFormatWMSError(layerConfig.layerPath, infoFormat, layerConfig.getLayerNameCascade());
+      throw new LayerInvalidFeatureInfoFormatWMSError(
+        layerConfig.layerPath,
+        GVWMS.MIME_TYPE_FORMAT_HTML,
+        layerConfig.getLayerNameCascade()
+      );
     }
 
     // The response is in html format
@@ -1464,19 +1506,23 @@ export class GVWMS extends AbstractGVRaster {
       viewResolution,
       qgisServerTolerance,
       projectionCode,
-      'text/plain',
+      GVWMS.MIME_TYPE_FORMAT_TEXT,
       undefined,
       abortController
     );
 
     // Sanitize response by stripping any HTML/XML nodes and keeping only text content
     const parser = new DOMParser();
-    const htmlDoc = parser.parseFromString(responseData, 'text/html');
+    const htmlDoc = parser.parseFromString(responseData, GVWMS.MIME_TYPE_FORMAT_HTML);
     const sanitizedText = htmlDoc.body?.textContent?.trim() || '';
 
     // If no meaningful text remains after sanitization, treat as invalid
     if (!sanitizedText) {
-      throw new LayerInvalidFeatureInfoFormatWMSError(layerConfig.layerPath, 'text/plain', layerConfig.getLayerNameCascade());
+      throw new LayerInvalidFeatureInfoFormatWMSError(
+        layerConfig.layerPath,
+        GVWMS.MIME_TYPE_FORMAT_TEXT,
+        layerConfig.getLayerNameCascade()
+      );
     }
 
     // The response is in plain format
@@ -1811,6 +1857,21 @@ export class GVWMS extends AbstractGVRaster {
 
     // Return the polygon
     return new Polygon([coordinates]);
+  }
+
+  /**
+   * Logs the provided error with the given message if the error is not a `RequestAbortedError`. If the error is a `RequestAbortedError`, it rethrows it to be handled by the caller.
+   *
+   * @param error - The error to check and log if necessary
+   * @param message - The message to log alongside the error if it's not a `RequestAbortedError`
+   * @throws {RequestAbortedError} When the error is an instance of `RequestAbortedError`, it is rethrown for the caller to handle
+   */
+  static #logErrorThrowIfAborted(error: unknown, message: string): void {
+    // If the error is a RequestAborted error, rethrow it, we want it to be handled by the caller and not eaten by the various attempts to get the feature info
+    if (error instanceof RequestAbortedError) throw error;
+
+    // Failed to retrieve features, log it as a warning
+    logger.logWarning(message, error);
   }
 
   // #endregion STATIC METHODS

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -274,12 +274,14 @@ export class GVWMS extends AbstractGVRaster {
       );
     }
 
+    // Get the map projection
+    const mapProjection = map.getView().getProjection();
+
     // Project the lon/lat to the map's projection
-    const clickCoordinate = Projection.transformFromLonLat(lonlat, map.getView().getProjection());
+    const clickCoordinate = Projection.transformFromLonLat(lonlat, mapProjection);
 
     // Get the source and resolution
     const viewResolution = map.getView().getResolution()!;
-    const projectionCode = map.getView().getProjection().getCode();
 
     // Get the Geoview Layer Config WFS equivalent if any
     const wfsLayerConfig = wmsLayerConfig.getWfsLayerConfig();
@@ -293,7 +295,7 @@ export class GVWMS extends AbstractGVRaster {
           wfsLayerConfig,
           clickCoordinate,
           viewResolution,
-          projectionCode,
+          mapProjection.getCode(),
           language,
           this.getLayerFilters(),
           abortController
@@ -305,7 +307,14 @@ export class GVWMS extends AbstractGVRaster {
     }
 
     // Try various info formats patterns to get feature info
-    return this.#getFeatureInfoUsingWMS(wmsLayerConfig, clickCoordinate, viewResolution, projectionCode, language, abortController);
+    return this.#getFeatureInfoUsingWMS(
+      wmsLayerConfig,
+      clickCoordinate,
+      viewResolution,
+      mapProjection.getCode(),
+      language,
+      abortController
+    );
   }
 
   /**
@@ -771,7 +780,7 @@ export class GVWMS extends AbstractGVRaster {
       const geomFieldName = wfsLayerConfig.getGeometryField()?.name || 'geometry'; // default: geometry
 
       // Buffer the point into a polygon-circle to get features around the click point
-      const bufferedPoint = GVWMS.#buildBufferPolygon(clickCoordinate, projectionCode, viewResolution, this.getGetFeatureInfoTolerance());
+      const bufferedPoint = GVWMS.#buildBufferPolygon(clickCoordinate, viewResolution, this.getGetFeatureInfoTolerance());
 
       // Write the polygon to GML
       const polygonGML = GeoUtilities.writeGeometryToGML(bufferedPoint, projectionCode);
@@ -1780,12 +1789,11 @@ export class GVWMS extends AbstractGVRaster {
    * Build a buffered polygon (GML) around a clicked coordinate.
    *
    * @param clickCoordinate - coordinate in map projection
-   * @param srsName - The srs name
    * @param resolution - The map resolution
    * @param pixelTolerance - number of screen pixels (like ArcGIS Identify)
    * @returns The buffered polygon
    */
-  static #buildBufferPolygon(clickCoordinate: Coordinate, srsName: string, resolution: number, pixelTolerance = 10): Polygon {
+  static #buildBufferPolygon(clickCoordinate: Coordinate, resolution: number, pixelTolerance = 10): Polygon {
     // The buffer radius
     const bufferRadius = resolution * (pixelTolerance / 2); // buffer in map units
 

--- a/packages/geoview-core/src/geo/layer/gv-layers/utils.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/utils.ts
@@ -176,7 +176,7 @@ export class GVLayerUtilities {
     const likeRegex = new RegExp(`\\b(${escapedFields.join('|')})\\b\\s+like\\s+('([^']*)')`, 'gi');
 
     // Proceed
-    filterValueToUse = filterValueToUse.replace(likeRegex, (_match, field: string, quotedValue: string, rawValue: string) => {
+    filterValueToUse = filterValueToUse.replace(likeRegex, (_match: string, field: string, _quotedValue: string, rawValue: string) => {
       // Uppercase the literal content, not the quotes
       const upperValue = rawValue.toUpperCase();
       return `UPPER(${field}) LIKE '${upperValue}'`;

--- a/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/vector/abstract-gv-vector.ts
@@ -240,7 +240,9 @@ export abstract class AbstractGVVector extends AbstractGVLayer {
    * @returns A promise that resolves with the feature info result.
    */
   protected override getAllFeatureInfo(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     map: OLMap,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     layerFilters: LayerFilters,
     language: TypeDisplayLanguage,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/geoview-core/src/geo/layer/layer-sets/abstract-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/abstract-layer-set.ts
@@ -309,18 +309,18 @@ export abstract class AbstractLayerSet {
    * from the layer domain and registers it into the system's layer set. If registration fails, errors
    * are logged appropriately.
    *
-   * @param layerConfig - The configuration object for the layer
+   * @param sender - The configuration object for the layer
    * @param event - The layer status change event
    */
-  #handleLayerStatusChanged(layerConfig: ConfigBaseClass, event: LayerStatusChangedEvent): void {
+  #handleLayerStatusChanged(sender: ConfigBaseClass, event: LayerStatusChangedEvent): void {
     try {
       // If the layer status is 'loaded', otherwise, don't even try yet
       if (event.layerStatus === 'loaded') {
         // The layer has become loaded
-        layerConfig.offLayerStatusChanged(this.#boundedHandleLayerStatusChanged);
+        sender.offLayerStatusChanged(this.#boundedHandleLayerStatusChanged);
 
         // Get the layer
-        const layer = this.layerDomain.getGeoviewLayer(layerConfig.layerPath);
+        const layer = this.layerDomain.getGeoviewLayer(sender.layerPath);
 
         // Register the layer itself (not the layer config) automatically in the layer set
         this.registerLayer(layer).catch((error: unknown) => {

--- a/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
@@ -85,7 +85,6 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
     // Abort all in-flight queries from a previous call and create a fresh controller for this call
     this.#abortController.abort();
     this.#abortController = new AbortController();
-    const { signal } = this.#abortController;
 
     // The result set to be returned
     const querySet: TypeFeatureInfoResultSet = {};
@@ -115,7 +114,7 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
         setStoreFeatureInfoDetails(this.getMapId(), layerPath, 'processing', undefined, false);
 
         // Process query and handle results
-        return this.#queryLayerAndProcess(layerPath, lonLatCoordinate, querySet, signal, callbackWhenFirstQueryStarted);
+        return this.#queryLayerAndProcess(layerPath, lonLatCoordinate, querySet, callbackWhenFirstQueryStarted);
       });
 
     // Await for the promises to settle
@@ -169,7 +168,6 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
     layerPath: string,
     lonLatCoordinate: Coordinate,
     querySet: TypeFeatureInfoResultSet,
-    signal: AbortSignal,
     callbackWhenFirstQueryStarted?: () => void
   ): Promise<void> {
     // Get the layer associated with the layer path
@@ -203,7 +201,7 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
             querySet[layerPath].featuresHaveGeometry = true;
 
             // Only propagate to the store if this query has not been superseded
-            if (!signal.aborted) {
+            if (!this.#abortController.signal.aborted) {
               setStoreFeatureInfoDetailsUpdateFeaturesHaveGeometry(this.getMapId(), layerPath, true);
             }
           })
@@ -237,12 +235,12 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
       querySet[layerPath].features = arrayOfRecords;
 
       // Only propagate to the store if this query has not been superseded
-      if (!signal.aborted) {
+      if (!this.#abortController.signal.aborted) {
         setStoreFeatureInfoDetails(this.getMapId(), layerPath, 'processed', arrayOfRecords, !promiseResult.promiseGeometries);
       }
     } catch (error: unknown) {
       // If aborted
-      if (error instanceof RequestAbortedError || signal.aborted) {
+      if (error instanceof RequestAbortedError || this.#abortController.signal.aborted) {
         // Log
         logger.logDebug('Query aborted and replaced by another one.. keep spinning..');
       } else {

--- a/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
@@ -58,7 +58,6 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
     // Abort all in-flight queries from a previous call and create a fresh controller for this call
     this.#abortController.abort();
     this.#abortController = new AbortController();
-    const { signal } = this.#abortController;
 
     // The result set to be returned
     const querySet: TypeHoverResultSet = {};
@@ -79,7 +78,7 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
     // Query each hoverable layer and collect the promises
     const allPromises = orderedLayerPaths
       .filter((layerPath) => this.layerDomain.getGeoviewLayerRegular(layerPath).getHoverable())
-      .map((layerPath) => this.#queryLayerAndProcess(layerPath, coordinate, queryType, querySet, orderedLayerPaths, signal));
+      .map((layerPath) => this.#queryLayerAndProcess(layerPath, coordinate, queryType, querySet, orderedLayerPaths));
 
     // Await for the promises to settle
     await Promise.allSettled(allPromises);
@@ -108,15 +107,13 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
    * @param queryType - The query type
    * @param querySet - The result set to update with the query results
    * @param orderedLayerPaths - The ordered layer paths used to determine store update priority
-   * @param signal - The abort signal for this query call
    */
   async #queryLayerAndProcess(
     layerPath: string,
     coordinate: Coordinate,
     queryType: QueryType,
     querySet: TypeHoverResultSet,
-    orderedLayerPaths: string[],
-    signal: AbortSignal
+    orderedLayerPaths: string[]
   ): Promise<void> {
     // Get the layer associated with the layer path
     const layer = this.layerDomain.getGeoviewLayerRegular(layerPath);
@@ -133,7 +130,7 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
       );
 
       // If a newer queryLayers call has aborted this one, discard stale results
-      if (signal.aborted) return;
+      if (this.#abortController.signal.aborted) return;
 
       // Get the array of records in the results
       const arrayOfRecords = promiseResult.results;
@@ -176,7 +173,7 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
       }
     } catch (error: unknown) {
       // If aborted
-      if (error instanceof RequestAbortedError || signal.aborted) {
+      if (error instanceof RequestAbortedError || this.#abortController.signal.aborted) {
         // Log
         logger.logDebug('Query aborted and replaced by another one.. keep spinning..');
       } else {

--- a/packages/geoview-core/src/geo/layer/layer-sets/legends-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/legends-layer-set.ts
@@ -286,13 +286,13 @@ export class LegendsLayerSet extends AbstractLayerSet {
   /**
    * Handles when a layer status changed on a layer config.
    *
-   * @param layerConfig - The layer config
+   * @param sender - The layer config
    * @param layerStatusEvent - The new layer status
    */
-  #handleLayerStatusChanged(layerConfig: ConfigBaseClass, layerStatusEvent: LayerStatusChangedEvent): void {
+  #handleLayerStatusChanged(sender: ConfigBaseClass, layerStatusEvent: LayerStatusChangedEvent): void {
     try {
       // Save to the store
-      setStoreLayerStatus(this.getMapId(), layerConfig.layerPath, layerStatusEvent.layerStatus);
+      setStoreLayerStatus(this.getMapId(), sender.layerPath, layerStatusEvent.layerStatus);
 
       // TODO: CLEANUP - Remove commented code. In this refactoring of legends-layer-set, I'm not checking for query legend on
       // TO.DOCONT: every layer status change 2026-05-01
@@ -301,33 +301,33 @@ export class LegendsLayerSet extends AbstractLayerSet {
       // this.#checkQueryLegend(layer, false);
     } catch (error: unknown) {
       // Log
-      logger.logError('CAUGHT in handleLayerStatusChanged', layerConfig.layerPath, error);
+      logger.logError('CAUGHT in handleLayerStatusChanged', sender.layerPath, error);
     }
   }
 
   /**
    * Handles when a layer style changes on a registered layer.
    *
-   * @param layer - The layer which changed its styles
+   * @param sender - The layer which changed its styles
    * @param event - The layer style changed event
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  #handleLayerStyleChanged(layer: AbstractGVLayer, event: StyleChangedEvent): void {
+
+  #handleLayerStyleChanged(sender: AbstractGVLayer, event: StyleChangedEvent): void {
     // Force query the legend as we have a new style
-    this.#checkQueryLegend(layer, true);
+    this.#checkQueryLegend(sender, true);
   }
 
   /**
    * Handles when a layer style has been applied on a registered AbstractGVVector layer.
    *
-   * @param layer - The layer which got its style applied
+   * @param sender - The layer which got its style applied
    * @param event - The StyleAppliedEvent
    */
-  #handleStyleApplied(layer: AbstractGVVector, event: StyleAppliedEvent): void {
+  #handleStyleApplied(sender: AbstractGVVector, event: StyleAppliedEvent): void {
     // If the style has been applied
     if (event.styleApplied) {
       // Force query the legend as we have a new style
-      this.#checkQueryLegend(layer, true);
+      this.#checkQueryLegend(sender, true);
     }
   }
 

--- a/packages/geoview-core/src/geo/layer/layer.ts
+++ b/packages/geoview-core/src/geo/layer/layer.ts
@@ -206,7 +206,6 @@ export class LayerApi {
     });
 
     // Listen on the domain layer message
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     layerDomain.onLayerMessage((sender, event) => {
       // Do something? Wasn't doing anything before..
     });

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -1943,7 +1943,7 @@ export class MapViewer {
    * @param event - The map event associated with the ending of the map movement
    * @returns A promise that resolves when done processing the map move
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   async #handleMapMoveEnd(event: MapEvent): Promise<void> {
     try {
       // Update the store
@@ -2031,7 +2031,7 @@ export class MapViewer {
    *
    * @param event - The event associated with the zoom end
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   #handleMapZoomEnd(event: ObjectEvent): void {
     try {
       // Read the zoom value
@@ -2073,7 +2073,7 @@ export class MapViewer {
    *
    * @param event - The event associated with rotation
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   #handleMapRotation(event: ObjectEvent): void {
     try {
       // Get the map rotation
@@ -2096,7 +2096,7 @@ export class MapViewer {
    * @param event - The event associated with size change
    * @returns A promise that resolves when done processing the map change size
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   async #handleMapChangeSize(event: ObjectEvent): Promise<void> {
     try {
       // Get the scale information

--- a/packages/geoview-core/src/geo/map/map-viewer.ts
+++ b/packages/geoview-core/src/geo/map/map-viewer.ts
@@ -1943,7 +1943,6 @@ export class MapViewer {
    * @param event - The map event associated with the ending of the map movement
    * @returns A promise that resolves when done processing the map move
    */
-
   async #handleMapMoveEnd(event: MapEvent): Promise<void> {
     try {
       // Update the store
@@ -2031,7 +2030,6 @@ export class MapViewer {
    *
    * @param event - The event associated with the zoom end
    */
-
   #handleMapZoomEnd(event: ObjectEvent): void {
     try {
       // Read the zoom value
@@ -2073,7 +2071,6 @@ export class MapViewer {
    *
    * @param event - The event associated with rotation
    */
-
   #handleMapRotation(event: ObjectEvent): void {
     try {
       // Get the map rotation
@@ -2096,7 +2093,6 @@ export class MapViewer {
    * @param event - The event associated with size change
    * @returns A promise that resolves when done processing the map change size
    */
-
   async #handleMapChangeSize(event: ObjectEvent): Promise<void> {
     try {
       // Get the scale information

--- a/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/geoview-renderer.ts
@@ -1655,7 +1655,7 @@ export abstract class GeoviewRenderer {
   static evaluateArcadeExpression(expression: string, feature: Feature): string | number | boolean | null {
     try {
       // Replace $feature.fieldName with actual values
-      let evaluableExpression = expression.replace(/\$feature\.([a-zA-Z_][\w]*)/g, (match, fieldName) => {
+      let evaluableExpression = expression.replace(/\$feature\.([a-zA-Z_][\w]*)/g, (_match, fieldName) => {
         const value = feature.get(fieldName);
         if (value === undefined || value === null) return 'null';
         // Escape backslashes and then wrap strings in quotes for JavaScript evaluation
@@ -1664,7 +1664,7 @@ export abstract class GeoviewRenderer {
       });
 
       // Replace $feature["fieldName"] or $feature['fieldName'] with actual values
-      evaluableExpression = evaluableExpression.replace(/\$feature\[["']([^"']+)["']\]/g, (match, fieldName) => {
+      evaluableExpression = evaluableExpression.replace(/\$feature\[["']([^"']+)["']\]/g, (_match, fieldName) => {
         const value = feature.get(fieldName);
         if (value === undefined || value === null) return 'null';
         // Escape backslashes and then wrap strings in quotes for JavaScript evaluation
@@ -1739,7 +1739,7 @@ export abstract class GeoviewRenderer {
       }
 
       // Replace $feature["fieldName"] or $feature['fieldName'] with actual values
-      const evaluableExpression = expression.replace(/\$feature\[["']([^"']+)["']\]/g, (match, fieldName) => {
+      const evaluableExpression = expression.replace(/\$feature\[["']([^"']+)["']\]/g, (_match, fieldName) => {
         const value = feature.get(fieldName);
         if (value === undefined || value === null) {
           return 'null';

--- a/packages/geoview-core/src/geo/utils/renderer/wfs-renderer.ts
+++ b/packages/geoview-core/src/geo/utils/renderer/wfs-renderer.ts
@@ -803,17 +803,17 @@ export abstract class WfsRenderer {
     color?: string;
     width?: number;
     opacity?: number;
-    dasharray?: number[] | undefined;
-    lineJoin?: string | undefined;
-    lineCap?: string | undefined;
+    dasharray?: number[];
+    lineJoin?: string;
+    lineCap?: string;
   } {
     const out: {
       color?: string;
       width?: number;
       opacity?: number;
-      dasharray?: number[] | undefined;
-      lineJoin?: string | undefined;
-      lineCap?: string | undefined;
+      dasharray?: number[];
+      lineJoin?: string;
+      lineCap?: string;
     } = {};
 
     if (!strokeNode) return out;
@@ -1448,7 +1448,7 @@ export abstract class WfsRenderer {
    * @returns The XML string with comparison operators unescaped inside <Literal> elements
    */
   static #unescapeComparisonOperatorsInLiterals(xml: string): string {
-    return xml.replace(/<Literal>([\s\S]*?)<\/Literal>/g, (match, literalContent) => {
+    return xml.replace(/<Literal>([\s\S]*?)<\/Literal>/g, (_match, literalContent) => {
       const fixed = literalContent.replace(/&gt;/g, '>').replace(/&lt;/g, '<');
 
       return `<Literal>${fixed}</Literal>`;

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -43,8 +43,8 @@ export const layerTypes = CONST_LAYER_TYPES;
 interface EsriFeature {
   attributes?: Record<string, unknown>;
   geometry?: {
-    x?: number | string | undefined;
-    y?: number | string | undefined;
+    x?: number | string;
+    y?: number | string;
     rings?: (number | string)[][][];
     paths?: (number | string)[][][];
     points?: (number | string)[][];

--- a/packages/geoview-core/src/ui/tabs/tabs.tsx
+++ b/packages/geoview-core/src/ui/tabs/tabs.tsx
@@ -50,7 +50,7 @@ export interface TypeTabsProps {
   rightButtons?: unknown;
   isCollapsed?: boolean;
   activeTrap?: boolean;
-  TabContentVisibilty?: string | undefined;
+  TabContentVisibilty?: string;
   onToggleCollapse?: () => void;
   onSelectedTabChanged?: (tab: TypeTabs) => void;
   onOpenKeyboard?: (uiFocus: FocusItemProps) => void;

--- a/packages/geoview-custom-legend/src/components/group-item.tsx
+++ b/packages/geoview-custom-legend/src/components/group-item.tsx
@@ -1,5 +1,4 @@
 import type { TypeWindow } from 'geoview-core/core/types/global-types';
-import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/states/app-state';
 import { logger } from 'geoview-core/core/utils/logger';
 import { useStoreLayerArrayVisibility } from 'geoview-core/core/stores/states/layer-state';
 import { useTranslation } from 'geoview-core/core/translation/i18n';
@@ -66,7 +65,6 @@ export function GroupItem({ item, sxClasses, itemPath }: GroupItemProps): JSX.El
     KeyboardArrowUpIcon,
   } = ui.elements;
 
-  const displayLanguage = useStoreAppDisplayLanguage();
   const layerController = useLayerController();
   const { t } = useTranslation<string>();
 
@@ -190,7 +188,7 @@ export function GroupItem({ item, sxClasses, itemPath }: GroupItemProps): JSX.El
         <Collapse id={collapseRegionId} role="region" aria-labelledby={collapseButtonId} in={!collapsed} sx={{ marginRight: '6px' }}>
           <List sx={sxClasses.groupChildren}>
             {item.children.map((child, index) => {
-              const childId = generateLegendItemId(child, index, displayLanguage);
+              const childId = generateLegendItemId(child, index);
               return <LegendItem key={childId} item={child} sxClasses={sxClasses} itemPath={`${currentPath}/${childId}`} />;
             })}
           </List>

--- a/packages/geoview-custom-legend/src/custom-legend-panel.tsx
+++ b/packages/geoview-custom-legend/src/custom-legend-panel.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
 import type { TypeWindow } from 'geoview-core/core/types/global-types';
-import { useStoreAppDisplayLanguage } from 'geoview-core/core/stores/states/app-state';
 import { logger } from 'geoview-core/core/utils/logger';
 
 import { getSxClasses } from './custom-legend-style';
@@ -33,13 +32,11 @@ export function CustomLegendPanel(props: CustomLegendPanelProps): JSX.Element {
   const theme = ui.useTheme();
   const sxClasses = useMemo(() => getSxClasses(theme), [theme]);
 
-  const appDisplayLanguage = useStoreAppDisplayLanguage();
-
   return (
     <Box sx={sxClasses.container}>
       <List className="legendList" sx={sxClasses.legendList}>
         {legendList.map((item, index) => {
-          const itemId = generateLegendItemId(item, index, appDisplayLanguage);
+          const itemId = generateLegendItemId(item, index);
           return <LegendItem key={itemId} item={item} sxClasses={sxClasses} itemPath={itemId} />;
         })}
       </List>

--- a/packages/geoview-custom-legend/src/custom-legend-types.ts
+++ b/packages/geoview-custom-legend/src/custom-legend-types.ts
@@ -76,11 +76,10 @@ export const isGroupLayer = (item: TypeLegendItem): item is TypeGroupLayer => {
  *
  * @param item - The legend item
  * @param index - The item's position in the list
- * @param language - The language of the current text
  * @param parentPath - Optional parent path for nested items
  * @returns A unique identifier
  */
-export function generateLegendItemId(item: TypeLegendItem, index: number, language: 'en' | 'fr', parentPath = ''): string {
+export function generateLegendItemId(item: TypeLegendItem, index: number, parentPath = ''): string {
   const basePath = parentPath ? `${parentPath}/` : '';
 
   if (isLegendLayer(item)) {

--- a/packages/geoview-test-suite/src/tests/testers/map-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/map-tester.ts
@@ -634,7 +634,7 @@ export class MapTester extends GVAbstractTester {
         Test.assertIsArray(layerDataOn2?.features);
         Test.assertIsArrayLengthEqual(layerDataOn2.features, 2);
       },
-      (test, result) => {
+      (_test, result) => {
         // Make sure to turn it back to queryable
         result.layer.setQueryable(true);
       }
@@ -721,7 +721,7 @@ export class MapTester extends GVAbstractTester {
         test.addStep('Verifying layer data features when hoverable again...');
         Test.assertJsonObject(result.results[2], { fieldInfo: { value: 'Ontario' } });
       },
-      (test, result) => {
+      (_test, result) => {
         // Make sure to turn it back to hoverable
         result.layer.setHoverable(true);
       }


### PR DESCRIPTION

# Description

- Modified the eslint no-unused-param rule to be a bit more strict while still allowing unused parameters for handlers. This allows us to catch a bit more cases when the parameter truly isn't used and shouldn't be part of the function signature.
- Standardized error handling between querying via WMS or via WFS and improved the error handling in general as well for the WMS layer type in particular.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

~~Hosted May 28 @ 14h00 : https://alex-nrcan.github.io/geoview/~~
Hosted May 28 @ 18h30 : https://alex-nrcan.github.io/geoview/
- Nothing min particular to test, code syntax changes, test in general everything.. 
- Also, test the WMS getFeatureInfo queries

# Checklist:

- [ ] I have run the **Test Suite** and **No errors have been introduced**
- [ ] I have run `@BranchReview` agent in VS Code Chat and addressed all violations
- [x] I have run `@DocUpdate` agent in VS Code Chat and documentation is in sync with code changes
- [ ] I have run `@IssueReview` agent in VS Code Chat and the implementation aligns with the linked issue
- [ ] I have build **(rush build)** and deploy **(rush host)** my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~New and existing unit tests pass locally with my changes~~

# Pre-PR Copilot Agent Checks

Before creating your PR, run the following two Copilot agents in VS Code Chat to catch common issues automatically.

## Branch Review (`@BranchReview`)

Audits all changed `.ts`/`.tsx` files against the GeoView coding standards (JSDoc, logging, return types, naming, accessibility, imports, performance patterns).

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **BranchReview** agent from the agent picker (or type `@BranchReview`)
3. Type the target branch name (defaults to `develop`):
   ```
   @BranchReview  against upstream/develop
   ```
4. Review the violation report and fix flagged items (the agent can auto-fix most issues on approval)

- [ ] `@BranchReview` has been run and all violations have been addressed

## Documentation Update (`@DocUpdate`)

Checks that documentation in `docs/` is still consistent with the code you changed. Catches stale references, missing docs for new features, and incorrect code examples.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **DocUpdate** agent from the agent picker (or type `@DocUpdate`)
3. Run a full audit or target a specific section:
   ```
   @DocUpdate full audit of docs/programming/
   @DocUpdate check docs/app/layers/
   ```
4. Review the audit summary and approve any proposed documentation updates

- [ ] `@DocUpdate` has been run and documentation is in sync with code changes

## Issue Review (`@IssueReview`)

Compares your branch changes against the linked GitHub issue's proposed fix. Checks whether the implementation aligns with what was proposed, catches gaps, and provides feedback to improve future issue drafts.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **IssueReview** agent from the agent picker (or type `@IssueReview`)
3. Provide the issue number:
   ```
   @IssueReview #1234
   ```
4. Review the alignment report — it will flag items that were proposed but not implemented, unexpected changes, and root cause accuracy

- [ ] `@IssueReview` has been run and the alignment report has been reviewed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3499)
<!-- Reviewable:end -->
