### PR TITLE
update to add "canRemoveSublayers: false" to OSDP configs

### DIFF
--- a/packages/geoview-core/public/configs/OSDP/osdp-air.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-air.json
@@ -265,5 +265,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-air_en.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-air_en.json
@@ -66,5 +66,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-air_fr.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-air_fr.json
@@ -66,5 +66,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-biodiversity_en.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-biodiversity_en.json
@@ -66,5 +66,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-biodiversity_fr.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-biodiversity_fr.json
@@ -66,5 +66,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-climate_en.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-climate_en.json
@@ -72,5 +72,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-climate_fr.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-climate_fr.json
@@ -72,5 +72,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-economy_en.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-economy_en.json
@@ -97,5 +97,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-economy_fr.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-economy_fr.json
@@ -97,5 +97,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-empty.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-empty.json
@@ -54,10 +54,14 @@
       "core": [
         "layers",
         "data-table",
-        "time-slider"
+        "time-slider",
+        "geochart"
       ]
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-health_en.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-health_en.json
@@ -147,6 +147,9 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca",
   "corePackagesConfig": [
     {

--- a/packages/geoview-core/public/configs/OSDP/osdp-health_fr.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-health_fr.json
@@ -147,6 +147,9 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca",
   "corePackagesConfig": [
     {

--- a/packages/geoview-core/public/configs/OSDP/osdp-land_en.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-land_en.json
@@ -102,6 +102,9 @@
   "corePackages": [
     "swiper"
   ],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca",
   "corePackagesConfig": [
     {

--- a/packages/geoview-core/public/configs/OSDP/osdp-land_fr.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-land_fr.json
@@ -102,6 +102,9 @@
   "corePackages": [
     "swiper"
   ],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca",
   "corePackagesConfig": [
     {

--- a/packages/geoview-core/public/configs/OSDP/osdp-search.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-search.json
@@ -31,5 +31,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-simple.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-simple.json
@@ -29,5 +29,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-society_en.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-society_en.json
@@ -78,5 +78,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-society_fr.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-society_fr.json
@@ -78,5 +78,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-water_en.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-water_en.json
@@ -66,5 +66,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }

--- a/packages/geoview-core/public/configs/OSDP/osdp-water_fr.json
+++ b/packages/geoview-core/public/configs/OSDP/osdp-water_fr.json
@@ -66,5 +66,8 @@
     }
   },
   "corePackages": [],
+  "globalSettings": {
+    "canRemoveSublayers": false
+  },
   "theme": "geo.ca"
 }


### PR DESCRIPTION
# Description

Update to all OSDP configs to remove the ability of the user to delete a sublayer. Also adds geochart to the empty config.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

**Add the URL for your deploy!**

# Checklist:

- [ ] I have run the **Test Suite** and **No errors have been introduced**
- [ ] I have run `@BranchReview` agent in VS Code Chat and addressed all violations
- [ ] I have run `@DocUpdate` agent in VS Code Chat and documentation is in sync with code changes
- [ ] I have run `@IssueReview` agent in VS Code Chat and the implementation aligns with the linked issue
- [ ] I have build **(rush build)** and deploy **(rush host)** my PR
- [ ] I have connected the issues(s) to this PR
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have created new issue(s) related to the outcome of this PR is needed
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~New and existing unit tests pass locally with my changes~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geoview/3603)
<!-- Reviewable:end -->
