### PR TITLE
fix(proxy-configuration) Fixes the proxy configuration usage as well as testing the new proxy and more..

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -249,6 +249,34 @@ const isVisible =
 
 **Always use `getLayerNameCascade()` when you need a display name.** Use `getLayerName()` only when you specifically need to check if the entry has its own name set.
 
+### Layer Proxy Architecture
+
+**Per-instance proxy** — Each layer stores its own proxy URL on `AbstractBaseLayerEntryConfig`. There is NO shared mutable static for proxy configuration.
+
+| Method on `AbstractBaseLayerEntryConfig` | Purpose |
+|---|---|
+| `getProxyUrl()` | Returns the proxy URL for this layer, or `undefined` if none |
+| `setProxyUrl(proxy)` | Sets the proxy URL; also snapshots `#dataAccessPathBeforeProxy` |
+| `getIsUsingProxy()` | Returns `true` if a proxy URL is set (`!!this.#proxy`) |
+| `getIsUsingEsriProxy()` | Returns `true` if the proxy matches the ESRI proxy pattern |
+| `getDataAccessPathBeforeProxy()` | Returns the original URL before proxy was applied (falls back to current data access path) |
+
+**How proxy is assigned** — `LayerCreatorController.#addGeoviewLayerStep2()` calls `geoviewLayer.setConfigServiceUrls(mapFeaturesConfig.serviceUrls)` on the `AbstractGeoViewLayer` instance. During metadata fetch, if a network error triggers a proxy retry, the callback calls `layerConfig.setProxyUrl(proxyUsed)` on the individual layer entry config.
+
+**ESRI proxy detection** — `GeoUtilities.isEsriProxy(proxyUrl)` checks if the proxy URL contains `executeFromProxy`. When true, OGC `LAYERS` params must be double-encoded before being sent through the proxy.
+
+**GV layer (runtime) proxy usage pattern:**
+
+```typescript
+// In image load function or feature info request:
+if (layerConfig.getIsUsingProxy()) {
+  url = `${layerConfig.getProxyUrl()}?${url}`;
+}
+
+// For OL source URL (proxy applied in load callback, not source URL):
+const sourceUrl = layerConfig.getDataAccessPathBeforeProxy();
+```
+
 ### Layer Opacity System
 
 **Hierarchical capping** — `AbstractBaseGVLayer.onSetOpacity()` clamps each layer's opacity to `Math.min(parent.getOpacity(), opacity)`. A child can never exceed its parent's opacity. This means:

--- a/docs/programming/best-practices.md
+++ b/docs/programming/best-practices.md
@@ -213,7 +213,7 @@ Tags Worth Using
 - @returns
 - @throws (@throws {TheErrorType} (description)  e.g. @throws {LayerNotGeoJsonError} When...)
 - @example
-- @deprecated
+- @deprecated (must include a reason, e.g. `@deprecated Use \`newMethod()\` instead`)
 - @see
 
 Tags Usually Overkill in TS

--- a/packages/eslint.config.js
+++ b/packages/eslint.config.js
@@ -141,6 +141,7 @@ export default [
         1,
         {
           allowExpressions: true,
+          allowTypedFunctionExpressions: true
         },
       ],
 

--- a/packages/geoview-core/public/configs/navigator/layers/wms.json
+++ b/packages/geoview-core/public/configs/navigator/layers/wms.json
@@ -265,5 +265,8 @@
     }
   },
   "corePackages": [],
-  "theme": "geo.ca"
+  "theme": "geo.ca",
+  "serviceUrls": {
+    "proxyUrl": "https://proxy.app-dev.geo.ca"
+  }
 }

--- a/packages/geoview-core/public/configs/navigator/layers/xyz-tile-errors.json
+++ b/packages/geoview-core/public/configs/navigator/layers/xyz-tile-errors.json
@@ -11,18 +11,6 @@
     },
     "listOfGeoviewLayerConfig": [
       {
-        "geoviewLayerId": "xyzTilesLYR1",
-        "geoviewLayerName": "Error metadata",
-        "metadataAccessPath": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServerERROR/",
-        "geoviewLayerType": "xyzTiles",
-        "listOfLayerEntryConfig": [
-          {
-            "layerId": "0",
-            "layerName": "World Topo Map"
-          }
-        ]
-      },
-      {
         "geoviewLayerId": "xyzTilesLYR2",
         "geoviewLayerName": "Error layerId",
         "metadataAccessPath": "https://maps.gnosis.earth/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad",
@@ -47,6 +35,18 @@
             "source": {
               "dataAccessPath": "https://demo.mapserver.org/cgi-bin/mapserv?map=/var/www/htdocs/msautotest/naturalearth_tiles.map&MODE=tile&TILE={x}+{y}+{z}&LAYERS=countries&TILEMODE=gmap"
             }
+          }
+        ]
+      },
+      {
+        "geoviewLayerId": "xyzTilesLYR1",
+        "geoviewLayerName": "Error metadata",
+        "metadataAccessPath": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServerERROR/",
+        "geoviewLayerType": "xyzTiles",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "0",
+            "layerName": "World Topo Map"
           }
         ]
       }

--- a/packages/geoview-core/public/configs/navigator/layers/xyz-tile-errors.json
+++ b/packages/geoview-core/public/configs/navigator/layers/xyz-tile-errors.json
@@ -36,6 +36,19 @@
             }
           }
         ]
+      },
+      {
+        "geoviewLayerId": "xyzTilesNatEarth",
+        "geoviewLayerName": "Natural Earth",
+        "geoviewLayerType": "xyzTiles",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "natEarth",
+            "source": {
+              "dataAccessPath": "https://demo.mapserver.org/cgi-bin/mapserv?map=/var/www/htdocs/msautotest/naturalearth_tiles.map&MODE=tile&TILE={x}+{y}+{z}&LAYERS=countries&TILEMODE=gmap"
+            }
+          }
+        ]
       }
     ]
   },

--- a/packages/geoview-core/public/configs/navigator/layers/xyz-tile.json
+++ b/packages/geoview-core/public/configs/navigator/layers/xyz-tile.json
@@ -11,29 +11,77 @@
     },
     "listOfGeoviewLayerConfig": [
       {
-        "geoviewLayerId": "xyzTilesLYR1",
-        "geoviewLayerName": "World_Topo_Map",
-        "metadataAccessPath": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/",
-        "geoviewLayerType": "xyzTiles",
-        "listOfLayerEntryConfig": [
-          {
-            "layerId": "0",
-            "layerName": "World Topo Map"
-          }
-        ]
-      },
-      {
-        "geoviewLayerId": "xyzTilesLYR2",
-        "geoviewLayerName": "GNOSIS_Blue_Marble",
+        "geoviewLayerId": "xyzTilesBlue",
+        "geoviewLayerName": "GNOSIS Blue Marble",
         "metadataAccessPath": "https://maps.gnosis.earth/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad",
         "geoviewLayerType": "xyzTiles",
         "listOfLayerEntryConfig": [
           {
             "layerId": "blueMarble",
-            "layerName": "GNOSIS Blue Marble",
             "source": {
               "dataAccessPath": "https://maps.gnosis.earth/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad/{z}/{y}/{x}.jpg"
             }
+          }
+        ]
+      },
+      {
+        "geoviewLayerId": "xyzTilesOpenStreetMap",
+        "geoviewLayerName": "Open Street Map",
+        "geoviewLayerType": "xyzTiles",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "openStreetMap",
+            "source": {
+              "dataAccessPath": "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+            }
+          }
+        ]
+      },
+      {
+        "geoviewLayerId": "xyzTilesWikimedia",
+        "geoviewLayerName": "Wikimedia",
+        "geoviewLayerType": "xyzTiles",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "wikimedia",
+            "source": {
+              "dataAccessPath": "https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png"
+            }
+          }
+        ]
+      },
+      {
+        "geoviewLayerId": "xyzTilesNatEarth",
+        "geoviewLayerName": "Natural Earth",
+        "geoviewLayerType": "xyzTiles",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "natEarth",
+            "source": {
+              "dataAccessPath": "https://demo.mapserver.org/cgi-bin/mapserv?map=/var/www/htdocs/msautotest/naturalearth_tiles.map&MODE=tile&TILE={x}+{y}+{z}&LAYERS=countries&TILEMODE=gmap"
+            }
+          }
+        ]
+      },
+      {
+        "geoviewLayerId": "xyzTilesUsgsTopo",
+        "geoviewLayerName": "USGS Topo",
+        "metadataAccessPath": "https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer",
+        "geoviewLayerType": "xyzTiles",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "0"
+          }
+        ]
+      },
+      {
+        "geoviewLayerId": "xyzTilesWorldTopo",
+        "geoviewLayerName": "World Topo Map",
+        "metadataAccessPath": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/",
+        "geoviewLayerType": "xyzTiles",
+        "listOfLayerEntryConfig": [
+          {
+            "layerId": "0"
           }
         ]
       }

--- a/packages/geoview-core/public/configs/navigator/layers/xyz-tile.json
+++ b/packages/geoview-core/public/configs/navigator/layers/xyz-tile.json
@@ -39,26 +39,13 @@
       },
       {
         "geoviewLayerId": "xyzTilesWikimedia",
-        "geoviewLayerName": "Wikimedia",
+        "geoviewLayerName": "Wikimedia (localhost only)",
         "geoviewLayerType": "xyzTiles",
         "listOfLayerEntryConfig": [
           {
             "layerId": "wikimedia",
             "source": {
               "dataAccessPath": "https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png"
-            }
-          }
-        ]
-      },
-      {
-        "geoviewLayerId": "xyzTilesNatEarth",
-        "geoviewLayerName": "Natural Earth",
-        "geoviewLayerType": "xyzTiles",
-        "listOfLayerEntryConfig": [
-          {
-            "layerId": "natEarth",
-            "source": {
-              "dataAccessPath": "https://demo.mapserver.org/cgi-bin/mapserv?map=/var/www/htdocs/msautotest/naturalearth_tiles.map&MODE=tile&TILE={x}+{y}+{z}&LAYERS=countries&TILEMODE=gmap"
             }
           }
         ]
@@ -123,5 +110,8 @@
     }
   },
   "corePackages": [],
-  "theme": "geo.ca"
+  "theme": "geo.ca",
+  "serviceUrls": {
+    "proxyUrl": "https://proxy.app-dev.geo.ca"
+  }
 }

--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -416,7 +416,7 @@
       "missingSourceProjection": "The source.projection parameter is mandatory.",
       "unableToFetch": "Unable to fetch and read metadata for layer '{{layerNameOrId}}'.",
       "wmtsMetadataError": "Error with WMTS metadata for layer '{{layerNameOrId}}': {{missingElement}} missing in metadata.",
-      "serviceMetadataEmpty": "Metadata of the service was empty for layer '{{layerNameOrId}}'.",
+      "serviceMetadataEmpty": "Metadata of the service was empty or insufficient for layer '{{layerNameOrId}}'.",
       "invalidLayerFilter": "Layer '{{layerNameOrPath}}' has an invalid layer filter.\nfilter = '{{layerFilter}}'\ninternal filter = '{{filter}}'.",
       "failedToCreateLayer": "Failed to create the layer '{{layerNameOrId}}'.",
       "noCapabilitiesOrEmpty": "No capabilities (or empty) found for layer '{{layerNameOrId}}'.",

--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -228,6 +228,7 @@
     "errorImageLoadSizeLimitExceededWidth": "The image requested for layer '{{layerName}}' exceeds the maximum width allowed by the server ({{requestedWidth}}px > {{maxWidth}}px).",
     "errorImageLoadSizeLimitExceededHeight": "The image requested for layer '{{layerName}}' exceeds the maximum height allowed by the server ({{requestedHeight}}px > {{maxHeight}}px).",
     "errorImageLoadNoImageReturned": "No image was returned from the server for layer '{{layerName}}'.",
+    "errorTileLoad": "An error occurred with a tile for layer '{{layerName}}'.",
     "errorNoLastQueryToPerform": "No last query to perform.",
     "errorProj": "Projection '{{projectionCode}}' invalid.",
     "errorResponseNoFeaturesProperty": "The response from the service didn't provide a 'features' property.",

--- a/packages/geoview-core/public/locales/en/translation.json
+++ b/packages/geoview-core/public/locales/en/translation.json
@@ -289,6 +289,7 @@
     "layerTimeDimension": "Temporal dimension (time-slider): ",
     "layerTimeDimensionField": "Field",
     "layerServiceProjection": "Service projection",
+    "layerServiceProjectionAndMore": "and more",
     "layerHoverable": "Information on mouse over",
     "layerQueryable": "Queryable on mouse click",
     "layerQueryableSource": "Source is queryable",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -416,7 +416,7 @@
       "missingSourceProjection": "Le paramètre source.projection est obligatoire.",
       "unableToFetch": "Impossible de récupérer et de lire les métadonnées pour la couche '{{layerNameOrId}}'.",
       "wmtsMetadataError": "Erreur avec les métadonnées WMTS pour la couche '{{layerNameOrId}}' : {{missingElement}} manquant dans les métadonnées.",
-      "serviceMetadataEmpty": "Les métadonnées du service sont vides pour la couche '{{layerNameOrId}}'.",
+      "serviceMetadataEmpty": "Les métadonnées du service sont vides ou insuffisantes pour la couche '{{layerNameOrId}}'.",
       "invalidLayerFilter": "La couche '{{layerNameOrPath}}' contient un filtre invalide.\nfiltre = '{{layerFilter}}'\nfiltre interne = '{{filter}}'.",
       "failedToCreateLayer": "Échec de la création de la couche '{{layerNameOrId}}'.",
       "noCapabilitiesOrEmpty": "Aucune capacité trouvée (ou vide) pour la couche '{{layerNameOrId}}'.",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -228,6 +228,7 @@
     "errorImageLoadSizeLimitExceededWidth": "L'image demandée pour la couche '{{layerName}}' dépasse la taille maximale en largeur autorisée par le serveur ({{requestedWidth}}px > {{maxWidth}}px).",
     "errorImageLoadSizeLimitExceededHeight": "L'image demandée pour la couche '{{layerName}}' dépasse la taille maximale en hauteur autorisée par le serveur ({{requestedHeight}}px > {{maxHeight}}px).",
     "errorImageLoadNoImageReturned": "Aucune image n'a été renvoyée par le serveur pour la couche '{{layerName}}'.",
+    "errorTileLoad": "Une erreur est survenue avec une tuile pour la couche '{{layerName}}'.",
     "errorNoLastQueryToPerform": "Aucune dernière requête à effectuer.",
     "errorProj": "Projection {{projectionCode}} invalide.",
     "errorResponseNoFeaturesProperty": "La réponse du service ne contient pas de propriété 'features'.",

--- a/packages/geoview-core/public/locales/fr/translation.json
+++ b/packages/geoview-core/public/locales/fr/translation.json
@@ -289,6 +289,7 @@
     "layerTimeDimension": "Dimension temporelle (curseur temporel): ",
     "layerTimeDimensionField": "Champ",
     "layerServiceProjection": "Projection du service",
+    "layerServiceProjectionAndMore": "et plus",
     "layerHoverable": "Information au survol de la souris",
     "layerQueryable": "Interrogeable au clic de la souris",
     "layerQueryableSource": "Source est interrogeable",

--- a/packages/geoview-core/src/api/config/config-api.ts
+++ b/packages/geoview-core/src/api/config/config-api.ts
@@ -634,7 +634,16 @@ export class ConfigApi {
       case 'ogcFeature':
         return OgcFeature.processGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL, layerIds as string[], isTimeAware);
       case 'ogcWfs':
-        return WFS.processGeoviewLayerConfig(geoviewLayerId, geoviewLayerName, layerURL, layerIds as string[], isTimeAware, 'all', true);
+        return WFS.processGeoviewLayerConfig(
+          geoviewLayerId,
+          geoviewLayerName,
+          layerURL,
+          undefined,
+          layerIds as string[],
+          isTimeAware,
+          'all',
+          true
+        );
       default:
         // Unsupported
         throw new NotSupportedError(`Unsupported layer type ${layerType}`);

--- a/packages/geoview-core/src/api/config/geocore.ts
+++ b/packages/geoview-core/src/api/config/geocore.ts
@@ -53,7 +53,7 @@ export class GeoCore {
     }
 
     // Get the GV config from UUID and await
-    const response = await UUIDmapConfigReader.getGVConfigFromUUIDs(geocoreUrl, language, [uuid.split(':')[0]], abortSignal);
+    const response = await UUIDmapConfigReader.getGVConfigFromUUIDs(geocoreUrl!, language, [uuid.split(':')[0]], abortSignal);
 
     // For each found GeoChart associated with the Geocore UUIDs
     const geocharts: { [key: string]: GeoViewGeoChartConfig } = {};

--- a/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
@@ -54,7 +54,7 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
   /** The projection code as read from the metadata. */
   #metadataProjection?: OLProjection;
 
-  /** The proxy to use, when necessary */
+  /** The proxy to use, when one is being used */
   #proxy?: string;
 
   /** The data access path before applying the proxy. */
@@ -606,8 +606,9 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
 
   /**
    * Gets the proxy URL used for the layer's data access.
+   * GV Not to be confused with the layer processing function of the same name.
    *
-   * @returns The proxy URL, or undefined if no proxy is configured
+   * @returns The proxy URL, or undefined if no proxy is being used
    */
   getProxyUrl(): string | undefined {
     return this.#proxy;
@@ -615,6 +616,7 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
 
   /**
    * Sets the proxy URL to be used for the layer's data access.
+   * GV Not to be confused with the layer processing function of the same name.
    *
    * @param proxy - The proxy URL to set
    */
@@ -625,6 +627,7 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
 
   /**
    * Indicates whether the layer is using a proxy to connect to its service.
+   * GV Not to be confused with the layer processing function of the same name.
    *
    * @returns `true` if the layer is using a proxy; otherwise, `false`
    */

--- a/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
@@ -54,8 +54,11 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
   /** The projection code as read from the metadata. */
   #metadataProjection?: OLProjection;
 
-  /** Whether the layer is using proxy to connect to the service */
-  #isUsingProxy = false;
+  /** The proxy to use, when necessary */
+  #proxy?: string;
+
+  /** The data access path before applying the proxy. */
+  #dataAccessPathBeforeProxy?: string;
 
   /** The geometry field information. */
   #geometryField?: TypeOutfields;
@@ -553,6 +556,17 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
   }
 
   /**
+   * Gets the original data access path before the proxy was applied.
+   *
+   * Falls back to the current data access path if no proxy has been set.
+   *
+   * @returns The data access path before proxy application
+   */
+  getDataAccessPathBeforeProxy(): string {
+    return this.#dataAccessPathBeforeProxy ?? this.getDataAccessPath();
+  }
+
+  /**
    * Overrides the data access path using the value provided by metadata.
    *
    * If the metadata source does not define a data access path, no action is taken.
@@ -591,21 +605,40 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
   }
 
   /**
+   * Gets the proxy URL used for the layer's data access.
+   *
+   * @returns The proxy URL, or undefined if no proxy is configured
+   */
+  getProxyUrl(): string | undefined {
+    return this.#proxy;
+  }
+
+  /**
+   * Sets the proxy URL to be used for the layer's data access.
+   *
+   * @param proxy - The proxy URL to set
+   */
+  setProxyUrl(proxy: string | undefined): void {
+    if (proxy) this.#dataAccessPathBeforeProxy = this.getDataAccessPath();
+    this.#proxy = proxy;
+  }
+
+  /**
    * Indicates whether the layer is using a proxy to connect to its service.
    *
    * @returns `true` if the layer is using a proxy; otherwise, `false`
    */
   getIsUsingProxy(): boolean {
-    return this.#isUsingProxy;
+    return !!this.#proxy;
   }
 
   /**
-   * Sets whether the layer is using a proxy to connect to its service.
+   * Indicates whether the layer is using an ESRI proxy.
    *
-   * @param isUsingProxy - `true` if the layer is using a proxy; otherwise, `false`
+   * @returns `true` if the proxy URL matches the ESRI proxy pattern; otherwise, `false`
    */
-  setIsUsingProxy(isUsingProxy: boolean): void {
-    this.#isUsingProxy = isUsingProxy;
+  getIsUsingEsriProxy(): boolean {
+    return GeoUtilities.IS_ESRI_PROXY(this.getProxyUrl());
   }
 
   /**

--- a/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/abstract-base-layer-entry-config.ts
@@ -638,7 +638,7 @@ export abstract class AbstractBaseLayerEntryConfig extends ConfigBaseClass {
    * @returns `true` if the proxy URL matches the ESRI proxy pattern; otherwise, `false`
    */
   getIsUsingEsriProxy(): boolean {
-    return GeoUtilities.IS_ESRI_PROXY(this.getProxyUrl());
+    return GeoUtilities.isEsriProxy(this.getProxyUrl());
   }
 
   /**

--- a/packages/geoview-core/src/api/config/validation-classes/config-base-class.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/config-base-class.ts
@@ -609,26 +609,50 @@ export abstract class ConfigBaseClass {
 
   /**
    * Sets the layer status to loading.
+   *
+   * @param updateStatusParents - Indicate whether to update the status of parent layers as well.
    */
-  setLayerStatusLoading(): void {
+  setLayerStatusLoading(updateStatusParents: boolean): void {
     // Redirect
     this.setLayerStatus(LAYER_STATUS.LOADING);
+
+    // If setting parent to loaded as well
+    if (updateStatusParents) {
+      // Update the parent group if any
+      this.updateLayerStatusParent();
+    }
   }
 
   /**
    * Sets the layer status to loaded.
+   *
+   * @param updateStatusParents - Indicate whether to update the status of parent layers as well.
    */
-  setLayerStatusLoaded(): void {
+  setLayerStatusLoaded(updateStatusParents: boolean): void {
     // Redirect
     this.setLayerStatus(LAYER_STATUS.LOADED);
+
+    // If setting parent to loaded as well
+    if (updateStatusParents) {
+      // Update the parent group if any
+      this.updateLayerStatusParent();
+    }
   }
 
   /**
    * Sets the layer status to error.
+   *
+   * @param updateStatusParents - Indicate whether to update the status of parent layers as well.
    */
-  setLayerStatusError(): void {
+  setLayerStatusError(updateStatusParents: boolean): void {
     // Redirect
     this.setLayerStatus(LAYER_STATUS.ERROR);
+
+    // If setting parent to error as well
+    if (updateStatusParents) {
+      // Update the parent group if any
+      this.updateLayerStatusParent();
+    }
   }
 
   /**
@@ -855,9 +879,7 @@ export abstract class ConfigBaseClass {
     // If at least one layer is loading
     if (siblingsInLoading.length > 0) {
       // Set the parent layer status as loading
-      parentLayerConfig.setLayerStatusLoading();
-      // Continue with the parent
-      ConfigBaseClass.#updateLayerStatusParentRec(parentLayerConfig);
+      parentLayerConfig.setLayerStatusLoading(true);
       return;
     }
 
@@ -867,9 +889,7 @@ export abstract class ConfigBaseClass {
     // If all siblings are loaded
     if (siblings.length === siblingsInLoaded.length) {
       // Set the parent layer status as loaded
-      parentLayerConfig.setLayerStatusLoaded();
-      // Continue with the parent
-      ConfigBaseClass.#updateLayerStatusParentRec(parentLayerConfig);
+      parentLayerConfig.setLayerStatusLoaded(true);
       return;
     }
 
@@ -880,13 +900,11 @@ export abstract class ConfigBaseClass {
     if (siblings.length === siblingsInTerminalState.length) {
       // If at least one sibling is loaded, the parent is loaded (partial success — some children loaded, some errored)
       if (siblingsInLoaded.length > 0) {
-        parentLayerConfig.setLayerStatusLoaded();
+        parentLayerConfig.setLayerStatusLoaded(true);
       } else {
         // All siblings are in error
-        parentLayerConfig.setLayerStatusError();
+        parentLayerConfig.setLayerStatusError(true);
       }
-      // Continue with the parent
-      ConfigBaseClass.#updateLayerStatusParentRec(parentLayerConfig);
     }
   }
 

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
@@ -356,9 +356,10 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
    * 3. Modifying each generated entry to include the current WMS layer ID.
    * 4. Returning the first generated WFS layer configuration.
    *
+   * @param configProxyUrl - Proxy URL to use when necessary
    * @returns A promise that resolves with the first generated WFS layer entry configuration
    */
-  async createGeoviewLayerConfigWfs(): Promise<OgcWfsLayerEntryConfig> {
+  async createGeoviewLayerConfigWfs(configProxyUrl: string | undefined): Promise<OgcWfsLayerEntryConfig> {
     // The base url
     let url = this.getMetadataAccessPath()!;
 
@@ -370,6 +371,7 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
       'wfsConfigForWms',
       `Temporary WFS layer config for the WMS layer '${this.getLayerNameCascade()}'`,
       url,
+      configProxyUrl,
       [this.getWfsStylesLayerId() || this.layerId],
       false,
       'all',

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
@@ -395,7 +395,7 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
    */
   override async onRefreshMetadata(displayDateMode: DisplayDateMode): Promise<void> {
     // Refetch the metadata again with the new date mode and update the config
-    const layerMetadata = await WMS.fetchMetadataWMSForLayer(this.getMetadataAccessPath()!, this.layerId);
+    const layerMetadata = await WMS.fetchMetadataWMSForLayer(this.getMetadataAccessPath()!, undefined, this.layerId);
 
     // Read the capabilities
     const layerCapabilities = WMS.findLayerMetadataInCapability(this.layerId, layerMetadata.Capability.Layer);

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/ogc-wms-layer-entry-config.ts
@@ -395,7 +395,7 @@ export class OgcWmsLayerEntryConfig extends AbstractBaseLayerEntryConfig {
    */
   override async onRefreshMetadata(displayDateMode: DisplayDateMode): Promise<void> {
     // Refetch the metadata again with the new date mode and update the config
-    const layerMetadata = await WMS.fetchMetadataWMSForLayer(this.getMetadataAccessPath()!, undefined, this.layerId);
+    const layerMetadata = await WMS.fetchMetadataWMSForLayer(this.getMetadataAccessPath()!, this.getProxyUrl(), this.layerId);
 
     // Read the capabilities
     const layerCapabilities = WMS.findLayerMetadataInCapability(this.layerId, layerMetadata.Capability.Layer);

--- a/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/xyz-layer-entry-config.ts
+++ b/packages/geoview-core/src/api/config/validation-classes/raster-validation-classes/xyz-layer-entry-config.ts
@@ -34,11 +34,14 @@ export class XYZTilesLayerEntryConfig extends TileLayerEntryConfig {
     // Value for this.source.featureInfo.queryable can only be false.
     this.setQueryableSource(false);
 
-    // If pointing to something else than {z}/{y}/{x}
-    if (!this.getDataAccessPath().includes('{z}/{y}/{x}')) {
-      // Set it
+    // If there's no z,y,z parameters in the data access path, append it to the end of the path (e.g. Esri XYZ service)
+    if (!XYZTilesLayerEntryConfig.containsXYZParams(this.getDataAccessPath())) {
+      // Append the tile/{z}/{y}/{x}
       this.setDataAccessPath(`${this.getDataAccessPath(true)}tile/{z}/{y}/{x}`);
     }
+
+    // If the layer entry config has no layerId (that's possible for XYZ Tile layer when there's only a dataAccessPath), default to 0
+    this.layerId ??= '0';
   }
 
   // #region OVERRIDES
@@ -85,6 +88,16 @@ export class XYZTilesLayerEntryConfig extends TileLayerEntryConfig {
   static isClassOrTypeXYZTiles(layerConfig: ConfigClassOrType | TypeGeoviewLayerConfig): layerConfig is TypeXYZTilesConfig {
     // Redirect
     return this.isClassOrTypeSchemaTag(layerConfig, CONST_LAYER_TYPES.XYZ_TILES);
+  }
+
+  /**
+   * Checks whether the given URL contains the XYZ tile parameters ({x}, {y}, {z}).
+   *
+   * @param url - The URL to check
+   * @returns `true` if the URL contains the XYZ tile parameters; otherwise `false`
+   */
+  static containsXYZParams(url: string): boolean {
+    return url.includes('{x}') && url.includes('{y}') && url.includes('{z}');
   }
 
   // #endregion STATIC METHODS

--- a/packages/geoview-core/src/api/types/map-schema-types.ts
+++ b/packages/geoview-core/src/api/types/map-schema-types.ts
@@ -176,7 +176,7 @@ export type TypeServiceUrls = {
    * Service end point to access API for layers specification (loading and plugins parameters). By default it is GeoCore but can
    * be another endpoint with similar output. Default = CONFIG_GEOCORE_URL ('https://geocore.api.geo.ca').
    */
-  geocoreUrl: string;
+  geocoreUrl?: string;
   /**
    * Service end point to access API for layers specification for RCS gcGeo.
    */

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -892,66 +892,70 @@ export function AddNewLayer(): JSX.Element {
         // Clear previous errors when input changes
         setUrlError(false);
         setUrlErrorMessage('');
-        // Allow blob URLs (local files) and GeoCore UUIDs without validation
-        if (layerURL.startsWith('blob') || isValidUUID(layerURL.trim())) {
-          // Check if this UUID is already loaded on the map
-          if (isValidUUID(layerURL.trim()) && layerController.getGeoviewLayerIds().includes(layerURL.trim())) {
-            setStepButtonEnabled(false);
-            setUrlError(true);
-            setUrlErrorMessage(t('layers.errorUrlDuplicateUUID'));
-            uiController.addMessage('error', 'layers.errorUrlDuplicateUUID', {});
-            return;
-          }
+
+        const trimmedUrl = layerURL.trim();
+
+        // Nothing to validate if empty
+        if (!trimmedUrl) {
+          setStepButtonEnabled(false);
+          return;
+        }
+
+        // Allow blob URLs (local files) without validation
+        if (layerURL.startsWith('blob')) {
           setStepButtonEnabled(true);
           return;
         }
 
-        // Validate and ping HTTPS URLs
-        if (layerURL.startsWith('https://')) {
-          setIsLoading(true);
-          try {
-            const check = await validateAndPingUrl(layerURL, proxyUrl);
-            logger.logDebug('URL validation check', check);
-            const isOk = check.isValid && check.isReachable;
-            setStepButtonEnabled(isOk);
-            if (!isOk) {
-              setUrlError(true);
-              if (check.error) {
-                setUrlErrorMessage(t('layers.errorUrlUnreachable'));
-                uiController.addMessage('error', 'layers.errorUrlUnreachable', {});
-              } else if (!check.isValid) {
-                setUrlErrorMessage(t('layers.errorUrlInvalid'));
-                uiController.addMessage('error', 'layers.errorUrlInvalid', {});
-              } else {
-                setUrlErrorMessage(t('layers.errorUrlUnreachable'));
-                uiController.addMessage('error', 'layers.errorUrlUnreachable', {});
-              }
-            }
-          } catch (error: unknown) {
-            // Handle exceptions from validateAndPingUrl (network errors, timeouts, etc.)
-            logger.logError('URL validation failed', error);
+        // Allow GeoCore UUIDs without ping validation, but check for duplicates
+        if (isValidUUID(trimmedUrl)) {
+          if (layerController.getGeoviewLayerIds().includes(trimmedUrl)) {
             setStepButtonEnabled(false);
             setUrlError(true);
-            setUrlErrorMessage(t('layers.errorUrlUnreachable'));
-            uiController.addMessage('error', 'layers.errorUrlUnreachable', {});
-          } finally {
-            setIsLoading(false);
+            setUrlErrorMessage(t('layers.errorUrlDuplicateUUID'));
+            uiController.addMessage('error', 'layers.errorUrlDuplicateUUID', {});
+          } else {
+            setStepButtonEnabled(true);
           }
-        } else {
-          // This else block MUST remain outside the try-catch
-          // It handles invalid UUID format and non-HTTPS URLs
+          return;
+        }
+
+        // Reject non-HTTPS URLs (not blob, not UUID)
+        if (!layerURL.startsWith('https://')) {
           setStepButtonEnabled(false);
-          if (layerURL.trim() !== '') {
-            const trimmedUrl = layerURL.trim();
-            setUrlError(true);
-            if (!isValidUUID(trimmedUrl) && !trimmedUrl.includes('.') && !trimmedUrl.includes('/')) {
-              setUrlErrorMessage(t('layers.errorUrlInvalidUUID'));
-              uiController.addMessage('error', 'layers.errorUrlInvalidUUID', {});
-            } else {
-              setUrlErrorMessage(t('layers.errorUrlHttps'));
-              uiController.addMessage('error', 'layers.errorUrlHttps', {});
-            }
+          setUrlError(true);
+          // Distinguish between malformed UUID attempts and plain HTTP URLs
+          if (!trimmedUrl.includes('.') && !trimmedUrl.includes('/')) {
+            setUrlErrorMessage(t('layers.errorUrlInvalidUUID'));
+            uiController.addMessage('error', 'layers.errorUrlInvalidUUID', {});
+          } else {
+            setUrlErrorMessage(t('layers.errorUrlHttps'));
+            uiController.addMessage('error', 'layers.errorUrlHttps', {});
           }
+          return;
+        }
+
+        // Validate and ping HTTPS URLs
+        setIsLoading(true);
+        try {
+          const check = await validateAndPingUrl(layerURL, proxyUrl);
+          logger.logDebug('URL validation check', check);
+          const isOk = check.isValid && check.isReachable;
+          setStepButtonEnabled(isOk);
+          if (!isOk) {
+            setUrlError(true);
+            const errorKey = !check.isValid ? 'layers.errorUrlInvalid' : 'layers.errorUrlUnreachable';
+            setUrlErrorMessage(t(errorKey));
+            uiController.addMessage('error', errorKey, {});
+          }
+        } catch (error: unknown) {
+          logger.logError('URL validation failed', error);
+          setStepButtonEnabled(false);
+          setUrlError(true);
+          setUrlErrorMessage(t('layers.errorUrlUnreachable'));
+          uiController.addMessage('error', 'layers.errorUrlUnreachable', {});
+        } finally {
+          setIsLoading(false);
         }
       };
 

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -25,7 +25,7 @@ import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { useStoreAppDisabledLayerTypes, useStoreAppDisplayLanguage, useStoreAppShellContainer } from '@/core/stores/states/app-state';
 import { useStoreMapConfigServiceUrlsProxyUrl } from '@/core/stores/states/map-state';
 import { logger } from '@/core/utils/logger';
-import { delay, generateId, isValidUUID, validateAndPingUrl } from '@/core/utils/utilities';
+import { delay, generateId, isValidUUID, validateAndPingUrlOGC } from '@/core/utils/utilities';
 import { VALID_FILE_EXTENSIONS_ACCEPT } from '@/core/utils/constant';
 import { Config } from '@/api/config/config';
 import type { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
@@ -938,7 +938,7 @@ export function AddNewLayer(): JSX.Element {
         // Validate and ping HTTPS URLs
         setIsLoading(true);
         try {
-          const check = await validateAndPingUrl(layerURL, configProxyUrl);
+          const check = await validateAndPingUrlOGC(layerURL, configProxyUrl);
           logger.logDebug('URL validation check', check);
           const isOk = check.isValid && check.isReachable;
           setStepButtonEnabled(isOk);

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -20,9 +20,10 @@ import {
   Stepper,
   TextField,
 } from '@/ui';
+import { ConfigApi } from '@/api/config/config-api';
 import { useStoreGeoViewMapId } from '@/core/stores/geoview-store';
 import { useStoreAppDisabledLayerTypes, useStoreAppDisplayLanguage, useStoreAppShellContainer } from '@/core/stores/states/app-state';
-import { ConfigApi } from '@/api/config/config-api';
+import { useStoreMapConfigServiceUrlsProxyUrl } from '@/core/stores/states/map-state';
 import { logger } from '@/core/utils/logger';
 import { delay, generateId, isValidUUID, validateAndPingUrl } from '@/core/utils/utilities';
 import { VALID_FILE_EXTENSIONS_ACCEPT } from '@/core/utils/constant';
@@ -357,6 +358,7 @@ export function AddNewLayer(): JSX.Element {
   const disabledLayerTypes = useStoreAppDisabledLayerTypes();
   const language = useStoreAppDisplayLanguage();
   const shellContainer = useStoreAppShellContainer();
+  const proxyUrl = useStoreMapConfigServiceUrlsProxyUrl();
   const uiController = useUIController();
   const geoChartController = useGeoChartControllerIfExists();
   const layerController = useLayerController();
@@ -908,7 +910,7 @@ export function AddNewLayer(): JSX.Element {
         if (layerURL.startsWith('https://')) {
           setIsLoading(true);
           try {
-            const check = await validateAndPingUrl(layerURL);
+            const check = await validateAndPingUrl(layerURL, proxyUrl);
             logger.logDebug('URL validation check', check);
             const isOk = check.isValid && check.isReachable;
             setStepButtonEnabled(isOk);
@@ -965,7 +967,7 @@ export function AddNewLayer(): JSX.Element {
     }
     if (activeStep === 2 && layerIdsToAdd.length > 0) setStepButtonEnabled(true);
     if (activeStep === 2 && !layerIdsToAdd.length) setStepButtonEnabled(false);
-  }, [layerURL, activeStep, layerIdsToAdd, layerType, uiController, layerController, t]);
+  }, [layerURL, activeStep, layerIdsToAdd, layerType, uiController, layerController, proxyUrl, t]);
 
   /**
    * Manages focus when Step 2 validation errors occur.

--- a/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
+++ b/packages/geoview-core/src/core/components/layers/left-panel/add-new-layer/add-new-layer.tsx
@@ -358,7 +358,7 @@ export function AddNewLayer(): JSX.Element {
   const disabledLayerTypes = useStoreAppDisabledLayerTypes();
   const language = useStoreAppDisplayLanguage();
   const shellContainer = useStoreAppShellContainer();
-  const proxyUrl = useStoreMapConfigServiceUrlsProxyUrl();
+  const configProxyUrl = useStoreMapConfigServiceUrlsProxyUrl();
   const uiController = useUIController();
   const geoChartController = useGeoChartControllerIfExists();
   const layerController = useLayerController();
@@ -938,7 +938,7 @@ export function AddNewLayer(): JSX.Element {
         // Validate and ping HTTPS URLs
         setIsLoading(true);
         try {
-          const check = await validateAndPingUrl(layerURL, proxyUrl);
+          const check = await validateAndPingUrl(layerURL, configProxyUrl);
           logger.logDebug('URL validation check', check);
           const isOk = check.isValid && check.isReachable;
           setStepButtonEnabled(isOk);
@@ -971,7 +971,7 @@ export function AddNewLayer(): JSX.Element {
     }
     if (activeStep === 2 && layerIdsToAdd.length > 0) setStepButtonEnabled(true);
     if (activeStep === 2 && !layerIdsToAdd.length) setStepButtonEnabled(false);
-  }, [layerURL, activeStep, layerIdsToAdd, layerType, uiController, layerController, proxyUrl, t]);
+  }, [layerURL, activeStep, layerIdsToAdd, layerType, uiController, layerController, configProxyUrl, t]);
 
   /**
    * Manages focus when Step 2 validation errors occur.

--- a/packages/geoview-core/src/core/components/layers/right-panel/layer-info/layer-info.tsx
+++ b/packages/geoview-core/src/core/components/layers/right-panel/layer-info/layer-info.tsx
@@ -160,7 +160,9 @@ export function LayerInfoPanel({ layerPath }: LayerInfoPanelProps): JSX.Element 
         <Box sx={memoSxClasses.infoSectionContent}>
           {isLocalhost() && <Box>{`${t('layers.layerPath')}: ${layerPath}`}</Box>}
           <Box>{`${t('layers.layerType')}${memoLocalizedTypeName}`}</Box>
-          {layerDataProjectionCode && <Box>{`${t('layers.layerServiceProjection')}: ${layerDataProjectionCode}`}</Box>}
+          {layerDataProjectionCode && (
+            <Box>{`${t('layers.layerServiceProjection')}: ${layerDataProjectionCode}${schemaTag === CONST_LAYER_TYPES.WMS ? ` (${t('layers.layerServiceProjectionAndMore')})` : ''}`}</Box>
+          )}
           {memoResources !== '' && (
             <Box className="info-container">
               {`${t('layers.layerResource')}`}

--- a/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
@@ -685,6 +685,10 @@ export class LayerCreatorController extends AbstractMapViewerController {
     // Create the layer for the processing
     const layerBeingAdded = LayerCreatorController.createLayerConfigFromType(geoviewLayerConfig);
 
+    // Set the map-level service URLs configuration so the layer knows which proxy to use
+    const { serviceUrls } = this.getMapViewer().mapFeaturesConfig;
+    if (serviceUrls) layerBeingAdded.setConfigServiceUrls(serviceUrls);
+
     // Add in the geoviewLayers set
     this.#geoviewLayers[layerBeingAdded.getGeoviewLayerId()] = layerBeingAdded;
 

--- a/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
+++ b/packages/geoview-core/src/core/controllers/layer-creator-controller.ts
@@ -685,7 +685,7 @@ export class LayerCreatorController extends AbstractMapViewerController {
     // Create the layer for the processing
     const layerBeingAdded = LayerCreatorController.createLayerConfigFromType(geoviewLayerConfig);
 
-    // Set the map-level service URLs configuration so the layer knows which proxy to use
+    // Set the map-level service URLs configuration so the layer knows service urls to use
     const { serviceUrls } = this.getMapViewer().mapFeaturesConfig;
     if (serviceUrls) layerBeingAdded.setConfigServiceUrls(serviceUrls);
 

--- a/packages/geoview-core/src/core/exceptions/geoview-exceptions.ts
+++ b/packages/geoview-core/src/core/exceptions/geoview-exceptions.ts
@@ -721,6 +721,26 @@ export class LayerImageFailedNoImageError extends GeoViewError {
 }
 
 /**
+ * Error thrown when a Tiled Layer fails to produce a tile on the map.
+ */
+export class LayerTileFailedToLoadError extends GeoViewError {
+  /**
+   * Creates an instance of LayerTileFailedToLoadError.
+   *
+   * @param layerName - The layer name of the layer tile that couldn't produce a tile
+   */
+  constructor(layerName: string, cause?: Error) {
+    super('layers.errorTileLoad', { layerName }, { cause });
+
+    // Set a custom name for the error type to differentiate it from other error types
+    this.name = 'LayerTileFailedToLoadError';
+
+    // Ensure correct inheritance (important for transpilation targets)
+    Object.setPrototypeOf(this, LayerTileFailedToLoadError.prototype);
+  }
+}
+
+/**
  * Error thrown when there's no last query to perform.
  */
 export class LayerNoLastQueryToPerformError extends GeoViewError {

--- a/packages/geoview-core/src/core/stores/states/map-state.ts
+++ b/packages/geoview-core/src/core/stores/states/map-state.ts
@@ -888,6 +888,10 @@ export const getStoreMapConfigGlobalSettings = (mapId: string): TypeGlobalSettin
 /** Returns the service URLs from the map config. */
 export const getStoreMapConfigServiceUrls = (mapId: string): TypeServiceUrls => getStoreMapConfigState(mapId).serviceUrls;
 
+/** Returns the proxy URL from the service URLs in the map config. */
+export const useStoreMapConfigServiceUrlsProxyUrl = (): string | undefined =>
+  useStore(useGeoViewStore(), (state) => state.mapConfig?.serviceUrls.proxyUrl);
+
 /** Returns the config metadata from the map config. */
 export const getStoreMapConfigMeta = (mapId: string): TypeConfigMeta | undefined => getStoreMapConfigState(mapId).configMeta;
 

--- a/packages/geoview-core/src/core/utils/ogc-url-helper.ts
+++ b/packages/geoview-core/src/core/utils/ogc-url-helper.ts
@@ -53,7 +53,7 @@ export function ensureServiceRequestUrl(url: string, service: string, request: s
 export function encodeLayersParam(url: string): string {
   // Use regex (not URL parsing) so we don't touch the rest of the URL.
   // This preserves proxy-style URLs that embed another URL after `?`
-  // (e.g. "{...proxyUrl...}?https://other?layer=foo").
+  // (e.g. "{...configProxyUrl...}?https://other?layer=foo").
   return url.replace(/([?&])(layers?)=([^&]*)/gi, (_match, sep: string, key: string, value: string) => {
     return `${sep}${key}=${encodeURIComponent(value)}`;
   });

--- a/packages/geoview-core/src/core/utils/ogc-url-helper.ts
+++ b/packages/geoview-core/src/core/utils/ogc-url-helper.ts
@@ -53,7 +53,7 @@ export function ensureServiceRequestUrl(url: string, service: string, request: s
 export function encodeLayersParam(url: string): string {
   // Use regex (not URL parsing) so we don't touch the rest of the URL.
   // This preserves proxy-style URLs that embed another URL after `?`
-  // (e.g. ".../executeFromProxy?https://other?layer=foo").
+  // (e.g. "{...proxyUrl...}?https://other?layer=foo").
   return url.replace(/([?&])(layers?)=([^&]*)/gi, (_match, sep: string, key: string, value: string) => {
     return `${sep}${key}=${encodeURIComponent(value)}`;
   });

--- a/packages/geoview-core/src/core/utils/utilities.ts
+++ b/packages/geoview-core/src/core/utils/utilities.ts
@@ -489,8 +489,14 @@ export async function validateAndPingUrl(
     status: null,
   };
 
+  // Replace XYZ tile template placeholders with valid sample coordinates so the URL is pingable
+  const resolvedUrl = targetUrl
+    .replace(/\{z\}/gi, '0')
+    .replace(/\{x\}/gi, '0')
+    .replace(/\{-?y\}/gi, '0');
+
   // Strip query params for the reachability check
-  const targetUrlWithoutParams = targetUrl.split('?')[0];
+  const targetUrlWithoutParams = resolvedUrl.split('?')[0];
 
   // Syntax validation
   try {
@@ -503,9 +509,9 @@ export async function validateAndPingUrl(
 
   // Build OGC GetCapabilities check URLs
   const ogcCheckUrls = [
-    ensureServiceRequestUrl(targetUrl, 'WMS', 'GetCapabilities'),
-    ensureServiceRequestUrl(targetUrl, 'WFS', 'GetCapabilities'),
-    ensureServiceRequestUrl(targetUrl, 'WMTS', 'GetCapabilities'),
+    ensureServiceRequestUrl(resolvedUrl, 'WMS', 'GetCapabilities'),
+    ensureServiceRequestUrl(resolvedUrl, 'WFS', 'GetCapabilities'),
+    ensureServiceRequestUrl(resolvedUrl, 'WMTS', 'GetCapabilities'),
   ];
 
   // HEAD request to see if the server responds

--- a/packages/geoview-core/src/core/utils/utilities.ts
+++ b/packages/geoview-core/src/core/utils/utilities.ts
@@ -4,6 +4,7 @@ import sanitizeHtml from 'sanitize-html';
 import { fromUrl } from 'geotiff';
 
 import type { TypeDisplayLanguage } from '@/api/types/map-schema-types';
+import { CONFIG_PROXY_URL } from '@/api/types/map-schema-types';
 import { logger } from '@/core/utils/logger';
 import i18n from '@/core/translation/i18n';
 import type { TypeGuideObject } from '@/core/stores/states/app-state';
@@ -11,7 +12,6 @@ import { Fetch } from '@/core/utils/fetch-helper';
 import { ensureServiceRequestUrl } from '@/core/utils/ogc-url-helper';
 import type { TypeHTMLElement } from '@/core/types/global-types';
 import { TIMEOUT, VALID_FILE_EXTENSIONS_REGEX } from '@/core/utils/constant';
-import { CONFIG_PROXY_URL } from '@/api/types/map-schema-types';
 
 /** The observers to monitor element removals from the DOM tree */
 const observers: Record<string, MutationObserver> = {};
@@ -473,13 +473,13 @@ async function probeFileUrl(url: string): Promise<boolean> {
  * The function never throws — all failures are returned as part of the result object.
  *
  * @param targetUrl - The URL to validate and ping
- * @param proxyBase - Optional proxy server base URL (defaults to CONFIG_PROXY_URL)
+ * @param proxyUrl - Proxy URL to use if necessary (defaults to CONFIG_PROXY_URL)
  * @param timeoutMs - Optional request timeout in milliseconds (defaults to none)
  * @returns A promise that resolves with a result object containing isValid, isReachable, needsProxy, status, and optional error
  */
 export async function validateAndPingUrl(
   targetUrl: string,
-  proxyBase: string = CONFIG_PROXY_URL,
+  proxyUrl: string = CONFIG_PROXY_URL,
   timeoutMs = undefined
 ): Promise<PingResult> {
   const result: PingResult = {
@@ -562,7 +562,7 @@ export async function validateAndPingUrl(
   if (reason === 'cors') {
     // Use fetchTextPermissive because the proxy may forward non-2xx responses
     // that still contain valid capabilities XML in the body.
-    const proxyChecks = await Promise.allSettled(ogcCheckUrls.map((checkUrl) => Fetch.fetchTextPermissive(`${proxyBase}?${checkUrl}`)));
+    const proxyChecks = await Promise.allSettled(ogcCheckUrls.map((checkUrl) => Fetch.fetchTextPermissive(`${proxyUrl}?${checkUrl}`)));
 
     // Same as above: if either WMS or WFS GetCapabilities succeeds through the proxy, it's reachable.
     for (const settled of proxyChecks) {
@@ -574,7 +574,7 @@ export async function validateAndPingUrl(
     }
 
     // Not a valid OGC service through proxy — try a lightweight GET for file-based URLs
-    if (VALID_FILE_EXTENSIONS_REGEX.test(targetUrlWithoutParams) && (await probeFileUrl(`${proxyBase}?${targetUrlWithoutParams}`))) {
+    if (VALID_FILE_EXTENSIONS_REGEX.test(targetUrlWithoutParams) && (await probeFileUrl(`${proxyUrl}?${targetUrlWithoutParams}`))) {
       result.isReachable = true;
       result.needsProxy = true;
       return result;

--- a/packages/geoview-core/src/core/utils/utilities.ts
+++ b/packages/geoview-core/src/core/utils/utilities.ts
@@ -473,7 +473,7 @@ async function probeFileUrl(url: string): Promise<boolean> {
  * The function never throws — all failures are returned as part of the result object.
  *
  * @param targetUrl - The URL to validate and ping
- * @param proxyUrl - Proxy URL to use if necessary (defaults to CONFIG_PROXY_URL)
+ * @param proxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
  * @param timeoutMs - Optional request timeout in milliseconds (defaults to none)
  * @returns A promise that resolves with a result object containing isValid, isReachable, needsProxy, status, and optional error
  */

--- a/packages/geoview-core/src/core/utils/utilities.ts
+++ b/packages/geoview-core/src/core/utils/utilities.ts
@@ -473,13 +473,13 @@ async function probeFileUrl(url: string): Promise<boolean> {
  * The function never throws — all failures are returned as part of the result object.
  *
  * @param targetUrl - The URL to validate and ping
- * @param proxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
+ * @param configProxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
  * @param timeoutMs - Optional request timeout in milliseconds (defaults to none)
  * @returns A promise that resolves with a result object containing isValid, isReachable, needsProxy, status, and optional error
  */
 export async function validateAndPingUrl(
   targetUrl: string,
-  proxyUrl: string = CONFIG_PROXY_URL,
+  configProxyUrl: string = CONFIG_PROXY_URL,
   timeoutMs = undefined
 ): Promise<PingResult> {
   const result: PingResult = {
@@ -568,7 +568,9 @@ export async function validateAndPingUrl(
   if (reason === 'cors') {
     // Use fetchTextPermissive because the proxy may forward non-2xx responses
     // that still contain valid capabilities XML in the body.
-    const proxyChecks = await Promise.allSettled(ogcCheckUrls.map((checkUrl) => Fetch.fetchTextPermissive(`${proxyUrl}?${checkUrl}`)));
+    const proxyChecks = await Promise.allSettled(
+      ogcCheckUrls.map((checkUrl) => Fetch.fetchTextPermissive(`${configProxyUrl}?${checkUrl}`))
+    );
 
     // Same as above: if either WMS or WFS GetCapabilities succeeds through the proxy, it's reachable.
     for (const settled of proxyChecks) {
@@ -580,7 +582,7 @@ export async function validateAndPingUrl(
     }
 
     // Not a valid OGC service through proxy — try a lightweight GET for file-based URLs
-    if (VALID_FILE_EXTENSIONS_REGEX.test(targetUrlWithoutParams) && (await probeFileUrl(`${proxyUrl}?${targetUrlWithoutParams}`))) {
+    if (VALID_FILE_EXTENSIONS_REGEX.test(targetUrlWithoutParams) && (await probeFileUrl(`${configProxyUrl}?${targetUrlWithoutParams}`))) {
       result.isReachable = true;
       result.needsProxy = true;
       return result;

--- a/packages/geoview-core/src/core/utils/utilities.ts
+++ b/packages/geoview-core/src/core/utils/utilities.ts
@@ -460,16 +460,16 @@ async function probeFileUrl(url: string): Promise<boolean> {
 }
 
 /**
- * Validates a URL's syntax and tests whether the server is reachable.
+ * Validates a URL's syntax and tests whether the server is reachable using a simple HEAD request
+ * with file extension probe fallback.
  *
  * Strategy:
  * 1. **HEAD → 2xx/3xx** → reachable, no proxy needed.
- * 2. **HEAD → 4xx/5xx** → server is alive but the bare path fails. Try OGC GetCapabilities
- *    directly (CORS was fine since HEAD got a response). If valid → reachable. Otherwise → not reachable.
- * 3. **HEAD → CORS** → server is alive but blocks cross-origin. Try OGC GetCapabilities
- *    through the proxy. If valid → reachable + needsProxy. Otherwise → not reachable.
+ * 2. **HEAD → 4xx/5xx** → try file extension probe. If valid → reachable. Otherwise → not reachable.
+ * 3. **HEAD → CORS** → try file extension probe through proxy. If valid → reachable + needsProxy. Otherwise → not reachable.
  * 4. **HEAD → network/timeout** → server unreachable.
  *
+ * This function has no OGC/GetCapabilities knowledge. For OGC-aware validation, use `validateAndPingUrl`.
  * The function never throws — all failures are returned as part of the result object.
  *
  * @param targetUrl - The URL to validate and ping
@@ -490,10 +490,11 @@ export async function validateAndPingUrl(
   };
 
   // Replace XYZ tile template placeholders with valid sample coordinates so the URL is pingable
+  // GV Putting '1' instead of '0', because some web services will accept 0/0/0.png but not any other tiles, e.g. https://maps.wikimedia.org/osm-intl/0/0/0.png
   const resolvedUrl = targetUrl
-    .replace(/\{z\}/gi, '0')
-    .replace(/\{x\}/gi, '0')
-    .replace(/\{-?y\}/gi, '0');
+    .replace(/\{z\}/gi, '1')
+    .replace(/\{x\}/gi, '1')
+    .replace(/\{-?y\}/gi, '1');
 
   // Strip query params for the reachability check
   const targetUrlWithoutParams = resolvedUrl.split('?')[0];
@@ -506,13 +507,6 @@ export async function validateAndPingUrl(
     result.error = 'Invalid URL format';
     return result;
   }
-
-  // Build OGC GetCapabilities check URLs
-  const ogcCheckUrls = [
-    ensureServiceRequestUrl(resolvedUrl, 'WMS', 'GetCapabilities'),
-    ensureServiceRequestUrl(resolvedUrl, 'WFS', 'GetCapabilities'),
-    ensureServiceRequestUrl(resolvedUrl, 'WMTS', 'GetCapabilities'),
-  ];
 
   // HEAD request to see if the server responds
   const { response, reason } = await Fetch.fetchHeadWithTimeout(targetUrlWithoutParams, timeoutMs);
@@ -527,29 +521,15 @@ export async function validateAndPingUrl(
     }
 
     // 4xx/5xx — server is alive but bare path fails.
-    // WMS/WFS services often return 4xx without query params. Since HEAD succeeded (no CORS issue),
-    // try GetCapabilities directly to see if it is a valid OGC service.
-    // Use fetchTextPermissive because OGC services may return valid capabilities XML with non-2xx status.
-    const directChecks = await Promise.allSettled(ogcCheckUrls.map((url) => Fetch.fetchTextPermissive(url)));
-
-    // We fire both WMS and WFS GetCapabilities in parallel. If either one returns a valid
-    // capabilities response, the URL is considered reachable — we don't need both to succeed.
-    for (const settled of directChecks) {
-      if (settled.status === 'fulfilled' && isOgcCapabilitiesResponse(settled.value)) {
-        result.isReachable = true;
-        return result;
-      }
-    }
-
-    // Not a valid OGC service — try a lightweight GET for file-based URLs
+    // Try a lightweight GET for file-based URLs
     if (VALID_FILE_EXTENSIONS_REGEX.test(targetUrlWithoutParams) && (await probeFileUrl(targetUrlWithoutParams))) {
       result.isReachable = true;
       return result;
     }
 
-    // The path is truly wrong
+    // The path is not reachable
     result.isReachable = false;
-    result.error = `Server returned status ${response.status} and no OGC service found at this URL`;
+    result.error = `Server returned status ${response.status}`;
     return result;
   }
 
@@ -564,24 +544,8 @@ export async function validateAndPingUrl(
   }
 
   // CORS — server is alive but blocks cross-origin.
-  // Try OGC GetCapabilities through proxy (only WMS/WFS have CORS issues).
+  // Try a lightweight GET for file-based URLs through proxy
   if (reason === 'cors') {
-    // Use fetchTextPermissive because the proxy may forward non-2xx responses
-    // that still contain valid capabilities XML in the body.
-    const proxyChecks = await Promise.allSettled(
-      ogcCheckUrls.map((checkUrl) => Fetch.fetchTextPermissive(`${configProxyUrl}?${checkUrl}`))
-    );
-
-    // Same as above: if either WMS or WFS GetCapabilities succeeds through the proxy, it's reachable.
-    for (const settled of proxyChecks) {
-      if (settled.status === 'fulfilled' && isOgcCapabilitiesResponse(settled.value)) {
-        result.isReachable = true;
-        result.needsProxy = true;
-        return result;
-      }
-    }
-
-    // Not a valid OGC service through proxy — try a lightweight GET for file-based URLs
     if (VALID_FILE_EXTENSIONS_REGEX.test(targetUrlWithoutParams) && (await probeFileUrl(`${configProxyUrl}?${targetUrlWithoutParams}`))) {
       result.isReachable = true;
       result.needsProxy = true;
@@ -589,12 +553,93 @@ export async function validateAndPingUrl(
     }
 
     result.isReachable = false;
-    result.error = 'Server blocks cross-origin requests and no OGC service found';
+    result.error = 'Server blocks cross-origin requests';
     return result;
   }
 
   // Unknown failure
   result.error = 'Unexpected error during URL validation';
+  return result;
+}
+
+/**
+ * Validates a URL's syntax and tests whether the server is reachable, with OGC GetCapabilities fallback.
+ *
+ * Strategy:
+ * 1. Calls `pingUrl` for basic HEAD + file probe validation.
+ * 2. If HEAD returned 4xx/5xx (server alive but bare path fails), tries OGC GetCapabilities
+ *    directly (WMS/WFS/WMTS) since CORS was fine.
+ * 3. If HEAD returned CORS error, tries OGC GetCapabilities through the proxy.
+ *
+ * The function never throws — all failures are returned as part of the result object.
+ *
+ * @param targetUrl - The URL to validate and ping
+ * @param configProxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
+ * @param timeoutMs - Optional request timeout in milliseconds (defaults to none)
+ * @returns A promise that resolves with a result object containing isValid, isReachable, needsProxy, status, and optional error
+ */
+export async function validateAndPingUrlOGC(
+  targetUrl: string,
+  configProxyUrl: string = CONFIG_PROXY_URL,
+  timeoutMs = undefined
+): Promise<PingResult> {
+  // First, try the simple ping
+  const result = await validateAndPingUrl(targetUrl, configProxyUrl, timeoutMs);
+
+  // If already reachable or invalid URL, return immediately
+  if (result.isReachable || !result.isValid) return result;
+
+  // Resolve XYZ placeholders for the OGC check URLs (same logic as validateAndPingUrl)
+  const resolvedUrl = targetUrl
+    .replace(/\{z\}/gi, '1')
+    .replace(/\{x\}/gi, '1')
+    .replace(/\{-?y\}/gi, '1');
+
+  // Build OGC GetCapabilities check URLs
+  const ogcCheckUrls = [
+    ensureServiceRequestUrl(resolvedUrl, 'WMS', 'GetCapabilities'),
+    ensureServiceRequestUrl(resolvedUrl, 'WFS', 'GetCapabilities'),
+    ensureServiceRequestUrl(resolvedUrl, 'WMTS', 'GetCapabilities'),
+  ];
+
+  // If server responded with 4xx/5xx (status is set), try OGC GetCapabilities directly
+  if (result.status !== null && result.status >= 400) {
+    const directChecks = await Promise.allSettled(ogcCheckUrls.map((url) => Fetch.fetchTextPermissive(url)));
+
+    for (const settled of directChecks) {
+      if (settled.status === 'fulfilled' && isOgcCapabilitiesResponse(settled.value)) {
+        result.isReachable = true;
+        result.error = undefined;
+        return result;
+      }
+    }
+
+    // Update error message
+    result.error = `Server returned status ${result.status} and no OGC service found at this URL`;
+    return result;
+  }
+
+  // If CORS blocked (status is null, error mentions cross-origin), try OGC GetCapabilities through proxy
+  if (result.error?.includes('cross-origin')) {
+    const proxyChecks = await Promise.allSettled(
+      ogcCheckUrls.map((checkUrl) => Fetch.fetchTextPermissive(`${configProxyUrl}?${checkUrl}`))
+    );
+
+    for (const settled of proxyChecks) {
+      if (settled.status === 'fulfilled' && isOgcCapabilitiesResponse(settled.value)) {
+        result.isReachable = true;
+        result.needsProxy = true;
+        result.error = undefined;
+        return result;
+      }
+    }
+
+    // Update error message
+    result.error = 'Server blocks cross-origin requests and no OGC service found';
+    return result;
+  }
+
+  // Return whatever pingUrl returned (timeout, network error, etc.)
   return result;
 }
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -9,7 +9,7 @@ import type { AbstractBaseLayerEntryConfig } from '@/api/config/validation-class
 import { GroupLayerEntryConfig } from '@/api/config/validation-classes/group-layer-entry-config';
 import type { EventDelegateBase } from '@/api/events/event-helper';
 import EventHelper from '@/api/events/event-helper';
-import type { DisplayDateMode } from '@/api/types/map-schema-types';
+import type { DisplayDateMode, TypeServiceUrls } from '@/api/types/map-schema-types';
 import type {
   TypeGeoviewLayerConfig,
   TypeLayerEntryConfig,
@@ -102,6 +102,9 @@ export abstract class AbstractGeoViewLayer {
 
   /** The service metadata. */
   #metadata?: unknown;
+
+  /** The map-level service URLs configuration (proxy, geocore, geolocator, etc.) for this layer's map instance. */
+  #configServiceUrls?: TypeServiceUrls;
 
   /** Callback delegates for the layer entry register init event */
   #onLayerEntryRegisterInitHandlers: LayerEntryRegisterInitDelegate[] = [];
@@ -283,6 +286,33 @@ export abstract class AbstractGeoViewLayer {
    */
   getGeoviewLayerConfig(): TypeGeoviewLayerConfig {
     return this.#geoviewLayerConfig;
+  }
+
+  /**
+   * Gets the map-level service URLs configuration for this layer's map instance.
+   *
+   * @returns The service URLs configuration, or undefined if not set
+   */
+  getConfigServiceUrls(): TypeServiceUrls | undefined {
+    return this.#configServiceUrls;
+  }
+
+  /**
+   * Gets the proxy URL from the map-level service URLs configuration.
+   *
+   * @returns The proxy URL, or undefined if not configured
+   */
+  getConfigProxyUrl(): string | undefined {
+    return this.getConfigServiceUrls()?.proxyUrl;
+  }
+
+  /**
+   * Sets the map-level service URLs configuration for this layer's map instance.
+   *
+   * @param serviceUrls - The service URLs configuration from the map features config
+   */
+  setConfigServiceUrls(serviceUrls: TypeServiceUrls): void {
+    this.#configServiceUrls = serviceUrls;
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -662,10 +662,7 @@ export abstract class AbstractGeoViewLayer {
     this.#layerLoadError.push(error);
 
     // Set the layer status to error
-    layerConfig?.setLayerStatusError();
-
-    // Propagate error to parent group layers, if any
-    layerConfig?.updateLayerStatusParent();
+    layerConfig?.setLayerStatusError(true);
   }
 
   /**
@@ -1405,13 +1402,13 @@ export abstract class AbstractGeoViewLayer {
         // Recursively set the status to the children
         AbstractGeoViewLayer.#setStatusErrorAll(error, layerConfig.listOfLayerEntryConfig);
         // Set the layer status to error
-        layerConfig?.setLayerStatusError();
+        layerConfig?.setLayerStatusError(false);
       } else {
         // If already set to error, don't touch it
         if (layerConfig.layerStatus === 'error') return;
 
         // Set the layer status to error
-        layerConfig?.setLayerStatusError();
+        layerConfig?.setLayerStatusError(false);
       }
     });
   }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -722,8 +722,10 @@ export abstract class AbstractGeoViewLayer {
    */
   async #fetchAndSetServiceMetadata(abortSignal?: AbortSignal): Promise<void> {
     try {
-      // If there's no metadata access path
-      // GV e.g.: CSV (csvLYR2) and some outlier demos, we want to skip those (not fail)
+      // If there's no metadata access path, we want to skip those
+      // GV e.g.: XYZ Tiles added via configuration without a metadataAccessPath
+      // GV e.g.: XYZ Tiles added via add-new-layer component like 'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
+      // GV e.g.: CSV (csvLYR2) and some outlier demos
       if (!this.hasMetadataAccessPath()) return;
 
       // Log

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -106,6 +106,9 @@ export abstract class AbstractGeoViewLayer {
   /** The map-level service URLs configuration (proxy, geocore, geolocator, etc.) for this layer's map instance. */
   #configServiceUrls?: TypeServiceUrls;
 
+  /** The proxy to use, when one is being used */
+  #proxy?: string;
+
   /** Callback delegates for the layer entry register init event */
   #onLayerEntryRegisterInitHandlers: LayerEntryRegisterInitDelegate[] = [];
 
@@ -323,6 +326,37 @@ export abstract class AbstractGeoViewLayer {
   setConfigProxyUrl(configProxyUrl: string | undefined): void {
     this.#configServiceUrls ??= {};
     this.#configServiceUrls.proxyUrl = configProxyUrl;
+  }
+
+  /**
+   * Gets the proxy URL used for the layer's processing.
+   * GV Not to be confused with the layer entry config function of the same name.
+   *
+   *
+   * @returns The proxy URL, or undefined if no proxy is being used
+   */
+  getProxyUrl(): string | undefined {
+    return this.#proxy;
+  }
+
+  /**
+   * Sets the proxy URL to be used for the layer's processing.
+   * GV Not to be confused with the layer entry config function of the same name.
+   *
+   * @param proxy - The proxy URL to set
+   */
+  setProxyUrl(proxy: string | undefined): void {
+    this.#proxy = proxy;
+  }
+
+  /**
+   * Indicates whether the layer is using a proxy to connect to its service.
+   * GV Not to be confused with the layer entry config function of the same name.
+   *
+   * @returns `true` if the layer is using a proxy; otherwise, `false`
+   */
+  getIsUsingProxy(): boolean {
+    return !!this.#proxy;
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/abstract-geoview-layers.ts
@@ -298,6 +298,15 @@ export abstract class AbstractGeoViewLayer {
   }
 
   /**
+   * Sets the map-level service URLs configuration for this layer's map instance.
+   *
+   * @param serviceUrls - The service URLs configuration from the map features config
+   */
+  setConfigServiceUrls(serviceUrls: TypeServiceUrls): void {
+    this.#configServiceUrls = serviceUrls;
+  }
+
+  /**
    * Gets the proxy URL from the map-level service URLs configuration.
    *
    * @returns The proxy URL, or undefined if not configured
@@ -307,12 +316,13 @@ export abstract class AbstractGeoViewLayer {
   }
 
   /**
-   * Sets the map-level service URLs configuration for this layer's map instance.
+   * Sets the proxy URL in the map-level service URLs configuration.
    *
-   * @param serviceUrls - The service URLs configuration from the map features config
+   * @param configProxyUrl - The proxy URL to set, or undefined to clear it
    */
-  setConfigServiceUrls(serviceUrls: TypeServiceUrls): void {
-    this.#configServiceUrls = serviceUrls;
+  setConfigProxyUrl(configProxyUrl: string | undefined): void {
+    this.#configServiceUrls ??= {};
+    this.#configServiceUrls.proxyUrl = configProxyUrl;
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/abstract-geoview-raster.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/abstract-geoview-raster.ts
@@ -72,7 +72,7 @@ export abstract class AbstractGeoViewRaster extends AbstractGeoViewLayer {
    * The response is parsed and checked for service-level errors. If an error is found, an exception is thrown.
    *
    * @param url - The base URL to fetch the metadata from (e.g., ArcGIS REST endpoint).
-   * @param proxyUrl - Proxy URL to use when necessary (not implemented yet..)
+   * @param configProxyUrl - Proxy URL to use when necessary (not implemented yet..)
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata (not implemented yet..)
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process.
    * @returns A promise resolving to the parsed JSON metadata response.
@@ -84,7 +84,7 @@ export abstract class AbstractGeoViewRaster extends AbstractGeoViewLayer {
   static fetchMetadata<T>(
     url: string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    proxyUrl: string | undefined,
+    configProxyUrl: string | undefined,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/abstract-geoview-raster.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/abstract-geoview-raster.ts
@@ -39,7 +39,12 @@ export abstract class AbstractGeoViewRaster extends AbstractGeoViewLayer {
     let responseJson;
     try {
       // Fetch it
-      responseJson = await AbstractGeoViewRaster.fetchMetadata<T>(this.getMetadataAccessPath(), undefined, abortSignal);
+      responseJson = await AbstractGeoViewRaster.fetchMetadata<T>(
+        this.getMetadataAccessPath(),
+        this.getConfigProxyUrl(),
+        undefined,
+        abortSignal
+      );
     } catch (error: unknown) {
       // Throw
       throw new LayerServiceMetadataUnableToFetchError(
@@ -67,7 +72,8 @@ export abstract class AbstractGeoViewRaster extends AbstractGeoViewLayer {
    * The response is parsed and checked for service-level errors. If an error is found, an exception is thrown.
    *
    * @param url - The base URL to fetch the metadata from (e.g., ArcGIS REST endpoint).
-   * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata
+   * @param proxyUrl - Proxy URL to use if necessary (not implemented yet..)
+   * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata (not implemented yet..)
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process.
    * @returns A promise resolving to the parsed JSON metadata response.
    * @throws {RequestTimeoutError} When the request exceeds the timeout duration.
@@ -75,8 +81,14 @@ export abstract class AbstractGeoViewRaster extends AbstractGeoViewLayer {
    * @throws {ResponseError} When the response is not OK (non-2xx).
    * @throws {ResponseEmptyError} When the JSON response is empty.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static fetchMetadata<T>(url: string, callbackNewMetadataUrl?: CallbackNewMetadataDelegate, abortSignal?: AbortSignal): Promise<T> {
+  static fetchMetadata<T>(
+    url: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    proxyUrl: string | undefined,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
+    abortSignal?: AbortSignal
+  ): Promise<T> {
     // The url
     const parsedUrl = url.toLowerCase().endsWith('json') ? url : `${url}?f=json`;
 

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/abstract-geoview-raster.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/abstract-geoview-raster.ts
@@ -72,7 +72,7 @@ export abstract class AbstractGeoViewRaster extends AbstractGeoViewLayer {
    * The response is parsed and checked for service-level errors. If an error is found, an exception is thrown.
    *
    * @param url - The base URL to fetch the metadata from (e.g., ArcGIS REST endpoint).
-   * @param proxyUrl - Proxy URL to use if necessary (not implemented yet..)
+   * @param proxyUrl - Proxy URL to use when necessary (not implemented yet..)
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata (not implemented yet..)
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process.
    * @returns A promise resolving to the parsed JSON metadata response.

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-dynamic.ts
@@ -122,6 +122,7 @@ export class EsriDynamic extends AbstractGeoViewRaster {
    * @param mapProjection - Optional map projection
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
    * @returns A promise that the layer entry configuration has gotten its metadata processed
+   * @throws {LayerServiceMetadataUnableToFetchError} When the metadata fetch fails or contains an error
    */
   protected override onProcessLayerMetadata(
     layerConfig: EsriDynamicLayerEntryConfig,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/esri-image.ts
@@ -81,6 +81,7 @@ export class EsriImage extends AbstractGeoViewRaster {
    * @param mapProjection - Optional map projection
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
    * @returns A promise that the layer entry configuration has gotten its metadata processed
+   * @throws {LayerServiceMetadataUnableToFetchError} When the metadata fetch fails or contains an error
    */
   protected override onProcessLayerMetadata(
     layerConfig: EsriImageLayerEntryConfig,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -902,7 +902,7 @@ export class WMS extends AbstractGeoViewRaster {
    * Fetches the metadata for WMS Capabilities.
    *
    * @param url - The url to query the metadata from
-   * @param proxyUrl - Proxy URL to use when necessary
+   * @param configProxyUrl - Proxy URL to use when necessary
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
@@ -914,19 +914,19 @@ export class WMS extends AbstractGeoViewRaster {
    */
   static fetchMetadataWMS(
     url: string,
-    proxyUrl: string | undefined,
+    configProxyUrl: string | undefined,
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal
   ): Promise<TypeMetadataWMS> {
     // Redirect
-    return GeoUtilities.getWMSServiceMetadata(url, proxyUrl, undefined, callbackNewMetadataUrl, abortSignal);
+    return GeoUtilities.getWMSServiceMetadata(url, configProxyUrl, undefined, callbackNewMetadataUrl, abortSignal);
   }
 
   /**
    * Fetches the metadata for WMS Capabilities for particular layer(s).
    *
    * @param url - The url to query the metadata from
-   * @param proxyUrl - Proxy URL to use when necessary
+   * @param configProxyUrl - Proxy URL to use when necessary
    * @param layers - The layers to get the capabilities for
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
@@ -940,20 +940,20 @@ export class WMS extends AbstractGeoViewRaster {
    */
   static fetchMetadataWMSForLayer(
     url: string,
-    proxyUrl: string | undefined,
+    configProxyUrl: string | undefined,
     layers: string,
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal
   ): Promise<TypeMetadataWMS> {
     // Redirect
-    return GeoUtilities.getWMSServiceMetadata(url, proxyUrl, layers, callbackNewMetadataUrl, abortSignal);
+    return GeoUtilities.getWMSServiceMetadata(url, configProxyUrl, layers, callbackNewMetadataUrl, abortSignal);
   }
 
   /**
    * Fetches the WMS styles for the specified layer(s) from a WMS service.
    *
    * @param url - The url to query the metadata from
-   * @param proxyUrl - Proxy URL to use when necessary
+   * @param configProxyUrl - Proxy URL to use when necessary
    * @param layers - The layers to get the capabilities for
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
@@ -967,13 +967,13 @@ export class WMS extends AbstractGeoViewRaster {
    */
   static fetchStylesForLayer(
     url: string,
-    proxyUrl: string | undefined,
+    configProxyUrl: string | undefined,
     layers: string,
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal
   ): Promise<TypeStylesWMS> {
     // Redirect
-    return GeoUtilities.getWMSServiceStyles(url, proxyUrl, layers, callbackNewMetadataUrl, abortSignal);
+    return GeoUtilities.getWMSServiceStyles(url, configProxyUrl, layers, callbackNewMetadataUrl, abortSignal);
   }
 
   /**
@@ -984,7 +984,7 @@ export class WMS extends AbstractGeoViewRaster {
    * types to their corresponding layer style settings.
    *
    * @param url - The base WMS service URL used to fetch styles
-   * @param proxyUrl - Proxy URL to use when necessary
+   * @param configProxyUrl - Proxy URL to use when necessary
    * @param layers - A comma-separated list of WMS layer names to retrieve styles for
    * @param geomType - Optional geometry type
    * @returns A promise that resolves to a record mapping geometry types to layer style settings
@@ -992,12 +992,12 @@ export class WMS extends AbstractGeoViewRaster {
    */
   static async createStylesFromWMS(
     url: string,
-    proxyUrl: string | undefined,
+    configProxyUrl: string | undefined,
     layers: string,
     geomType: TypeStyleGeometry | undefined
   ): Promise<Record<TypeStyleGeometry, TypeLayerStyleSettings>> {
     // Fetch styles using the WMS url associated with the WFS
-    const styles = await WMS.fetchStylesForLayer(url, proxyUrl, layers);
+    const styles = await WMS.fetchStylesForLayer(url, configProxyUrl, layers);
 
     // Log it, leaving the logDebug for dev purposes
     // logger.logDebug('STYLES', styles);
@@ -1024,13 +1024,13 @@ export class WMS extends AbstractGeoViewRaster {
    * resolve to a metadata result or reject with a wrapped error.
    *
    * @param url - The base GetCapabilities URL used to fetch layer-specific metadata
-   * @param proxyUrl - Proxy URL to use when necessary
+   * @param configProxyUrl - Proxy URL to use when necessary
    * @param layers - An array of layer configurations to fetch metadata for
    * @returns An array of metadata fetch promises, one per unique layer config
    */
   static #createLayerMetadataPromises(
     url: string,
-    proxyUrl: string | undefined,
+    configProxyUrl: string | undefined,
     layers: AbstractBaseLayerEntryConfig[]
   ): Promise<MetatadaFetchResult>[] {
     const seen = new Map<string, Promise<MetatadaFetchResult>>();
@@ -1040,7 +1040,7 @@ export class WMS extends AbstractGeoViewRaster {
       if (!seen.has(layerConfig.layerId)) {
         const promise = new Promise<MetatadaFetchResult>((resolve, reject) => {
           // Perform the actual metadata fetch
-          WMS.fetchMetadataWMSForLayer(url, proxyUrl, layerConfig.layerId, (proxiedUrl, proxyUsed) => {
+          WMS.fetchMetadataWMSForLayer(url, configProxyUrl, layerConfig.layerId, (proxiedUrl, proxyUsed) => {
             // Indicate the proxy that was used
             layerConfig.setProxyUrl(proxyUsed);
 
@@ -1251,14 +1251,14 @@ export class WMS extends AbstractGeoViewRaster {
    * Failures during processing do not stop execution; they are logged as warnings.
    *
    * @param layerConfig - The WMS layer configuration being processed
-   * @param proxyUrl - Proxy URL to use when necessary
+   * @param configProxyUrl - Proxy URL to use when necessary
    * @returns A promise that resolves when processing is complete
    * @throws {LayerDataAccessPathMandatoryError} When the Data Access Path was undefined, likely because initDataAccessPath wasn't called
    * @throws {LayerEntryConfigFieldsNotFoundError} When WFS `outfields` cannot be read from the derived config
    */
   static async #tryProcessLayerVectorialInformationIfAny(
     layerConfig: OgcWmsLayerEntryConfig,
-    proxyUrl: string | undefined
+    configProxyUrl: string | undefined
   ): Promise<Record<TypeStyleGeometry, TypeLayerStyleSettings> | undefined> {
     // If should fetch vectorial information from WFS
     if (layerConfig.getShouldFetchVectorInformationFromWFS()) {
@@ -1267,7 +1267,7 @@ export class WMS extends AbstractGeoViewRaster {
         const baseUrl = GeoUtilities.getBaseUrl(layerConfig.getDataAccessPath());
 
         // Create the Geoview Layer Config WFS equivalent
-        const wfsLayerConfig = await layerConfig.createGeoviewLayerConfigWfs();
+        const wfsLayerConfig = await layerConfig.createGeoviewLayerConfigWfs(configProxyUrl);
 
         // Keep it as reference
         layerConfig.setWfsLayerConfig(wfsLayerConfig);
@@ -1287,7 +1287,7 @@ export class WMS extends AbstractGeoViewRaster {
           // If the service metadata offers GetStyles
           if (layerConfig.getSupportsGetStyles()) {
             // Try to create dynamic style from the WMS GetStyles metadata
-            return await WMS.createStylesFromWMS(baseUrl, proxyUrl, layerConfig.layerId, wfsLayerConfig.getGeometryType());
+            return await WMS.createStylesFromWMS(baseUrl, configProxyUrl, layerConfig.layerId, wfsLayerConfig.getGeometryType());
           }
 
           // Log

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -795,7 +795,7 @@ export class WMS extends AbstractGeoViewRaster {
       }
 
       // Read the first CRS from the list
-      // TODO: Do we want to have an array instead - just for WMS (other types don't work like this)?
+      // TODO: MINOR - do we want to have an array instead - just for WMS (other types don't work like this)?
       const firstCRS = layerCapabilities.CRS?.[0];
       if (firstCRS) await layerConfig.initProjectionFromMetadata(firstCRS);
 
@@ -931,6 +931,7 @@ export class WMS extends AbstractGeoViewRaster {
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
+   * @returns A promise that resolves with the parsed WMS metadata
    * @throws {RequestTimeoutError} When the request exceeds the timeout duration
    * @throws {RequestAbortedError} When the request was aborted by the caller's signal
    * @throws {ResponseError} When the response is not OK (non-2xx)
@@ -1025,7 +1026,7 @@ export class WMS extends AbstractGeoViewRaster {
    * @param url - The base GetCapabilities URL used to fetch layer-specific metadata
    * @param proxyUrl - Proxy URL to use if necessary
    * @param layers - An array of layer configurations to fetch metadata for
-   * @returns A promise that resolves to an array of metadata fetch promises, one per layer config
+   * @returns An array of metadata fetch promises, one per unique layer config
    */
   static #createLayerMetadataPromises(
     url: string,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -211,7 +211,7 @@ export class WMS extends AbstractGeoViewRaster {
     // If found
     if (layerCapabilities) {
       // Try processing vectorial information on the WMS, if any
-      const layerStyle = await WMS.#tryProcessLayerVectorialInformationIfAny(layerConfig);
+      const layerStyle = await WMS.#tryProcessLayerVectorialInformationIfAny(layerConfig, this.getConfigProxyUrl());
 
       // Initialize the layer style by filling the blanks with the information from the metadata
       layerConfig.initLayerStyleFromMetadata(layerStyle);
@@ -261,11 +261,10 @@ export class WMS extends AbstractGeoViewRaster {
 
     // The layers parameter
     let layers = layerConfig.layerId;
-    // If using proxy
-    if (layerConfig.getIsUsingProxy()) {
-      if (GeoUtilities.DOUBLE_ENCODING_LAYERS_WHEN_BEHIND_PROXY) {
-        layers = encodeURIComponent(layers);
-      }
+
+    // If using Esri proxy
+    if (layerConfig.getIsUsingEsriProxy()) {
+      layers = encodeURIComponent(layers);
     }
 
     // Create the source params
@@ -278,8 +277,8 @@ export class WMS extends AbstractGeoViewRaster {
     const styleToUse = layerConfig.getStyleToUse();
     if (styleToUse) sourceParams.STYLES = styleToUse;
 
-    // Get the data access path
-    let dataAccessPathUrl = layerConfig.getDataAccessPath();
+    // Get the data access path without any proxy url applied, the proxy url is prefixed in the setImageLoadFunction callback
+    let dataAccessPathUrl = layerConfig.getDataAccessPathBeforeProxy();
 
     // Strip down parameters that should not be in the OL param url
     // -> 'request' and 'service' shouldn't be there, OL will write them automatically
@@ -381,7 +380,7 @@ export class WMS extends AbstractGeoViewRaster {
     let metadata;
     try {
       // Fetch the WMS GetCapabilities document from the given URL
-      metadata = await WMS.fetchMetadataWMS(url, callbackNewMetadataUrl);
+      metadata = await WMS.fetchMetadataWMS(url, this.getConfigProxyUrl(), callbackNewMetadataUrl);
     } catch (error: unknown) {
       // Throw
       throw new LayerServiceMetadataUnableToFetchError(
@@ -417,7 +416,7 @@ export class WMS extends AbstractGeoViewRaster {
    */
   async #fetchAndMergeMultipleWmsMetadata(url: string, layers: AbstractBaseLayerEntryConfig[]): Promise<TypeMetadataWMS | undefined> {
     // Create one metadata fetch promise per unique layerId
-    const metadataPromises = WMS.#createLayerMetadataPromises(url, layers);
+    const metadataPromises = WMS.#createLayerMetadataPromises(url, this.getConfigProxyUrl(), layers);
 
     // Wait for all requests to settle (either fulfilled or rejected)
     const results = await Promise.allSettled(metadataPromises);
@@ -463,69 +462,6 @@ export class WMS extends AbstractGeoViewRaster {
   }
 
   /**
-   * Creates a list of promises to fetch WMS metadata for a set of layer configurations.
-   *
-   * This function ensures that each unique `layerId` results in only one network request,
-   * even if multiple layer configs share the same ID. The resulting promises will either
-   * resolve to a metadata result or reject with a wrapped error.
-   *
-   * @param url - The base GetCapabilities URL used to fetch layer-specific metadata
-   * @param layers - An array of layer configurations to fetch metadata for
-   * @returns A promise that resolves to an array of metadata fetch promises, one per layer config
-   */
-  static #createLayerMetadataPromises(url: string, layers: AbstractBaseLayerEntryConfig[]): Promise<MetatadaFetchResult>[] {
-    const seen = new Map<string, Promise<MetatadaFetchResult>>();
-
-    return layers.map((layerConfig) => {
-      // Avoid duplicate fetches for the same layerId
-      if (!seen.has(layerConfig.layerId)) {
-        const promise = new Promise<MetatadaFetchResult>((resolve, reject) => {
-          // Perform the actual metadata fetch
-          WMS.fetchMetadataWMSForLayer(url, layerConfig.layerId, (proxiedUrl) => {
-            // Indicate that we're using a proxy
-            layerConfig.setIsUsingProxy(true);
-
-            // Update the layer's data access path
-            layerConfig.setDataAccessPath(proxiedUrl);
-          })
-            .then((metadata) => {
-              if (metadata.Capability) {
-                resolve({ metadata, layerConfig });
-              } else {
-                // Wrap error about no capabilities found. Search id: 8c97d776.
-                reject(
-                  new PromiseRejectErrorWrapper(
-                    new LayerNoCapabilitiesError(layerConfig.getGeoviewLayerId(), layerConfig.getLayerNameCascade()),
-                    layerConfig
-                  )
-                );
-              }
-            })
-            .catch((error) => {
-              // Wrap error with additional layer context. Search id: 8c97d776.
-              reject(
-                new PromiseRejectErrorWrapper(
-                  new LayerServiceMetadataUnableToFetchError(
-                    layerConfig.getGeoviewLayerId(),
-                    layerConfig.getLayerNameCascade(),
-                    formatError(error)
-                  ),
-                  layerConfig
-                )
-              );
-            });
-        });
-
-        // Store the promise for this layerId to avoid duplicate requests
-        seen.set(layerConfig.layerId, promise);
-      }
-
-      // Return the cached or newly created promise
-      return seen.get(layerConfig.layerId)!;
-    });
-  }
-
-  /**
    * This method reads the service metadata from a XML metadataAccessPath.
    *
    * @param metadataUrl - The metadataAccessPath
@@ -543,7 +479,7 @@ export class WMS extends AbstractGeoViewRaster {
     let metadata;
     try {
       // Fetch it
-      metadata = await WMS.fetchMetadataWMS(metadataUrl, callbackNewMetadataUrl, abortSignal);
+      metadata = await WMS.fetchMetadataWMS(metadataUrl, this.getConfigProxyUrl(), callbackNewMetadataUrl, abortSignal);
     } catch (error: unknown) {
       // Throw
       throw new LayerServiceMetadataUnableToFetchError(
@@ -966,6 +902,7 @@ export class WMS extends AbstractGeoViewRaster {
    * Fetches the metadata for WMS Capabilities.
    *
    * @param url - The url to query the metadata from
+   * @param proxyUrl - Proxy URL to use if necessary
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
@@ -977,20 +914,23 @@ export class WMS extends AbstractGeoViewRaster {
    */
   static fetchMetadataWMS(
     url: string,
+    proxyUrl: string | undefined,
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal
   ): Promise<TypeMetadataWMS> {
     // Redirect
-    return GeoUtilities.getWMSServiceMetadata(url, undefined, callbackNewMetadataUrl, abortSignal);
+    return GeoUtilities.getWMSServiceMetadata(url, proxyUrl, undefined, callbackNewMetadataUrl, abortSignal);
   }
 
   /**
    * Fetches the metadata for WMS Capabilities for particular layer(s).
    *
    * @param url - The url to query the metadata from
+   * @param proxyUrl - Proxy URL to use if necessary
    * @param layers - The layers to get the capabilities for
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
+   * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
    * @throws {RequestTimeoutError} When the request exceeds the timeout duration
    * @throws {RequestAbortedError} When the request was aborted by the caller's signal
    * @throws {ResponseError} When the response is not OK (non-2xx)
@@ -999,18 +939,24 @@ export class WMS extends AbstractGeoViewRaster {
    */
   static fetchMetadataWMSForLayer(
     url: string,
+    proxyUrl: string | undefined,
     layers: string,
-    callbackNewMetadataUrl?: CallbackNewMetadataDelegate
+    callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
+    abortSignal?: AbortSignal
   ): Promise<TypeMetadataWMS> {
     // Redirect
-    return GeoUtilities.getWMSServiceMetadata(url, layers, callbackNewMetadataUrl);
+    return GeoUtilities.getWMSServiceMetadata(url, proxyUrl, layers, callbackNewMetadataUrl, abortSignal);
   }
 
   /**
    * Fetches the WMS styles for the specified layer(s) from a WMS service.
    *
    * @param url - The url to query the metadata from
+   * @param proxyUrl - Proxy URL to use if necessary
    * @param layers - The layers to get the capabilities for
+   * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
+   * The parameter sent in the callback is the proxy prefix with the '?' at the end.
+   * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
    * @returns A promise that resolves with a TypeStylesWMS object for the layer(s)
    * @throws {RequestTimeoutError} When the request exceeds the timeout duration
    * @throws {RequestAbortedError} When the request was aborted by the caller's signal
@@ -1018,9 +964,15 @@ export class WMS extends AbstractGeoViewRaster {
    * @throws {ResponseEmptyError} When the JSON response is empty
    * @throws {NetworkError} When a network issue happened
    */
-  static fetchStylesForLayer(url: string, layers: string): Promise<TypeStylesWMS> {
+  static fetchStylesForLayer(
+    url: string,
+    proxyUrl: string | undefined,
+    layers: string,
+    callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
+    abortSignal?: AbortSignal
+  ): Promise<TypeStylesWMS> {
     // Redirect
-    return GeoUtilities.getWMSServiceStyles(url, layers);
+    return GeoUtilities.getWMSServiceStyles(url, proxyUrl, layers, callbackNewMetadataUrl, abortSignal);
   }
 
   /**
@@ -1031,6 +983,7 @@ export class WMS extends AbstractGeoViewRaster {
    * types to their corresponding layer style settings.
    *
    * @param url - The base WMS service URL used to fetch styles
+   * @param proxyUrl - Proxy URL to use if necessary
    * @param layers - A comma-separated list of WMS layer names to retrieve styles for
    * @param geomType - Optional geometry type
    * @returns A promise that resolves to a record mapping geometry types to layer style settings
@@ -1038,11 +991,12 @@ export class WMS extends AbstractGeoViewRaster {
    */
   static async createStylesFromWMS(
     url: string,
+    proxyUrl: string | undefined,
     layers: string,
     geomType: TypeStyleGeometry | undefined
   ): Promise<Record<TypeStyleGeometry, TypeLayerStyleSettings>> {
     // Fetch styles using the WMS url associated with the WFS
-    const styles = await WMS.fetchStylesForLayer(url, layers);
+    const styles = await WMS.fetchStylesForLayer(url, proxyUrl, layers);
 
     // Log it, leaving the logDebug for dev purposes
     // logger.logDebug('STYLES', styles);
@@ -1060,6 +1014,74 @@ export class WMS extends AbstractGeoViewRaster {
   // #endregion STATIC PUBLIC METHODS
 
   // #region STATIC PRIVATE METHODS
+
+  /**
+   * Creates a list of promises to fetch WMS metadata for a set of layer configurations.
+   *
+   * This function ensures that each unique `layerId` results in only one network request,
+   * even if multiple layer configs share the same ID. The resulting promises will either
+   * resolve to a metadata result or reject with a wrapped error.
+   *
+   * @param url - The base GetCapabilities URL used to fetch layer-specific metadata
+   * @param proxyUrl - Proxy URL to use if necessary
+   * @param layers - An array of layer configurations to fetch metadata for
+   * @returns A promise that resolves to an array of metadata fetch promises, one per layer config
+   */
+  static #createLayerMetadataPromises(
+    url: string,
+    proxyUrl: string | undefined,
+    layers: AbstractBaseLayerEntryConfig[]
+  ): Promise<MetatadaFetchResult>[] {
+    const seen = new Map<string, Promise<MetatadaFetchResult>>();
+
+    return layers.map((layerConfig) => {
+      // Avoid duplicate fetches for the same layerId
+      if (!seen.has(layerConfig.layerId)) {
+        const promise = new Promise<MetatadaFetchResult>((resolve, reject) => {
+          // Perform the actual metadata fetch
+          WMS.fetchMetadataWMSForLayer(url, proxyUrl, layerConfig.layerId, (proxiedUrl, proxyUsed) => {
+            // Indicate the proxy that was used
+            layerConfig.setProxyUrl(proxyUsed);
+
+            // Update the layer's data access path
+            layerConfig.setDataAccessPath(proxiedUrl);
+          })
+            .then((metadata) => {
+              if (metadata.Capability) {
+                resolve({ metadata, layerConfig });
+              } else {
+                // Wrap error about no capabilities found. Search id: 8c97d776.
+                reject(
+                  new PromiseRejectErrorWrapper(
+                    new LayerNoCapabilitiesError(layerConfig.getGeoviewLayerId(), layerConfig.getLayerNameCascade()),
+                    layerConfig
+                  )
+                );
+              }
+            })
+            .catch((error) => {
+              // Wrap error with additional layer context. Search id: 8c97d776.
+              reject(
+                new PromiseRejectErrorWrapper(
+                  new LayerServiceMetadataUnableToFetchError(
+                    layerConfig.getGeoviewLayerId(),
+                    layerConfig.getLayerNameCascade(),
+                    formatError(error)
+                  ),
+                  layerConfig
+                )
+              );
+            });
+        });
+
+        // Store the promise for this layerId to avoid duplicate requests
+        seen.set(layerConfig.layerId, promise);
+      }
+
+      // Return the cached or newly created promise
+      return seen.get(layerConfig.layerId)!;
+    });
+  }
 
   /**
    * Creates a WMS layer entry configuration object, handling both group and leaf layers.
@@ -1228,12 +1250,14 @@ export class WMS extends AbstractGeoViewRaster {
    * Failures during processing do not stop execution; they are logged as warnings.
    *
    * @param layerConfig - The WMS layer configuration being processed
+   * @param proxyUrl - Proxy URL to use if necessary
    * @returns A promise that resolves when processing is complete
    * @throws {LayerDataAccessPathMandatoryError} When the Data Access Path was undefined, likely because initDataAccessPath wasn't called
    * @throws {LayerEntryConfigFieldsNotFoundError} When WFS `outfields` cannot be read from the derived config
    */
   static async #tryProcessLayerVectorialInformationIfAny(
-    layerConfig: OgcWmsLayerEntryConfig
+    layerConfig: OgcWmsLayerEntryConfig,
+    proxyUrl: string | undefined
   ): Promise<Record<TypeStyleGeometry, TypeLayerStyleSettings> | undefined> {
     // If should fetch vectorial information from WFS
     if (layerConfig.getShouldFetchVectorInformationFromWFS()) {
@@ -1262,7 +1286,7 @@ export class WMS extends AbstractGeoViewRaster {
           // If the service metadata offers GetStyles
           if (layerConfig.getSupportsGetStyles()) {
             // Try to create dynamic style from the WMS GetStyles metadata
-            return await WMS.createStylesFromWMS(baseUrl, layerConfig.layerId, wfsLayerConfig.getGeometryType());
+            return await WMS.createStylesFromWMS(baseUrl, proxyUrl, layerConfig.layerId, wfsLayerConfig.getGeometryType());
           }
 
           // Log

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -433,7 +433,7 @@ export class WMS extends AbstractGeoViewRaster {
     // TODO: Think of a better way to handle this? Improve the 'setLayerStatusError' internally to check for siblings and set the parent - instead of here?
     if (results.every((r) => r.status === 'rejected')) {
       // Set the parent in error
-      layers[0].getParentLayerConfig()?.setLayerStatusError();
+      layers[0].getParentLayerConfig()?.setLayerStatusError(false);
     }
 
     // Merge metadata results

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -322,9 +322,12 @@ export class WMS extends AbstractGeoViewRaster {
       // Fetch the XML
       return this.#fetchXmlServiceMetadata(
         this.getMetadataAccessPath(),
-        (proxiedUrl) => {
+        (proxiedUrl, proxyUsed) => {
           // If updating the metadataAccessPath as we go
           if (updateMetadataAccessPath) {
+            // Indicate the proxy that was used
+            this.setProxyUrl(proxyUsed);
+
             // Update the access path to use the proxy if one was required
             this.setMetadataAccessPath(proxiedUrl);
           }
@@ -341,7 +344,10 @@ export class WMS extends AbstractGeoViewRaster {
 
     if (layerConfigsToQuery.length === 0) {
       // If no specific layers to query, fetch and process metadata for the entire service
-      return this.#fetchAndProcessSingleWmsMetadata(url, (proxiedUrl) => {
+      return this.#fetchAndProcessSingleWmsMetadata(url, (proxiedUrl, proxyUsed) => {
+        // Indicate the proxy that was used
+        this.setProxyUrl(proxyUsed);
+
         // If updating the metadataAccessPath as we go
         if (updateMetadataAccessPath) {
           // Update the metadata access path accordingly
@@ -1036,6 +1042,10 @@ export class WMS extends AbstractGeoViewRaster {
     const seen = new Map<string, Promise<MetatadaFetchResult>>();
 
     return layers.map((layerConfig) => {
+      // TODO: PERFORMANCE - For the service that requires a proxy, this will attempt with the base url and then the proxy for each layer entry
+      // TO.DOCONT: A better approach would be that once a proxy is determined necessary, it's immediately applied for each layer entry call
+      // TO.DOCONT: However, to do so, requires changing the logic of the parallelism happening here..
+
       // Avoid duplicate fetches for the same layerId
       if (!seen.has(layerConfig.layerId)) {
         const promise = new Promise<MetatadaFetchResult>((resolve, reject) => {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -902,7 +902,7 @@ export class WMS extends AbstractGeoViewRaster {
    * Fetches the metadata for WMS Capabilities.
    *
    * @param url - The url to query the metadata from
-   * @param proxyUrl - Proxy URL to use if necessary
+   * @param proxyUrl - Proxy URL to use when necessary
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
@@ -926,7 +926,7 @@ export class WMS extends AbstractGeoViewRaster {
    * Fetches the metadata for WMS Capabilities for particular layer(s).
    *
    * @param url - The url to query the metadata from
-   * @param proxyUrl - Proxy URL to use if necessary
+   * @param proxyUrl - Proxy URL to use when necessary
    * @param layers - The layers to get the capabilities for
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
@@ -953,7 +953,7 @@ export class WMS extends AbstractGeoViewRaster {
    * Fetches the WMS styles for the specified layer(s) from a WMS service.
    *
    * @param url - The url to query the metadata from
-   * @param proxyUrl - Proxy URL to use if necessary
+   * @param proxyUrl - Proxy URL to use when necessary
    * @param layers - The layers to get the capabilities for
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
@@ -984,7 +984,7 @@ export class WMS extends AbstractGeoViewRaster {
    * types to their corresponding layer style settings.
    *
    * @param url - The base WMS service URL used to fetch styles
-   * @param proxyUrl - Proxy URL to use if necessary
+   * @param proxyUrl - Proxy URL to use when necessary
    * @param layers - A comma-separated list of WMS layer names to retrieve styles for
    * @param geomType - Optional geometry type
    * @returns A promise that resolves to a record mapping geometry types to layer style settings
@@ -1024,7 +1024,7 @@ export class WMS extends AbstractGeoViewRaster {
    * resolve to a metadata result or reject with a wrapped error.
    *
    * @param url - The base GetCapabilities URL used to fetch layer-specific metadata
-   * @param proxyUrl - Proxy URL to use if necessary
+   * @param proxyUrl - Proxy URL to use when necessary
    * @param layers - An array of layer configurations to fetch metadata for
    * @returns An array of metadata fetch promises, one per unique layer config
    */
@@ -1251,7 +1251,7 @@ export class WMS extends AbstractGeoViewRaster {
    * Failures during processing do not stop execution; they are logged as warnings.
    *
    * @param layerConfig - The WMS layer configuration being processed
-   * @param proxyUrl - Proxy URL to use if necessary
+   * @param proxyUrl - Proxy URL to use when necessary
    * @returns A promise that resolves when processing is complete
    * @throws {LayerDataAccessPathMandatoryError} When the Data Access Path was undefined, likely because initDataAccessPath wasn't called
    * @throws {LayerEntryConfigFieldsNotFoundError} When WFS `outfields` cannot be read from the derived config

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wms.ts
@@ -100,7 +100,7 @@ export class WMS extends AbstractGeoViewRaster {
    * @throws {LayerServiceMetadataUnableToFetchError} When the metadata fetch fails or contains an error
    */
   protected override onFetchServiceMetadata<T = TypeMetadataWMS | undefined>(abortSignal?: AbortSignal): Promise<T> {
-    // Redirect and when a proxy has to be used, update the metadataAccessPath along the way
+    // Redirect and update the metadataAccessPath when a proxy has to be used
     return this.fetchServiceMetadataWMS(true, abortSignal) as Promise<T>;
   }
 
@@ -811,7 +811,7 @@ export class WMS extends AbstractGeoViewRaster {
 
         // TODO: Validate the layerConfig.layerFilter is compatible with the layerCapabilities.Dimension and if not remove it completely like `delete layerConfig.layerFilter`
 
-        const timeDimension = layerCapabilities.Dimension.find((dimension) => dimension.name === 'time');
+        const timeDimension = layerCapabilities.Dimension.find((dimension) => dimension.name?.toLowerCase() === 'time');
 
         // If a temporal dimension was found
         if (timeDimension) {

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wmts.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wmts.ts
@@ -214,9 +214,12 @@ export class WMTS extends AbstractGeoViewRaster {
     // Fetch the XML
     return this.#fetchXmlServiceMetadata(
       url,
-      (proxiedUrl) => {
+      (proxiedUrl, proxyUsed) => {
         // If updating the metadataAccessPath as we go
         if (updateMetadataAccessPath) {
+          // Indicate the proxy that was used
+          this.setProxyUrl(proxyUsed);
+
           // Update the access path to use the proxy if one was required
           this.setMetadataAccessPath(proxiedUrl);
         }

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wmts.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wmts.ts
@@ -471,7 +471,7 @@ export class WMTS extends AbstractGeoViewRaster {
    * Fetches the metadata for WMS Capabilities.
    *
    * @param url - The url to query the metadata from
-   * @param proxyUrl - Proxy URL to use when necessary
+   * @param configProxyUrl - Proxy URL to use when necessary
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata
    * @param abortSignal - Optional abort signal to handle cancelling of the process
    * @returns A promise that resolves to the parsed metadata object
@@ -483,12 +483,12 @@ export class WMTS extends AbstractGeoViewRaster {
    */
   static override fetchMetadata<T = TypeMetadataWMTS>(
     url: string,
-    proxyUrl: string | undefined,
+    configProxyUrl: string | undefined,
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal
   ): Promise<T> {
     // Redirect
-    return GeoUtilities.getWMTSServiceMetadata(url, proxyUrl, undefined, callbackNewMetadataUrl, abortSignal) as Promise<T>;
+    return GeoUtilities.getWMTSServiceMetadata(url, configProxyUrl, undefined, callbackNewMetadataUrl, abortSignal) as Promise<T>;
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wmts.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wmts.ts
@@ -471,7 +471,7 @@ export class WMTS extends AbstractGeoViewRaster {
    * Fetches the metadata for WMS Capabilities.
    *
    * @param url - The url to query the metadata from
-   * @param proxyUrl - Proxy URL to use if necessary
+   * @param proxyUrl - Proxy URL to use when necessary
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata
    * @param abortSignal - Optional abort signal to handle cancelling of the process
    * @returns A promise that resolves to the parsed metadata object

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/wmts.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/wmts.ts
@@ -94,37 +94,6 @@ export class WMTS extends AbstractGeoViewRaster {
   }
 
   /**
-   * This method reads the service metadata from a XML metadataAccessPath.
-   *
-   * @param metadataUrl - The metadataAccessPath
-   * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata
-   * @param abortSignal - Optional abort signal to handle cancelling of the process
-   * @returns A promise that resolves once the execution is completed
-   * @throws {LayerServiceMetadataUnableToFetchError} When the metadata fetch fails or contains an error
-   */
-  async #fetchXmlServiceMetadata(
-    metadataUrl: string,
-    callbackNewMetadataUrl: CallbackNewMetadataDelegate,
-    abortSignal?: AbortSignal
-  ): Promise<TypeMetadataWMTS> {
-    let metadata;
-    try {
-      // Fetch it
-      metadata = await WMTS.fetchMetadata(metadataUrl, callbackNewMetadataUrl, abortSignal);
-    } catch (error: unknown) {
-      // Throw
-      throw new LayerServiceMetadataUnableToFetchError(
-        this.getGeoviewLayerId(),
-        this.getLayerEntryNameOrGeoviewLayerName(),
-        formatError(error)
-      );
-    }
-
-    // Return the metadata
-    return metadata;
-  }
-
-  /**
    * Overrides the way a geoview layer config initializes its layer entries.
    *
    * @returns A promise that resolves once the layer entries have been initialized
@@ -255,6 +224,41 @@ export class WMTS extends AbstractGeoViewRaster {
       abortSignal
     );
   }
+
+  // #region PRIVATE METHODS
+
+  /**
+   * This method reads the service metadata from a XML metadataAccessPath.
+   *
+   * @param metadataUrl - The metadataAccessPath
+   * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata
+   * @param abortSignal - Optional abort signal to handle cancelling of the process
+   * @returns A promise that resolves once the execution is completed
+   * @throws {LayerServiceMetadataUnableToFetchError} When the metadata fetch fails or contains an error
+   */
+  async #fetchXmlServiceMetadata(
+    metadataUrl: string,
+    callbackNewMetadataUrl: CallbackNewMetadataDelegate,
+    abortSignal?: AbortSignal
+  ): Promise<TypeMetadataWMTS> {
+    let metadata;
+    try {
+      // Fetch it
+      metadata = await WMTS.fetchMetadata(metadataUrl, this.getConfigProxyUrl(), callbackNewMetadataUrl, abortSignal);
+    } catch (error: unknown) {
+      // Throw
+      throw new LayerServiceMetadataUnableToFetchError(
+        this.getGeoviewLayerId(),
+        this.getLayerEntryNameOrGeoviewLayerName(),
+        formatError(error)
+      );
+    }
+
+    // Return the metadata
+    return metadata;
+  }
+
+  // #endregion PRIVATE METHODS
 
   // #endregion PROTECTED METHODS
 
@@ -467,6 +471,7 @@ export class WMTS extends AbstractGeoViewRaster {
    * Fetches the metadata for WMS Capabilities.
    *
    * @param url - The url to query the metadata from
+   * @param proxyUrl - Proxy URL to use if necessary
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata
    * @param abortSignal - Optional abort signal to handle cancelling of the process
    * @returns A promise that resolves to the parsed metadata object
@@ -478,11 +483,12 @@ export class WMTS extends AbstractGeoViewRaster {
    */
   static override fetchMetadata<T = TypeMetadataWMTS>(
     url: string,
+    proxyUrl: string | undefined,
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal
   ): Promise<T> {
     // Redirect
-    return GeoUtilities.getWMTSServiceMetadata(url, undefined, callbackNewMetadataUrl, abortSignal) as Promise<T>;
+    return GeoUtilities.getWMTSServiceMetadata(url, proxyUrl, undefined, callbackNewMetadataUrl, abortSignal) as Promise<T>;
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -96,11 +96,12 @@ export class XYZTiles extends AbstractGeoViewRaster {
    * @param layerConfig - The layer entry config to validate
    */
   protected override onValidateLayerEntryConfig(layerConfig: ConfigBaseClass): void {
-    // TODO: Update to properly use metadata from map server
-    // Note that XYZ metadata as we defined it does not contain metadata layer group. If you need geojson layer group,
-    // you can define them in the configuration section.
+    // GV Note that XYZ metadata as we defined it does not contain metadata layer group. If you need geojson layer group,
+    // GV you can define them in the configuration section.
 
     // Get the metadata
+    // TODO: METADATA - Add support/validation for metadata coming from another XYZ Tile service than Esri. Search id: f32d024b
+    // TO.DOCONT: e.g. https://tiles.stadiamaps.com/tiles/osm_bright/{z}/{x}/{y}.png
     const metadata = this.getMetadata();
 
     if (Array.isArray(metadata?.listOfLayerEntryConfig)) {
@@ -146,7 +147,7 @@ export class XYZTiles extends AbstractGeoViewRaster {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     abortSignal?: AbortSignal
   ): Promise<XYZTilesLayerEntryConfig> {
-    // TODO: Need to see why the metadata isn't handled properly for ESRI XYZ tiles.
+    // TODO: METADATA - Need to see why the metadata isn't handled properly for ESRI XYZ tiles. Search id: f32d024b
     // GV Possibly caused by a difference between OGC and ESRI XYZ Tiles, but only have ESRI XYZ Tiles as example currently
     // GV Also, might be worth checking out OGCMapTile for this? https://openlayers.org/en/latest/examples/ogc-map-tiles-geographic.html
     // GV Seems like it can deal with less specificity in the url and can handle the x y z internally?

--- a/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/raster/xyz-tiles.ts
@@ -8,6 +8,7 @@ import { AbstractGeoViewRaster } from '@/geo/layer/geoview-layers/raster/abstrac
 import type { DisplayDateMode } from '@/api/types/map-schema-types';
 import type { TypeSourceTileInitialConfig, TypeGeoviewLayerConfig } from '@/api/types/layer-schema-types';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
+import { LayerServiceMetadataUnableToFetchError } from '@/core/exceptions/layer-exceptions';
 import type { ConfigBaseClass, TypeLayerEntryShell } from '@/api/config/validation-classes/config-base-class';
 import {
   XYZTilesLayerEntryConfig,
@@ -20,6 +21,7 @@ import {
 import { GVXYZTiles } from '@/geo/layer/gv-layers/tile/gv-xyz-tiles';
 import { AbstractGeoViewLayer } from '@/geo/layer/geoview-layers/abstract-geoview-layers';
 import type { TypeProjection } from '@/geo/utils/projection';
+import { validateAndPingUrl } from '@/core/utils/utilities';
 
 // ? Do we keep this TODO ? Dynamic parameters can be placed on the dataAccessPath and initial settings can be used on xyz-tiles.
 // TODO: Implement method to validate XYZ tile service
@@ -137,6 +139,7 @@ export class XYZTiles extends AbstractGeoViewRaster {
    * @param mapProjection - Optional map projection
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
    * @returns A promise that resolves once the layer entry configuration has gotten its metadata processed
+   * @throws {LayerServiceMetadataUnableToFetchError} When the metadata fetch fails or contains an error
    */
   protected override async onProcessLayerMetadata(
     layerConfig: XYZTilesLayerEntryConfig,
@@ -151,6 +154,32 @@ export class XYZTiles extends AbstractGeoViewRaster {
     // GV Possibly caused by a difference between OGC and ESRI XYZ Tiles, but only have ESRI XYZ Tiles as example currently
     // GV Also, might be worth checking out OGCMapTile for this? https://openlayers.org/en/latest/examples/ogc-map-tiles-geographic.html
     // GV Seems like it can deal with less specificity in the url and can handle the x y z internally?
+
+    // Get the data access path
+    const dataAccessPath = layerConfig.getDataAccessPath();
+
+    // Get the configProxyUrl
+    const configProxyUrl = this.getConfigProxyUrl();
+
+    // Test to reach one tile to see if the service is reachable
+    const test = await validateAndPingUrl(layerConfig.getDataAccessPath(), configProxyUrl);
+
+    // If not reachable, throw an error immediately
+    if (!test.isReachable)
+      throw new LayerServiceMetadataUnableToFetchError(
+        layerConfig.getGeoviewLayerId(),
+        layerConfig.getLayerNameCascade(),
+        new Error(test.error)
+      );
+
+    // If a proxy was necessary
+    if (test.needsProxy) {
+      // Indicate the proxy that was used
+      layerConfig.setProxyUrl(configProxyUrl);
+
+      // Update the access path to use the proxy if one was required
+      layerConfig.setDataAccessPath(`${configProxyUrl}?${dataAccessPath}`);
+    }
 
     // Get the metadata
     const metadata = this.getMetadata();

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/abstract-geoview-vector.ts
@@ -54,6 +54,7 @@ export abstract class AbstractGeoViewVector extends AbstractGeoViewLayer {
    * @param sourceOptions - The OpenLayers vector source options associated with the layer
    * @param readOptions - Options controlling how features are read, including the target `featureProjection`
    * @returns A promise that resolves to an array of OpenLayers features created from the underlying data source
+   * @throws {LayerTooManyEsriFeatures} When the layer has too many features
    */
   protected abstract onCreateVectorSourceLoadFeatures(
     layerConfig: VectorLayerEntryConfig,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/esri-feature.ts
@@ -168,7 +168,7 @@ export class EsriFeature extends AbstractGeoViewVector {
    * @param mapProjection - Optional map projection
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
    * @returns A promise that resolves once the layer entry configuration has gotten its metadata processed
-   * @throws {LayerTooManyEsriFeatures} When the layer has too many Esri features
+   * @throws {LayerServiceMetadataUnableToFetchError} When the metadata fetch fails or contains an error
    */
   protected override onProcessLayerMetadata(
     layerConfig: EsriFeatureLayerEntryConfig,
@@ -188,6 +188,7 @@ export class EsriFeature extends AbstractGeoViewVector {
    * @param sourceOptions - The OpenLayers vector source options associated with the layer
    * @param readOptions - Options controlling how features are read, including the target `featureProjection`
    * @returns A promise that resolves to an array of OpenLayers features
+   * @throws {LayerTooManyEsriFeatures} When the layer has too many Esri features
    */
   protected override async onCreateVectorSourceLoadFeatures(
     layerConfig: VectorLayerEntryConfig,

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -781,7 +781,7 @@ export class WFS extends AbstractGeoViewVector {
    * style retrieval through WMS `GetStyles`.
    *
    * @param layerConfig - The WFS layer configuration for which styling should be processed
-   * @param proxyUrl - Proxy URL to use if necessary
+   * @param proxyUrl - Proxy URL to use when necessary
    * @returns A promise that resolves with the layer style settings or undefined
    * @throws {LayerDataAccessPathMandatoryError} When the Data Access Path was undefined, likely because initDataAccessPath wasn't called
    */

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -543,7 +543,7 @@ export class WFS extends AbstractGeoViewVector {
       })
     );
 
-    // If not fetching styles on the WMS
+    // Keep track if fetching styles on the WMS
     layerConfig.fetchStylesOnWMS = fetchStylesOnWMS;
 
     // Create the class from geoview-layers package

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -23,7 +23,6 @@ import type {
   TypeMetadataWFSTextOnly,
 } from '@/api/types/layer-schema-types';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
-import { findPropertyByRegexPath } from '@/core/utils/utilities';
 import { Fetch } from '@/core/utils/fetch-helper';
 import {
   OgcWfsLayerEntryConfig,
@@ -34,7 +33,7 @@ import { LayerNoCapabilitiesError, LayerServiceMetadataUnableToFetchError } from
 import { GVWFS } from '@/geo/layer/gv-layers/vector/gv-wfs';
 import type { ConfigBaseClass, TypeLayerEntryShell } from '@/api/config/validation-classes/config-base-class';
 import { formatError } from '@/core/exceptions/core-exceptions';
-import { GeoUtilities, type SourceFeaturesInfo } from '@/geo/utils/utilities';
+import { GeoUtilities, type CallbackNewMetadataDelegate, type SourceFeaturesInfo } from '@/geo/utils/utilities';
 import { Projection } from '@/geo/utils/projection';
 import { logger } from '@/core/utils/logger';
 
@@ -341,7 +340,15 @@ export class WFS extends AbstractGeoViewVector {
     let metadata;
     try {
       // Fetch it
-      metadata = await WFS.fetchMetadata(this.getMetadataAccessPath(), abortSignal);
+      metadata = await WFS.fetchMetadata(
+        this.getMetadataAccessPath(),
+        this.getConfigProxyUrl(),
+        (proxiedUrl) => {
+          // Update the metadata access path to use the proxy
+          this.setMetadataAccessPath(proxiedUrl);
+        },
+        abortSignal
+      );
     } catch (error: unknown) {
       // Throw
       throw new LayerServiceMetadataUnableToFetchError(
@@ -496,14 +503,19 @@ export class WFS extends AbstractGeoViewVector {
    * @param geoviewLayerId - The unique identifier for the GeoView layer
    * @param geoviewLayerName - The display name for the GeoView layer
    * @param url - The URL of the service endpoint
+   * @param configProxyUrl - Proxy URL to use when necessary
    * @param layerIds - An array of layer IDs to include in the configuration
    * @param isTimeAware - Indicates if the layer is time aware
+   * @param vectorStrategy - The strategy to use for fetching vector data
+   * @param fetchStylesOnWMS - Indicates whether to fetch styles from WMS
+   * @param callbackCreateLayerEntryConfig - Optional callback to customize each layer entry configuration
    * @returns A promise that resolves to an array of layer configurations
    */
   static processGeoviewLayerConfig(
     geoviewLayerId: string,
     geoviewLayerName: string,
     url: string,
+    configProxyUrl: string | undefined,
     layerIds: string[],
     isTimeAware: boolean,
     vectorStrategy: VectorStrategy,
@@ -532,12 +544,13 @@ export class WFS extends AbstractGeoViewVector {
     );
 
     // If not fetching styles on the WMS
-    if (!fetchStylesOnWMS) {
-      layerConfig.fetchStylesOnWMS = false;
-    }
+    layerConfig.fetchStylesOnWMS = fetchStylesOnWMS;
 
     // Create the class from geoview-layers package
     const myLayer = new WFS(layerConfig);
+
+    // Set the proxy url, if any
+    myLayer.setConfigProxyUrl(configProxyUrl);
 
     // Process it
     return AbstractGeoViewVector.processConfig(myLayer);
@@ -611,18 +624,25 @@ export class WFS extends AbstractGeoViewVector {
    * Fetches the metadata for a typical WFS class.
    *
    * @param url - The url to query the metadata from
+   * @param configProxyUrl - Proxy URL to use when necessary
+   * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
+   * The parameter sent in the callback is the proxy prefix with the '?' at the end.
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
    * @returns A promise that resolves with the metadata when fetched or undefined when capabilities weren't found
+   * @throws {RequestTimeoutError} When the request exceeds the timeout duration
+   * @throws {RequestAbortedError} When the request was aborted by the caller's signal
+   * @throws {ResponseError} When the response is not OK (non-2xx)
+   * @throws {ResponseEmptyError} When the JSON response is empty
+   * @throws {NetworkError} When a network issue happened
    */
-  static async fetchMetadata(url: string, abortSignal?: AbortSignal): Promise<TypeMetadataWFS | undefined> {
-    // Get the GetCapabilities url
-    const urlGetCap = GeoUtilities.ensureServiceRequestUrlGetCapabilities(url, 'WFS');
-
-    // Query XML to Json
-    const responseJson = await Fetch.fetchXMLToJson(`${urlGetCap}`, { signal: abortSignal });
-
-    // Parse the WFS_Capabilities opening the root node right away to skip to the meat.
-    return findPropertyByRegexPath(responseJson, /(?:WFS_Capabilities)/);
+  static fetchMetadata(
+    url: string,
+    configProxyUrl: string | undefined,
+    callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
+    abortSignal?: AbortSignal
+  ): Promise<TypeMetadataWFS | undefined> {
+    // Redirect
+    return GeoUtilities.getWFSServiceMetadata(url, configProxyUrl, callbackNewMetadataUrl, abortSignal);
   }
 
   /**
@@ -643,7 +663,8 @@ export class WFS extends AbstractGeoViewVector {
    */
   static async fetchMetadataAndRetrieveFieldsInfo(url: string, layerId: string, abortSignal?: AbortSignal): Promise<TypeOutfields[]> {
     // Fetch the WFS metadata
-    const metadata = await WFS.fetchMetadata(url, abortSignal);
+    // TODO: CHECK - Do we need to send the configProxyUrl (this.getConfigProxyUrl()) here
+    const metadata = await WFS.fetchMetadata(url, undefined, undefined, abortSignal);
     const version = metadata?.['@attributes'].version || '1.1.0';
     const outputFormat = WFS.extractDescribeFeatureOutputFormat(metadata!);
 
@@ -781,13 +802,13 @@ export class WFS extends AbstractGeoViewVector {
    * style retrieval through WMS `GetStyles`.
    *
    * @param layerConfig - The WFS layer configuration for which styling should be processed
-   * @param proxyUrl - Proxy URL to use when necessary
+   * @param configProxyUrl - Proxy URL to use when necessary
    * @returns A promise that resolves with the layer style settings or undefined
    * @throws {LayerDataAccessPathMandatoryError} When the Data Access Path was undefined, likely because initDataAccessPath wasn't called
    */
   static async #tryProcessLayerStylingInformationIfAny(
     layerConfig: OgcWfsLayerEntryConfig,
-    proxyUrl: string | undefined
+    configProxyUrl: string | undefined
   ): Promise<Record<TypeStyleGeometry, TypeLayerStyleSettings> | undefined> {
     // If should fetch styles from the WMS (default)
     if (layerConfig.getShouldFetchStylesFromWMS()) {
@@ -799,7 +820,7 @@ export class WFS extends AbstractGeoViewVector {
         const tweakedUrl = layerConfig.getDataAccessPath().replaceAll('cgi-bin/wfs', 'cgi-bin/wms');
 
         // Create the layer style and return
-        return await WMS.createStylesFromWMS(tweakedUrl, proxyUrl, wmsLayerId, layerConfig.getGeometryType());
+        return await WMS.createStylesFromWMS(tweakedUrl, configProxyUrl, wmsLayerId, layerConfig.getGeometryType());
       } catch (error: unknown) {
         // Log warning
         logger.logWarning(`Failed to create a dynamic layer style for the WFS using the WMS styles for ${layerConfig.layerPath}`, error);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -343,7 +343,10 @@ export class WFS extends AbstractGeoViewVector {
       metadata = await WFS.fetchMetadata(
         this.getMetadataAccessPath(),
         this.getConfigProxyUrl(),
-        (proxiedUrl) => {
+        (proxiedUrl, proxyUsed) => {
+          // Indicate the proxy that was used
+          this.setProxyUrl(proxyUsed);
+
           // Update the metadata access path to use the proxy
           this.setMetadataAccessPath(proxiedUrl);
         },

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -230,7 +230,7 @@ export class WFS extends AbstractGeoViewVector {
     WFS.initLayerMetadata(layerConfig as OgcWfsLayerEntryConfig, featureProps);
 
     // Try
-    const layerStyle = await WFS.#tryProcessLayerStylingInformationIfAny(layerConfigWFS);
+    const layerStyle = await WFS.#tryProcessLayerStylingInformationIfAny(layerConfigWFS, this.getConfigProxyUrl());
 
     // Initialize the layer style by filling the blanks with the information from the metadata
     layerConfig.initLayerStyleFromMetadata(layerStyle);
@@ -781,11 +781,13 @@ export class WFS extends AbstractGeoViewVector {
    * style retrieval through WMS `GetStyles`.
    *
    * @param layerConfig - The WFS layer configuration for which styling should be processed
+   * @param proxyUrl - Proxy URL to use if necessary
    * @returns A promise that resolves with the layer style settings or undefined
    * @throws {LayerDataAccessPathMandatoryError} When the Data Access Path was undefined, likely because initDataAccessPath wasn't called
    */
   static async #tryProcessLayerStylingInformationIfAny(
-    layerConfig: OgcWfsLayerEntryConfig
+    layerConfig: OgcWfsLayerEntryConfig,
+    proxyUrl: string | undefined
   ): Promise<Record<TypeStyleGeometry, TypeLayerStyleSettings> | undefined> {
     // If should fetch styles from the WMS (default)
     if (layerConfig.getShouldFetchStylesFromWMS()) {
@@ -797,7 +799,7 @@ export class WFS extends AbstractGeoViewVector {
         const tweakedUrl = layerConfig.getDataAccessPath().replaceAll('cgi-bin/wfs', 'cgi-bin/wms');
 
         // Create the layer style and return
-        return await WMS.createStylesFromWMS(tweakedUrl, wmsLayerId, layerConfig.getGeometryType());
+        return await WMS.createStylesFromWMS(tweakedUrl, proxyUrl, wmsLayerId, layerConfig.getGeometryType());
       } catch (error: unknown) {
         // Log warning
         logger.logWarning(`Failed to create a dynamic layer style for the WFS using the WMS styles for ${layerConfig.layerPath}`, error);

--- a/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
+++ b/packages/geoview-core/src/geo/layer/geoview-layers/vector/wfs.ts
@@ -552,7 +552,7 @@ export class WFS extends AbstractGeoViewVector {
     // Create the class from geoview-layers package
     const myLayer = new WFS(layerConfig);
 
-    // Set the proxy url, if any
+    // Set the config proxy url, if any in case the layer needs a proxy during processing
     myLayer.setConfigProxyUrl(configProxyUrl);
 
     // Process it

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -1593,8 +1593,18 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
 
     // If we were not error before
     if (layerStatusBefore !== 'error') {
-      // Tile errors are non-fatal => at this point it was the last tile in flight, we can process the layer as loaded
-      this.#processLoaded();
+      // If loaded once already
+      if (this.loadedOnce) {
+        // Tile errors are non-fatal => at this point it was the last tile in flight, we can process the layer as loaded
+        this.#processLoaded();
+      } else {
+        // Never got loaded, ever
+        // Set the layer config status to error to keep mirroring the AbstractGeoViewLayer for now
+        this.getLayerConfig().setLayerStatusError();
+
+        // Update the parent group if any
+        this.getLayerConfig().updateLayerStatusParent();
+      }
     }
 
     // Emit event for all layer error events

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -115,6 +115,9 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
   /** Indicates if the layer is currently hoverable. */
   #hoverable: boolean;
 
+  /** Indicates if a message about a tile error has been emitted. */
+  #emittedMessageAboutTileError = false;
+
   /** Callback delegates for the layer style changed event. */
   #onLayerStyleChangedHandlers: StyleChangedDelegate[] = [];
 
@@ -1322,10 +1325,10 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
 
     if (!wasLast) return;
 
-    // Decipher the error, allowing children classes to be more specific (ex: Vector specific errors)
+    // Decipher the error, allowing children classes to be more specific
     const gvError = this.onErrorDecipherError(event);
 
-    // Call overridable method (sets layer status to error)
+    // Call overridable method
     this.onFeaturesLoadError(gvError);
   }
 
@@ -1357,7 +1360,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     // Decipher the error, allowing children classes to be more specific (ex: WMS GetMap specific errors)
     const gvError = this.onImageLoadErrorDecipherError(event);
 
-    // Call overridable method (sets layer status to error)
+    // Call overridable method
     this.onImageLoadError(gvError);
   }
 
@@ -1387,10 +1390,10 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
 
     if (!wasLast) return;
 
-    // Decipher the error, allowing children classes to be more specific (ex: Vector specific errors)
+    // Decipher the error, allowing children classes to be more specific
     const gvError = this.onErrorDecipherError(event);
 
-    // Call overridable method (does not flip status to error)
+    // Call overridable method
     this.onImageTileLoadError(gvError);
   }
 
@@ -1587,14 +1590,23 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
       // If loaded once already
       if (this.loadedOnce) {
         // Tile errors are non-fatal => at this point it was the last tile in flight, we can process the layer as loaded
+        // GV For example, Circompolar view, we don't want a error to pop for the user all the time
         this.#processLoaded();
       } else {
         // Never got loaded, ever
+        // GV For example, a service that is reachable, but fails to return actual tiles on the map
+
         // Set the layer config status to error to keep mirroring the AbstractGeoViewLayer for now
         this.getLayerConfig().setLayerStatusError(true);
 
-        // Emits a user-facing error message
-        this.emitMessage(error.messageKey, error.messageParams, 'error');
+        // If we never warned the user about a tile issue for that layer, warn them once
+        if (!this.#emittedMessageAboutTileError) {
+          // Flag
+          this.#emittedMessageAboutTileError = true;
+
+          // Emits a user-facing error message
+          this.emitMessage(error.messageKey, error.messageParams, 'error');
+        }
       }
     }
 

--- a/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/abstract-gv-layer.ts
@@ -1511,10 +1511,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     const layerConfig = this.getLayerConfig();
 
     // Set the layer has loading
-    layerConfig.setLayerStatusLoading();
-
-    // Update the parent group if any
-    this.getLayerConfig().updateLayerStatusParent();
+    layerConfig.setLayerStatusLoading(true);
 
     // Emit event for all layer load events
     this.#emitLayerLoading();
@@ -1530,15 +1527,12 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     const layerConfig = this.getLayerConfig();
 
     // Set the layer config status to loaded to keep mirroring the AbstractGeoViewLayer for now
-    layerConfig.setLayerStatusLoaded();
-
-    // Update the parent group if any
-    this.getLayerConfig().updateLayerStatusParent();
+    layerConfig.setLayerStatusLoaded(true);
 
     // If first time
     if (!this.loadedOnce) {
       // If it's a basemap layer, put it at the bottom of the stack to avoid any issue with layers order on map.
-      if (this.getLayerConfig().getGeoviewLayerConfig().useAsBasemap === true) this.getOLLayer().setZIndex(-1);
+      if (layerConfig.getGeoviewLayerConfig().useAsBasemap === true) this.getOLLayer().setZIndex(-1);
       // Now that the layer is loaded, set its visibility correctly (had to be done in the loaded event, not before, per prior note in pre-refactor)
       this.setVisible(layerConfig.getInitialSettings()?.states?.visible ?? true); // default: true
 
@@ -1566,13 +1560,10 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     // If we were not error before
     if (layerStatusBefore !== 'error') {
       // Set the layer config status to error to keep mirroring the AbstractGeoViewLayer for now
-      this.getLayerConfig().setLayerStatusError();
+      this.getLayerConfig().setLayerStatusError(true);
 
-      // Update the parent group if any
-      this.getLayerConfig().updateLayerStatusParent();
-
-      // Emit about the error
-      this.#emitError(error);
+      // Emits a user-facing error message
+      this.emitMessage(error.messageKey, error.messageParams, 'error');
     } else {
       // We've already emitted an error to the user about the layer being in error, skip so that we don't spam
     }
@@ -1600,10 +1591,10 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
       } else {
         // Never got loaded, ever
         // Set the layer config status to error to keep mirroring the AbstractGeoViewLayer for now
-        this.getLayerConfig().setLayerStatusError();
+        this.getLayerConfig().setLayerStatusError(true);
 
-        // Update the parent group if any
-        this.getLayerConfig().updateLayerStatusParent();
+        // Emits a user-facing error message
+        this.emitMessage(error.messageKey, error.messageParams, 'error');
       }
     }
 
@@ -1624,13 +1615,10 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
     // If we were not error before
     if (layerStatusBefore !== 'error') {
       // Set the layer config status to error to keep mirroring the AbstractGeoViewLayer for now
-      this.getLayerConfig().setLayerStatusError();
+      this.getLayerConfig().setLayerStatusError(true);
 
-      // Update the parent group if any
-      this.getLayerConfig().updateLayerStatusParent();
-
-      // Emit about the error
-      this.#emitError(error);
+      // Emits a user-facing error message
+      this.emitMessage(error.messageKey, error.messageParams, 'error');
     } else {
       // We've already emitted an error to the user about the layer being in error, skip so that we don't spam
     }
@@ -1663,7 +1651,7 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
 
         // If still loading
         if (layerStatus === 'loading') {
-          // Emit about the delay
+          // Emits a user-facing error message
           this.emitMessage('warning.layer.slowRender', { layerName: this.getLayerName() }, 'warning');
         }
 
@@ -1671,16 +1659,6 @@ export abstract class AbstractGVLayer extends AbstractBaseGVLayer {
       },
       (error: unknown) => logger.logPromiseFailed('Delay in #startLoadingPeriodWatcher failed', error)
     );
-  }
-
-  /**
-   * Emits a user-facing error message for a source loading error.
-   *
-   * @param gvError - The GeoView Error containing the message to emit
-   */
-  #emitError(gvError: GeoViewError): void {
-    // Emit about the error
-    this.emitMessage(gvError.messageKey, gvError.messageParams, 'error');
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -23,7 +23,6 @@ import type {
   TypeDisplayLanguage,
   TypeLayerStyleConfig,
 } from '@/api/types/map-schema-types';
-import { CONFIG_PROXY_URL } from '@/api/types/map-schema-types';
 import type { TypeLegend, TypeMetadataFeatureInfo } from '@/api/types/layer-schema-types';
 import { CONST_LAYER_TYPES } from '@/api/types/layer-schema-types';
 import { GeoviewRenderer } from '@/geo/utils/renderer/geoview-renderer';
@@ -127,6 +126,12 @@ export class GVWMS extends AbstractGVRaster {
       // Assign the src to the image, this is the regular behavior
       let theUrl = src;
 
+      // If we're behind a proxy
+      if (layerConfig.getIsUsingProxy()) {
+        // Tweak the url to use the proxy
+        theUrl = `${layerConfig.getProxyUrl()}?${theUrl}`;
+      }
+
       // If we're overriding the CRS for the layer as an attempt to do on-the-fly projection for tricky layers
       const overridingCRS = this.getOverrideCRS();
       if (overridingCRS) {
@@ -139,7 +144,7 @@ export class GVWMS extends AbstractGVRaster {
         );
 
         // Replace the BBOX param in the src url
-        theUrl = GeoUtilities.replaceCRSandBBOXParam(src, overridingCRS.layerProjection, supportedBBOX);
+        theUrl = GeoUtilities.replaceCRSandBBOXParam(theUrl, overridingCRS.layerProjection, supportedBBOX);
       }
 
       // eslint-disable-next-line no-param-reassign
@@ -1599,10 +1604,16 @@ export class GVWMS extends AbstractGVRaster {
     params.FI_POLYGON_TOLERANCE = qgisServerTolerance;
 
     // Generate the url
-    const featureInfoUrl = wmsSource?.getFeatureInfoUrl(clickCoordinate, viewResolution, projectionCode, params);
+    let featureInfoUrl = wmsSource?.getFeatureInfoUrl(clickCoordinate, viewResolution, projectionCode, params);
 
     // If generated a url
     if (featureInfoUrl) {
+      // If using a proxy
+      if (layerConfig.getIsUsingProxy()) {
+        // Tweak the url to use the proxy
+        featureInfoUrl = `${layerConfig.getProxyUrl()}?${featureInfoUrl}`;
+      }
+
       // Get the response data as text
       return Fetch.fetchText(featureInfoUrl, { signal: abortController?.signal });
     }
@@ -1831,10 +1842,10 @@ export class GVWMS extends AbstractGVRaster {
       // Retry with proxy if it's a network error (e.g., CORS)
       if (error instanceof NetworkError) {
         // Read the blob again, using the proxy this time
-        let proxyUrl = `${CONFIG_PROXY_URL}?${queryUrl}`;
+        let proxyUrl = `${layerConfig.getProxyUrl()!}?${queryUrl}`;
 
-        // If need to double layer encoding
-        if (GeoUtilities.DOUBLE_ENCODING_LAYERS_WHEN_BEHIND_PROXY) {
+        // If the proxy to use is the Esri proxy
+        if (layerConfig.getIsUsingEsriProxy()) {
           // Encode the layers parameter if present
           proxyUrl = encodeLayersParam(proxyUrl);
         }

--- a/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/raster/gv-wms.ts
@@ -34,7 +34,7 @@ import {
   LayerInvalidLayerFilterError,
 } from '@/core/exceptions/layer-exceptions';
 import { encodeLayersParam } from '@/core/utils/ogc-url-helper';
-import { formatError, NetworkError, RequestAbortedError, ResponseContentError } from '@/core/exceptions/core-exceptions';
+import { formatError, RequestAbortedError, ResponseContentError } from '@/core/exceptions/core-exceptions';
 import { AbstractGVLayer } from '@/geo/layer/gv-layers/abstract-gv-layer';
 import type { EsriImageLayerEntryConfig } from '@/api/config/validation-classes/raster-validation-classes/esri-image-layer-entry-config';
 import { WfsRenderer } from '@/geo/utils/renderer/wfs-renderer';
@@ -1810,7 +1810,7 @@ export class GVWMS extends AbstractGVRaster {
    * @returns A promise that resolves to an image blob or null if it fails to retrieve the legend image
    * @throws {ResponseContentError} When no URL is available to fetch the legend image
    */
-  static async #getLegendImage(layerConfig: OgcWmsLayerEntryConfig, chosenStyle?: string): Promise<string | ArrayBuffer | null> {
+  static #getLegendImage(layerConfig: OgcWmsLayerEntryConfig, chosenStyle?: string): Promise<string | ArrayBuffer | null> {
     // Get the legend URL from the layer metadata
     let queryUrl = layerConfig.getLegendUrl(chosenStyle);
 
@@ -1835,28 +1835,19 @@ export class GVWMS extends AbstractGVRaster {
       queryUrl = `https${queryUrl.slice(4)}`;
     }
 
-    try {
-      // Fetch the image (must await so CORS/network errors are caught below)
-      return await Fetch.fetchBlobImage(queryUrl);
-    } catch (error) {
-      // Retry with proxy if it's a network error (e.g., CORS)
-      if (error instanceof NetworkError) {
-        // Read the blob again, using the proxy this time
-        let proxyUrl = `${layerConfig.getProxyUrl()!}?${queryUrl}`;
+    // If we know that the layer is using a proxy, use it right away instead of even attempting to fetch the image directly (which would fail due to CORS)
+    if (layerConfig.getIsUsingProxy()) {
+      queryUrl = `${layerConfig.getProxyUrl()}?${queryUrl}`;
 
-        // If the proxy to use is the Esri proxy
-        if (layerConfig.getIsUsingEsriProxy()) {
-          // Encode the layers parameter if present
-          proxyUrl = encodeLayersParam(proxyUrl);
-        }
-
-        // Requery
-        return Fetch.fetchBlobImage(proxyUrl);
+      // If the proxy to use is the Esri proxy
+      if (layerConfig.getIsUsingEsriProxy()) {
+        // Encode the layers parameter if present
+        queryUrl = encodeLayersParam(queryUrl);
       }
-
-      // Failed
-      throw error;
     }
+
+    // Fetch the image (must await so CORS/network errors are caught below)
+    return Fetch.fetchBlobImage(queryUrl);
   }
 
   /**

--- a/packages/geoview-core/src/geo/layer/gv-layers/tile/abstract-gv-tile.ts
+++ b/packages/geoview-core/src/geo/layer/gv-layers/tile/abstract-gv-tile.ts
@@ -2,6 +2,7 @@ import type BaseTileLayer from 'ol/layer/BaseTile';
 import type TileSource from 'ol/source/Tile';
 import type LayerRenderer from 'ol/renderer/Layer';
 
+import { LayerTileFailedToLoadError, type GeoViewError } from '@/core/exceptions/geoview-exceptions';
 import { AbstractGVLayer } from '@/geo/layer/gv-layers/abstract-gv-layer';
 
 /**
@@ -22,6 +23,17 @@ export abstract class AbstractGVTile extends AbstractGVLayer {
     // Disabling 'any', because that's how it is in OpenLayers
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return super.getOLLayer() as BaseTileLayer<TileSource, LayerRenderer<any>>;
+  }
+
+  /**
+   * Overridable method called to get a more specific error code for all errors.
+   *
+   * @param event - The event which is being triggered.
+   * @returns The GeoViewError stored in the GVVectorSource if any or the one from the parent method.
+   */
+  protected override onErrorDecipherError(event: Event): GeoViewError {
+    // Generic error for a tile that failed to load
+    return new LayerTileFailedToLoadError(this.getLayerName());
   }
 
   // #endregion OVERRIDES

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -15,11 +15,6 @@ import { LineString, Point, Polygon } from 'ol/geom';
 import type { Coordinate } from 'ol/coordinate';
 import GML3 from 'ol/format/GML3';
 
-import type { TypeFeatureStyle } from '@/geo/layer/geometry/geometry-types';
-import { parseXMLToJson } from '@/core/utils/utilities';
-import { encodeLayersParam, ensureServiceRequestUrl } from '@/core/utils/ogc-url-helper';
-import { Fetch } from '@/core/utils/fetch-helper';
-import { Projection } from '@/geo/utils/projection';
 import { CONST_LAYER_TYPES, validVectorLayerLegendTypes } from '@/api/types/layer-schema-types';
 import {
   CONFIG_PROXY_URL,
@@ -28,9 +23,11 @@ import {
   type TypeStyleGeometry,
   type TypeValidMapProjectionCodes,
 } from '@/api/types/map-schema-types';
+import type { TypeMetadataWMTS } from '@/api/config/validation-classes/raster-validation-classes/ogc-wmts-layer-entry-config';
 import type {
   TypeGeoviewLayerType,
   TypeLegend,
+  TypeMetadataWFS,
   TypeMetadataWMS,
   TypeMetadataWMSCapabilityLayer,
   TypeMetadataWMSRoot,
@@ -38,10 +35,15 @@ import type {
   TypeStylesWMS,
   TypeVectorLayerStyles,
 } from '@/api/types/layer-schema-types';
-import type { TypeBasemapLayer } from '@/geo/layer/basemap/basemap-types';
 import { NetworkError, NotSupportedError, ResponseEmptyError } from '@/core/exceptions/core-exceptions';
-import type { TypeMetadataWMTS } from '@/api/config/validation-classes/raster-validation-classes/ogc-wmts-layer-entry-config';
+import { parseXMLToJson } from '@/core/utils/utilities';
+import { encodeLayersParam, ensureServiceRequestUrl } from '@/core/utils/ogc-url-helper';
+import { Fetch } from '@/core/utils/fetch-helper';
+import { findPropertyByRegexPath } from '@/core/utils/utilities';
 import type { TypeLegendItem, TypeLegendLayerItem } from '@/core/components/layers/types';
+import type { TypeBasemapLayer } from '@/geo/layer/basemap/basemap-types';
+import type { TypeFeatureStyle } from '@/geo/layer/geometry/geometry-types';
+import { Projection } from '@/geo/utils/projection';
 
 // available layer types
 export const layerTypes = CONST_LAYER_TYPES;
@@ -264,7 +266,7 @@ export abstract class GeoUtilities {
    * Fetch the json response from the XML response of a WMS getCapabilities request.
    *
    * @param url - The url the url of the WMS server
-   * @param proxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
+   * @param configProxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
@@ -277,7 +279,7 @@ export abstract class GeoUtilities {
    */
   static async getWMSServiceString(
     url: string,
-    proxyUrl: string = CONFIG_PROXY_URL,
+    configProxyUrl: string = CONFIG_PROXY_URL,
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal
   ): Promise<string> {
@@ -292,20 +294,20 @@ export abstract class GeoUtilities {
       // If a network error such as CORS
       if (error instanceof NetworkError) {
         // If the proxy to use is the Esri proxy
-        if (GeoUtilities.isEsriProxy(proxyUrl)) {
+        if (GeoUtilities.isEsriProxy(configProxyUrl)) {
           // Encode the layers parameter if present
           // eslint-disable-next-line no-param-reassign
           url = encodeLayersParam(url);
         }
 
         // We're going to change the metadata url to use a proxy
-        const newProxiedMetadataUrl = `${proxyUrl}?${url}`;
+        const newProxiedMetadataUrl = `${configProxyUrl}?${url}`;
 
         // Try again with the proxy this time
         capabilitiesString = await Fetch.fetchText(newProxiedMetadataUrl);
 
         // Callback about it
-        callbackNewMetadataUrl?.(newProxiedMetadataUrl, proxyUrl);
+        callbackNewMetadataUrl?.(newProxiedMetadataUrl, configProxyUrl);
 
         // Return it
         return capabilitiesString;
@@ -320,7 +322,7 @@ export abstract class GeoUtilities {
    * Fetch the json response from the XML response of a WMS getCapabilities request.
    *
    * @param url - The url the url of the WMS server
-   * @param proxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
+   * @param configProxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
    * @param layers - The layers to query separate by
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
@@ -334,7 +336,7 @@ export abstract class GeoUtilities {
    */
   static async getWMSServiceMetadata(
     url: string,
-    proxyUrl: string = CONFIG_PROXY_URL,
+    configProxyUrl: string = CONFIG_PROXY_URL,
     layers?: string,
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal
@@ -343,7 +345,7 @@ export abstract class GeoUtilities {
     const capUrl = this.ensureServiceRequestUrlGetCapabilities(url, 'WMS', layers);
 
     // Redirect
-    const metadataRaw = await this.getWMSServiceString(capUrl, proxyUrl, callbackNewMetadataUrl, abortSignal);
+    const metadataRaw = await this.getWMSServiceString(capUrl, configProxyUrl, callbackNewMetadataUrl, abortSignal);
 
     // Parse it
     const metadataParsed = parseXMLToJson<TypeMetadataWMSRoot>(metadataRaw);
@@ -385,10 +387,44 @@ export abstract class GeoUtilities {
   }
 
   /**
+   * Fetch the json response from the XML response of a WFS getCapabilities request.
+   *
+   * @param url - The url of the WFS server
+   * @param configProxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
+   * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
+   * The parameter sent in the callback is the proxy prefix with the '?' at the end.
+   * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
+   * @returns A promise that resolves with the parsed WFS metadata, or undefined when capabilities weren't found
+   * @throws {RequestTimeoutError} When the request exceeds the timeout duration
+   * @throws {RequestAbortedError} When the request was aborted by the caller's signal
+   * @throws {ResponseError} When the response is not OK (non-2xx)
+   * @throws {ResponseEmptyError} When the JSON response is empty
+   * @throws {NetworkError} When a network issue happened
+   */
+  static async getWFSServiceMetadata(
+    url: string,
+    configProxyUrl: string = CONFIG_PROXY_URL,
+    callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
+    abortSignal?: AbortSignal
+  ): Promise<TypeMetadataWFS | undefined> {
+    // Make sure the URL has necessary information
+    const capUrl = this.ensureServiceRequestUrlGetCapabilities(url, 'WFS');
+
+    // Redirect
+    const metadataRaw = await this.getWMSServiceString(capUrl, configProxyUrl, callbackNewMetadataUrl, abortSignal);
+
+    // Parse it
+    const metadataParsed = parseXMLToJson<Record<string, unknown>>(metadataRaw);
+
+    // Parse the WFS_Capabilities opening the root node right away to skip to the meat.
+    return findPropertyByRegexPath<TypeMetadataWFS>(metadataParsed, /(?:WFS_Capabilities)/);
+  }
+
+  /**
    * Fetch the json response from the XML response of a WMTS getCapabilities request.
    *
    * @param url - The url the url of the WMTS server
-   * @param proxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
+   * @param configProxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
    * @param layers - The layers to query, separated by comma
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * @param abortSignal - Optional abort signal to handle cancelling of the process
@@ -401,7 +437,7 @@ export abstract class GeoUtilities {
    */
   static async getWMTSServiceMetadata(
     url: string,
-    proxyUrl: string = CONFIG_PROXY_URL,
+    configProxyUrl: string = CONFIG_PROXY_URL,
     layers?: string,
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal
@@ -410,7 +446,7 @@ export abstract class GeoUtilities {
     const capUrl = this.ensureServiceRequestUrlGetCapabilities(url, 'WMTS', layers);
 
     // Redirect
-    const metadataRaw = await this.getWMSServiceString(capUrl, proxyUrl, callbackNewMetadataUrl, abortSignal);
+    const metadataRaw = await this.getWMSServiceString(capUrl, configProxyUrl, callbackNewMetadataUrl, abortSignal);
 
     // Parse it
     const metadataParsed = parseXMLToJson<TypeMetadataWMTS>(metadataRaw);
@@ -421,6 +457,104 @@ export abstract class GeoUtilities {
     // Return it
     return metadataParsed;
   }
+
+  /**
+   * Fetch the json response from the XML response of a WMS GetStyles request.
+   *
+   * @param url - The url the url of the WMS server
+   * @param configProxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
+   * @param layers - The layers to query, separated by comma
+   * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
+   * The parameter sent in the callback is the proxy prefix with the '?' at the end.
+   * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
+   * @returns A promise that resolves with the parsed WMS styles
+   * @throws {RequestTimeoutError} When the request exceeds the timeout duration
+   * @throws {RequestAbortedError} When the request was aborted by the caller's signal
+   * @throws {ResponseError} When the response is not OK (non-2xx)
+   * @throws {ResponseEmptyError} When the JSON response is empty
+   * @throws {NetworkError} When a network issue happened
+   */
+  static async getWMSServiceStyles(
+    url: string,
+    configProxyUrl: string = CONFIG_PROXY_URL,
+    layers?: string,
+    callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
+    abortSignal?: AbortSignal
+  ): Promise<TypeStylesWMS> {
+    // Make sure the URL has necessary information
+    const stylesUrl = this.ensureServiceRequestUrlGetStyles(url, layers);
+
+    // Redirect
+    const responseXML = await this.getWMSServiceString(stylesUrl, configProxyUrl, callbackNewMetadataUrl, abortSignal);
+
+    // Read the styles
+    return parseXMLToJson(responseXML);
+  }
+
+  /**
+   * Return the map server url from a layer service.
+   *
+   * @param url - The service url for a wms / dynamic or feature layers
+   * @param rest - Boolean value to add rest services if not present (default false)
+   * @returns The map server url
+   * @deprecated As it's not being used anymore (or only used by external developers?)
+   */
+  static getMapServerUrl(url: string, rest = false): string {
+    let mapServerUrl = url;
+    if (mapServerUrl.includes('MapServer')) {
+      mapServerUrl = mapServerUrl.slice(0, mapServerUrl.indexOf('MapServer') + 'MapServer'.length);
+    }
+    if (mapServerUrl.includes('FeatureServer')) {
+      mapServerUrl = mapServerUrl.slice(0, mapServerUrl.indexOf('FeatureServer') + 'FeatureServer'.length);
+    }
+
+    if (rest) {
+      const urlRightSide = mapServerUrl.slice(mapServerUrl.indexOf('/services/'));
+      mapServerUrl = `${mapServerUrl.slice(0, url.indexOf('services/'))}rest${urlRightSide}`;
+    }
+
+    return mapServerUrl;
+  }
+
+  /**
+   * Return the root server url from a OGC layer service.
+   *
+   * @param url - The service url for an ogc layer
+   * @returns The root ogc server url
+   * @deprecated As it's not being used anymore (or only used by external developers?)
+   */
+  static getOGCServerUrl(url: string): string {
+    let ogcServerUrl = url;
+    if (ogcServerUrl.includes('collections')) {
+      ogcServerUrl = ogcServerUrl.slice(0, ogcServerUrl.indexOf('collections'));
+    }
+    return ogcServerUrl;
+  }
+
+  /**
+   * Replaces or adds the BBOX parameter in a WMS GetMap URL.
+   *
+   * @param url - The original WMS GetMap URL
+   * @param newCRS - The new CRS
+   * @param newBBOX - The new BBOX to set, as an array of 4 numbers: [minX, minY, maxX, maxY]
+   * @returns A new URL string with the updated BBOX parameter
+   */
+  static replaceCRSandBBOXParam(url: string, newCRS: string, newBBOX: number[]): string {
+    const urlObj = new URL(url);
+
+    // Format the new BBOX as a comma-separated string
+    const bboxString = newBBOX.join(',');
+
+    // Replace or add the BBOX parameter
+    urlObj.searchParams.set('BBOX', bboxString);
+    urlObj.searchParams.set('CRS', newCRS);
+
+    return urlObj.toString();
+  }
+
+  // #endregion FETCH METADATA
+
+  // #region FETCH METADATA - PRIVATE METHODS
 
   /**
    * Detects whether a WMS GetCapabilities document was produced by QGIS Server.
@@ -660,101 +794,7 @@ export abstract class GeoUtilities {
     });
   }
 
-  /**
-   * Fetch the json response from the XML response of a WMS GetStyles request.
-   *
-   * @param url - The url the url of the WMS server
-   * @param proxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
-   * @param layers - The layers to query, separated by comma
-   * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
-   * The parameter sent in the callback is the proxy prefix with the '?' at the end.
-   * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
-   * @returns A promise that resolves with the parsed WMS styles
-   * @throws {RequestTimeoutError} When the request exceeds the timeout duration
-   * @throws {RequestAbortedError} When the request was aborted by the caller's signal
-   * @throws {ResponseError} When the response is not OK (non-2xx)
-   * @throws {ResponseEmptyError} When the JSON response is empty
-   * @throws {NetworkError} When a network issue happened
-   */
-  static async getWMSServiceStyles(
-    url: string,
-    proxyUrl: string = CONFIG_PROXY_URL,
-    layers?: string,
-    callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
-    abortSignal?: AbortSignal
-  ): Promise<TypeStylesWMS> {
-    // Make sure the URL has necessary information
-    const stylesUrl = this.ensureServiceRequestUrlGetStyles(url, layers);
-
-    // Redirect
-    const responseXML = await this.getWMSServiceString(stylesUrl, proxyUrl, callbackNewMetadataUrl, abortSignal);
-
-    // Read the styles
-    return parseXMLToJson(responseXML);
-  }
-
-  /**
-   * Return the map server url from a layer service.
-   *
-   * @param url - The service url for a wms / dynamic or feature layers
-   * @param rest - Boolean value to add rest services if not present (default false)
-   * @returns The map server url
-   * @deprecated
-   */
-  static getMapServerUrl(url: string, rest = false): string {
-    let mapServerUrl = url;
-    if (mapServerUrl.includes('MapServer')) {
-      mapServerUrl = mapServerUrl.slice(0, mapServerUrl.indexOf('MapServer') + 'MapServer'.length);
-    }
-    if (mapServerUrl.includes('FeatureServer')) {
-      mapServerUrl = mapServerUrl.slice(0, mapServerUrl.indexOf('FeatureServer') + 'FeatureServer'.length);
-    }
-
-    if (rest) {
-      const urlRightSide = mapServerUrl.slice(mapServerUrl.indexOf('/services/'));
-      mapServerUrl = `${mapServerUrl.slice(0, url.indexOf('services/'))}rest${urlRightSide}`;
-    }
-
-    return mapServerUrl;
-  }
-
-  /**
-   * Return the root server url from a OGC layer service.
-   *
-   * @param url - The service url for an ogc layer
-   * @returns The root ogc server url
-   * @deprecated
-   */
-  static getOGCServerUrl(url: string): string {
-    let ogcServerUrl = url;
-    if (ogcServerUrl.includes('collections')) {
-      ogcServerUrl = ogcServerUrl.slice(0, ogcServerUrl.indexOf('collections'));
-    }
-    return ogcServerUrl;
-  }
-
-  /**
-   * Replaces or adds the BBOX parameter in a WMS GetMap URL.
-   *
-   * @param url - The original WMS GetMap URL
-   * @param newCRS - The new CRS
-   * @param newBBOX - The new BBOX to set, as an array of 4 numbers: [minX, minY, maxX, maxY]
-   * @returns A new URL string with the updated BBOX parameter
-   */
-  static replaceCRSandBBOXParam(url: string, newCRS: string, newBBOX: number[]): string {
-    const urlObj = new URL(url);
-
-    // Format the new BBOX as a comma-separated string
-    const bboxString = newBBOX.join(',');
-
-    // Replace or add the BBOX parameter
-    urlObj.searchParams.set('BBOX', bboxString);
-    urlObj.searchParams.set('CRS', newCRS);
-
-    return urlObj.toString();
-  }
-
-  // #endregion FETCH METADATA
+  // #endregion FETCH METADATA - PRIVATE METHODS
 
   // #region LEGEND
 

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -76,7 +76,7 @@ export abstract class GeoUtilities {
    * @param proxyUrl - The proxy URL to check
    * @returns `true` if the proxy URL includes "executeFromProxy", indicating an Esri proxy; otherwise, `false`.
    */
-  static IS_ESRI_PROXY(proxyUrl: string | undefined): boolean {
+  static isEsriProxy(proxyUrl: string | undefined): boolean {
     return proxyUrl?.includes('executeFromProxy') ?? false; // default: false
   }
 
@@ -292,7 +292,7 @@ export abstract class GeoUtilities {
       // If a network error such as CORS
       if (error instanceof NetworkError) {
         // If the proxy to use is the Esri proxy
-        if (GeoUtilities.IS_ESRI_PROXY(proxyUrl)) {
+        if (GeoUtilities.isEsriProxy(proxyUrl)) {
           // Encode the layers parameter if present
           // eslint-disable-next-line no-param-reassign
           url = encodeLayersParam(url);
@@ -385,11 +385,11 @@ export abstract class GeoUtilities {
   }
 
   /**
-   * Fetch the json response from the XML response of a WMS getCapabilities request.
+   * Fetch the json response from the XML response of a WMTS getCapabilities request.
    *
-   * @param url - The url the url of the WMS server
+   * @param url - The url the url of the WMTS server
    * @param proxyUrl - Proxy URL to use if necessary (defaults to CONFIG_PROXY_URL)
-   * @param layers - The layers to query separate by
+   * @param layers - The layers to query, separated by comma
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * @param abortSignal - Optional abort signal to handle cancelling of the process
    * @returns A promise that resolves with the parsed WMTS metadata
@@ -661,11 +661,11 @@ export abstract class GeoUtilities {
   }
 
   /**
-   * Fetch the json response from the XML response of a WMS getCapabilities request.
+   * Fetch the json response from the XML response of a WMS GetStyles request.
    *
    * @param url - The url the url of the WMS server
    * @param proxyUrl - Proxy URL to use if necessary (defaults to CONFIG_PROXY_URL)
-   * @param layers - The layers to query separate by
+   * @param layers - The layers to query, separated by comma
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -264,7 +264,7 @@ export abstract class GeoUtilities {
    * Fetch the json response from the XML response of a WMS getCapabilities request.
    *
    * @param url - The url the url of the WMS server
-   * @param proxyUrl - Proxy URL to use if necessary (defaults to CONFIG_PROXY_URL)
+   * @param proxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
@@ -320,7 +320,7 @@ export abstract class GeoUtilities {
    * Fetch the json response from the XML response of a WMS getCapabilities request.
    *
    * @param url - The url the url of the WMS server
-   * @param proxyUrl - Proxy URL to use if necessary (defaults to CONFIG_PROXY_URL)
+   * @param proxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
    * @param layers - The layers to query separate by
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
@@ -388,7 +388,7 @@ export abstract class GeoUtilities {
    * Fetch the json response from the XML response of a WMTS getCapabilities request.
    *
    * @param url - The url the url of the WMTS server
-   * @param proxyUrl - Proxy URL to use if necessary (defaults to CONFIG_PROXY_URL)
+   * @param proxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
    * @param layers - The layers to query, separated by comma
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * @param abortSignal - Optional abort signal to handle cancelling of the process
@@ -664,7 +664,7 @@ export abstract class GeoUtilities {
    * Fetch the json response from the XML response of a WMS GetStyles request.
    *
    * @param url - The url the url of the WMS server
-   * @param proxyUrl - Proxy URL to use if necessary (defaults to CONFIG_PROXY_URL)
+   * @param proxyUrl - Proxy URL to use when necessary (defaults to CONFIG_PROXY_URL)
    * @param layers - The layers to query, separated by comma
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.

--- a/packages/geoview-core/src/geo/utils/utilities.ts
+++ b/packages/geoview-core/src/geo/utils/utilities.ts
@@ -20,9 +20,14 @@ import { parseXMLToJson } from '@/core/utils/utilities';
 import { encodeLayersParam, ensureServiceRequestUrl } from '@/core/utils/ogc-url-helper';
 import { Fetch } from '@/core/utils/fetch-helper';
 import { Projection } from '@/geo/utils/projection';
-import { CONFIG_PROXY_URL } from '@/api/types/map-schema-types';
 import { CONST_LAYER_TYPES, validVectorLayerLegendTypes } from '@/api/types/layer-schema-types';
-import type { TypeMapMouseInfo, TypeOutfields, TypeStyleGeometry, TypeValidMapProjectionCodes } from '@/api/types/map-schema-types';
+import {
+  CONFIG_PROXY_URL,
+  type TypeMapMouseInfo,
+  type TypeOutfields,
+  type TypeStyleGeometry,
+  type TypeValidMapProjectionCodes,
+} from '@/api/types/map-schema-types';
 import type {
   TypeGeoviewLayerType,
   TypeLegend,
@@ -65,8 +70,15 @@ interface EsriJSONReadResult {
 // #region FETCH METADATA
 
 export abstract class GeoUtilities {
-  /** Whether to double encode the layers when behind a proxy */
-  static readonly DOUBLE_ENCODING_LAYERS_WHEN_BEHIND_PROXY = true;
+  /**
+   * Checks if the provided proxy URL is an Esri proxy.
+   *
+   * @param proxyUrl - The proxy URL to check
+   * @returns `true` if the proxy URL includes "executeFromProxy", indicating an Esri proxy; otherwise, `false`.
+   */
+  static IS_ESRI_PROXY(proxyUrl: string | undefined): boolean {
+    return proxyUrl?.includes('executeFromProxy') ?? false; // default: false
+  }
 
   /**
    * Extracts the base URL (origin + pathname) from a full URL string,
@@ -252,6 +264,7 @@ export abstract class GeoUtilities {
    * Fetch the json response from the XML response of a WMS getCapabilities request.
    *
    * @param url - The url the url of the WMS server
+   * @param proxyUrl - Proxy URL to use if necessary (defaults to CONFIG_PROXY_URL)
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
    * @param abortSignal - Optional {@link AbortSignal} used to cancel the layer creation process
@@ -264,6 +277,7 @@ export abstract class GeoUtilities {
    */
   static async getWMSServiceString(
     url: string,
+    proxyUrl: string = CONFIG_PROXY_URL,
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal
   ): Promise<string> {
@@ -277,21 +291,21 @@ export abstract class GeoUtilities {
     } catch (error: unknown) {
       // If a network error such as CORS
       if (error instanceof NetworkError) {
-        // If double encoding the layers param when behind proxy
-        if (GeoUtilities.DOUBLE_ENCODING_LAYERS_WHEN_BEHIND_PROXY) {
+        // If the proxy to use is the Esri proxy
+        if (GeoUtilities.IS_ESRI_PROXY(proxyUrl)) {
           // Encode the layers parameter if present
           // eslint-disable-next-line no-param-reassign
           url = encodeLayersParam(url);
         }
 
         // We're going to change the metadata url to use a proxy
-        const newProxiedMetadataUrl = `${CONFIG_PROXY_URL}?${url}`;
+        const newProxiedMetadataUrl = `${proxyUrl}?${url}`;
 
         // Try again with the proxy this time
         capabilitiesString = await Fetch.fetchText(newProxiedMetadataUrl);
 
         // Callback about it
-        callbackNewMetadataUrl?.(newProxiedMetadataUrl, CONFIG_PROXY_URL);
+        callbackNewMetadataUrl?.(newProxiedMetadataUrl, proxyUrl);
 
         // Return it
         return capabilitiesString;
@@ -306,6 +320,7 @@ export abstract class GeoUtilities {
    * Fetch the json response from the XML response of a WMS getCapabilities request.
    *
    * @param url - The url the url of the WMS server
+   * @param proxyUrl - Proxy URL to use if necessary (defaults to CONFIG_PROXY_URL)
    * @param layers - The layers to query separate by
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
@@ -319,6 +334,7 @@ export abstract class GeoUtilities {
    */
   static async getWMSServiceMetadata(
     url: string,
+    proxyUrl: string = CONFIG_PROXY_URL,
     layers?: string,
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal
@@ -327,7 +343,7 @@ export abstract class GeoUtilities {
     const capUrl = this.ensureServiceRequestUrlGetCapabilities(url, 'WMS', layers);
 
     // Redirect
-    const metadataRaw = await this.getWMSServiceString(capUrl, callbackNewMetadataUrl, abortSignal);
+    const metadataRaw = await this.getWMSServiceString(capUrl, proxyUrl, callbackNewMetadataUrl, abortSignal);
 
     // Parse it
     const metadataParsed = parseXMLToJson<TypeMetadataWMSRoot>(metadataRaw);
@@ -372,6 +388,7 @@ export abstract class GeoUtilities {
    * Fetch the json response from the XML response of a WMS getCapabilities request.
    *
    * @param url - The url the url of the WMS server
+   * @param proxyUrl - Proxy URL to use if necessary (defaults to CONFIG_PROXY_URL)
    * @param layers - The layers to query separate by
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * @param abortSignal - Optional abort signal to handle cancelling of the process
@@ -384,6 +401,7 @@ export abstract class GeoUtilities {
    */
   static async getWMTSServiceMetadata(
     url: string,
+    proxyUrl: string = CONFIG_PROXY_URL,
     layers?: string,
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal
@@ -392,7 +410,7 @@ export abstract class GeoUtilities {
     const capUrl = this.ensureServiceRequestUrlGetCapabilities(url, 'WMTS', layers);
 
     // Redirect
-    const metadataRaw = await this.getWMSServiceString(capUrl, callbackNewMetadataUrl, abortSignal);
+    const metadataRaw = await this.getWMSServiceString(capUrl, proxyUrl, callbackNewMetadataUrl, abortSignal);
 
     // Parse it
     const metadataParsed = parseXMLToJson<TypeMetadataWMTS>(metadataRaw);
@@ -646,6 +664,7 @@ export abstract class GeoUtilities {
    * Fetch the json response from the XML response of a WMS getCapabilities request.
    *
    * @param url - The url the url of the WMS server
+   * @param proxyUrl - Proxy URL to use if necessary (defaults to CONFIG_PROXY_URL)
    * @param layers - The layers to query separate by
    * @param callbackNewMetadataUrl - Optional callback executed when a proxy had to be used to fetch the metadata.
    * The parameter sent in the callback is the proxy prefix with the '?' at the end.
@@ -659,6 +678,7 @@ export abstract class GeoUtilities {
    */
   static async getWMSServiceStyles(
     url: string,
+    proxyUrl: string = CONFIG_PROXY_URL,
     layers?: string,
     callbackNewMetadataUrl?: CallbackNewMetadataDelegate,
     abortSignal?: AbortSignal
@@ -667,7 +687,7 @@ export abstract class GeoUtilities {
     const stylesUrl = this.ensureServiceRequestUrlGetStyles(url, layers);
 
     // Redirect
-    const responseXML = await this.getWMSServiceString(stylesUrl, callbackNewMetadataUrl, abortSignal);
+    const responseXML = await this.getWMSServiceString(stylesUrl, proxyUrl, callbackNewMetadataUrl, abortSignal);
 
     // Read the styles
     return parseXMLToJson(responseXML);

--- a/packages/geoview-test-suite/src/tests/suites/suite-core.ts
+++ b/packages/geoview-test-suite/src/tests/suites/suite-core.ts
@@ -50,14 +50,27 @@ export class GVTestSuiteCore extends GVAbstractTestSuite {
    * @returns A promise that resolves when tests are completed
    */
   protected override onLaunchTestSuite(): Promise<unknown> {
-    // Test validateAndPingUrl
-    const pPingValidReachable = this.#coreTester.testValidateAndPingUrlValidReachable();
+    // Test validateAndPingUrl (simple)
+    const pSimplePingValid = this.#coreTester.testSimplePingValidReachable();
+    const pSimplePingXyz = this.#coreTester.testSimplePingXyzTileUrl();
+    const pSimplePingXyz401 = this.#coreTester.testSimplePingXyzTileUrlUnauthorized();
+
+    // Test validateAndPingUrlOGC (OGC-aware)
     const pPingInvalidFormat = this.#coreTester.testValidateAndPingUrlInvalidFormat();
     const pPingUnreachable = this.#coreTester.testValidateAndPingUrlUnreachable();
     const pPingWmsService = this.#coreTester.testValidateAndPingUrlWmsService();
+
     const pGeometryCollectionLegendStyles = this.#coreTester.testGeometryCollectionLegendStyles();
 
     // Resolve when all
-    return Promise.all([pPingValidReachable, pPingInvalidFormat, pPingUnreachable, pPingWmsService, pGeometryCollectionLegendStyles]);
+    return Promise.all([
+      pSimplePingValid,
+      pSimplePingXyz,
+      pSimplePingXyz401,
+      pPingInvalidFormat,
+      pPingUnreachable,
+      pPingWmsService,
+      pGeometryCollectionLegendStyles,
+    ]);
   }
 }

--- a/packages/geoview-test-suite/src/tests/testers/core-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/core-tester.ts
@@ -1,5 +1,5 @@
 ﻿import type { PingResult } from 'geoview-core/core/utils/utilities';
-import { validateAndPingUrl } from 'geoview-core/core/utils/utilities';
+import { validateAndPingUrl, validateAndPingUrlOGC } from 'geoview-core/core/utils/utilities';
 import type { TypeLayerStyleConfig, TypePolygonVectorConfig } from 'geoview-core/api/types/map-schema-types';
 import { GeoviewRenderer } from 'geoview-core/geo/utils/renderer/geoview-renderer';
 
@@ -19,22 +19,22 @@ export class CoreTester extends GVAbstractTester {
     return 'CoreTester';
   }
 
-  // #region VALIDATE AND PING URL
+  // #region VALIDATE AND PING URL (SIMPLE)
 
   /**
-   * Tests validateAndPingUrl with a valid and reachable URL.
+   * Tests validateAndPingUrl (simple) with a directly reachable URL.
    *
-   * Uses the Historical Flood MapServer URL which is known to be reachable.
-   * Asserts that the result has isValid=true and isReachable=true.
+   * Uses the Historical Flood MapServer URL which responds to HEAD with 2xx.
+   * Asserts that the simple ping succeeds without needing OGC fallback.
    *
    * @returns A promise that resolves when the test completes
    */
-  testValidateAndPingUrlValidReachable(): Promise<Test<PingResult>> {
+  testSimplePingValidReachable(): Promise<Test<PingResult>> {
     return this.test(
-      `Test validateAndPingUrl with a valid reachable URL...`,
+      `Test validateAndPingUrl (simple) with a directly reachable URL...`,
       async (test) => {
         const url = GVAbstractTester.HISTORICAL_FLOOD_URL_MAP_SERVER;
-        test.addStep(`Pinging valid reachable URL: ${url}...`);
+        test.addStep(`Simple pinging valid reachable URL: ${url}...`);
         const result = await validateAndPingUrl(url);
         return result;
       },
@@ -45,6 +45,9 @@ export class CoreTester extends GVAbstractTester {
         test.addStep('Verifying isReachable is true...');
         Test.assertIsEqual(result.isReachable, true);
 
+        test.addStep('Verifying needsProxy is false...');
+        Test.assertIsEqual(result.needsProxy, false);
+
         test.addStep('Verifying no error message...');
         Test.assertIsUndefined('error', result.error);
       }
@@ -52,7 +55,74 @@ export class CoreTester extends GVAbstractTester {
   }
 
   /**
-   * Tests validateAndPingUrl with an invalid URL format.
+   * Tests validateAndPingUrl (simple) with an XYZ tile URL template.
+   *
+   * Verifies that XYZ placeholder tokens ({z}, {x}, {y}) are resolved before pinging.
+   * Uses the OpenStreetMap tile server which is publicly reachable.
+   *
+   * @returns A promise that resolves when the test completes
+   */
+  testSimplePingXyzTileUrl(): Promise<Test<PingResult>> {
+    return this.test(
+      `Test validateAndPingUrl (simple) with an XYZ tile URL template...`,
+      async (test) => {
+        const url = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+        test.addStep(`Simple pinging XYZ tile URL: ${url}...`);
+        const result = await validateAndPingUrl(url);
+        return result;
+      },
+      (test, result) => {
+        test.addStep('Verifying isValid is true (XYZ placeholders resolved)...');
+        Test.assertIsEqual(result.isValid, true);
+
+        test.addStep('Verifying isReachable is true...');
+        Test.assertIsEqual(result.isReachable, true);
+
+        test.addStep('Verifying needsProxy is false...');
+        Test.assertIsEqual(result.needsProxy, false);
+      }
+    );
+  }
+
+  /**
+   * Tests validateAndPingUrl (simple) with an XYZ tile URL that requires authentication.
+   *
+   * Uses the Gnosis Earth OGC API tile endpoint which returns 401 Unauthorized.
+   * Asserts that the result has isValid=true but isReachable=false with a 401 status.
+   *
+   * @returns A promise that resolves when the test completes
+   */
+  testSimplePingXyzTileUrlUnauthorized(): Promise<Test<PingResult>> {
+    return this.test(
+      `Test validateAndPingUrl (simple) with an XYZ tile URL returning 401...`,
+      async (test) => {
+        const url = 'https://maps.gnosis.earth/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad/{z}/{x}/{y}.jpg';
+        test.addStep(`Simple pinging XYZ tile URL requiring auth: ${url}...`);
+        const result = await validateAndPingUrl(url);
+        return result;
+      },
+      (test, result) => {
+        test.addStep('Verifying isValid is true (URL format is valid)...');
+        Test.assertIsEqual(result.isValid, true);
+
+        test.addStep('Verifying isReachable is false (401 Unauthorized)...');
+        Test.assertIsEqual(result.isReachable, false);
+
+        test.addStep('Verifying status is 401...');
+        Test.assertIsEqual(result.status, 401);
+
+        test.addStep('Verifying error message exists...');
+        Test.assertIsDefined('error', result.error);
+      }
+    );
+  }
+
+  // #endregion VALIDATE AND PING URL (SIMPLE)
+
+  // #region VALIDATE AND PING URL (OGC)
+
+  /**
+   * Tests validateAndPingUrlOGC with an invalid URL format.
    *
    * Uses a malformed string that is not a valid URL.
    * Asserts that the result has isValid=false and isReachable=false.
@@ -65,7 +135,7 @@ export class CoreTester extends GVAbstractTester {
       async (test) => {
         const url = 'not-a-valid-url';
         test.addStep(`Pinging invalid URL format: ${url}...`);
-        const result = await validateAndPingUrl(url);
+        const result = await validateAndPingUrlOGC(url);
         return result;
       },
       (test, result) => {
@@ -85,7 +155,7 @@ export class CoreTester extends GVAbstractTester {
   }
 
   /**
-   * Tests validateAndPingUrl with a valid URL that is unreachable.
+   * Tests validateAndPingUrlOGC with a valid URL that is unreachable.
    *
    * Uses GVAbstractTester.BAD_URL which has valid URL syntax but the server does not exist.
    * Asserts that the result has isValid=true and isReachable=false.
@@ -98,7 +168,7 @@ export class CoreTester extends GVAbstractTester {
       async (test) => {
         const url = GVAbstractTester.BAD_URL;
         test.addStep(`Pinging unreachable URL: ${url}...`);
-        const result = await validateAndPingUrl(url);
+        const result = await validateAndPingUrlOGC(url);
         return result;
       },
       (test, result) => {
@@ -115,7 +185,7 @@ export class CoreTester extends GVAbstractTester {
   }
 
   /**
-   * Tests validateAndPingUrl with a WMS service URL.
+   * Tests validateAndPingUrlOGC with a WMS service URL.
    *
    * Uses the Geomet WMS URL. WMS services often require query params to respond properly,
    * so this validates that the OGC GetCapabilities fallback logic works.
@@ -129,7 +199,7 @@ export class CoreTester extends GVAbstractTester {
       async (test) => {
         const url = GVAbstractTester.GEOMET_URL;
         test.addStep(`Pinging WMS service URL: ${url}...`);
-        const result = await validateAndPingUrl(url);
+        const result = await validateAndPingUrlOGC(url);
         return result;
       },
       (test, result) => {
@@ -141,6 +211,8 @@ export class CoreTester extends GVAbstractTester {
       }
     );
   }
+
+  // #endregion VALIDATE AND PING URL (OGC)
 
   /**
    * Tests GeometryCollection legend generation through the renderer.


### PR DESCRIPTION
# Description

- Switching the default proxy to our new proxy instead of the old Esri one (via wms.json configuration)
- Fixing the proxy configuration reading
- Minor, added an indication of more projections available in the case of WMS services in the layer info
- Improved support for XYZ Tile layers
- Added more XYZ Tile layers in the XYZ layers navigator template
- Improved the code logic when going from step 1 to step 2 in add-new-layer.tsx
- Fix so the WMS layer service which has a WFS associated uses the same proxy as the paired configuration when it needs to
- Fixed the check for the 'time' named property in TimeDimension to be done case-insensitive, as per OGC documentation
- Split the validateAndPingUrl function into a more simple one called the same name and a more elaborate one when specifically testing for WFS/WMS/WMTS services called validateAndPingUrlOGC which will also do GetCapabilities requests
- Improved the check if the layer needs to be put in error or not when a tile has failed to load (Arctic stays loaded state even if some tiles fail - whereas GNOSIS Blue Marble is set to error, because no tile ever loads)
- Improved the core test suite to test some url
- Improved the way the tile services provide context on their errors to the user via the notifications

Fixes: #3553

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

~~Hosted July 15 @ 14h10 : https://alex-nrcan.github.io/geoview/~~
~~Hosted July 16 @ 9h10 : https://alex-nrcan.github.io/geoview/~~
~~Hosted July 16 @ 16h00 : https://alex-nrcan.github.io/geoview/~~
~~Hosted July 16 @ 17h20 : https://alex-nrcan.github.io/geoview/~~
Hosted July 17 @ 10h50 : https://alex-nrcan.github.io/geoview/
- Test the WMS template page notably the Nonna layer going through proxy
- Test the XYZ Tile template page to see additional layer tests
- Test adding a XYZ Tile layer such as https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png via the add-new-layer component (fixed issue)
- Run the core test suite
- Test all layers on https://alex-nrcan.github.io/geoview/layers-navigator.html?config=./configs/navigator/layers/wms.json
- Test all layers on https://alex-nrcan.github.io/geoview/layers-navigator.html?config=./configs/navigator/layers/xyz-tile.json
- Test https://alex-nrcan.github.io/geoview/layers-navigator.html?cconfig=./configs/navigator/layers/xyz-tile-errors.json to confirm the error messages

# Checklist:

- [x] I have run the **Test Suite** and **No errors have been introduced**
- [x] I have run `@BranchReview` agent in VS Code Chat and addressed all violations
- [x] I have run `@DocUpdate` agent in VS Code Chat and documentation is in sync with code changes
- [ ] I have run `@IssueReview` agent in VS Code Chat and the implementation aligns with the linked issue
- [x] I have build **(rush build)** and deploy **(rush host)** my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~New and existing unit tests pass locally with my changes~~

# Pre-PR Copilot Agent Checks

Before creating your PR, run the following two Copilot agents in VS Code Chat to catch common issues automatically.

## Branch Review (`@BranchReview`)

Audits all changed `.ts`/`.tsx` files against the GeoView coding standards (JSDoc, logging, return types, naming, accessibility, imports, performance patterns).

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **BranchReview** agent from the agent picker (or type `@BranchReview`)
3. Type the target branch name (defaults to `develop`):
   ```
   @BranchReview  against upstream/develop
   ```
4. Review the violation report and fix flagged items (the agent can auto-fix most issues on approval)

- [ ] `@BranchReview` has been run and all violations have been addressed

## Documentation Update (`@DocUpdate`)

Checks that documentation in `docs/` is still consistent with the code you changed. Catches stale references, missing docs for new features, and incorrect code examples.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **DocUpdate** agent from the agent picker (or type `@DocUpdate`)
3. Run a full audit or target a specific section:
   ```
   @DocUpdate full audit of docs/programming/
   @DocUpdate check docs/app/layers/
   ```
4. Review the audit summary and approve any proposed documentation updates

- [ ] `@DocUpdate` has been run and documentation is in sync with code changes

## Issue Review (`@IssueReview`)

Compares your branch changes against the linked GitHub issue's proposed fix. Checks whether the implementation aligns with what was proposed, catches gaps, and provides feedback to improve future issue drafts.

**How to run:**

1. Open VS Code Chat (Ctrl+Shift+I)
2. Select the **IssueReview** agent from the agent picker (or type `@IssueReview`)
3. Provide the issue number:
   ```
   @IssueReview #1234
   ```
4. Review the alignment report — it will flag items that were proposed but not implemented, unexpected changes, and root cause accuracy

- [ ] `@IssueReview` has been run and the alignment report has been reviewed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3564)
<!-- Reviewable:end -->
