### PR TITLE
fix(layers): Fix sort bug

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -740,6 +740,21 @@ Per [best-practices.md](../docs/programming/best-practices.md), order functions 
 
 1. Class name → 2. Abstracts → 3. Overrides → 4. Public → 5. Private → 6. Event emits/hooks → 7. Static public → 8. Static private → 9. Event types
 
+Each group must be wrapped in `// #region LABEL` / `// #endregion LABEL` markers (UPPER CASE). Common labels:
+
+| Region label | Contents |
+|---|---|
+| `OVERRIDES` | Abstract / override methods |
+| `PUBLIC METHODS` | Public instance methods (sub-regions allowed, e.g., `PUBLIC METHODS - UI RELATED`) |
+| `PROTECTED METHODS` | Protected instance methods |
+| `PRIVATE METHODS` | Private instance methods |
+| `DOMAIN HANDLERS` | Private handlers subscribed to domain events |
+| `EVENTS` | Event emit/on/off methods |
+| `STATIC METHODS` | Static public and private methods |
+| `EVENT TYPES` or `EVENTS & DELEGATES` | Delegate types and event interfaces (outside the class body) |
+
+A region is only needed when the group has at least one member. The `// #endregion` comment should repeat the label.
+
 ## Styling System
 
 ### getSxClasses Pattern

--- a/docs/programming/best-practices.md
+++ b/docs/programming/best-practices.md
@@ -270,6 +270,68 @@ In classes, functions should be ordered in the following way:
 - static private
 - event types
 
+Each group must be wrapped in `// #region` / `// #endregion` markers so that VS Code can collapse them. Use **UPPER CASE** labels that match the group:
+
+```ts
+export class MyController extends AbstractMapViewerController {
+  // properties …
+
+  // #region OVERRIDES
+  override onHook(): void { /* … */ }
+  // #endregion OVERRIDES
+
+  // #region PUBLIC METHODS
+  doSomething(): void { /* … */ }
+  // #endregion PUBLIC METHODS
+
+  // #region PROTECTED METHODS
+  protected helperMethod(): void { /* … */ }
+  // #endregion PROTECTED METHODS
+
+  // #region PRIVATE METHODS
+  #internalWork(): void { /* … */ }
+  // #endregion PRIVATE METHODS
+
+  // #region DOMAIN HANDLERS
+  #handleLayerLoaded(sender: unknown, event: LayerLoadedEvent): void { /* … */ }
+  // #endregion DOMAIN HANDLERS
+
+  // #region EVENTS
+  #emitMyEvent(event: MyEvent): void { /* … */ }
+  onMyEvent(callback: MyDelegate): void { /* … */ }
+  offMyEvent(callback: MyDelegate): void { /* … */ }
+  // #endregion EVENTS
+
+  // #region STATIC METHODS
+  static createConfig(): MyConfig { /* … */ }
+  // #endregion STATIC METHODS
+}
+
+// #region EVENT TYPES
+type MyDelegate = EventDelegateBase<MyController, MyEvent, void>;
+export type MyEvent = { /* … */ };
+// #endregion EVENT TYPES
+```
+
+**Common region labels used in the codebase:**
+
+| Region label | Contents |
+|---|---|
+| `OVERRIDES` | Abstract / override methods |
+| `PUBLIC METHODS` | Public instance methods (may have sub-regions like `PUBLIC METHODS - DOMAIN SIMPLE GETTERS`) |
+| `PROTECTED METHODS` | Protected instance methods |
+| `PRIVATE METHODS` | Private instance methods |
+| `DOMAIN HANDLERS` | Private handlers subscribed to domain events |
+| `EVENTS` | Event emit/on/off methods |
+| `STATIC METHODS` | Static public and private methods |
+| `EVENT TYPES` or `EVENTS & DELEGATES` | Delegate types and event interfaces (outside the class body) |
+
+**Rules:**
+- A region is only needed when the group has at least one member
+- Sub-regions are allowed for large classes (e.g., `PUBLIC METHODS - UI RELATED`)
+- The `// #endregion` comment should repeat the label for readability
+- Delegate types and event interfaces live **outside** the class, in their own region
+
 ## 12- EventHelper handler parameter naming
 
 When subscribing to events emitted through our `EventHelper` delegates, handler methods should use the parameter names `sender` and `event`.

--- a/packages/geoview-core/src/core/stores/state-api.ts
+++ b/packages/geoview-core/src/core/stores/state-api.ts
@@ -16,6 +16,7 @@ import {
   setStoreReorderLegendLayers,
   utilFindLayerAndChildrenPaths,
 } from './states/layer-state';
+
 import type { TypeLegendLayer } from '@/core/components/layers/types';
 import { logger } from '@/core/utils/logger';
 import type { EventDelegateBase } from '@/api/events/event-helper';
@@ -29,22 +30,23 @@ export class StateApi {
   /** The layer controller instance */
   #layerController: LayerController;
 
-  /** Keep all callback delegates references */
+  /** Callback delegates for the layers reordered event. */
   #onLayersReorderedHandlers: LayersReorderedDelegate[] = [];
 
   /**
-   * Instantiates an StateApi class.
+   * Instantiates a StateApi class.
    *
-   * @param layerController - The layer controller instance to interact with layer-related states.
+   * @param layerController - The layer controller instance to interact with layer-related states
    */
   constructor(layerController: LayerController) {
     this.#layerController = layerController;
   }
 
   /**
-   * Get the collapsed state of layer's legend.
-   * @param layerPath - Path of the layer to get state for.
-   * @returns If the legend is collapsed.
+   * Gets the collapsed state of layer's legend.
+   *
+   * @param layerPath - Path of the layer to get state for
+   * @returns Whether the legend is collapsed
    */
   getLegendCollapsedState(layerPath: string): boolean {
     // Get from store
@@ -52,10 +54,11 @@ export class StateApi {
   }
 
   /**
-   * Get a specific state from a plugin.
-   * @param pluginId - The plugin to get state for.
-   * @param state - The state to get.
-   * @returns The requested state.
+   * Gets a specific state from a plugin.
+   *
+   * @param pluginId - The plugin to get state for
+   * @param state - The state to get
+   * @returns The requested state
    */
   getPluginState(
     pluginId: 'geochart' | 'swiper' | 'time-slider',
@@ -93,10 +96,10 @@ export class StateApi {
   }
 
   /**
-   * Set the collapsed state of layer's legend.
-   * @param layerPath - Path of the layer to get state for.
-   * @param collapsed - The new state
-   * @returns If the legend is collapsed.
+   * Sets the collapsed state of layer's legend.
+   *
+   * @param layerPath - Path of the layer to set state for
+   * @param collapsed - The new collapsed state
    */
   setLegendCollapsedState(layerPath: string, collapsed: boolean): void {
     // Redirect to controller
@@ -104,7 +107,8 @@ export class StateApi {
   }
 
   /**
-   * Set selected layer in layers tab.
+   * Sets the selected layer in layers tab.
+   *
    * @param layerPath - The path of the layer to set
    */
   setSelectedLayersTabLayer(layerPath: string): void {
@@ -193,6 +197,7 @@ export class StateApi {
 
   /**
    * Emits layers reordered event.
+   *
    * @param event - The event to emit
    */
   #emitLayersReordered(event: LayersReorderedEvent): void {
@@ -202,6 +207,7 @@ export class StateApi {
 
   /**
    * Registers a layers reordered event handler.
+   *
    * @param callback - The callback to be executed whenever the event is emitted
    */
   onLayersReordered(callback: LayersReorderedDelegate): void {
@@ -211,6 +217,7 @@ export class StateApi {
 
   /**
    * Unregisters a layers reordered event handler.
+   *
    * @param callback - The callback to stop being called whenever the event is emitted
    */
   offLayersReordered(callback: LayersReorderedDelegate): void {
@@ -236,7 +243,7 @@ export class StateApi {
       return legendLayers.map((layer) => layer.layerPath).filter((path) => path !== layerPath);
     }
 
-    // Recursively search for the parent group containing this layer
+    // Walks children arrays to find the group that contains the target layer path.
     const findInChildren = (layers: TypeLegendLayer[]): string[] | undefined => {
       for (const layer of layers) {
         if (layer.children.some((child) => child.layerPath === layerPath)) {
@@ -254,16 +261,12 @@ export class StateApi {
 
 // #region EVENTS & DELEGATES
 
-/**
- * Define a delegate for the event handler function signature
- */
+/** Defines a delegate for the event handler function signature. */
 type LayersReorderedDelegate = EventDelegateBase<StateApi, LayersReorderedEvent, void>;
 
-/**
- * Define an event for the delegate
- */
+/** Defines an event for the delegate. */
 export type LayersReorderedEvent = {
-  // The layer paths in the new order
+  /** The layer paths in the new order. */
   orderedLayers: string[];
 };
 

--- a/packages/geoview-core/src/core/stores/state-api.ts
+++ b/packages/geoview-core/src/core/stores/state-api.ts
@@ -11,10 +11,12 @@ import { getStoreTimeSliderLayers } from './states/time-slider-state';
 import { getStoreSwiperLayerPaths } from './states/swiper-state';
 import {
   getStoreLayerLegendCollapsed,
+  getStoreLayerLegendLayers,
   getStoreLayerOrderedLayerPaths,
   setStoreReorderLegendLayers,
   utilFindLayerAndChildrenPaths,
 } from './states/layer-state';
+import type { TypeLegendLayer } from '@/core/components/layers/types';
 import { logger } from '@/core/utils/logger';
 import type { EventDelegateBase } from '@/api/events/event-helper';
 import EventHelper from '@/api/events/event-helper';
@@ -114,17 +116,16 @@ export class StateApi {
    * Reorders a layer and its children within the ordered layers list by a given number of positions.
    *
    * The layer (along with any child paths) is extracted from its current position and re-inserted
-   * at the target index, skipping only siblings at the same depth. Updates the store, reorders the
-   * legend layers, and emits a layers reordered event.
+   * at the target index. Only layers that are siblings in the legend tree are considered valid swap
+   * targets, so children can never escape their parent group.
    *
    * @param layerPath - The path of the layer to move
    * @param move - The number of sibling positions to move (negative = toward index 0, positive = toward end)
    */
   reorderLayers(layerPath: string, move: number): void {
-    // Apply some ordering logic
     const direction = move < 0 ? -1 : 1;
-    let absoluteMoves = Math.abs(move);
-    const orderedLayers = [...getStoreLayerOrderedLayerPaths(this.#layerController.getMapId())];
+    const mapId = this.#layerController.getMapId();
+    const orderedLayers = [...getStoreLayerOrderedLayerPaths(mapId)];
     const startingIndex = orderedLayers.indexOf(layerPath);
 
     // If layer not found, exit early
@@ -133,17 +134,50 @@ export class StateApi {
       return;
     }
 
+    // Extract the layer block (layer + all descendants)
     const movedLayers = utilFindLayerAndChildrenPaths(layerPath, orderedLayers);
     orderedLayers.splice(startingIndex, movedLayers.length);
-    let nextIndex = startingIndex;
-    const pathLength = layerPath.split('/').length;
-    while (absoluteMoves > 0) {
-      nextIndex += direction;
-      if (nextIndex === orderedLayers.length || nextIndex === 0) {
-        absoluteMoves = 0;
-      } else if (orderedLayers[nextIndex].split('/').length === pathLength) absoluteMoves--;
+
+    // Find sibling paths from the legend tree (same source of truth as the UI)
+    const legendLayers = getStoreLayerLegendLayers(mapId);
+    const siblingPaths = StateApi.#findSiblingPaths(layerPath, legendLayers);
+
+    // Collect indices of all siblings (excluding the moved layer) in the modified array
+    const siblingIndices: number[] = [];
+    for (let i = 0; i < orderedLayers.length; i++) {
+      if (siblingPaths.includes(orderedLayers[i])) {
+        siblingIndices.push(i);
+      }
     }
-    orderedLayers.splice(nextIndex, 0, ...movedLayers);
+
+    // Compute insertion index based on direction
+    let insertionIndex = startingIndex;
+
+    if (siblingIndices.length > 0) {
+      if (direction === 1) {
+        // Moving DOWN: find the first sibling at or after startingIndex, then advance past its subtree
+        const nextSiblingPos = siblingIndices.findIndex((idx) => idx >= startingIndex);
+        if (nextSiblingPos !== -1) {
+          const targetPos = Math.min(nextSiblingPos + Math.abs(move) - 1, siblingIndices.length - 1);
+          const targetSiblingIndex = siblingIndices[targetPos];
+          const targetSiblingPath = orderedLayers[targetSiblingIndex];
+          // Insert after the target sibling's subtree
+          insertionIndex = targetSiblingIndex + 1;
+          while (insertionIndex < orderedLayers.length && orderedLayers[insertionIndex].startsWith(`${targetSiblingPath}/`)) {
+            insertionIndex++;
+          }
+        }
+      } else {
+        // Moving UP: find siblings before startingIndex, then insert at the target sibling's position
+        const prevSiblings = siblingIndices.filter((idx) => idx < startingIndex);
+        if (prevSiblings.length > 0) {
+          const targetPos = Math.max(prevSiblings.length - Math.abs(move), 0);
+          insertionIndex = siblingIndices[targetPos];
+        }
+      }
+    }
+
+    orderedLayers.splice(insertionIndex, 0, ...movedLayers);
 
     // Redirect
     this.#layerController.setMapOrderedLayersDirectly(orderedLayers);
@@ -185,6 +219,37 @@ export class StateApi {
   }
 
   // #endregion EVENTS
+
+  /**
+   * Finds the sibling layer paths for a given layer by walking the legend tree.
+   *
+   * Top-level layers are siblings of each other regardless of their path prefix.
+   * Children within a group are siblings of each other.
+   *
+   * @param layerPath - The layer path to find siblings for
+   * @param legendLayers - The root legend layers array
+   * @returns The sibling paths (excluding the layer itself)
+   */
+  static #findSiblingPaths(layerPath: string, legendLayers: TypeLegendLayer[]): string[] {
+    // Check if it's a top-level layer
+    if (legendLayers.some((layer) => layer.layerPath === layerPath)) {
+      return legendLayers.map((layer) => layer.layerPath).filter((path) => path !== layerPath);
+    }
+
+    // Recursively search for the parent group containing this layer
+    const findInChildren = (layers: TypeLegendLayer[]): string[] | undefined => {
+      for (const layer of layers) {
+        if (layer.children.some((child) => child.layerPath === layerPath)) {
+          return layer.children.map((child) => child.layerPath).filter((path) => path !== layerPath);
+        }
+        const result = findInChildren(layer.children);
+        if (result) return result;
+      }
+      return undefined;
+    };
+
+    return findInChildren(legendLayers) ?? [];
+  }
 }
 
 // #region EVENTS & DELEGATES

--- a/packages/geoview-core/src/core/stores/state-api.ts
+++ b/packages/geoview-core/src/core/stores/state-api.ts
@@ -227,6 +227,8 @@ export class StateApi {
 
   // #endregion EVENTS
 
+  // #region STATIC METHODS
+
   /**
    * Finds the sibling layer paths for a given layer by walking the legend tree.
    *
@@ -257,6 +259,8 @@ export class StateApi {
 
     return findInChildren(legendLayers) ?? [];
   }
+
+  /// #endregion STATIC METHODS
 }
 
 // #region EVENTS & DELEGATES

--- a/packages/geoview-test-suite/src/tests/testers/abstract-gv-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/abstract-gv-tester.ts
@@ -312,6 +312,7 @@ export abstract class GVAbstractTester extends AbstractTester {
   /** Toronto */
   static readonly FEATURE_SERVER_TORONTO_NEIGHBOURHOODS_URL: string =
     'https://services.arcgis.com/V6ZHFr6zdgNZuVG0/ArcGIS/rest/services/Toronto_Neighbourhoods/FeatureServer';
+  static readonly FEATURE_SERVER_TORONTO_NEIGHBOURHOODS_FEATURE_SERVER: string = `${GVAbstractTester.FEATURE_SERVER_TORONTO_NEIGHBOURHOODS_URL}/0`;
   static readonly FEATURE_SERVER_TORONTO_NEIGHBOURHOODS_LAYER_NAME: string = 'Toronto_Neighbourhoods';
 
   /** Elevation */

--- a/packages/geoview-test-suite/src/tests/testers/config-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/config-tester.ts
@@ -171,11 +171,12 @@ export class ConfigTester extends GVAbstractTester {
    */
   testEsriFeatureWithTorontoNeighbourhoods(): Promise<Test<TypeGeoviewLayerConfig>> {
     // The url
-    const url = ConfigTester.FEATURE_SERVER_TORONTO_NEIGHBOURHOODS_URL;
+    const url = ConfigTester.FEATURE_SERVER_TORONTO_NEIGHBOURHOODS_FEATURE_SERVER;
+    const expectedUrl = ConfigTester.FEATURE_SERVER_TORONTO_NEIGHBOURHOODS_URL;
 
     // Test the Esri Feature config
     return this.testEsriFeature('Test an Esri Feature with Toronto Neighbourhoods', url, {
-      metadataAccessPath: url,
+      metadataAccessPath: expectedUrl,
       listOfLayerEntryConfig: [
         { layerEntryProps: { layerId: '0', layerName: ConfigTester.FEATURE_SERVER_TORONTO_NEIGHBOURHOODS_LAYER_NAME } },
       ],


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

Hosted June 15, 9 am

https://jolevesq.github.io/geoview/layers-navigator.html?config=./configs/navigator/layers/all-layers.json

# Checklist:

- [x] I have run the **Test Suite** and **No errors have been introduced**
- [x] I have run `@BranchReview` agent in VS Code Chat and addressed all violations
- [ ] I have run `@DocUpdate` agent in VS Code Chat and documentation is in sync with code changes
- [ ] I have run `@IssueReview` agent in VS Code Chat and the implementation aligns with the linked issue
- [ ] I have build **(rush build)** and deploy **(rush host)** my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~New and existing unit tests pass locally with my changes~~

# Pre-PR Copilot Agent Checks

Before creating your PR, run the following two Copilot agents in VS Code Chat to catch common issues automatically.

## Branch Review (`@BranchReview`)

Audits all changed `.ts`/`.tsx` files against the GeoView coding standards (JSDoc, logging, return types, naming, accessibility, imports, performance patterns).

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **BranchReview** agent from the agent picker (or type `@BranchReview`)
3. Type the target branch name (defaults to `develop`):
   ```
   @BranchReview  against upstream/develop
   ```
4. Review the violation report and fix flagged items (the agent can auto-fix most issues on approval)

- [ ] `@BranchReview` has been run and all violations have been addressed

## Documentation Update (`@DocUpdate`)

Checks that documentation in `docs/` is still consistent with the code you changed. Catches stale references, missing docs for new features, and incorrect code examples.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **DocUpdate** agent from the agent picker (or type `@DocUpdate`)
3. Run a full audit or target a specific section:
   ```
   @DocUpdate full audit of docs/programming/
   @DocUpdate check docs/app/layers/
   ```
4. Review the audit summary and approve any proposed documentation updates

- [ ] `@DocUpdate` has been run and documentation is in sync with code changes

## Issue Review (`@IssueReview`)

Compares your branch changes against the linked GitHub issue's proposed fix. Checks whether the implementation aligns with what was proposed, catches gaps, and provides feedback to improve future issue drafts.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **IssueReview** agent from the agent picker (or type `@IssueReview`)
3. Provide the issue number:
   ```
   @IssueReview #1234
   ```
4. Review the alignment report — it will flag items that were proposed but not implemented, unexpected changes, and root cause accuracy

- [ ] `@IssueReview` has been run and the alignment report has been reviewed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3531)
<!-- Reviewable:end -->
