### PR TITLE
fix(deepMerge) Fixing the deepMerge happening in the configuration duplicating the geoviewLayerConfig object

### DIFF
--- a/packages/geoview-core/src/api/config/geocore.ts
+++ b/packages/geoview-core/src/api/config/geocore.ts
@@ -7,7 +7,6 @@ import { generateId } from '@/core/utils/utilities';
 import type { TypeDisplayLanguage } from '@/api/types/map-schema-types';
 import { DEFAULT_MAP_FEATURE_CONFIG } from '@/api/types/map-schema-types';
 import type { GeoCoreLayerConfig, TypeGeoviewLayerConfig } from '@/api/types/layer-schema-types';
-import { ConfigBaseClass } from '@/api/config/validation-classes/config-base-class';
 import type { GeoViewError } from '@/core/exceptions/geoview-exceptions';
 import { getStoreMapConfigServiceUrls, getStoreMapConfigState } from '@/core/stores/states/map-state';
 
@@ -68,7 +67,6 @@ export class GeoCore {
     // Use user supplied listOfLayerEntryConfig if provided
     if (layerConfig?.listOfLayerEntryConfig || layerConfig?.initialSettings) {
       // TODO: CHECK - Should we really spread here and create a 'new' TypeGeoviewLayerConfig json object here?
-      // TO.DOCONT: It complicates things a bit in the geoviewLayerConfig in all layer entries if they are different than the root geoviewLayerConfig, search id: e80ea1d4
       const tempLayerConfig = { ...layerConfig } as unknown as TypeGeoviewLayerConfig;
       tempLayerConfig.metadataAccessPath = response.layers[0].metadataAccessPath;
       tempLayerConfig.geoviewLayerType = response.layers[0].geoviewLayerType;
@@ -105,11 +103,6 @@ export class GeoCore {
     if (uuid.includes(':') && uuid.split(':')[0] === response.layers[0].geoviewLayerId) {
       // Update the geoview layer id
       response.layers[0].geoviewLayerId = uuid;
-
-      // Make sure the geoviewLayerConfig reference in all layer entries are updated as well because of a deepMergeObjects happening.., search id: e80ea1d4
-      response.layers[0].listOfLayerEntryConfig.forEach((layerEntryConfig) => {
-        ConfigBaseClass.getClassOrTypeGeoviewLayerConfig(layerEntryConfig).geoviewLayerId = uuid;
-      });
     }
 
     // Always only first one

--- a/packages/geoview-core/src/api/config/reader/uuid-config-reader.ts
+++ b/packages/geoview-core/src/api/config/reader/uuid-config-reader.ts
@@ -1,7 +1,20 @@
 import type { TypeDisplayLanguage } from '@/api/types/map-schema-types';
-import type { TypeGeoviewLayerConfig, TypeGeoviewLayerType, TypeOfServer } from '@/api/types/layer-schema-types';
+import type {
+  TypeBaseSourceInitialConfig,
+  TypeGeoviewLayerConfig,
+  TypeGeoviewLayerType,
+  TypeOfServer,
+} from '@/api/types/layer-schema-types';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
-
+import type { TypeLayerEntryShell } from '@/api/config/validation-classes/config-base-class';
+import { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
+import { formatError, NotSupportedError } from '@/core/exceptions/core-exceptions';
+import {
+  LayerGeoCoreServiceFailError,
+  LayerGeoCoreInvalidResponseError,
+  LayerGeoCoreNoLayersError,
+} from '@/core/exceptions/geocore-exceptions';
+import { Fetch } from '@/core/utils/fetch-helper';
 import { EsriDynamic } from '@/geo/layer/geoview-layers/raster/esri-dynamic';
 import { EsriFeature } from '@/geo/layer/geoview-layers/vector/esri-feature';
 import { EsriImage } from '@/geo/layer/geoview-layers/raster/esri-image';
@@ -15,16 +28,6 @@ import { WFS } from '@/geo/layer/geoview-layers/vector/wfs';
 import { WMS } from '@/geo/layer/geoview-layers/raster/wms';
 import { WMTS } from '@/geo/layer/geoview-layers/raster/wmts';
 import { XYZTiles } from '@/geo/layer/geoview-layers/raster/xyz-tiles';
-
-import {
-  LayerGeoCoreServiceFailError,
-  LayerGeoCoreInvalidResponseError,
-  LayerGeoCoreNoLayersError,
-} from '@/core/exceptions/geocore-exceptions';
-import { Fetch } from '@/core/utils/fetch-helper';
-import { formatError, NotSupportedError } from '@/core/exceptions/core-exceptions';
-import type { TypeLayerEntryShell } from '@/api/config/validation-classes/config-base-class';
-
 /** A class to generate GeoView layers config from a URL using a UUID. */
 export class UUIDmapConfigReader {
   /**
@@ -248,9 +251,22 @@ export class UUIDmapConfigReader {
           // Add it
           listOfGeoviewLayerConfig.push(geoviewLayerConfig);
 
-          // If there's only the one layer AND customGeocoreLayerConfig.layerName is provided, replace the layer name with the name from config
-          if (listOfGeoviewLayerConfig[i].listOfLayerEntryConfig.length === 1 && customGeocoreLayerConfig?.layerName) {
-            listOfGeoviewLayerConfig[i].listOfLayerEntryConfig[0].setLayerName(customGeocoreLayerConfig.layerName);
+          // Get the layer entry
+          const layerConfig = listOfGeoviewLayerConfig[i];
+
+          // If there's only the one layer AND customGeocoreLayerConfig is provided
+          if (layerConfig.listOfLayerEntryConfig.length === 1 && customGeocoreLayerConfig) {
+            const layerEntryConfig = layerConfig.listOfLayerEntryConfig[0];
+
+            // Replace the layer name with the metadata name from geocore config
+            if (customGeocoreLayerConfig.layerName) {
+              layerEntryConfig.setLayerName(customGeocoreLayerConfig.layerName);
+            }
+
+            if (layerEntryConfig instanceof AbstractBaseLayerEntryConfig && customGeocoreLayerConfig.source) {
+              // Init the source from the metadata coming from geocore config
+              layerEntryConfig.initSourceFromMetadata(customGeocoreLayerConfig.source);
+            }
           }
         }
       }
@@ -351,11 +367,12 @@ export type GeoCoreConfigResponseRCSLayers = {
 
 export type GeoCoreConfigResponseGCSLayers = {
   layers?: GeoCoreConfigResponseGCSLayer;
-  packages: GeoCoreConfigResponsePackages;
+  packages?: GeoCoreConfigResponsePackages;
 };
 
 export type GeoCoreConfigResponseGCSLayer = {
   layerName: string;
+  source?: TypeBaseSourceInitialConfig;
 };
 
 export type GeoCoreConfigResponsePackages = {

--- a/packages/geoview-core/src/api/config/reader/uuid-config-reader.ts
+++ b/packages/geoview-core/src/api/config/reader/uuid-config-reader.ts
@@ -254,6 +254,7 @@ export class UUIDmapConfigReader {
           // Get the layer entry
           const layerConfig = listOfGeoviewLayerConfig[i];
 
+          // TODO: Add support for more than 1 layer overrides, see issue #3548
           // If there's only the one layer AND customGeocoreLayerConfig is provided
           if (layerConfig.listOfLayerEntryConfig.length === 1 && customGeocoreLayerConfig) {
             const layerEntryConfig = layerConfig.listOfLayerEntryConfig[0];

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -11,7 +11,6 @@ import type { ConfigBaseClass, TypeLayerEntryShell } from '@/api/config/validati
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 
 import { EsriUtilities } from '@/geo/layer/geoview-layers/esri-layer-common';
-import { deepMergeObjects } from '@/core/utils/utilities';
 import { GVEsriDynamic } from '@/geo/layer/gv-layers/raster/gv-esri-dynamic';
 import { GroupLayerEntryConfig } from '@/api/config/validation-classes/group-layer-entry-config';
 import type { DisplayDateMode } from '@/api/types/map-schema-types';
@@ -189,7 +188,6 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @param metadataAccessPath - The URL or path to access metadata
    * @param isTimeAware - Indicates whether the layer supports time-based filtering
    * @param layerEntries - An array of layer entries objects to be included in the configuration
-   * @param customGeocoreLayerConfig - An optional layer config from Geocore
    * @returns The constructed configuration object for the Esri Dynamic layer
    */
   static createGeoviewLayerConfig(
@@ -197,8 +195,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
     geoviewLayerName: string,
     metadataAccessPath: string,
     isTimeAware: boolean | undefined,
-    layerEntries: TypeLayerEntryShell[],
-    customGeocoreLayerConfig: unknown = {}
+    layerEntries: TypeLayerEntryShell[]
   ): TypeEsriDynamicLayerConfig {
     const geoviewLayerConfig: TypeEsriDynamicLayerConfig = {
       geoviewLayerId,
@@ -210,11 +207,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
     };
 
     // Convert the tree of entries to GeoviewLayerConfigs
-    geoviewLayerConfig.listOfLayerEntryConfig = EsriDynamic.#convertTreeToLayerConfigs(
-      geoviewLayerConfig,
-      layerEntries,
-      customGeocoreLayerConfig
-    );
+    geoviewLayerConfig.listOfLayerEntryConfig = EsriDynamic.#convertTreeToLayerConfigs(geoviewLayerConfig, layerEntries);
 
     // Return it
     return geoviewLayerConfig;
@@ -251,8 +244,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
       isTimeAware,
       layerIds.map((layerId) => {
         return { id: layerId, index: layerId };
-      }),
-      {}
+      })
     );
 
     // Create the class from geoview-layers package
@@ -273,20 +265,18 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    *
    * @param geoviewLayerConfig - The top-level ESRI dynamic layer configuration object
    * @param layerEntries - An array representing the tree structure of the layer entries (may include groups or leaves)
-   * @param customGeocoreLayerConfig - Optional GeoCore-specific configuration overrides to apply to each entry
    * @returns An array of fully-formed layer entry configuration instances
    */
   static #convertTreeToLayerConfigs(
     geoviewLayerConfig: TypeEsriDynamicLayerConfig,
-    layerEntries: TypeLayerEntryShell[],
-    customGeocoreLayerConfig: unknown = {}
+    layerEntries: TypeLayerEntryShell[]
   ): (GroupLayerEntryConfig | EsriDynamicLayerEntryConfig)[] {
     // For each layer entry
     return layerEntries.map((layerEntry) => {
       // If is a group layer
       if (layerEntry.subLayers && layerEntry.subLayers.length > 0) {
         // Recursively convert sublayers
-        const subConfigs = EsriDynamic.#convertTreeToLayerConfigs(geoviewLayerConfig, layerEntry.subLayers, customGeocoreLayerConfig);
+        const subConfigs = EsriDynamic.#convertTreeToLayerConfigs(geoviewLayerConfig, layerEntry.subLayers);
 
         return new GroupLayerEntryConfig({
           geoviewLayerConfig,
@@ -303,17 +293,8 @@ export class EsriDynamic extends AbstractGeoViewRaster {
         layerName: layerEntry.layerName,
       };
 
-      // Overwrite default from geocore custom config
-      // TODO: CHECK - Should we really deep merge a 'new' geoviewLayerConfig json object here?
-      // TO.DOCONT: It complicates things a bit in the geoviewLayerConfig in all layer entries if they are different than
-      // TO.DOCONT: the root geoviewLayerConfig, search id: e80ea1d4
-      // TO.DOCONT: If we keep the deepmerge, maybe we reoverride the geoviewLayerConfig reference at least
-      // TO.DOCONT: (mergedConfig.geoviewLayerConfig = geoviewLayerConfig) (added and commented below)?
-      const mergedConfig = deepMergeObjects<EsriDynamicLayerEntryConfigProps>(layerEntryConfig, customGeocoreLayerConfig);
-      // mergedConfig.geoviewLayerConfig = geoviewLayerConfig;
-
       // Reconstruct
-      return new EsriDynamicLayerEntryConfig(mergedConfig);
+      return new EsriDynamicLayerEntryConfig(layerEntryConfig);
     });
   }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -32,7 +32,7 @@ import {
   LayerEntryConfigLayerIdNotFoundError,
   LayerEntryConfigWMSSubLayerNotFoundError,
 } from '@/core/exceptions/layer-entry-config-exceptions';
-import { deepMergeObjects, generateId, normalizeDatacubeAccessPath } from '@/core/utils/utilities';
+import { generateId, normalizeDatacubeAccessPath } from '@/core/utils/utilities';
 import { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import { GVWMS } from '@/geo/layer/gv-layers/raster/gv-wms';
 import type { AbstractBaseLayerEntryConfig } from '@/api/config/validation-classes/abstract-base-layer-entry-config';
@@ -759,7 +759,6 @@ export class WMS extends AbstractGeoViewRaster {
    * @param isTimeAware - Indicates whether the layer supports time-based filtering
    * @param layerEntries - The root array of parsed layer entries (may include nested groups)
    * @param useFullWmsSublayers - Optional to indicates if we want the full sublayers of all wms or grouped (default is all sublayers)
-   * @param customGeocoreLayerConfig - Optional custom layer configuration to merge into leaf layers
    * @returns The fully constructed WMS layer configuration object
    */
   static createGeoviewLayerConfig(
@@ -769,8 +768,7 @@ export class WMS extends AbstractGeoViewRaster {
     serverType: TypeOfServer | undefined,
     isTimeAware: boolean | undefined,
     layerEntries: TypeLayerEntryShell[],
-    useFullWmsSublayers: boolean = this.DEFAULT_WMS_LAYER_GROUP_FULL_SUB_LAYERS,
-    customGeocoreLayerConfig: unknown = {}
+    useFullWmsSublayers: boolean = this.DEFAULT_WMS_LAYER_GROUP_FULL_SUB_LAYERS
   ): TypeWMSLayerConfig {
     const geoviewLayerConfig: TypeWMSLayerConfig = {
       geoviewLayerId,
@@ -784,7 +782,7 @@ export class WMS extends AbstractGeoViewRaster {
 
     // Recursively map layer entries
     geoviewLayerConfig.listOfLayerEntryConfig = layerEntries.map((layerEntry) =>
-      WMS.#createLayerEntryConfig(layerEntry, geoviewLayerConfig, serverType, customGeocoreLayerConfig)
+      WMS.#createLayerEntryConfig(layerEntry, geoviewLayerConfig, serverType)
     ) as OgcWmsLayerEntryConfig[]; // Untrue 'as' operation, but we'll fix later
 
     // Return it
@@ -1069,14 +1067,12 @@ export class WMS extends AbstractGeoViewRaster {
    * @param layerEntry - The WMS layer entry shell to convert (may be a group or leaf)
    * @param geoviewLayerConfig - The parent GeoView layer config that this entry belongs to
    * @param serverType - The type of WMS server (e.g., 'geoserver', 'mapserver', etc.)
-   * @param customGeocoreLayerConfig - Optional custom layer configuration to merge into leaf layers
    * @returns The fully constructed layer entry configuration object
    */
   static #createLayerEntryConfig(
     layerEntry: TypeLayerEntryShell,
     geoviewLayerConfig: TypeWMSLayerConfig,
-    serverType: TypeOfServer | undefined,
-    customGeocoreLayerConfig: unknown
+    serverType: TypeOfServer | undefined
   ): OgcWmsLayerEntryConfig | GroupLayerEntryConfig {
     // Check if it's a group layer (has children)
     const isGroup = Array.isArray(layerEntry.listOfLayerEntryConfig) && layerEntry.listOfLayerEntryConfig.length > 0;
@@ -1107,14 +1103,8 @@ export class WMS extends AbstractGeoViewRaster {
       },
     };
 
-    // Merge with custom config if provided
-    // TODO: CHECK - Should we really deep merge a 'new' geoviewLayerConfig json object here?
-    // TO.DOCONT: It complicates things a bit in the geoviewLayerConfig in all layer entries if they are different than
-    // TO.DOCONT: the root geoviewLayerConfig, search id: e80ea1d4
-    const mergedConfig = deepMergeObjects<OgcWmsLayerEntryConfigProps>(layerEntryConfig, customGeocoreLayerConfig);
-
     // Construct and return layer entry
-    return new OgcWmsLayerEntryConfig(mergedConfig);
+    return new OgcWmsLayerEntryConfig(layerEntryConfig);
   }
 
   /**
@@ -1252,12 +1242,15 @@ export class WMS extends AbstractGeoViewRaster {
         // Keep it as reference
         layerConfig.setWfsLayerConfig(wfsLayerConfig);
 
-        // Validate the outfields could be read
-        const outFields = wfsLayerConfig.getOutfields();
-        if (!outFields) throw new LayerEntryConfigFieldsNotFoundError(layerConfig.getGeoviewLayerId(), layerConfig.getLayerNameCascade());
+        // If no outfields already configured
+        if (!layerConfig.getOutfields()?.length) {
+          // Validate the outfields could be read
+          const outFields = wfsLayerConfig.getOutfields();
+          if (!outFields) throw new LayerEntryConfigFieldsNotFoundError(layerConfig.getGeoviewLayerId(), layerConfig.getLayerNameCascade());
 
-        // Override the outfields of the WMS to leverage possibilities working with a WMS layer, like knowing the field types when performing WMS queries
-        layerConfig.setOutfields(outFields);
+          // Override the outfields of the WMS to leverage possibilities working with a WMS layer, like knowing the field types when performing WMS queries
+          layerConfig.setOutfields(outFields);
+        }
 
         // If no layer style defined
         if (!layerConfig.getLayerStyle()) {


### PR DESCRIPTION
# Description

- Removing the recently added patch about the geoview layer config and fixing the issue at the core (the deepMergeObjects) that was deep merging for nothing in all our calling scenarios it turns out..

_Note: this PR closes some issues that were in fact fixed in some PRs prior to this one._

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

~~Hosted June 8th @ 10h30 : https://alex-nrcan.github.io/geoview/~~
Hosted June 9th @ 10h45 : https://alex-nrcan.github.io/geoview/
- Test all geocore layer configurations templates, EsriDynamic and WMS layers with geocore combinations

# Checklist:

- [x] I have run the **Test Suite** and **No errors have been introduced**
- [ ] I have run `@BranchReview` agent in VS Code Chat and addressed all violations
- [ ] I have run `@DocUpdate` agent in VS Code Chat and documentation is in sync with code changes
- [ ] I have run `@IssueReview` agent in VS Code Chat and the implementation aligns with the linked issue
- [x] I have build **(rush build)** and deploy **(rush host)** my PR
- [ ] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~New and existing unit tests pass locally with my changes~~

# Pre-PR Copilot Agent Checks

Before creating your PR, run the following two Copilot agents in VS Code Chat to catch common issues automatically.

## Branch Review (`@BranchReview`)

Audits all changed `.ts`/`.tsx` files against the GeoView coding standards (JSDoc, logging, return types, naming, accessibility, imports, performance patterns).

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **BranchReview** agent from the agent picker (or type `@BranchReview`)
3. Type the target branch name (defaults to `develop`):
   ```
   @BranchReview  against upstream/develop
   ```
4. Review the violation report and fix flagged items (the agent can auto-fix most issues on approval)

- [ ] `@BranchReview` has been run and all violations have been addressed

## Documentation Update (`@DocUpdate`)

Checks that documentation in `docs/` is still consistent with the code you changed. Catches stale references, missing docs for new features, and incorrect code examples.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **DocUpdate** agent from the agent picker (or type `@DocUpdate`)
3. Run a full audit or target a specific section:
   ```
   @DocUpdate full audit of docs/programming/
   @DocUpdate check docs/app/layers/
   ```
4. Review the audit summary and approve any proposed documentation updates

- [ ] `@DocUpdate` has been run and documentation is in sync with code changes

## Issue Review (`@IssueReview`)

Compares your branch changes against the linked GitHub issue's proposed fix. Checks whether the implementation aligns with what was proposed, catches gaps, and provides feedback to improve future issue drafts.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **IssueReview** agent from the agent picker (or type `@IssueReview`)
3. Provide the issue number:
   ```
   @IssueReview #1234
   ```
4. Review the alignment report — it will flag items that were proposed but not implemented, unexpected changes, and root cause accuracy

- [ ] `@IssueReview` has been run and the alignment report has been reviewed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3547)
<!-- Reviewable:end -->
