### PR TITLE
bug(swiper): Hide Hover and Feature Details when features are swiped

### DIFF
--- a/packages/geoview-core/public/configs/navigator/demos/14-package-swiper.json
+++ b/packages/geoview-core/public/configs/navigator/demos/14-package-swiper.json
@@ -30,7 +30,7 @@
   "components": ["north-arrow", "overview-map"],
   "appBar": {
     "tabs": {
-      "core": ["legend"]
+      "core": ["legend", "details"]
     }
   },
   "corePackages": ["swiper"],

--- a/packages/geoview-core/src/core/controllers/swiper-controller.ts
+++ b/packages/geoview-core/src/core/controllers/swiper-controller.ts
@@ -1,12 +1,18 @@
+import type { Coordinate } from 'ol/coordinate';
+
 import { AbstractMapViewerController } from '@/core/controllers/base/abstract-map-viewer-controller';
 import type { ControllerRegistry } from '@/core/controllers/base/controller-registry';
 import type { MapViewer } from '@/geo/map/map-viewer';
 import {
   addStoreSwiperLayerPath,
+  getStoreSwiperLayerPaths,
+  getStoreSwiperOrientation,
+  getStoreSwiperPosition,
   removeAllStoreSwipers,
   removeStoreSwiperLayerPath,
   setStoreSwiperLayerPaths,
   setStoreSwiperOrientation,
+  setStoreSwiperPosition,
   type SwipeOrientation,
 } from '@/core/stores/states/swiper-state';
 
@@ -25,6 +31,15 @@ export class SwiperController extends AbstractMapViewerController {
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor
   constructor(mapViewer: MapViewer, controllerRegistry: ControllerRegistry) {
     super(mapViewer, controllerRegistry);
+  }
+
+  /**
+   * Sets the swiper position, which determines the current position of the swipe comparison.
+   *
+   * @param position - The new swiper position, between 0 and 1.
+   */
+  setSwiperPosition(position: number): void {
+    setStoreSwiperPosition(this.getMapId(), position);
   }
 
   /**
@@ -91,5 +106,42 @@ export class SwiperController extends AbstractMapViewerController {
   removeAllLayerPaths(): void {
     // Remove all layers from the store
     removeAllStoreSwipers(this.getMapId());
+  }
+
+  /**
+   * Checks if a pixel coordinate should be queried for a layer considering swiper clipping.
+   *
+   * @param layerPath - The layer path to check
+   * @param pixelCoordinate - The pixel coordinate [x, y] relative to the map viewport
+   * @param mapSize - The current map size [width, height] in pixels
+   * @returns True if the coordinate should be queried (not clipped by swiper)
+   */
+  shouldQueryAtPixel(layerPath: string, pixelCoordinate: Coordinate, mapSize: number[]): boolean {
+    // Get swiper configuration from store
+    const swiperLayerPaths = getStoreSwiperLayerPaths(this.getMapId());
+
+    // No layers configured for swiping
+    if (!swiperLayerPaths || swiperLayerPaths.length === 0) {
+      return true;
+    }
+
+    // Check if this layer is affected by swiper
+    const isLayerSwiped = swiperLayerPaths.some((path) => layerPath.includes(path));
+    if (!isLayerSwiped) {
+      return true;
+    }
+
+    // Get swiper state from store
+    const swiperOrientation = getStoreSwiperOrientation(this.getMapId());
+    const swiperPosition = getStoreSwiperPosition(this.getMapId());
+
+    // Check if coordinate is in visible region
+    if (swiperOrientation === 'vertical') {
+      const swiperX = (mapSize[0] * swiperPosition) / 100;
+      return pixelCoordinate[0] <= swiperX;
+    }
+
+    const swiperY = (mapSize[1] * swiperPosition) / 100;
+    return pixelCoordinate[1] <= swiperY;
   }
 }

--- a/packages/geoview-core/src/core/controllers/swiper-controller.ts
+++ b/packages/geoview-core/src/core/controllers/swiper-controller.ts
@@ -36,7 +36,7 @@ export class SwiperController extends AbstractMapViewerController {
   /**
    * Sets the swiper position, which determines the current position of the swipe comparison.
    *
-   * @param position - The new swiper position, between 0 and 1.
+   * @param position - The new swiper position, between 0 and 100.
    */
   setSwiperPosition(position: number): void {
     setStoreSwiperPosition(this.getMapId(), position);
@@ -133,15 +133,11 @@ export class SwiperController extends AbstractMapViewerController {
 
     // Get swiper state from store
     const swiperOrientation = getStoreSwiperOrientation(this.getMapId());
-    const swiperPosition = getStoreSwiperPosition(this.getMapId());
+    const swiperPositionPercentage = getStoreSwiperPosition(this.getMapId()); // 0-100
 
     // Check if coordinate is in visible region
-    if (swiperOrientation === 'vertical') {
-      const swiperX = (mapSize[0] * swiperPosition) / 100;
-      return pixelCoordinate[0] <= swiperX;
-    }
-
-    const swiperY = (mapSize[1] * swiperPosition) / 100;
-    return pixelCoordinate[1] <= swiperY;
+    const orientationIndex = swiperOrientation === 'vertical' ? 0 : 1; // 0 for vertical (x-axis), 1 for horizontal (y-axis)
+    const swiperPositionPixelValue = (mapSize[orientationIndex] * swiperPositionPercentage) / 100; // Convert swiper position to pixel value
+    return pixelCoordinate[orientationIndex] <= swiperPositionPixelValue;
   }
 }

--- a/packages/geoview-core/src/core/controllers/use-controllers.ts
+++ b/packages/geoview-core/src/core/controllers/use-controllers.ts
@@ -9,6 +9,7 @@ import type { LayerSetController } from '@/core/controllers/layer-set-controller
 import type { UIController } from '@/core/controllers/ui-controller';
 import type { DataTableController } from '@/core/controllers/data-table-controller';
 import type { DetailsController } from '@/core/controllers/details-controller';
+import type { SwiperController } from '@/core/controllers/swiper-controller';
 import type { DrawerController } from '@/core/controllers/drawer-controller';
 import type { PluginController } from '@/core/controllers/plugin-controller';
 import type { TimeSliderController } from '@/core/controllers/time-slider-controller';
@@ -93,6 +94,16 @@ export function useDetailsController(): DetailsController {
  */
 export function useDataTableController(): DataTableController {
   return useControllers().dataTableController;
+}
+
+export function useSwiperController(): SwiperController {
+  const controller = useControllers().swiperController;
+  if (!controller) throw new Error('useSwiperController must be used with an initialized swiper plugin state');
+  return controller;
+}
+
+export function useSwiperControllerIfExists(): SwiperController | undefined {
+  return useControllers().swiperController;
 }
 
 /**

--- a/packages/geoview-core/src/core/controllers/use-controllers.ts
+++ b/packages/geoview-core/src/core/controllers/use-controllers.ts
@@ -96,12 +96,28 @@ export function useDataTableController(): DataTableController {
   return useControllers().dataTableController;
 }
 
+/**
+ * Hook to access the SwiperController from the controller context.
+ *
+ * @returns The swiper controller instance
+ * @throws {Error} When used outside of a ControllerContext.Provider
+ */
 export function useSwiperController(): SwiperController {
   const controller = useControllers().swiperController;
   if (!controller) throw new Error('useSwiperController must be used with an initialized swiper plugin state');
   return controller;
 }
 
+/**
+ * Hook to optionally access the SwiperController from the controller context.
+ *
+ * Unlike `useSwiperController`, this hook does not throw when the Swiper
+ * plugin is not configured. Use this in shared components that may or may not
+ * have the swiper plugin active.
+ *
+ * @returns The swiper controller instance, or undefined if the plugin is not configured
+ * @throws {Error} When used outside of a ControllerContext.Provider
+ */
 export function useSwiperControllerIfExists(): SwiperController | undefined {
   return useControllers().swiperController;
 }

--- a/packages/geoview-core/src/core/stores/states/map-state.ts
+++ b/packages/geoview-core/src/core/stores/states/map-state.ts
@@ -722,10 +722,19 @@ export const getStoreMapHighlightedFeaturesByUid = (mapId: string, featureUid: s
   return getStoreMapState(mapId).highlightedFeatures.filter((feature) => feature.uid === featureUid);
 };
 
+/** Returns the current map extent in the map's projection, or undefined if not yet set. */
+export const getStoreMapExtent = (mapId: string): Extent | undefined => getStoreMapState(mapId).mapExtent;
+
+/** Selects the current map extent from the store. */
+export const useStoreMapExtent = (): Extent | undefined => useStore(useGeoViewStore(), (state) => state.mapState.mapExtent);
+
 /** Returns the current map size. */
 export const getStoreMapSize = (mapId: string): Size => {
   return getStoreMapState(mapId).size;
 };
+
+/** Selects the map size from the store. */
+export const useStoreMapSize = (): Size => useStore(useGeoViewStore(), (state) => state.mapState.size);
 
 // #endregion STATE GETTERS & HOOKS
 
@@ -739,12 +748,6 @@ export const useStoreMapCenterCoordinates = (): Coordinate => useStore(useGeoVie
 
 /** Selects the click marker state from the store. */
 export const useStoreMapClickMarker = (): TypeClickMarker | undefined => useStore(useGeoViewStore(), (state) => state.mapState.clickMarker);
-
-/** Returns the current map extent in the map's projection, or undefined if not yet set. */
-export const getStoreMapExtent = (mapId: string): Extent | undefined => getStoreMapState(mapId).mapExtent;
-
-/** Selects the current map extent from the store. */
-export const useStoreMapExtent = (): Extent | undefined => useStore(useGeoViewStore(), (state) => state.mapState.mapExtent);
 
 /** Selects whether the map has a geoview basemap layer from the store. */
 export const useStoreMapHasGeoviewBasemapLayer = (): boolean =>
@@ -773,9 +776,6 @@ export const useStoreMapOverviewMapHideZoom = (): number => useStore(useGeoViewS
 
 /** Selects the map scale information from the store. */
 export const useStoreMapScale = (): TypeScaleInfo => useStore(useGeoViewStore(), (state) => state.mapState.scale);
-
-/** Selects the map size from the store. */
-export const useStoreMapSize = (): Size => useStore(useGeoViewStore(), (state) => state.mapState.size);
 
 /** Selects the current zoom level from the store. */
 export const useStoreMapZoom = (): number => useStore(useGeoViewStore(), (state) => state.mapState.zoom);

--- a/packages/geoview-core/src/core/stores/states/map-state.ts
+++ b/packages/geoview-core/src/core/stores/states/map-state.ts
@@ -722,6 +722,11 @@ export const getStoreMapHighlightedFeaturesByUid = (mapId: string, featureUid: s
   return getStoreMapState(mapId).highlightedFeatures.filter((feature) => feature.uid === featureUid);
 };
 
+/** Returns the current map size. */
+export const getStoreMapSize = (mapId: string): Size => {
+  return getStoreMapState(mapId).size;
+};
+
 // #endregion STATE GETTERS & HOOKS
 
 // #region STATE GETTERS & HOOKS - OTHERS (no match between getter-hook)

--- a/packages/geoview-core/src/core/stores/states/swiper-state.ts
+++ b/packages/geoview-core/src/core/stores/states/swiper-state.ts
@@ -13,7 +13,7 @@ import { logger } from '@/core/utils/logger';
  * Manages state for the swiper including layer paths and orientation.
  */
 export interface ISwiperState {
-  /** The position of the swiper divider, between 0 and 1. */
+  /** The position of the swiper divider, between 0 and 100. */
   swiperPosition: number;
 
   /** The list of layer paths currently participating in the swiper. */

--- a/packages/geoview-core/src/core/stores/states/swiper-state.ts
+++ b/packages/geoview-core/src/core/stores/states/swiper-state.ts
@@ -13,6 +13,9 @@ import { logger } from '@/core/utils/logger';
  * Manages state for the swiper including layer paths and orientation.
  */
 export interface ISwiperState {
+  /** The position of the swiper divider, between 0 and 1. */
+  swiperPosition: number;
+
   /** The list of layer paths currently participating in the swiper. */
   layerPaths: string[];
 
@@ -21,6 +24,9 @@ export interface ISwiperState {
 
   /** Actions to mutate the Swiper state. */
   actions: {
+    /** Sets the swiper position. */
+    setSwiperPosition: (position: number) => void;
+
     /** Sets the full list of layer paths for the swiper. */
     setLayerPaths: (layerPaths: string[]) => void;
 
@@ -42,10 +48,25 @@ export interface ISwiperState {
  */
 export function initializeSwiperState(set: TypeSetStore, get: TypeGetStore): ISwiperState {
   const init = {
+    swiperPosition: 50,
     layerPaths: [],
     orientation: 'vertical',
 
     actions: {
+      /**
+       * Sets the swiper position in the store.
+       *
+       * @param position - The new swiper position, between 0 and 1.
+       */
+      setSwiperPosition(position: number) {
+        set({
+          swiperState: {
+            ...get().swiperState,
+            swiperPosition: position,
+          },
+        });
+      },
+
       /**
        * Sets the layer paths for the swiper.
        *
@@ -119,6 +140,18 @@ export const isStoreSwiperInitialized = (mapId: string): boolean => {
 };
 
 /**
+ * Gets the swiper position from the store.
+ *
+ * @param mapId - The map id to read swiper position from.
+ * @returns The swiper position as a number.
+ * @throws {PluginStateUninitializedError} When the Swiper plugin is uninitialized.
+ */
+export const getStoreSwiperPosition = (mapId: string): number => {
+  // Return the swiper position from the state
+  return getStoreSwiperState(mapId).swiperPosition;
+};
+
+/**
  * Gets the swiper layer paths from the store.
  *
  * @param mapId - The map id to read swiper layer paths from.
@@ -152,6 +185,21 @@ export const useStoreSwiperOrientation = (): SwipeOrientation => useStore(useGeo
 
 // #region STATE ADAPTORS
 // GV These methods should be called from a State Adaptor class listening on domain events triggered by controllers.
+
+/**
+ * Sets the swiper position in the store.
+ *
+ * @param mapId - The map id.
+ * @param position - The new swiper position, between 0 and 1.
+ * @throws {PluginStateUninitializedError} When the Swiper plugin is uninitialized.
+ */
+export const setStoreSwiperPosition = (mapId: string, position: number): void => {
+  // Get the swiper state which is only initialized if the Swiper Plugin exists.
+  const swiperState = getStoreSwiperState(mapId);
+
+  // set store position
+  swiperState.actions.setSwiperPosition(position);
+};
 
 /**
  * Sets the swiper layer paths in the store.

--- a/packages/geoview-core/src/geo/layer/layer-sets/abstract-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/abstract-layer-set.ts
@@ -23,6 +23,7 @@ import { GVEsriImage } from '@/geo/layer/gv-layers/raster/gv-esri-image';
 import { AbstractGVVector } from '@/geo/layer/gv-layers/vector/abstract-gv-vector';
 import { GVWMS } from '@/geo/layer/gv-layers/raster/gv-wms';
 import type { AbstractBaseGVLayer } from '@/geo/layer/gv-layers/abstract-base-layer';
+import type { Coordinate } from 'ol/coordinate';
 
 /**
  * A class to hold a set of layers associated with a value of any type.
@@ -281,6 +282,28 @@ export abstract class AbstractLayerSet {
 
     // Get Feature Info
     return geoviewLayer.getFeatureInfo(this.mapViewer.map, queryType, location, queryGeometry, language, abortController);
+  }
+
+  /**
+   * Checks if a pixel coordinate should be queried for a layer considering swiper clipping.
+   *
+   * @param layerPath - The layer path to check
+   * @param pixelCoordinate - The pixel coordinate relative to the map viewport
+   * @returns True if the coordinate should be queried (not clipped by swiper)
+   */
+  protected shouldQueryAtPixel(layerPath: string, pixelCoordinate: Coordinate): boolean {
+    // Check if swiper plugin is loaded via controller existence
+    const { swiperController } = this.controllerRegistry;
+    if (!swiperController) {
+      // Swiper plugin not loaded - no filtering needed
+      return true;
+    }
+
+    // Delegate to swiper controller
+    const mapSize = this.mapViewer.map.getSize();
+    if (!mapSize) return true;
+
+    return swiperController.shouldQueryAtPixel(layerPath, pixelCoordinate, mapSize);
   }
 
   // #endregion PROTECTED METHODS

--- a/packages/geoview-core/src/geo/layer/layer-sets/abstract-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/abstract-layer-set.ts
@@ -299,10 +299,11 @@ export abstract class AbstractLayerSet {
       return true;
     }
 
-    // Delegate to swiper controller
+    // Get map size. Required to check if the pixel coordinate is in the visible region considering the swiper position and orientation.
     const mapSize = this.mapViewer.map.getSize();
     if (!mapSize) return true;
 
+    // Delegate to swiper controller
     return swiperController.shouldQueryAtPixel(layerPath, pixelCoordinate, mapSize);
   }
 

--- a/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
@@ -15,6 +15,7 @@ import { getStoreAppShowUnsymbolizedFeatures } from '@/core/stores/states/app-st
 import { RequestAbortedError } from '@/core/exceptions/core-exceptions';
 import { LayerNoLastQueryToPerformError } from '@/core/exceptions/geoview-exceptions';
 import { logger } from '@/core/utils/logger';
+import { Projection } from '@/geo/utils/projection';
 
 /**
  * A Layer-set working with the LayerSetController at handling a result set of registered layers and synchronizing
@@ -103,9 +104,17 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
     // Keep the lon/lat for possible repeat
     this.#lastQueryLonLat = lonLatCoordinate;
 
+    // Get pixel coordinate for should query check
+    const mapProjection = this.mapViewer.getProjection();
+    const transformedCoordinate = Projection.transformFromLonLat(lonLatCoordinate, mapProjection);
+    const pixelCoordinate = this.mapViewer.map.getPixelFromCoordinate(transformedCoordinate);
+
     // Query each queryable layer and collect the promises
     const allPromises = this.getRegisteredLayerPaths()
-      .filter((layerPath) => this.layerDomain.getGeoviewLayerRegular(layerPath).getQueryable())
+      .filter((layerPath) => {
+        const layer = this.layerDomain.getGeoviewLayerRegular(layerPath);
+        return layer.getQueryable() && this.shouldQueryAtPixel(layerPath, pixelCoordinate);
+      })
       .map((layerPath) => {
         // Update
         querySet[layerPath].queryStatus = 'processing';

--- a/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/feature-info-layer-set.ts
@@ -104,7 +104,7 @@ export class FeatureInfoLayerSet extends AbstractLayerSet {
     // Keep the lon/lat for possible repeat
     this.#lastQueryLonLat = lonLatCoordinate;
 
-    // Get pixel coordinate for should query check
+    // Get pixel coordinate for shouldQueryAtPixel check
     const mapProjection = this.mapViewer.getProjection();
     const transformedCoordinate = Projection.transformFromLonLat(lonLatCoordinate, mapProjection);
     const pixelCoordinate = this.mapViewer.map.getPixelFromCoordinate(transformedCoordinate);

--- a/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
+++ b/packages/geoview-core/src/geo/layer/layer-sets/hover-feature-info-layer-set.ts
@@ -77,7 +77,10 @@ export class HoverFeatureInfoLayerSet extends AbstractLayerSet {
 
     // Query each hoverable layer and collect the promises
     const allPromises = orderedLayerPaths
-      .filter((layerPath) => this.layerDomain.getGeoviewLayerRegular(layerPath).getHoverable())
+      .filter((layerPath) => {
+        const layer = this.layerDomain.getGeoviewLayerRegular(layerPath);
+        return layer.getHoverable() && this.shouldQueryAtPixel(layerPath, coordinate);
+      })
       .map((layerPath) => this.#queryLayerAndProcess(layerPath, coordinate, queryType, querySet, orderedLayerPaths));
 
     // Await for the promises to settle

--- a/packages/geoview-swiper/src/swiper.tsx
+++ b/packages/geoview-swiper/src/swiper.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 
 import { getRenderPixel } from 'ol/render';
 import type RenderEvent from 'ol/render/Event';
-import type BaseLayer from 'ol/layer/Base';
 import type { EventTypes } from 'ol/Observable';
 import type BaseEvent from 'ol/events/Event';
 
@@ -83,7 +82,6 @@ export function Swiper(props: SwiperProps): JSX.Element {
   }, [mapHeight]);
 
   // States
-  const [olLayers, setOlLayers] = useState<BaseLayer[]>([]);
   const [xPositionVertical, setXPositionVertical] = useState(mapSize.current[0] / 2);
   const [yPositionVertical, setYPositionVertical] = useState(0);
   const [xPositionHorizontal, setXPositionHorizontal] = useState(0);
@@ -166,34 +164,54 @@ export function Swiper(props: SwiperProps): JSX.Element {
   };
 
   /**
-   * On Drag and Drag Stop, calculates the clipping extent.
+   * Handles drag events - update refs and render map.
    */
-  const onStop = debounce(() => {
-    if (layerPaths.length) {
-      // Get map size
-      mapSize.current = viewer.map.getSize() || [0, 0];
+  const onDrag = debounce(() => {
+    if (!layerPaths.length) return;
 
-      // Update the position and swiper %
-      if (orientation === 'vertical') {
-        const [x] = getSwiperStyle();
-        swiperValueVertical.current = (x / mapSize.current[0]) * 100;
-        setXPositionVertical(x);
-        controllerRegistry.swiperController?.setSwiperPosition(swiperValueVertical.current);
-        setYPositionVertical(0);
-      } else {
-        const [, y] = getSwiperStyle();
-        swiperValueHorizontal.current = (y / mapSize.current[1]) * 100;
-        setXPositionHorizontal(0);
-        setYPositionHorizontal(y);
-        controllerRegistry.swiperController?.setSwiperPosition(swiperValueHorizontal.current);
-      }
+    // Get map size
+    mapSize.current = viewer.map.getSize() || [0, 0];
 
-      // Force refresh
-      olLayers.forEach((layer: BaseLayer) => {
-        layer.changed();
-      });
+    // Update refs ONLY
+    if (orientation === 'vertical') {
+      const [x] = getSwiperStyle();
+      swiperValueVertical.current = (x / mapSize.current[0]) * 100;
+    } else {
+      const [, y] = getSwiperStyle();
+      swiperValueHorizontal.current = (y / mapSize.current[1]) * 100;
     }
+
+    // Single map render
+    viewer.map.render();
   }, 100);
+
+  /**
+   * Handles drag stop - sync everything to React state and store.
+   */
+  const onStop = useCallback((): void => {
+    if (!layerPaths.length) return;
+
+    // Get map size
+    mapSize.current = viewer.map.getSize() || [0, 0];
+
+    // Update refs, React state, and controller/store
+    if (orientation === 'vertical') {
+      const [x] = getSwiperStyle();
+      swiperValueVertical.current = (x / mapSize.current[0]) * 100;
+      setXPositionVertical(x);
+      setYPositionVertical(0);
+      controllerRegistry.swiperController?.setSwiperPosition(swiperValueVertical.current);
+    } else {
+      const [, y] = getSwiperStyle();
+      swiperValueHorizontal.current = (y / mapSize.current[1]) * 100;
+      setXPositionHorizontal(0);
+      setYPositionHorizontal(y);
+      controllerRegistry.swiperController?.setSwiperPosition(swiperValueHorizontal.current);
+    }
+
+    // Final render
+    viewer.map.render();
+  }, [layerPaths.length, viewer.map, orientation, controllerRegistry.swiperController]);
 
   /**
    * Updates swiper and layers from keyboard CTRL + Arrow key.
@@ -245,9 +263,6 @@ export function Swiper(props: SwiperProps): JSX.Element {
       try {
         // Get the layer at the layer path
         const olLayer = await controllerRegistry.layerController.getOLLayerAsync(layerPath, CONST_LAYERS_WAIT, CONST_LAYERS_RETRY);
-
-        // Set the OL layers
-        setOlLayers((prevArray) => [...prevArray, olLayer]);
 
         // Wire events on the layer
         olLayer.on(['precompose' as EventTypes, 'prerender' as EventTypes], prerender);
@@ -316,9 +331,6 @@ export function Swiper(props: SwiperProps): JSX.Element {
           logger.logError('SWIPER - Failed to un-attach layer events', layerPath, error);
         }
       });
-
-      // Empty layers array
-      setOlLayers([]);
     };
   }, [controllerRegistry, layerPaths, attachLayerEventsOnPath, prerender, visibleLayers]);
 
@@ -370,7 +382,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
             orientation === 'vertical' ? { x: xPositionVertical, y: yPositionVertical } : { x: xPositionHorizontal, y: yPositionHorizontal }
           }
           onStop={onStop}
-          onDrag={onStop}
+          onDrag={onDrag}
         >
           <Box
             sx={[orientation === 'vertical' ? memoSxClasses.vertical : memoSxClasses.horizontal, memoSxClasses.bar]}

--- a/packages/geoview-swiper/src/swiper.tsx
+++ b/packages/geoview-swiper/src/swiper.tsx
@@ -178,12 +178,14 @@ export function Swiper(props: SwiperProps): JSX.Element {
         const [x] = getSwiperStyle();
         swiperValueVertical.current = (x / mapSize.current[0]) * 100;
         setXPositionVertical(x);
+        controllerRegistry.swiperController?.setSwiperPosition(swiperValueVertical.current);
         setYPositionVertical(0);
       } else {
         const [, y] = getSwiperStyle();
         swiperValueHorizontal.current = (y / mapSize.current[1]) * 100;
         setXPositionHorizontal(0);
         setYPositionHorizontal(y);
+        controllerRegistry.swiperController?.setSwiperPosition(swiperValueHorizontal.current);
       }
 
       // Force refresh

--- a/packages/geoview-swiper/src/swiper.tsx
+++ b/packages/geoview-swiper/src/swiper.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 
 import { getRenderPixel } from 'ol/render';
 import type RenderEvent from 'ol/render/Event';
+import type BaseLayer from 'ol/layer/Base';
 import type { EventTypes } from 'ol/Observable';
 import type BaseEvent from 'ol/events/Event';
 
@@ -82,6 +83,7 @@ export function Swiper(props: SwiperProps): JSX.Element {
   }, [mapHeight]);
 
   // States
+  const [olLayers, setOlLayers] = useState<BaseLayer[]>([]);
   const [xPositionVertical, setXPositionVertical] = useState(mapSize.current[0] / 2);
   const [yPositionVertical, setYPositionVertical] = useState(0);
   const [xPositionHorizontal, setXPositionHorizontal] = useState(0);
@@ -181,8 +183,10 @@ export function Swiper(props: SwiperProps): JSX.Element {
       swiperValueHorizontal.current = (y / mapSize.current[1]) * 100;
     }
 
-    // Single map render
-    viewer.map.render();
+    // Force refresh
+    olLayers.forEach((layer: BaseLayer) => {
+      layer.changed();
+    });
   }, 100);
 
   /**
@@ -209,9 +213,11 @@ export function Swiper(props: SwiperProps): JSX.Element {
       controllerRegistry.swiperController?.setSwiperPosition(swiperValueHorizontal.current);
     }
 
-    // Final render
-    viewer.map.render();
-  }, [layerPaths.length, viewer.map, orientation, controllerRegistry.swiperController]);
+    // Force refresh
+    olLayers.forEach((layer: BaseLayer) => {
+      layer.changed();
+    });
+  }, [layerPaths.length, viewer.map, orientation, olLayers, controllerRegistry.swiperController]);
 
   /**
    * Updates swiper and layers from keyboard CTRL + Arrow key.
@@ -263,6 +269,9 @@ export function Swiper(props: SwiperProps): JSX.Element {
       try {
         // Get the layer at the layer path
         const olLayer = await controllerRegistry.layerController.getOLLayerAsync(layerPath, CONST_LAYERS_WAIT, CONST_LAYERS_RETRY);
+
+        // Set the OL layers
+        setOlLayers((prevArray) => [...prevArray, olLayer]);
 
         // Wire events on the layer
         olLayer.on(['precompose' as EventTypes, 'prerender' as EventTypes], prerender);
@@ -331,6 +340,9 @@ export function Swiper(props: SwiperProps): JSX.Element {
           logger.logError('SWIPER - Failed to un-attach layer events', layerPath, error);
         }
       });
+
+      // Empty layers array
+      setOlLayers([]);
     };
   }, [controllerRegistry, layerPaths, attachLayerEventsOnPath, prerender, visibleLayers]);
 


### PR DESCRIPTION
# Description

Added a method to the swiper controller to check if a point has been 'swiped'. This is then used in the hover and feature details layer sets to filter out those features so you don't have ghost popups and details for invisible features.

Fixes #

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
### Host updated 2026-06-03 11:55AM

Hover over where a point was, it no longer appears. Try clicking on where a point was, no details will appear.

[**Swiper Navigator Demo**](https://matthewmuehlhausernrcan.github.io/geoview/demos-navigator.html?config=./configs/navigator/demos/14-package-swiper.json)

# Checklist:

- [X] I have run the **Test Suite** and **No errors have been introduced**
- [ ] I have run `@BranchReview` agent in VS Code Chat and addressed all violations
- [ ] I have run `@DocUpdate` agent in VS Code Chat and documentation is in sync with code changes
- [ ] I have run `@IssueReview` agent in VS Code Chat and the implementation aligns with the linked issue
- [X] I have build **(rush build)** and deploy **(rush host)** my PR
- [ ] I have connected the issues(s) to this PR
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~New and existing unit tests pass locally with my changes~~

# Pre-PR Copilot Agent Checks

Before creating your PR, run the following two Copilot agents in VS Code Chat to catch common issues automatically.

## Branch Review (`@BranchReview`)

Audits all changed `.ts`/`.tsx` files against the GeoView coding standards (JSDoc, logging, return types, naming, accessibility, imports, performance patterns).

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **BranchReview** agent from the agent picker (or type `@BranchReview`)
3. Type the target branch name (defaults to `develop`):
   ```
   @BranchReview  against upstream/develop
   ```
4. Review the violation report and fix flagged items (the agent can auto-fix most issues on approval)

- [ ] `@BranchReview` has been run and all violations have been addressed

## Documentation Update (`@DocUpdate`)

Checks that documentation in `docs/` is still consistent with the code you changed. Catches stale references, missing docs for new features, and incorrect code examples.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **DocUpdate** agent from the agent picker (or type `@DocUpdate`)
3. Run a full audit or target a specific section:
   ```
   @DocUpdate full audit of docs/programming/
   @DocUpdate check docs/app/layers/
   ```
4. Review the audit summary and approve any proposed documentation updates

- [ ] `@DocUpdate` has been run and documentation is in sync with code changes

## Issue Review (`@IssueReview`)

Compares your branch changes against the linked GitHub issue's proposed fix. Checks whether the implementation aligns with what was proposed, catches gaps, and provides feedback to improve future issue drafts.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **IssueReview** agent from the agent picker (or type `@IssueReview`)
3. Provide the issue number:
   ```
   @IssueReview #1234
   ```
4. Review the alignment report — it will flag items that were proposed but not implemented, unexpected changes, and root cause accuracy

- [ ] `@IssueReview` has been run and the alignment report has been reviewed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3507)
<!-- Reviewable:end -->
