### PR TITLE
3601 geoview map height not honoured

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -172,6 +172,8 @@ cgpv.init();
 - The **map element** is keyboard-focusable (`tabIndex=0`). Ctrl+M focuses it and activates the crosshair.
 - The **viewer** renders the full shell: app bar with all tabs, footer bar, nav bar, map info bar.
 
+**Fixed-height viewer sizing:** When a `geoview-map` div has an explicit CSS height, or when `createMapFromConfig()` / `createMapFromConfigFast()` receives a height, that height is the full collapsed GeoView viewer height, not just the map shell or OpenLayers canvas height. If a dynamic footer bar exists, `Shell` measures the collapsed footer chrome and `useMapResize()` subtracts that height from the map shell height. The viewer may exceed the configured height only when the footer panel is expanded. Keep `box-sizing: border-box` on the viewer/shell/map containers so border thickness does not create small fixed-height overruns.
+
 **Map info bar** — The map info bar (attribution, scale, rotation display) is **separate from the footer bar** and has no schema configuration. It always renders automatically:
 
 - **Dynamic mode**: Displays attribution, scale, and rotation value.

--- a/docs/app/config/create-map.md
+++ b/docs/app/config/create-map.md
@@ -40,6 +40,7 @@ Specifically, it looks for `<div>` elements with the `geoview-map` class that id
 - `cgpv.init()` finds all such elements in the DOM.
 - For each, it reads the configuration and initializes a map viewer instance inside the div.
 - The initialization process uses the provided attributes to determine map settings, language, and data sources.
+- When the container has an explicit CSS height, that height applies to the full collapsed GeoView viewer. If a footer bar is configured, the collapsed footer header is included in that height; only expanded footer panel content may make the viewer taller.
 
 **Tip:**
 Make sure your map container divs are present in the DOM before calling `cgpv.init()`, and that they have the required attributes for your use case.
@@ -80,7 +81,7 @@ The JSON file should have the same structure as the inline `data-config` value.
 
 #### `data-footer-height`
 
-The `data-footer-height` attribute allows for manually setting the height of the footer bar so that it is not default 600px or the same height as the map. The value can be any css height value although pixels (px) and view height (vh) are recommended.
+The `data-footer-height` attribute allows for manually setting the expanded footer panel height so that it is not default 600px or the same height as the map. The value can be any css height value although pixels (px) and view height (vh) are recommended. This attribute does not set the height of the collapsed footer header; the collapsed header is automatically accounted for inside the map container's explicit height.
 
 ```html
 <div

--- a/docs/programming/release-testing/RELEASE-CANDIDATE.md
+++ b/docs/programming/release-testing/RELEASE-CANDIDATE.md
@@ -146,6 +146,7 @@ _(Fixes discovered or applied during this cycle)_
 - Fixed WMS CRS override when layers are behind a proxy — was re-encoding the entire string instead of only adjusting CRS and BBOX properties (#3562)
 - Fixed zoom-to-feature-geometry working even when the geometry field is not included in the outFields configuration (#3562)
 - Fixed initial extent being slightly off vertically vs the home view extent, causing the home view button to shift the map (#3562)
+- Fixed configured `geoview-map` height being exceeded when the collapsed footer bar is rendered (#3601)
 - Fixed CESI layer in outlier-style.html template to point to a valid layer id (#3562)
 - Fixed Permafrost by Ecoprovince in outlier-metadata template to point to a valid layer URL (#3562)
 - Fixed broken layer in performance.json template demo (#3562)
@@ -247,6 +248,7 @@ _(Tests added, moved, removed, or reorganized)_
 - New `RUN_DEBUG_ONLY` flag for isolating test execution during development (#3562)
 - Added a swiper rendering-isolation regression test covering descendant path resolution, per-target OL render handlers, CSS clip-path removal, and listener cleanup
 - Added `suite-time-slider` with reset-to-default and dual-handle overlap constraint regression tests, plus a dedicated temporal-layer test map
+- Added fixed-height map layout tests for maps with and without a footer bar (#3601)
 
 ## Config Schema Changes
 
@@ -256,8 +258,8 @@ _(Properties added, renamed, or with changed defaults)_
 
 | Metric        | Before | After |
 | ------------- | ------ | ----- |
-| Total tests   | 900    | 901   |
-| Automated (A) | 59     | 60    |
+| Total tests   | 901    | 903   |
+| Automated (A) | 60     | 62    |
 | Candidate (C) | 169    | 169   |
 | Manual (M)    | 672    | 672   |
 

--- a/packages/geoview-core/public/templates/demos-specific/demo-osdp-integration.html
+++ b/packages/geoview-core/public/templates/demos-specific/demo-osdp-integration.html
@@ -32,10 +32,11 @@
       <h4 id="HMap1">OSDP Integration</h4>
     </div>
 
-    <div id="mapSection">
+    <div id="mapSection" style="display: grid; min-height: 700px">
       <div
         id="Map1"
         class="geoview-map"
+        style="height: 100%"
         data-lang="fr"
         data-config="{
         'map': {
@@ -68,6 +69,9 @@
         'corePackages': [],
         'serviceUrls': {
           'metadataUrl': 'https://osdp-psdo.canada.ca/dp/en/search/metadata/NRCAN-FGP-1-'
+        },
+        'globalSettings': {
+          'canRemoveSublayers': false
         },
         'theme': 'geo.ca'
       }"
@@ -374,6 +378,9 @@ cgpv.api.getMapViewer('Map1').replaceMapConfigLayerNames(pairs, mapConfig, true)
         corePackages: [],
         serviceUrls: {
           metadataUrl: 'https://osdp-psdo.canada.ca/dp/en/search/metadata/NRCAN-FGP-1-',
+        },
+        globalSettings: {
+          canRemoveSublayers: false
         },
         theme: 'geo.ca',
       };

--- a/packages/geoview-core/src/core/components/map/map-style.ts
+++ b/packages/geoview-core/src/core/components/map/map-style.ts
@@ -7,6 +7,7 @@ import type { SxStyles } from '@/ui/style/types';
  */
 export const getSxClasses = (): SxStyles => ({
   mapContainer: {
+    boxSizing: 'border-box',
     display: 'flex',
     flexDirection: 'column',
     width: '100%',

--- a/packages/geoview-core/src/core/containers/containers-style.ts
+++ b/packages/geoview-core/src/core/containers/containers-style.ts
@@ -78,6 +78,7 @@ export const getShellSxClasses = (theme: Theme, appHeight: number): SxStyles => 
     },
   },
   shell: {
+    boxSizing: 'border-box',
     scrollMarginTop: '20px',
     display: 'flex',
     flexDirection: 'column',
@@ -90,6 +91,7 @@ export const getShellSxClasses = (theme: Theme, appHeight: number): SxStyles => 
     height: '100%',
   },
   mapShellContainer: {
+    boxSizing: 'border-box',
     display: 'flex',
     flexDirection: 'row',
     height: `${appHeight}px`,
@@ -101,6 +103,7 @@ export const getShellSxClasses = (theme: Theme, appHeight: number): SxStyles => 
     containerName: 'map',
   },
   mapContainer: {
+    boxSizing: 'border-box',
     display: 'flex',
     flexDirection: 'column',
     height: '100%',

--- a/packages/geoview-core/src/core/containers/shell.tsx
+++ b/packages/geoview-core/src/core/containers/shell.tsx
@@ -253,13 +253,37 @@ export function Shell(props: ShellProps): JSX.Element {
     document.getElementById(`mapTargetElement-${mapId}`)?.focus();
   }, [mapId, uiController]);
 
+  /**
+   * Handles navigation from the top skip link to the bottom skip link.
+   */
+  const handleSkipToBottomLink = useCallback((): void => {
+    handleSkipLinkClick(`bottomlink-${mapViewer.mapId}`);
+  }, [handleSkipLinkClick, mapViewer.mapId]);
+
+  /**
+   * Handles navigation from the main-content skip link to the map.
+   */
+  const handleSkipToMap = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>): void => {
+      event.preventDefault();
+      handleSkipToMainContent();
+    },
+    [handleSkipToMainContent]
+  );
+
+  /**
+   * Handles navigation from the bottom skip link to the top skip link.
+   */
+  const handleSkipToTopLink = useCallback((): void => {
+    handleSkipLinkClick(`toplink-${mapViewer.mapId}`);
+  }, [handleSkipLinkClick, mapViewer.mapId]);
+
   // #endregion HANDLERS
 
   /**
    * Registers map viewer event listeners on mount and cleans up on unmount.
    */
   useEffect(() => {
-    // Log
     logger.logTraceUseEffect('SHELL - mount');
 
     // listen to Notifications event when app wants to show message
@@ -279,7 +303,7 @@ export function Shell(props: ShellProps): JSX.Element {
 
     return () => {
       mapViewer.offMapComponentRemoved(handleMapRemoveComponent);
-      mapViewer.onMapComponentAdded(handleMapAddComponent);
+      mapViewer.offMapComponentAdded(handleMapAddComponent);
       mapViewer.modal.offModalClosed(handleModalClose);
       mapViewer.modal.offModalOpened(handleModalOpen);
       mapViewer.notifications.offSnackbarOpen(handleSnackBarOpen);
@@ -290,7 +314,6 @@ export function Shell(props: ShellProps): JSX.Element {
    * Announces when the map finishes loading, then clears the announcement.
    */
   useEffect(() => {
-    // Log
     logger.logTraceUseEffect('SHELL - map loaded announcement', mapLoaded);
 
     // Capture previous value before updating
@@ -318,7 +341,6 @@ export function Shell(props: ShellProps): JSX.Element {
    * Announces when processing completes, then clears the announcement.
    */
   useEffect(() => {
-    // Log
     logger.logTraceUseEffect('SHELL - processing complete announcement', circularProgressActive);
 
     // Capture previous value before updating
@@ -346,14 +368,15 @@ export function Shell(props: ShellProps): JSX.Element {
    * Measures the collapsed footer header so fixed-height maps include it in the requested viewer height.
    */
   useEffect(() => {
-    // Log
     logger.logTraceUseEffect('SHELL - collapsed footer height measurement', isFooterBar, isOpen, mapId);
 
+    // Static maps do not render a footer bar, so no footer height belongs in the shell size calculation.
     if (!isFooterBar) {
       setCollapsedFooterHeight(0);
       return undefined;
     }
 
+    // Wait for both footer elements because the measured element depends on whether the panel is open.
     const footerContainer = document.getElementById(`${mapId}-tabsContainer`);
     const footerHeader = document.getElementById(`${mapId}-footerbar-header`);
     if (!footerHeader || !footerContainer) {
@@ -362,6 +385,7 @@ export function Shell(props: ShellProps): JSX.Element {
     }
 
     const updateCollapsedFooterHeight = (): void => {
+      // Use the full container while expanded and the header alone while collapsed.
       const measuredFooterElement = isOpen ? footerHeader : footerContainer;
       const nextHeight = Math.ceil(measuredFooterElement.getBoundingClientRect().height);
       setCollapsedFooterHeight((previousHeight) => (previousHeight === nextHeight ? previousHeight : nextHeight));
@@ -373,6 +397,7 @@ export function Shell(props: ShellProps): JSX.Element {
       return undefined;
     }
 
+    // Recalculate when either the footer panel or its header changes size.
     const resizeObserver = new ResizeObserver(updateCollapsedFooterHeight);
     resizeObserver.observe(footerContainer);
     resizeObserver.observe(footerHeader);
@@ -386,7 +411,6 @@ export function Shell(props: ShellProps): JSX.Element {
    * Updates the OpenLayers map size after shell height calculations change.
    */
   useEffect(() => {
-    // Log
     logger.logTraceUseEffect(
       'SHELL - update OpenLayers size after layout change',
       appHeight,
@@ -405,7 +429,7 @@ export function Shell(props: ShellProps): JSX.Element {
         href={`#bottomlink-${mapViewer.mapId}`}
         tabIndex={0}
         sx={{ ...memoSxClasses.skip, top: '0px' }}
-        onClick={() => handleSkipLinkClick(`bottomlink-${mapViewer.mapId}`)}
+        onClick={handleSkipToBottomLink}
       >
         {t('keyboardnav.start')}
       </Link>
@@ -430,10 +454,7 @@ export function Shell(props: ShellProps): JSX.Element {
               href={`#main-map-${mapViewer.mapId}`}
               tabIndex={0}
               sx={{ ...memoSxClasses.skip, top: '0px' }}
-              onClick={(e) => {
-                e.preventDefault();
-                handleSkipToMainContent();
-              }}
+              onClick={handleSkipToMap}
             >
               {t('keyboardnav.map')}
             </Link>
@@ -482,7 +503,7 @@ export function Shell(props: ShellProps): JSX.Element {
         href={`#toplink-${mapViewer.mapId}`}
         tabIndex={0}
         sx={{ ...memoSxClasses.skip, bottom: '0px' }}
-        onClick={() => handleSkipLinkClick(`toplink-${mapViewer.mapId}`)}
+        onClick={handleSkipToTopLink}
       >
         {t('keyboardnav.end')}
       </Link>

--- a/packages/geoview-core/src/core/containers/shell.tsx
+++ b/packages/geoview-core/src/core/containers/shell.tsx
@@ -99,9 +99,11 @@ export function Shell(props: ShellProps): JSX.Element {
   const geoviewElement = useStoreAppGeoviewHTMLElement();
   const appHeight = useStoreAppHeight();
   const uiController = useUIController();
+  const isFooterBar = !!geoviewConfig?.footerBar && interaction === 'dynamic';
 
   const prevMapLoadedRef = useRef<boolean>(mapLoaded);
   const prevCircularProgressActiveRef = useRef<boolean>(circularProgressActive);
+  const [collapsedFooterHeight, setCollapsedFooterHeight] = useState(0);
 
   /**
    * Computes the style classes for the shell container.
@@ -116,7 +118,8 @@ export function Shell(props: ShellProps): JSX.Element {
     isMapFullScreen,
     isFooterBarOpen: isOpen,
     footerPanelResizeValue,
-    isFooterBar: !!geoviewConfig?.footerBar,
+    isFooterBar,
+    collapsedFooterHeight,
     geoviewElement,
     appHeight,
   });
@@ -339,6 +342,62 @@ export function Shell(props: ShellProps): JSX.Element {
     return undefined;
   }, [circularProgressActive, t]);
 
+  /**
+   * Measures the collapsed footer header so fixed-height maps include it in the requested viewer height.
+   */
+  useEffect(() => {
+    // Log
+    logger.logTraceUseEffect('SHELL - collapsed footer height measurement', isFooterBar, isOpen, mapId);
+
+    if (!isFooterBar) {
+      setCollapsedFooterHeight(0);
+      return undefined;
+    }
+
+    const footerContainer = document.getElementById(`${mapId}-tabsContainer`);
+    const footerHeader = document.getElementById(`${mapId}-footerbar-header`);
+    if (!footerHeader || !footerContainer) {
+      setCollapsedFooterHeight(0);
+      return undefined;
+    }
+
+    const updateCollapsedFooterHeight = (): void => {
+      const measuredFooterElement = isOpen ? footerHeader : footerContainer;
+      const nextHeight = Math.ceil(measuredFooterElement.getBoundingClientRect().height);
+      setCollapsedFooterHeight((previousHeight) => (previousHeight === nextHeight ? previousHeight : nextHeight));
+    };
+
+    updateCollapsedFooterHeight();
+
+    if (typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+
+    const resizeObserver = new ResizeObserver(updateCollapsedFooterHeight);
+    resizeObserver.observe(footerContainer);
+    resizeObserver.observe(footerHeader);
+
+    return (): void => {
+      resizeObserver.disconnect();
+    };
+  }, [isFooterBar, isOpen, mapId]);
+
+  /**
+   * Updates the OpenLayers map size after shell height calculations change.
+   */
+  useEffect(() => {
+    // Log
+    logger.logTraceUseEffect(
+      'SHELL - update OpenLayers size after layout change',
+      appHeight,
+      collapsedFooterHeight,
+      isMapFullScreen,
+      isOpen
+    );
+
+    mapViewer.map?.updateSize();
+  }, [mapViewer, appHeight, collapsedFooterHeight, isMapFullScreen, isOpen]);
+
   return (
     <Box sx={memoSxClasses.all}>
       <Link
@@ -396,7 +455,7 @@ export function Shell(props: ShellProps): JSX.Element {
               onClose={handleSnackBarClose}
             />
           </Box>
-          {geoviewConfig?.footerBar && interaction === 'dynamic' && <FooterBar api={mapViewer.footerBarApi} />}
+          {isFooterBar && <FooterBar api={mapViewer.footerBarApi} />}
           {Object.keys(mapViewer.modal.modals).map((modalId) => (
             <Modal
               key={modalId}

--- a/packages/geoview-core/src/core/containers/use-map-resize.ts
+++ b/packages/geoview-core/src/core/containers/use-map-resize.ts
@@ -9,6 +9,7 @@ interface UseMapResizeProps {
   isFooterBarOpen: boolean;
   footerPanelResizeValue: number;
   isFooterBar: boolean;
+  collapsedFooterHeight: number;
   geoviewElement: HTMLElement;
   appHeight: number;
 }
@@ -29,6 +30,7 @@ export const useMapResize = ({
   isFooterBarOpen,
   footerPanelResizeValue,
   isFooterBar,
+  collapsedFooterHeight,
   geoviewElement,
   appHeight,
 }: UseMapResizeProps): TypeUseMapResize => {
@@ -44,8 +46,10 @@ export const useMapResize = ({
       return;
     }
 
+    const availableMapHeight = Math.max(appHeight - (isFooterBar ? collapsedFooterHeight : 0), 0);
+
     // default values as set by the height of the div
-    let containerHeight = `${appHeight}px`;
+    let containerHeight = `${availableMapHeight}px`;
     let containerFlex = '';
     let visibility = 'visible';
 
@@ -71,7 +75,7 @@ export const useMapResize = ({
     mapShellContainerRef.current.style.visibility = visibility;
     mapShellContainerRef.current.style.height = containerHeight;
     mapShellContainerRef.current.style.flex = containerFlex;
-  }, [footerPanelResizeValue, isFooterBarOpen, isMapFullScreen, appHeight]);
+  }, [footerPanelResizeValue, isFooterBar, isFooterBarOpen, isMapFullScreen, appHeight, collapsedFooterHeight]);
 
   /**
    * Adjusts geoviewElement height to accommodate the footer bar.

--- a/packages/geoview-core/src/core/containers/use-map-resize.ts
+++ b/packages/geoview-core/src/core/containers/use-map-resize.ts
@@ -5,17 +5,25 @@ import { logger } from '@/core/utils/logger';
 
 /** Props for the useMapResize hook. */
 interface UseMapResizeProps {
+  /** Whether the map is displayed in fullscreen mode. */
   isMapFullScreen: boolean;
+  /** Whether the footer bar panel is open. */
   isFooterBarOpen: boolean;
+  /** The footer panel resize percentage. */
   footerPanelResizeValue: number;
+  /** Whether the map has a footer bar. */
   isFooterBar: boolean;
+  /** The measured height of the collapsed footer chrome. */
   collapsedFooterHeight: number;
+  /** The root GeoView element whose height accommodates the footer bar. */
   geoviewElement: HTMLElement;
+  /** The configured application height in pixels. */
   appHeight: number;
 }
 
 /** Return type for the useMapResize hook. */
 type TypeUseMapResize = {
+  /** The ref for the map shell container. */
   mapShellContainerRef: React.RefObject<HTMLDivElement | null>;
 };
 

--- a/packages/geoview-core/src/ui/style/style.css
+++ b/packages/geoview-core/src/ui/style/style.css
@@ -11,6 +11,7 @@ Hold viewer specific css not inside theme
 }
 
 .geoview-map {
+  box-sizing: border-box;
   position: relative !important;
 }
 

--- a/packages/geoview-test-suite/src/tests/suites/suite-map-config.ts
+++ b/packages/geoview-test-suite/src/tests/suites/suite-map-config.ts
@@ -69,6 +69,14 @@ export class GVTestSuiteMapConfig extends GVAbstractTestSuite {
    * @returns A promise that resolves when tests are completed
    */
   protected override async onLaunchTestSuite(): Promise<unknown> {
+    // Test fixed-height map layout without footer bar
+    const pFixedHeightWithoutFooterBar = this.#mapConfigTester.testFixedHeightWithoutFooterBar();
+    await pFixedHeightWithoutFooterBar;
+
+    // Test fixed-height map layout with collapsed footer bar
+    const pFixedHeightWithCollapsedFooterBar = this.#mapConfigTester.testFixedHeightWithCollapsedFooterBar();
+    await pFixedHeightWithCollapsedFooterBar;
+
     // Test data table pre-loaded in footer bar
     const pDataTableInFooterBar = this.#mapConfigTester.testDataTableSelectedTabFooterBar();
     await pDataTableInFooterBar;

--- a/packages/geoview-test-suite/src/tests/suites/suite-map-varia.ts
+++ b/packages/geoview-test-suite/src/tests/suites/suite-map-varia.ts
@@ -94,8 +94,8 @@ export class GVTestSuiteMapVaria extends GVAbstractTestSuite {
     // Wait until the projection switch finishes before continuing manipulating the map
     await pProjection;
 
-    // Test zoom to extent
-    const pZoomToExtent = this.#mapTester.testZoomToExtent([-87, 51, -84, 53], [-88, 51, -83, 53]);
+    // Test zoom to extent. The expected extent reflects the corrected fixed-height map shell after collapsed footer sizing is applied.
+    const pZoomToExtent = this.#mapTester.testZoomToExtent([-87, 51, -84, 53], [-88, 50, -82, 53]);
 
     // Wait until the zoom finishes before continuing manipulating the map
     await pZoomToExtent;

--- a/packages/geoview-test-suite/src/tests/testers/map-config-tester.ts
+++ b/packages/geoview-test-suite/src/tests/testers/map-config-tester.ts
@@ -15,6 +15,7 @@ import {
   getStoreDataTableSelectedLayerPath,
 } from 'geoview-core/core/stores/states/data-table-state';
 import { getStoreLayerBounds, getStoreLayerControls, getStoreLayerLegendLayerByPath } from 'geoview-core/core/stores/states/layer-state';
+import { TIMEOUT } from 'geoview-core/core/utils/constant';
 import {
   getStoreMapPointMarkers,
   getStoreMapConfigOverviewMap,
@@ -23,6 +24,17 @@ import {
   getStoreMapNorthArrow,
 } from 'geoview-core/core/stores/states/map-state';
 import { Projection } from 'geoview-core/geo/utils/projection';
+
+/** Fixed map height used by map config layout tests. */
+const MAP_CONFIG_TEST_HEIGHT = 500;
+
+/** Height measurements for fixed-height map layout tests. */
+type TypeMapHeightMeasurements = {
+  /** Height of the root GeoView map element. */
+  geoviewMapHeight: number;
+  /** Height of the rendered collapsed footer chrome. */
+  footerChromeHeight: number;
+};
 
 /**
  * Main Map Config testing class.
@@ -35,6 +47,64 @@ export class MapConfigTester extends GVAbstractTester {
    */
   override getName(): string {
     return 'MapConfigTester';
+  }
+
+  /**
+   * Tests that a fixed-height map without a footer bar keeps the requested viewer height.
+   *
+   * @returns A promise that resolves when the test completes
+   */
+  testFixedHeightWithoutFooterBar(): Promise<Test<TypeMapHeightMeasurements>> {
+    const mapId = this.getMapId();
+
+    return this.test(
+      'Test fixed-height map without footer bar keeps requested viewer height...',
+      async (test) => {
+        test.addStep('Creating fixed-height map with no footer bar...');
+        await this.#helperCreateMapConfig(test, mapId, ['footerBar', { tabs: { core: [] } }]);
+
+        test.addStep('Waiting for layout effects to settle...');
+        await delay(TIMEOUT.tabsContainerResize);
+
+        return MapConfigTester.#measureMapHeights(mapId);
+      },
+      (test, result) => {
+        test.addStep('Verifying root GeoView map height matches requested height...');
+        Test.assertIsEqual(result.geoviewMapHeight, MAP_CONFIG_TEST_HEIGHT);
+
+        test.addStep('Verifying there is no collapsed footer chrome height...');
+        Test.assertIsEqual(result.footerChromeHeight, 0);
+      }
+    );
+  }
+
+  /**
+   * Tests that a fixed-height map with a collapsed footer bar keeps the requested viewer height.
+   *
+   * @returns A promise that resolves when the test completes
+   */
+  testFixedHeightWithCollapsedFooterBar(): Promise<Test<TypeMapHeightMeasurements>> {
+    const mapId = this.getMapId();
+
+    return this.test(
+      'Test fixed-height map with collapsed footer bar keeps requested viewer height...',
+      async (test) => {
+        test.addStep('Creating fixed-height map with default collapsed footer bar...');
+        await this.#helperCreateMapConfig(test, mapId);
+
+        test.addStep('Waiting for collapsed footer measurement to settle...');
+        await delay(TIMEOUT.tabsContainerResize);
+
+        return MapConfigTester.#measureMapHeights(mapId);
+      },
+      (test, result) => {
+        test.addStep('Verifying root GeoView map height matches requested height...');
+        Test.assertIsEqual(result.geoviewMapHeight, MAP_CONFIG_TEST_HEIGHT);
+
+        test.addStep('Verifying collapsed footer chrome is rendered...');
+        if (result.footerChromeHeight <= 0) Test.assertFail('Collapsed footer chrome height should be greater than 0.');
+      }
+    );
   }
 
   /**
@@ -1915,7 +1985,10 @@ export class MapConfigTester extends GVAbstractTester {
     };
 
     // Apply overrides - normalize to array format then apply each path-value pair
-    const overridesArray = Array.isArray(overrides[0]) ? (overrides as [string, unknown][]) : [overrides as [string, unknown]];
+    let overridesArray: [string, unknown][] = [];
+    if (overrides.length > 0) {
+      overridesArray = Array.isArray(overrides[0]) ? (overrides as [string, unknown][]) : [overrides as [string, unknown]];
+    }
     overridesArray.forEach(([path, value]) => {
       MapConfigTester.#setValueByPath(baseConfig, path, value);
     });
@@ -1958,5 +2031,23 @@ export class MapConfigTester extends GVAbstractTester {
     } else {
       current[finalKey] = value;
     }
+  }
+
+  /**
+   * Measures fixed-height map layout elements.
+   *
+   * @param mapId - The map identifier
+   * @returns The measured map layout heights
+   */
+  static #measureMapHeights(mapId: string): TypeMapHeightMeasurements {
+    const geoviewMapElement = document.getElementById(mapId) ?? undefined;
+    const footerContainerElement = document.getElementById(`${mapId}-tabsContainer`) ?? undefined;
+
+    Test.assertIsDefined('geoviewMapElement', geoviewMapElement);
+
+    return {
+      geoviewMapHeight: Math.round(geoviewMapElement.getBoundingClientRect().height),
+      footerChromeHeight: footerContainerElement ? Math.round(footerContainerElement.getBoundingClientRect().height) : 0,
+    };
   }
 }


### PR DESCRIPTION
Closes #3601

# Description

Fixes #3601 by ensuring configured geoview-map heights include the collapsed footer bar.

Changes
- Measure collapsed footer height and account for it in map resizing.
- Preserve configured viewer height when the footer bar is collapsed.
- Allow expanded footer panels to extend beyond the configured height.
- Add box-sizing: border-box to relevant map containers.
- Fix Shell event listener cleanup and skip-link handlers.
- Add fixed-height map configuration tests with and without a footer bar.
- Update configuration and release-testing documentation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://damonu2.github.io/geoview/sandbox.html - try different sizes and check div height

# Checklist:

- [x] I have run the **Test Suite** and **No errors have been introduced**
- [x] I have run `@BranchReview` agent in VS Code Chat and addressed all violations
- [ ] I have run `@DocUpdate` agent in VS Code Chat and documentation is in sync with code changes
- [x] I have run `@IssueReview` agent in VS Code Chat and the implementation aligns with the linked issue
- [x] I have build **(rush build)** and deploy **(rush host)** my PR
- [x] I have connected the issues(s) to this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3602)
<!-- Reviewable:end -->
